### PR TITLE
"grin wallet init" to create the initial wallet.seed file

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -17,7 +17,7 @@ The instructions below will assume a Linux system.
 In order to compile and run Grin on your machine, you should have installed:
 
 * <b>Git</b> - to clone the repository
-* <b>cmake</b> - 3.2 or greater should be installed and on your $PATH. Used by the build to compile the mining plugins found in the included [Cuckoo Miner](https://github.com/mimblewimble/cuckoo-miner) 
+* <b>cmake</b> - 3.2 or greater should be installed and on your $PATH. Used by the build to compile the mining plugins found in the included [Cuckoo Miner](https://github.com/mimblewimble/cuckoo-miner)
 * <b>Rust</b> - via [Rustup](https://www.rustup.rs/) - Can be installed via your package manager or manually via the following commands:
 ```
     curl https://sh.rustup.rs -sSf | sh
@@ -61,7 +61,7 @@ Provided all of the prerequisites were installed and there were no issues, there
 
 * A set of mining plugins, which should be in the 'plugins' directory located next to the grin executable
 
-* A configuration file in the root project directory named grin.toml 
+* A configuration file in the root project directory named grin.toml
 
 By default, executing:
 
@@ -98,22 +98,25 @@ At present, the relevant modes of operation are 'server' and 'wallet'. When runn
 
 For a basic example simulating a single node network, create a directory called 'node1' and change your working directory to it. You'll use this directory to run a wallet and create a new blockchain via a server running in mining mode.
 
-Before running your mining server, a wallet server needs to be set up and listening so that the mining server knows where to send mining rewards. Do this from the first node directory with the following command:
+Before running your mining server, a wallet server needs to be set up and listening so that the mining server knows where to send mining rewards. Do this from the first node directory with the following commands:
 
-    node1$ grin wallet -p "password" receive
+	node1$ grin wallet init
+	node1$ grin wallet -p "password" receive
+
+See [wallet](wallet.md) for more info on the various Grin wallet commands and options.
 
 This will create a wallet server listening on the default port 13416 with the password "password". Next, in another terminal window in the 'node1' directory, run a full mining node with the following command:
 
-    node1$ grin server -m run
+	node1$ grin server -m run
 
-This creates a new .grin database directory in the current directory, and begins mining new blocks (with no transactions, for now). Note this starts two services listening on two default ports, 
-port 13414 for the peer-to-peer (P2P) service which keeps all nodes synchronised, and 13413 for the Rest API service used to verify transactions and post new transactions to the pool (for example). These ports can be configured via command line switches, or via a grin.toml file in the working directory.
+This creates a new .grin database directory in the current directory, and begins mining new blocks (with no transactions, for now). Note this starts two services listening on two default ports,
+port 13414 for the peer-to-peer (P2P) service which keeps all nodes synchronized, and 13413 for the Rest API service used to verify transactions and post new transactions to the pool (for example). These ports can be configured via command line switches, or via a grin.toml file in the working directory.
 
 Let the mining server find a few blocks, then stop (just ctrl-c) the mining server and the wallet server. You'll notice grin has created a database directory (.grin) in which the blockchain and peer data is stored. There should also be a wallet.dat file in the current directory, which contains a few coinbase mining rewards created each time the server mines a new block.
 
 ## Advanced Example
 
-The following outlines a more advanced example simulating a multi-server network with transactions being posted. 
+The following outlines a more advanced example simulating a multi-server network with transactions being posted.
 
 For the sake of example, we're going to run three nodes with varying setups. Create two more directories beside your node1 directory, called node2 and node3. If you want to clear data from your previous run (or anytime you want to reset the blockchain and all peer data) just delete the wallet.dat file in the server1 directory and run rm -rf .grin to remove grin's database.
 
@@ -161,7 +164,7 @@ use node 2's API listener to validate our transaction inputs before sending:
 
     node1$ grin wallet -p "password" -a "http://127.0.0.1:20001" send 20000 -d "http://127.0.0.1:35000"
 
-Your terminal windows should all light up now. Node 1 will check its inputs against node 2, and then send a partial transaction to node 3's wallet listener. Node 3 has been configured to 
+Your terminal windows should all light up now. Node 1 will check its inputs against node 2, and then send a partial transaction to node 3's wallet listener. Node 3 has been configured to
 send signed and finalised transactions to the api listener on node 1, which should then add the transaction to the next block and validate it via mining.
 
 You can feel free to try any number of permutations or combinations of the above, just note that grin is very new and under active development, so your mileage may vary. You can also use a separate 'grin.toml' file in each server directory to simplify command line switches.

--- a/doc/wallet.md
+++ b/doc/wallet.md
@@ -1,0 +1,52 @@
+# Grin - Basic Wallet
+
+## Wallet Files
+
+A Grin wallet maintains its state in the following files -
+
+```
+wallet.seed  # *** passphrase protected seed file (keep this private) ***
+wallet.dat   # wallet outputs (both spent and unspent)
+wallet.lock  # lock file, prevents multiple processes writing to wallet.dat
+```
+
+By default Grin will look for these in the current working directory.
+
+## Basic Wallet Commands
+
+`grin wallet --help` will display usage info about the following. 
+
+### grin wallet init
+
+Before using a wallet a new seed file `wallet.seed` needs to be generated via `grin wallet init` -
+
+```
+grin wallet init
+Generating wallet seed file at: ./wallet.seed
+```
+
+### grin wallet info
+
+Some (very) basic information about current wallet outputs can be displayed with `grin wallet info` -
+
+```
+grin wallet -p "password" info
+Using wallet seed file at: ./wallet.seed
+Outputs -
+key_id, height, lock_height, status, spendable?, coinbase?, value
+----------------------------------
+96805837571719c692b6, 21, 24, Spent, false, true, 50000000000
+...
+```
+
+### grin wallet receive
+
+(tbd)
+
+### grin wallet send
+
+(tbd)
+
+### grin wallet burn
+
+[tbd]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -39,4 +39,4 @@ mod types;
 pub use info::show_info;
 pub use receiver::{WalletReceiver, receive_json_tx};
 pub use sender::{issue_send_tx, issue_burn_tx};
-pub use types::{WalletConfig, WalletReceiveRequest, BlockFees, CbData};
+pub use types::{BlockFees, CbData, WalletConfig, WalletReceiveRequest, WalletSeed};

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use blake2;
+use rand::{thread_rng, Rng};
 use std::{fmt, num, thread, time};
 use std::convert::From;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{self, Read, Write};
 use std::path::Path;
 use std::path::MAIN_SEPARATOR;
 use std::collections::HashMap;
+use std::cmp::min;
 
 use serde_json;
 use secp;
@@ -32,6 +35,7 @@ use util::LOGGER;
 
 const DAT_FILE: &'static str = "wallet.dat";
 const LOCK_FILE: &'static str = "wallet.lock";
+const SEED_FILE: &'static str = "wallet.seed";
 
 const DEFAULT_BASE_FEE: u64 = 10;
 
@@ -60,6 +64,8 @@ pub enum Error {
 	WalletData(String),
 	/// An error in the format of the JSON structures exchanged by the wallet
 	Format(String),
+	/// An IO Error
+	IOError(io::Error),
 	/// Error when contacting a node through its API
 	Node(api::Error),
 }
@@ -97,6 +103,12 @@ impl From<num::ParseIntError> for Error {
 impl From<api::Error> for Error {
 	fn from(e: api::Error) -> Error {
 		Error::Node(e)
+	}
+}
+
+impl From<io::Error> for Error {
+	fn from(e: io::Error) -> Error {
+		Error::IOError(e)
 	}
 }
 
@@ -200,6 +212,82 @@ impl OutputData {
 	}
 }
 
+#[derive(Clone, PartialEq)]
+pub struct WalletSeed([u8; 32]);
+
+impl WalletSeed {
+	pub fn from_bytes(bytes: &[u8]) -> WalletSeed {
+		let mut seed = [0; 32];
+		for i in 0..min(32, bytes.len()) {
+			seed[i] = bytes[i];
+		}
+		WalletSeed(seed)
+	}
+
+	fn from_hex(hex: &str) -> Result<WalletSeed, Error> {
+		let bytes = util::from_hex(hex.to_string())?;
+		Ok(WalletSeed::from_bytes(&bytes))
+	}
+
+	pub fn to_hex(&self) -> String {
+		util::to_hex(self.0.to_vec())
+	}
+
+	pub fn derive_keychain(&self, password: &str) -> Result<keychain::Keychain, Error> {
+		let seed = blake2::blake2b::blake2b(64, &password.as_bytes(), &self.0);
+		let result = keychain::Keychain::from_seed(seed.as_bytes())?;
+		Ok(result)
+	}
+
+	pub fn init_new() -> WalletSeed {
+		let seed: [u8; 32] = thread_rng().gen();
+		WalletSeed(seed)
+	}
+
+	pub fn init_file(wallet_config: &WalletConfig) -> Result<WalletSeed, Error> {
+		// create directory if it doesn't exist
+		fs::create_dir_all(&wallet_config.data_file_dir)?;
+
+		let seed_file_path = &format!(
+			"{}{}{}",
+			wallet_config.data_file_dir,
+			MAIN_SEPARATOR,
+			SEED_FILE,
+		);
+
+		if Path::new(seed_file_path).exists() {
+			panic!("wallet seed file already exists");
+		} else {
+			let seed = WalletSeed::init_new();
+			let mut file = File::create(seed_file_path)?;
+			file.write_all(&seed.to_hex().as_bytes())?;
+			Ok(seed)
+		}
+	}
+
+	pub fn from_file(wallet_config: &WalletConfig) -> Result<WalletSeed, Error> {
+		// create directory if it doesn't exist
+		fs::create_dir_all(&wallet_config.data_file_dir)?;
+
+		let seed_file_path = &format!(
+			"{}{}{}",
+			wallet_config.data_file_dir,
+			MAIN_SEPARATOR,
+			SEED_FILE,
+		);
+
+		if Path::new(seed_file_path).exists() {
+			let mut file = File::open(seed_file_path)?;
+			let mut buffer = String::new();
+			file.read_to_string(&mut buffer)?;
+			let wallet_seed = WalletSeed::from_hex(&buffer)?;
+			Ok(wallet_seed)
+		} else {
+			panic!("seed file does not yet exist");
+		}
+	}
+}
+
 /// Wallet information tracking all our outputs. Based on HD derivation and
 /// avoids storing any key data, only storing output amounts and child index.
 /// This data structure is directly based on the JSON representation stored
@@ -242,7 +330,7 @@ impl WalletData {
 				.map_err(|_| {
 					Error::WalletData(format!(
 						"Could not create wallet lock file. Either \
-					some other process is using the wallet or there's a write access issue."
+						some other process is using the wallet or there is a write access issue."
 					))
 				});
 			match result {
@@ -250,16 +338,22 @@ impl WalletData {
 					break;
 				}
 				Err(e) => {
-					if retries >= 3 {
+					if retries >= 6 {
+						info!(
+							LOGGER,
+							"failed to obtain wallet.lock after {} retries, \
+							unable to successfully open the wallet",
+							retries
+						);
 						return Err(e);
 					}
 					debug!(
 						LOGGER,
-						"failed to obtain wallet.lock, retries - {}, sleeping",
+						"failed to obtain wallet.lock, retries - {}, sleeping and retrying",
 						retries
 					);
 					retries += 1;
-					thread::sleep(time::Duration::from_millis(500));
+					thread::sleep(time::Duration::from_millis(1000));
 				}
 			}
 		}

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -255,6 +255,12 @@ impl WalletSeed {
 			SEED_FILE,
 		);
 
+		debug!(
+			LOGGER,
+			"Generating wallet seed file at: {}",
+			seed_file_path,
+		);
+
 		if Path::new(seed_file_path).exists() {
 			panic!("wallet seed file already exists");
 		} else {
@@ -276,6 +282,12 @@ impl WalletSeed {
 			SEED_FILE,
 		);
 
+		debug!(
+			LOGGER,
+			"Using wallet seed file at: {}",
+			seed_file_path,
+		);
+
 		if Path::new(seed_file_path).exists() {
 			let mut file = File::open(seed_file_path)?;
 			let mut buffer = String::new();
@@ -283,7 +295,11 @@ impl WalletSeed {
 			let wallet_seed = WalletSeed::from_hex(&buffer)?;
 			Ok(wallet_seed)
 		} else {
-			panic!("seed file does not yet exist");
+			error!(
+				LOGGER,
+				"Run: \"grin wallet init\" to initialize a new wallet.",
+			);
+			panic!("wallet seed file does not yet exist (grin wallet init)");
 		}
 	}
 }


### PR DESCRIPTION
We have been using the wallet "password" as the actual wallet seed for deriving keys.
As we get closer to `devnet/testnet` we're going to want wallets to be a bit less deterministic...

* introduce new `wallet.seed` file (hex representation of the seed)
* introduce new `grin wallet init` to initialize a new seed file
* keychain is derived from combination of seed file + password
  * for a given seed file, different passwords will generate different keychains/extended keys

TODO -
- [x] better error handling around seed file
- [x] better CLI error messages around seed file operations
- [x] `wallet init` does not actually use the password, so do not require it on CLI?
- [x] update docs

```
# must run wallet init first
grin wallet init

# then specify password to use in combination with the seed file for subsequent wallet operations
grin wallet -p "password" burn 1000
```
