### PR TITLE
secp import from tag instead of master

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,7 +10,6 @@ grin_chain = { path = "../chain" }
 grin_pool = { path = "../pool" }
 grin_store = { path = "../store" }
 grin_util = { path = "../util" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 hyper = "~0.10.6"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 iron = "~0.5.1"

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -24,7 +24,7 @@ use serde_json;
 use chain;
 use rest::*;
 use types::*;
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 use util;
 use util::LOGGER;
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -17,7 +17,6 @@ extern crate grin_chain as chain;
 extern crate grin_pool as pool;
 extern crate grin_store as store;
 extern crate grin_util as util;
-extern crate secp256k1zkp as secp;
 
 extern crate hyper;
 #[macro_use]

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use core::{core, global};
 use core::core::hash::Hashed;
 use chain;
-use secp::pedersen;
+use util::secp::pedersen;
 use rest::*;
 use util;
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -16,7 +16,6 @@ grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }
 grin_util = { path = "../util" }
 grin_store = { path = "../store" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 
 [dev-dependencies]
 env_logger="^0.3.5"

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -18,7 +18,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, RwLock};
 
-use secp::pedersen::{Commitment, RangeProof};
+use util::secp::pedersen::{Commitment, RangeProof};
 
 use core::core::{SumCommit};
 use core::core::pmmr::{NoSum, HashSum};

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -33,7 +33,6 @@ extern crate time;
 extern crate grin_core as core;
 extern crate grin_util as util;
 extern crate grin_store;
-extern crate secp256k1zkp as secp;
 
 mod chain;
 pub mod pipe;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -16,7 +16,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use secp;
+use util::secp;
 use time;
 
 use core::consensus;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 use types::*;
 use core::core::hash::{Hash, Hashed};

--- a/chain/src/sumtree.rs
+++ b/chain/src/sumtree.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use secp;
-use secp::pedersen::{RangeProof, Commitment};
+use util::secp;
+use util::secp::pedersen::{RangeProof, Commitment};
 
 use core::core::{Block, Output, SumCommit, TxKernel};
 use core::core::pmmr::{Summable, NoSum, PMMR, HashSum, Backend};

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -16,7 +16,7 @@
 
 use std::io;
 
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 use grin_store as store;
 use core::core::{Block, BlockHeader, block, Output};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,5 @@ serde = "~1.0.8"
 serde_derive = "~1.0.8"
 time = "^0.1"
 lazy_static = "~0.2.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 grin_keychain = { path = "../keychain" }
 grin_util = { path = "../util" }

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -15,7 +15,8 @@
 //! Blocks and blockheaders
 
 use time;
-use secp::{self, Secp256k1};
+use util;
+use util::secp::{self, Secp256k1};
 use std::collections::HashSet;
 
 use core::Committed;
@@ -515,7 +516,7 @@ impl Block {
 			"Block reward - Switch Commit Hash is: {:?}",
 			switch_commit_hash
 		);
