### PR TITLE
add new /v1/peers endpoints to the api

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ grin_chain = { path = "../chain" }
 grin_pool = { path = "../pool" }
 grin_store = { path = "../store" }
 grin_util = { path = "../util" }
+grin_p2p = { path = "../p2p" }
 hyper = "~0.10.6"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 iron = "~0.5.1"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate grin_chain as chain;
 extern crate grin_core as core;
 extern crate grin_pool as pool;
+extern crate grin_p2p as p2p;
 extern crate grin_store as store;
 extern crate grin_util as util;
 

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -150,6 +150,7 @@ impl Server {
 			config.api_http_addr.clone(),
 			shared_chain.clone(),
 			tx_pool.clone(),
+			p2p_server.clone(),
 			peer_store.clone(),
 		);
 

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -150,6 +150,7 @@ impl Server {
 			config.api_http_addr.clone(),
 			shared_chain.clone(),
 			tx_pool.clone(),
+			peer_store.clone(),
 		);
 
 		warn!(LOGGER, "Grin server started.");

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -207,6 +207,10 @@ impl Server {
 		addr.ip() == self.config.host && addr.port() == self.config.port
 	}
 
+	pub fn all_peers(&self) -> Vec<Arc<Peer>> {
+		self.peers.read().unwrap().clone()
+	}
+
 	/// Get a peer we're connected to by address.
 	pub fn get_peer(&self, addr: SocketAddr) -> Option<Arc<Peer>> {
 		for p in self.peers.read().unwrap().deref() {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -28,16 +28,16 @@ const PEER_PREFIX: u8 = 'p' as u8;
 
 /// Types of messages
 enum_from_primitive! {
-  #[derive(Debug, Clone, Copy, PartialEq)]
-  pub enum State {
-	Healthy,
-	Banned,
-	Defunct,
-  }
+	#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+	pub enum State {
+		Healthy,
+		Banned,
+		Defunct,
+	}
 }
 
 /// Data stored for any given peer we've encountered.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PeerData {
 	/// Network address of the peer.
 	pub addr: SocketAddr,
@@ -127,6 +127,17 @@ impl PeerStore {
 			}
 		}
 		peers
+	}
+
+	/// List all known peers (for the /v1/peers api endpoint)
+	pub fn all_peers(&self) -> Vec<PeerData> {
+		let peers_iter = self.db
+			.iter::<PeerData>(&to_key(PEER_PREFIX, &mut "".to_string().into_bytes()));
+			let mut peers = vec![];
+			for p in peers_iter {
+				peers.push(p);
+			}
+			peers
 	}
 
 	/// Convenience method to load a peer data, update its status and save it

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -100,7 +100,7 @@ bitflags! {
 }
 
 /// General information about a connected peer that's useful to other modules.
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct PeerInfo {
 	pub capabilities: Capabilities,
 	pub user_agent: String,


### PR DESCRIPTION
* GET /v1/peers/all
* GET /v1/peers/connected

`all` is from the `peer_store`
`connected` is from the `p2p_server`

```
curl 127.0.0.1:13413/v1/peers/all
[
  {
    "addr": "127.0.0.1:14414",
    "capabilities": {
      "bits": 7
    },
    "user_agent": "MW/Grin 0.1",
    "flags": "Healthy"
  }
]
```

```
curl 127.0.0.1:13413/v1/peers/connected
[
  {
    "capabilities": {
      "bits": 7
    },
    "user_agent": "MW/Grin 0.1",
    "version": 1,
    "addr": "127.0.0.1:14414",
    "total_difficulty": 37
  }
]
```

