### PR TITLE
only hold wallet write lock for write operations on the wallet

### DIFF
--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -295,7 +295,7 @@ impl ApiServer {
 
 		// declare a route for each method actually implemented by the endpoint
 		let route_postfix = &subpath[1..];
-		let root = self.root.clone() + &subpath;
+		let root = &subpath;
 		for op in endpoint.operations() {
 			let route_name = format!("{:?}_{}", op, route_postfix);
 
@@ -308,7 +308,7 @@ impl ApiServer {
 				let full_path = format!("{}/{}", root.clone(), op_s.clone());
 				self.router
 					.route(op.to_method(), full_path.clone(), wrapper, route_name);
-				info!(LOGGER, "route: POST {}", full_path);
+				info!(LOGGER, "route: POST {}{}", self.root, full_path);
 			} else {
 
 				// regular REST operations
@@ -322,7 +322,7 @@ impl ApiServer {
 				let wrapper = ApiWrapper(endpoint.clone());
 				self.router
 					.route(op.to_method(), full_path.clone(), wrapper, route_name);
-				info!(LOGGER, "route: {} {}", op.to_method(), full_path);
+				info!(LOGGER, "route: {} {}{}", op.to_method(), self.root, full_path);
 			}
 		}
 

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -295,7 +295,7 @@ impl ApiServer {
 
 		// declare a route for each method actually implemented by the endpoint
 		let route_postfix = &subpath[1..];
-		let root = &subpath;
+		let root = self.root.clone() + &subpath;
 		for op in endpoint.operations() {
 			let route_name = format!("{:?}_{}", op, route_postfix);
 
@@ -308,7 +308,7 @@ impl ApiServer {
 				let full_path = format!("{}/{}", root.clone(), op_s.clone());
 				self.router
 					.route(op.to_method(), full_path.clone(), wrapper, route_name);
-				info!(LOGGER, "route: POST {}{}", self.root, full_path);
+				info!(LOGGER, "route: POST {}", full_path);
 			} else {
 
 				// regular REST operations
@@ -322,7 +322,7 @@ impl ApiServer {
 				let wrapper = ApiWrapper(endpoint.clone());
 				self.router
 					.route(op.to_method(), full_path.clone(), wrapper, route_name);
-				info!(LOGGER, "route: {} {}{}", op.to_method(), self.root, full_path);
+				info!(LOGGER, "route: {} {}", op.to_method(), full_path);
 			}
 		}
 

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -50,53 +50,57 @@ pub fn refresh_outputs(
 	config: &WalletConfig,
 	keychain: &Keychain,
 ) -> Result<(), Error> {
-	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
-		let mut wallet_outputs: HashMap<pedersen::Commitment, Identifier> = HashMap::new();
-		let mut commits: Vec<pedersen::Commitment> = vec![];
 
-		// build a local map of wallet outputs by commits
-		// and a list of outputs we wantot query the node for
+	let mut wallet_outputs: HashMap<pedersen::Commitment, Identifier> = HashMap::new();
+	let mut commits: Vec<pedersen::Commitment> = vec![];
+
+	// build a local map of wallet outputs by commits
+	// and a list of outputs we wantot query the node for
+	WalletData::read_wallet(&config.data_file_dir, |wallet_data| {
 		for out in wallet_data.outputs
-			.values_mut()
+			.values()
 			.filter(|out| out.root_key_id == keychain.root_key_id())
-			.filter(|out| out.status != OutputStatus::Spent) {
-				let key_id = keychain.derive_key_id(out.n_child).unwrap();
-				let commit = keychain.commit(out.value, &key_id).unwrap();
-				commits.push(commit);
-				wallet_outputs.insert(commit, out.key_id.clone());
+			.filter(|out| out.status != OutputStatus::Spent)
+		{
+			let key_id = keychain.derive_key_id(out.n_child).unwrap();
+			let commit = keychain.commit(out.value, &key_id).unwrap();
+			commits.push(commit);
+			wallet_outputs.insert(commit, out.key_id.clone());
+		}
+	});
+
+	// build the necessary query params -
+	// ?id=xxx&id=yyy&id=zzz
+	let query_params: Vec<String> = commits
+		.iter()
+		.map(|commit| {
+			let id = util::to_hex(commit.as_ref().to_vec());
+			format!("id={}", id)
+		})
+		.collect();
+	let query_string = query_params.join("&");
+
+	let url = format!(
+		"{}/v2/chain/utxos?{}",
+		config.check_node_api_http_addr,
+		query_string,
+	);
+
+	// build a map of api outputs by commit so we can look them up efficiently
+	let mut api_outputs: HashMap<pedersen::Commitment, api::Output> = HashMap::new();
+	match api::client::get::<Vec<api::Output>>(url.as_str()) {
+		Ok(outputs) => {
+			for out in outputs {
+				api_outputs.insert(out.commit, out);
 			}
+		},
+		Err(_) => {},
+	};
 
-		// build the necessary query params -
-		// ?id=xxx&id=yyy&id=zzz
-		let query_params: Vec<String> = commits
-			.iter()
-			.map(|commit| {
-				let id = util::to_hex(commit.as_ref().to_vec());
-				format!("id={}", id)
-			})
-			.collect();
-		let query_string = query_params.join("&");
-
-		let url = format!(
-			"{}/v2/chain/utxos?{}",
-			config.check_node_api_http_addr,
-			query_string,
-		);
-
-		// build a map of api outputs by commit so we can look them up efficiently
-		let mut api_outputs: HashMap<pedersen::Commitment, api::Output> = HashMap::new();
-		match api::client::get::<Vec<api::Output>>(url.as_str()) {
-			Ok(outputs) => {
-				for out in outputs {
-					api_outputs.insert(out.commit, out);
-				}
-			},
-			Err(_) => {},
-		};
-
-		// now for each commit we want to refresh the output for
-		// find the corresponding api output (if it exists)
-		// and refresh it in-place in the wallet
+	// now for each commit, find the output in the wallet and
+	// the corresponding api output (if it exists)
+	// and refresh it in-place in the wallet
+	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
 		for commit in commits {
 			let id = wallet_outputs.get(&commit).unwrap();
 			if let Entry::Occupied(mut output) = wallet_data.outputs.entry(id.to_hex()) {

--- a/wallet/src/info.rs
+++ b/wallet/src/info.rs
@@ -20,8 +20,8 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 	let root_key_id = keychain.root_key_id();
 	let _ = checker::refresh_outputs(&config, &keychain);
 
-	// operate within a lock on wallet data
-	let _ = WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
+	// just read the wallet here, no need for a write lock
+	let _ = WalletData::read_wallet(&config.data_file_dir, |wallet_data| {
 
 		// get the current height via the api
 		// if we cannot get the current height use the max height known to the wallet

--- a/wallet/src/info.rs
+++ b/wallet/src/info.rs
@@ -35,11 +35,8 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 			}
 		};
 
-		// need to specify a default value here somehow
-		let minimum_confirmations = 1;
-
 		println!("Outputs - ");
-		println!("key_id, height, lock_height, status, spendable?, coinbase?, value");
+		println!("key_id, height, lock_height, status, coinbase?, num_confs, value");
 		println!("----------------------------------");
 
 		let mut outputs = wallet_data
@@ -55,8 +52,8 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 				out.height,
 				out.lock_height,
 				out.status,
-				out.eligible_to_spend(current_height, minimum_confirmations),
 				out.is_coinbase,
+				out.num_confirmations(current_height),
 				out.value,
 			);
 		}

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -188,6 +188,16 @@ impl OutputData {
 		self.status = OutputStatus::Locked;
 	}
 
+	/// How many confirmations has this output received?
+	pub fn num_confirmations(&self, current_height: u64) -> u64 {
+		if self.status == OutputStatus::Unconfirmed {
+			0
+		} else {
+			current_height - self.height
+		}
+	}
+
+	/// Check if output is eligible for spending based on state and height.
 	pub fn eligible_to_spend(
 		&self,
 		current_height: u64,
@@ -335,7 +345,7 @@ impl WalletData {
 		let data_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, DAT_FILE);
 		let lock_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, LOCK_FILE);
 
-		// create the lock files, if it already exists, will produce an error
+		// create the lock file, if it already exists, will produce an error
 		// sleep and retry a few times if we cannot get it the first time
 		let mut retries = 0;
 		loop {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -328,6 +328,17 @@ pub struct WalletData {
 }
 
 impl WalletData {
+
+	pub fn read_wallet<T, F>(data_file_dir: &str, f: F) -> Result<T, Error>
+		where F: FnOnce(&WalletData) -> T
+	{
+		// open the wallet readonly and so what needs to be done with it
+		let data_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, DAT_FILE);
+		let wdat = WalletData::read(data_file_path)?;
+		let res = f(&wdat);
+		Ok(res)
+	}
+
 	/// Allows the reading and writing of the wallet data within a file lock.
 	/// Just provide a closure taking a mutable WalletData. The lock should
 	/// be held for as short a period as possible to avoid contention.
@@ -364,7 +375,7 @@ impl WalletData {
 					break;
 				}
 				Err(e) => {
-					if retries >= 6 {
+					if retries >= 10 {
 						info!(
 							LOGGER,
 							"failed to obtain wallet.lock after {} retries, \
@@ -379,7 +390,7 @@ impl WalletData {
 						retries
 					);
 					retries += 1;
-					thread::sleep(time::Duration::from_millis(1000));
+					thread::sleep(time::Duration::from_millis(250));
 				}
 			}
 		}


### PR DESCRIPTION
* Add new `WalletData::read_wallet` to go with existing `WalletData::with_wallet`
* Rework the various wallet data operations so we hold the write lock via `with_wallet` as little as possible

Sample output now that we limit the use of the write lock (15ms here for a wallet refresh) - 

```
Oct 25 11:52:12.400 DEBG Refreshing wallet outputs
Oct 25 11:52:12.678 INFO acquired wallet lock ...
Oct 25 11:52:12.693 INFO ... released wallet lock
```