-		let msg = secp::pedersen::ProofMessage::empty();
+		let msg = util::secp::pedersen::ProofMessage::empty();
 		let rproof = keychain.range_proof(reward(fees), key_id, commit, msg)?;
 
 		let output = Output {
@@ -529,7 +530,7 @@ impl Block {
 		let out_commit = output.commitment();
 		let excess = secp.commit_sum(vec![out_commit], vec![over_commit])?;
 
-		let msg = secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE])?;
+		let msg = util::secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE])?;
 		let sig = keychain.sign(&msg, &key_id)?;
 
 		let proof = TxKernel {
@@ -553,7 +554,7 @@ mod test {
 	use consensus::*;
 	use std::time::Instant;
 
-	use secp;
+	use util::secp;
 
 	// utility to create a block without worrying about the key or previous
 	// header

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -25,7 +25,7 @@
 //! build::transaction(vec![input_rand(75), output_rand(42), output_rand(32),
 //!   with_fee(1)])
 
-use secp;
+use util::secp;
 
 use core::{Transaction, Input, Output, SwitchCommitHash, DEFAULT_OUTPUT};
 use core::transaction::kernel_sig_msg;

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -26,8 +26,8 @@ pub mod transaction;
 use std::fmt;
 use std::cmp::Ordering;
 
-use secp::{self, Secp256k1};
-use secp::pedersen::*;
+use util::secp::{self, Secp256k1};
+use util::secp::pedersen::*;
 
 pub use self::block::*;
 pub use self::transaction::*;

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -16,8 +16,8 @@
 
 use byteorder::{ByteOrder, BigEndian};
 use blake2::blake2b::blake2b;
-use secp::{self, Secp256k1, Message, Signature};
-use secp::pedersen::{RangeProof, Commitment};
+use util::secp::{self, Secp256k1, Message, Signature};
+use util::secp::pedersen::{RangeProof, Commitment};
 use std::ops;
 
 use core::Committed;
@@ -572,7 +572,7 @@ impl ops::Add for SumCommit {
 mod test {
 	use super::*;
 	use keychain::Keychain;
-	use secp;
+	use util::secp;
 
 	#[test]
 	fn test_kernel_ser_deser() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,7 +29,6 @@ extern crate byteorder;
 extern crate slog;
 extern crate num_bigint as bigint;
 extern crate rand;
-extern crate secp256k1zkp as secp;
 extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 extern crate serde;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -26,9 +26,9 @@ use keychain::{Identifier, IDENTIFIER_SIZE};
 use core::hash::Hashed;
 use consensus::VerifySortOrder;
 use core::transaction::{SWITCH_COMMIT_HASH_SIZE, SwitchCommitHash};
-use secp::pedersen::Commitment;
-use secp::pedersen::RangeProof;
-use secp::constants::{MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE};
+use util::secp::pedersen::Commitment;
+use util::secp::pedersen::RangeProof;
+use util::secp::constants::{MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE};
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Debug)]
@@ -547,22 +547,22 @@ impl AsFixedBytes for ::core::hash::Hash {
 		return 32;
 	}
 }
-impl AsFixedBytes for ::secp::pedersen::RangeProof {
+impl AsFixedBytes for ::util::secp::pedersen::RangeProof {
 	fn len(&self) -> usize {
 		return self.plen;
 	}
 }
-impl AsFixedBytes for ::secp::key::SecretKey {
+impl AsFixedBytes for ::util::secp::key::SecretKey {
 	fn len(&self) -> usize {
 		return 1;
 	}
 }
-impl AsFixedBytes for ::secp::Signature {
+impl AsFixedBytes for ::util::secp::Signature {
 	fn len(&self) -> usize {
 		return 64;
 	}
 }
-impl AsFixedBytes for ::secp::pedersen::Commitment {
+impl AsFixedBytes for ::util::secp::pedersen::Commitment {
 	fn len(&self) -> usize {
 		return PEDERSEN_COMMITMENT_SIZE;
 	}

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -15,7 +15,6 @@ grin_util = { path = "../util" }
 grin_keychain = { path = "../keychain" }
 grin_wallet = { path = "../wallet" }
 grin_pow = { path = "../pow" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 
 futures = "^0.1.15"
 futures-cpupool = "^0.1.3"

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -23,7 +23,7 @@ use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use p2p::{self, NetAdapter, Server, PeerStore, PeerData, State};
 use pool;
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 use util::OneTime;
 use store;
 use sync;

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -47,7 +47,6 @@ extern crate grin_util as util;
 extern crate grin_keychain as keychain;
 extern crate grin_wallet as wallet;
 extern crate grin_pow as pow;
-extern crate secp256k1zkp as secp;
 
 mod adapters;
 mod server;

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -37,7 +37,7 @@ use util::LOGGER;
 use types::Error;
 
 use chain;
-use secp;
+use util::secp;
 use pool;
 use util;
 use keychain::{Identifier, Keychain};

--- a/grin/tests/framework.rs
+++ b/grin/tests/framework.rs
@@ -20,7 +20,7 @@ extern crate grin_api as api;
 extern crate grin_wallet as wallet;
 extern crate grin_keychain as keychain;
 extern crate grin_pow as pow;
-extern crate secp256k1zkp as secp;
+extern crate grin_util as util;
 
 extern crate blake2_rfc as blake2;
 extern crate futures;
@@ -37,7 +37,7 @@ use std::sync::{Arc, Mutex};
 use tokio_core::reactor;
 use tokio_timer::Timer;
 
-use secp::Secp256k1;
+use util::secp::Secp256k1;
 // TODO - why does this need self here? Missing something somewhere.
 use self::keychain::Keychain;
 use wallet::WalletConfig;

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -20,7 +20,6 @@ extern crate grin_api as api;
 extern crate grin_wallet as wallet;
 extern crate grin_pow as pow;
 extern crate grin_util as util;
-extern crate secp256k1zkp as secp;
 
 extern crate futures;
 extern crate tokio_core;

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -11,4 +11,3 @@ serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.3"
 grin_util = { path = "../util" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }

--- a/keychain/src/blind.rs
+++ b/keychain/src/blind.rs
@@ -14,7 +14,7 @@
 /// Encapsulate a secret key for the blind_sum operation
 
 
-use secp::{self, Secp256k1};
+use util::secp::{self, Secp256k1};
 use extkey::Identifier;
 use keychain::Error;
 

--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -19,9 +19,9 @@ use serde::{de, ser};
 
 use byteorder::{ByteOrder, BigEndian};
 use blake2::blake2b::blake2b;
-use secp;
-use secp::Secp256k1;
-use secp::key::{PublicKey, SecretKey};
+use util::secp;
+use util::secp::Secp256k1;
+use util::secp::key::{PublicKey, SecretKey};
 use util;
 
 // Size of an identifier in bytes
@@ -277,8 +277,8 @@ impl ExtendedKey {
 mod test {
 	use serde_json;
 
-	use secp::Secp256k1;
-	use secp::key::SecretKey;
+	use util::secp::Secp256k1;
+	use util::secp::key::SecretKey;
 	use super::{ExtendedKey, Identifier};
 	use util;
 

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -15,10 +15,10 @@
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 
-use secp;
-use secp::{Message, Secp256k1, Signature};
-use secp::key::SecretKey;
-use secp::pedersen::{Commitment, ProofMessage, ProofInfo, RangeProof};
+use util::secp;
+use util::secp::{Message, Secp256k1, Signature};
+use util::secp::key::SecretKey;
+use util::secp::pedersen::{Commitment, ProofMessage, ProofInfo, RangeProof};
 use blake2;
 use blind::{BlindingFactor, BlindSum};
 use extkey::{self, Identifier};
@@ -195,8 +195,8 @@ impl Keychain {
 #[cfg(test)]
 mod test {
 	use keychain::Keychain;
-	use secp;
-	use secp::pedersen::ProofMessage;
+	use util::secp;
+	use util::secp::pedersen::ProofMessage;
 
 	#[test]
 	fn test_key_derivation() {

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -17,7 +17,6 @@
 extern crate blake2_rfc as blake2;
 extern crate byteorder;
 extern crate rand;
-extern crate secp256k1zkp as secp;
 extern crate grin_util as util;
 extern crate serde;
 #[macro_use]

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -10,7 +10,6 @@ grin_keychain = { path = "../keychain" }
 grin_store = { path = "../store" }
 grin_p2p = { path = "../p2p" }
 grin_util = { path = "../util" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 time = "^0.1"

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -14,7 +14,7 @@ use core::core::transaction;
 use std::collections::HashMap;
 use std::clone::Clone;
 
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 use std::sync::RwLock;
 

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -17,7 +17,7 @@
 use std::vec::Vec;
 use std::collections::{HashMap, HashSet};
 
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 use time;
 
@@ -288,7 +288,7 @@ pub fn transaction_identifier(tx: &core::transaction::Transaction) -> core::hash
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use secp;
+	use util::secp;
 	use keychain::Keychain;
 	use rand;
 	use core::core::SwitchCommitHash;

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -34,7 +34,7 @@ extern crate serde_derive;
 extern crate blake2_rfc as blake2;
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
-extern crate secp256k1zkp as secp;
+extern crate grin_util as util;
 
 pub use pool::TransactionPool;
 pub use types::{BlockChain, PoolAdapter, TxSource, PoolError, PoolConfig};

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -22,8 +22,8 @@ use core::core::block;
 use core::core::hash;
 use core::global;
 
-use secp;
-use secp::pedersen::Commitment;
+use util::secp;
+use util::secp::pedersen::Commitment;
 
 use std::sync::Arc;
 use std::collections::{HashMap, HashSet};
@@ -614,7 +614,7 @@ mod tests {
 	use super::*;
 	use core::core::build;
 	use blockchain::{DummyChain, DummyChainImpl, DummyUtxoSet};
-	use secp;
+	use util::secp;
 	use keychain::Keychain;
 	use std::sync::{Arc, RwLock};
 	use blake2;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter::Iterator;
 use std::fmt;
 
-use secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 pub use graph;
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,4 +12,5 @@ slog-async = "^2.1.0"
 lazy_static = "~0.2.8"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_1" }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -33,6 +33,10 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+// Re-export so only has to be included once
+pub extern crate secp256k1zkp as secp_;
+pub use secp_ as secp;
+
 // Logging related
 pub mod logger;
 pub use logger::{LOGGER, init_logger, init_test_logger};

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -27,4 +27,3 @@ grin_api = { path = "../api" }
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }
 grin_util = { path = "../util" }
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use api;
 use types::*;
 use keychain::{Identifier, Keychain};
-use secp::pedersen;
+use util::secp::pedersen;
 use util;
 use util::LOGGER;
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -37,7 +37,6 @@ extern crate grin_api as api;
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_util as util;
-extern crate secp256k1zkp as secp;
 
 mod checker;
 mod handlers;

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -25,7 +25,7 @@ use std::cmp::min;
 
 use hyper;
 use serde_json;
-use secp;
+use util::secp;
 use tokio_core::reactor;
 use tokio_retry::Retry;
 use tokio_retry::strategy::FibonacciBackoff;


### PR DESCRIPTION
Updating secp import to come from a tag instead of the master.. this will prevent people having to run 'cargo update' every time libsecp changes.

Also consolidates the import into the 'util' crate and re-exports it, so updating the tag on the grin side only has to be done in a single place.