### PR TITLE
default wallet receive to listen on 127.0.0.1

### DIFF
--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -279,7 +279,7 @@ impl LocalServerContainer {
 
 		let mut wallet_config = WalletConfig::default();
 
-		wallet_config.api_http_addr = format!("http://{}", url);
+		wallet_config.api_listen_port = format!("{}", self.config.wallet_port);
 		wallet_config.check_node_api_http_addr = self.config.wallet_validating_node_url.clone();
 		wallet_config.data_file_dir = self.working_dir.clone();
 
@@ -288,8 +288,8 @@ impl LocalServerContainer {
 			keychain: keychain.clone(),
 		};
 		let router = router!(
-      receive_tx: get "/receive/transaction" => receive_tx_handler,
-    );
+			receive_tx: get "/receive/transaction" => receive_tx_handler,
+		);
 
 		let mut api_server = api::ApiServer::new("/v1".to_string());
 		api_server.register_handler(router);

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -174,6 +174,11 @@ fn main() {
 			.long("port")
 			.help("Port on which to run the wallet receiver when in receiver mode")
 			.takes_value(true))
+		.arg(Arg::with_name("external")
+			.short("e")
+			.long("external")
+			.help("Listen on 0.0.0.0 interface to allow external connections (default is 127.0.0.1)")
+			.takes_value(false))
 		.arg(Arg::with_name("api_server_address")
 			.short("a")
 			.long("api_server_address")
@@ -338,8 +343,11 @@ fn wallet_command(wallet_args: &ArgMatches) {
 	let mut wallet_config = WalletConfig::default();
 
 	if let Some(port) = wallet_args.value_of("port") {
-		let default_ip = "0.0.0.0";
-		wallet_config.api_http_addr = format!("{}:{}", default_ip, port);
+		wallet_config.api_listen_port = port.to_string();
+	}
+
+	if wallet_args.is_present("external") {
+		wallet_config.api_listen_interface = "0.0.0.0".to_string();
 	}
 
 	if let Some(dir) = wallet_args.value_of("dir") {
@@ -351,7 +359,7 @@ fn wallet_command(wallet_args: &ArgMatches) {
 	}
 
 	// Derive the keychain based on seed from seed file and specified passphrase.
- // Generate the initial wallet seed if we are running "wallet init".
+	// Generate the initial wallet seed if we are running "wallet init".
 	if let ("init", Some(_)) = wallet_args.subcommand() {
 		wallet::WalletSeed::init_file(&wallet_config).expect("Failed to init wallet seed file.");
 

--- a/wallet/src/server.rs
+++ b/wallet/src/server.rs
@@ -24,7 +24,7 @@ pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
 	info!(
 		LOGGER,
 		"Starting the Grin wallet receiving daemon at {}...",
-		wallet_config.api_http_addr
+		wallet_config.api_listen_addr()
 	);
 
 	let receive_tx_handler = WalletReceiver {
@@ -43,7 +43,7 @@ pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
 
 	let mut apis = ApiServer::new("/v1".to_string());
 	apis.register_handler(router);
-	apis.start(wallet_config.api_http_addr).unwrap_or_else(|e| {
+	apis.start(wallet_config.api_listen_addr()).unwrap_or_else(|e| {
 		error!(LOGGER, "Failed to start Grin wallet receiver: {}.", e);
 	});
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -153,10 +153,13 @@ impl From<hyper::error::UriError> for Error {
 pub struct WalletConfig {
 	// Whether to run a wallet
 	pub enable_wallet: bool,
-	// The api address that this api server (i.e. this wallet) will run
-	pub api_http_addr: String,
-	// The api address of a running server node, against which transaction inputs will be checked
-	// during send
+	// The api interface/ip_address that this api server (i.e. this wallet) will run
+	// by default this is 127.0.0.1 (and will not accept connections from external clients)
+	pub api_listen_interface: String,
+	// The port this wallet will run on
+	pub api_listen_port: String,
+	// The api address of a running server node against which transaction inputs
+	// will be checked during send
 	pub check_node_api_http_addr: String,
 	// The directory in which wallet files are stored
 	pub data_file_dir: String,
@@ -166,10 +169,17 @@ impl Default for WalletConfig {
 	fn default() -> WalletConfig {
 		WalletConfig {
 			enable_wallet: false,
-			api_http_addr: "0.0.0.0:13415".to_string(),
+			api_listen_interface: "127.0.0.1".to_string(),
+			api_listen_port: "13415".to_string(),
 			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
 			data_file_dir: ".".to_string(),
 		}
+	}
+}
+
+impl WalletConfig {
+	pub fn api_listen_addr(&self) -> String {
+		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
 	}
 }
 


### PR DESCRIPTION
default wallet receive to listen on 127.0.0.1
optional flag on wallet command to listen on 0.0.0.0

```
grin wallet receive
Nov 02 14:42:55.947 INFO Starting the Grin wallet receiving daemon at 127.0.0.1:13415...

grin wallet --port 8080 receive
Nov 02 14:43:42.292 INFO Starting the Grin wallet receiving daemon at 127.0.0.1:8080...

grin wallet --external receive
Nov 02 14:49:16.429 INFO Starting the Grin wallet receiving daemon at 0.0.0.0:13415...

grin wallet --port 8080 --external receive
Nov 02 14:49:58.544 INFO Starting the Grin wallet receiving daemon at 0.0.0.0:8080...
```
