### PR TITLE
refresh multiple wallet outputs in single api call

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,6 +15,8 @@ hyper = "~0.10.6"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 iron = "~0.5.1"
 router = "~0.5.1"
+mount = "~0.3.0"
+urlencoded = "~0.5.0"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.2"

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -1,0 +1,87 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use std::sync::Arc;
+
+use iron::prelude::*;
+use iron::Handler;
+use iron::status;
+use urlencoded::UrlEncodedQuery;
+use serde_json;
+
+use chain;
+use rest::*;
+use types::*;
+use secp::pedersen::Commitment;
+use util;
+use util::LOGGER;
+
+
+pub struct UtxoHandler {
+	pub chain: Arc<chain::Chain>,
+}
+
+impl UtxoHandler {
+	fn get_utxo(&self, id: &str) -> Result<Output, Error> {
+		debug!(LOGGER, "getting utxo: {}", id);
+		let c = util::from_hex(String::from(id))
+			.map_err(|_| {
+				Error::Argument(format!("Not a valid commitment: {}", id))
+			})?;
+		let commit = Commitment::from_vec(c);
+
+		let out = self.chain.get_unspent(&commit)
+			.map_err(|_| Error::NotFound)?;
+
+		let header = self.chain
+			.get_block_header_by_output_commit(&commit)
+			.map_err(|_| Error::NotFound)?;
+
+		Ok(Output::from_output(&out, &header))
+	}
+}
+
+//
+// Supports retrieval of multiple outputs in a single request -
+// GET /v2/chain/utxos?id=xxx,yyy,zzz
+// GET /v2/chain/utxos?id=xxx&id=yyy&id=zzz
+//
+impl Handler for UtxoHandler {
+	fn handle(&self, req: &mut Request) -> IronResult<Response> {
+		let mut commitments: Vec<&str> = vec![];
+		if let Ok(params) = req.get_ref::<UrlEncodedQuery>() {
+			if let Some(ids) = params.get("id") {
+				for id in ids {
+					for id in id.split(",") {
+						commitments.push(id.clone());
+					}
+				}
+			}
+		}
+
+		let mut utxos: Vec<Output> = vec![];
+
+		for commit in commitments {
+			if let Ok(out) = self.get_utxo(commit) {
+				utxos.push(out);
+			}
+		}
+
+		match serde_json::to_string(&utxos) {
+			Ok(json) => Ok(Response::with((status::Ok, json))),
+			Err(_) => Ok(Response::with((status::BadRequest, ""))),
+		}
+	}
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -23,7 +23,10 @@ extern crate hyper;
 #[macro_use]
 extern crate slog;
 extern crate iron;
+extern crate urlencoded;
+#[macro_use]
 extern crate router;
+extern crate mount;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -31,6 +34,7 @@ extern crate serde_json;
 
 pub mod client;
 mod endpoints;
+mod handlers;
 mod rest;
 mod types;
 

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -34,13 +34,13 @@ impl Tip {
 	}
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum OutputType {
 	Coinbase,
 	Transaction,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Output {
 	/// The type of output Coinbase|Transaction
 	pub output_type: OutputType,

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -191,7 +191,6 @@ mod test {
 	use ser;
 	use keychain;
 	use keychain::{Keychain, BlindingFactor};
-	use blake2::blake2b::blake2b;
 
 	#[test]
 	#[should_panic(expected = "InvalidSecretKey")]

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -379,22 +379,7 @@ fn wallet_command(wallet_args: &ArgMatches) {
 				);
 				wallet::receive_json_tx(&wallet_config, &keychain, contents.as_str()).unwrap();
 			} else {
-				info!(
-					LOGGER,
-					"Starting the Grin wallet receiving daemon at {}...",
-					wallet_config.api_http_addr
-				);
-				let mut apis = api::ApiServer::new("/v1".to_string());
-				apis.register_endpoint(
-					"/receive".to_string(),
-					wallet::WalletReceiver {
-						keychain: keychain,
-						config: wallet_config.clone(),
-					},
-				);
-				apis.start(wallet_config.api_http_addr).unwrap_or_else(|e| {
-					error!(LOGGER, "Failed to start Grin wallet receiver: {}.", e);
-				});
+				wallet::server::start_rest_apis(wallet_config, keychain);
 			}
 		}
 		("send", Some(send_args)) => {

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,7 +16,8 @@ blake2-rfc = "~0.2.17"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.2"
-
+iron = "~0.5.1"
+router = "~0.5.1"
 grin_api = { path = "../api" }
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -24,6 +24,9 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
+extern crate iron;
+extern crate router;
+
 extern crate grin_api as api;
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
@@ -35,6 +38,7 @@ mod info;
 mod receiver;
 mod sender;
 mod types;
+pub mod server;
 
 pub use info::show_info;
 pub use receiver::{WalletReceiver, receive_json_tx};

--- a/wallet/src/server.rs
+++ b/wallet/src/server.rs
@@ -1,0 +1,42 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use api::ApiServer;
+use keychain::Keychain;
+use receiver::WalletReceiver;
+use types::WalletConfig;
+use util::LOGGER;
+
+pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
+	info!(
+		LOGGER,
+		"Starting the Grin wallet receiving daemon at {}...",
+		wallet_config.api_http_addr
+	);
+
+	let mut apis = ApiServer::new("/v1".to_string());
+
+	apis.register_endpoint(
+		"/receive".to_string(),
+		WalletReceiver {
+			keychain: keychain,
+			config: wallet_config.clone(),
+		},
+	);
+
+	apis.start(wallet_config.api_http_addr).unwrap_or_else(|e| {
+		error!(LOGGER, "Failed to start Grin wallet receiver: {}.", e);
+	});
+}


### PR DESCRIPTION
Refreshing ~50 unspent outputs in the wallet takes a _significant_ amount of time - each output required an api call to the node to get the latest state (`/v1/chain/utxo/:id`).

This PR reworks this so we make a single api call, asking for multiple outputs from the node in one go.
Also experimented with skipping the `ApiEndpoint` and building this directly as an Iron handler on the Iron router - primarily for flexibility (no id param in the url but need to parse query params).

* reworked /chain/utxos endpoint to support retrieving multiple utxos in one api call
  * `GET /v2/chain/utxos?id=xxx&id=yyy&id=zzz`
  * "v2" endpoints are based on iron router and handlers (removing the need for an `ApiEndpoint`)
* moved wallet api out of `bin/grin.rs` and into `wallet` crate
  * call `wallet::server::start_rest_apis` from `bin.grin.rs`
