### PR TITLE
height 0 means we have 0 confirmations (cut-through output?)

### DIFF
--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -189,8 +189,12 @@ impl OutputData {
 	}
 
 	/// How many confirmations has this output received?
+	/// If height == 0 then we are either Unconfirmed or the output was cut-through
+	/// so we do not actually know how many confirmations this output had (and never will).
 	pub fn num_confirmations(&self, current_height: u64) -> u64 {
 		if self.status == OutputStatus::Unconfirmed {
+			0
+		} else if self.status == OutputStatus::Spent && self.height == 0 {
 			0
 		} else {
 			current_height - self.height


### PR DESCRIPTION
We were incorrectly displaying the number of confirmations for cut-through outputs in `wallet info`.
We don't actually know how many confirmations these outputs have because they never appeared in the utxo set and the wallet never saw them via the chain/utxo api.

This PR fixes the output of `wallet info` to show 0 confirmations for these -

```
Outputs - 
key_id, height, lock_height, status, coinbase?, num_confs, value
----------------------------------
00898d22dd43e7cba7bb, 1, 4, Spent, true, 7, 50000000000
d82f4d17c7dbec84de13, 2, 5, Spent, true, 6, 50000000000
0e7297a1ce02a7bbe0bf, 3, 6, Unspent, true, 5, 50000000000
a7a149b6b19f08ecaa84, 4, 7, Unspent, true, 4, 50000000000
f3455ba4678b260bef32, 5, 8, Unspent, true, 3, 50000000000
27dfa81a48ec0764e97d, 6, 9, Unspent, true, 2, 50000000070
82669c7cfc4ce03b54d7, 0, 0, Spent, false, 0, 99995000000        # <-- spent (cut-through)
a93bb7db60f38ef63e68, 0, 0, Spent, false, 0, 4999930            # <-- spent (cut-through)
e4741137a85ee3bceecf, 6, 0, Unspent, false, 2, 99994999930
e571907c1477a74c1834, 6, 0, Unspent, false, 2, 4999930
```