### PR TITLE
Adding kcov code coverage to chain and core modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ addons:
     packages:
       - g++-5
       - cmake
-
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev 
 env:
   global:
     - RUST_BACKTRACE="1"
@@ -28,5 +33,41 @@ env:
     - TEST_DIR=keychain
     - TEST_DIR=core
     - TEST_DIR=util
+
+after_success: |
+  pwd &&
+  wget https://github.com/percytheprefect/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  cargo test --no-run &&
+  cd ../
+  pwd &&
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_core* && 
+  echo "Finished coverage for grin_core"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_chain* && 
+  echo "Finished coverage for grin_chain"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_keychain* &&
+  echo "Finished coverage for grin_keychain"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_p2p* &&
+  echo "Finished coverage for grin_p2p"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_pow* &&
+  echo "Finished coverage for grin_pow"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_store* &&
+  echo "Finished coverage for grin_store"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_wallet* &&
+  echo "Finished coverage for grin_wallet"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_util* &&
+  echo "Finished coverage for grin_util"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/mine_simple* &&
+  echo "Finished coverage for mine_simple"
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"
 
 script: cd $TEST_DIR && cargo test --verbose


### PR DESCRIPTION
This pull request implements code coverage for the core and chain modules of grin. It follows [this guide](http://sunjay.ca/2016/07/25/rust-code-coverage) to implement the test coverage. 

If anyone knows of a better way to make code coverage easily accessible for grin let me know. 