### PR TITLE
Wallet output selection performance

### DIFF
--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Antioch Peverell"]
 byteorder = "~1"
 blake2-rfc = "~0.2.17"
 rand = "~0.3"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.3"

--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -134,7 +134,7 @@ impl Identifier {
 	}
 
 	fn from_hex(hex: &str) -> Result<Identifier, Error> {
-		let bytes = util::from_hex(hex.to_string())?;
+		let bytes = util::from_hex(hex.to_string()).unwrap();
 		Ok(Identifier::from_bytes(&bytes))
 	}
 

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -19,6 +19,7 @@ use util::secp;
 use util::secp::{Message, Secp256k1, Signature};
 use util::secp::key::SecretKey;
 use util::secp::pedersen::{Commitment, ProofMessage, ProofInfo, RangeProof};
+use util::logger::LOGGER;
 use blake2;
 use blind::{BlindSum, BlindingFactor};
 use extkey::{self, Identifier};
@@ -93,10 +94,17 @@ impl Keychain {
 		Ok(key_id)
 	}
 
-	fn derived_key(&self, key_id: &Identifier) -> Result<SecretKey, Error> {
+	fn derived_key_search(&self, key_id: &Identifier, n_size: Option<u32>) -> Result<SecretKey, Error> {
 		if let Some(key) = self.key_overrides.get(key_id) {
 			return Ok(*key);
 		}
+
+		trace!(LOGGER, "Derived Key key_id: {}", key_id);
+		
+		if let Some(n) = n_size {
+			let extkey = self.extkey.derive(&self.secp, n)?;
+			return Ok(extkey.key);
+		};
 
 		for i in 1..10000 {
 			let extkey = self.extkey.derive(&self.secp, i)?;
@@ -109,8 +117,22 @@ impl Keychain {
 		))
 	}
 
+	fn derived_key(&self, key_id: &Identifier) -> Result<SecretKey, Error> {
+		self.derived_key_search(key_id, None)
+	}
+
+	fn derived_key_from_index(&self, key_id: &Identifier, n_child:u32) -> Result<SecretKey, Error> {
+		self.derived_key_search(key_id, Some(n_child))
+	}
+
 	pub fn commit(&self, amount: u64, key_id: &Identifier) -> Result<Commitment, Error> {
 		let skey = self.derived_key(key_id)?;
+		let commit = self.secp.commit(amount, skey)?;
+		Ok(commit)
+	}
+
+	pub fn commit_with_key_index(&self, amount: u64, key_id: &Identifier, n_child: u32) -> Result<Commitment, Error> {
+		let skey = self.derived_key_from_index(key_id, n_child)?;
 		let commit = self.secp.commit(amount, skey)?;
 		Ok(commit)
 	}

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -22,6 +22,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+#[macro_use]
+extern crate slog;
 
 mod blind;
 mod extkey;

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -67,7 +67,7 @@ pub fn refresh_outputs(config: &WalletConfig, keychain: &Keychain) -> Result<(),
 			.filter(|out| out.status != OutputStatus::Spent)
 		{
 			let key_id = keychain.derive_key_id(out.n_child).unwrap();
-			let commit = keychain.commit(out.value, &key_id).unwrap();
+			let commit = keychain.commit_with_key_index(out.value, &key_id, out.n_child).unwrap();
 			commits.push(commit);
 			wallet_outputs.insert(commit, out.key_id.clone());
 		}


### PR DESCRIPTION
Half the solution to: https://github.com/mimblewimble/grin/issues/237

This should solve the wallet-side performance issue during a wallet_info command, it just allows for providing the key index stored in the wallet when retrieving a commit, as opposed to iterating to find it each time. 

Would appreciate a quick review to ensure I haven't misunderstood anything.

Server side still seems sluggish when actually selecting the UTXOs via the API, (as in there's a scroll delay as it outputs each of them in the log) so that's the next bit to address.