### PR TITLE
Wallet outputs becoming spent

### DIFF
--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -96,7 +96,11 @@ pub fn refresh_outputs(config: &WalletConfig, keychain: &Keychain) -> Result<(),
 		Ok(outputs) => for out in outputs {
 			api_outputs.insert(out.commit, out);
 		},
-		Err(_) => {}
+		Err(e) => {
+			// if we got anything other than 200 back from server, don't attempt to refresh the wallet
+			// data after
+			return Err(Error::Node(e));
+		}
 	};
 
 	// now for each commit, find the output in the wallet and

--- a/wallet/src/info.rs
+++ b/wallet/src/info.rs
@@ -19,7 +19,7 @@ use types::{WalletConfig, WalletData};
 
 pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 	let root_key_id = keychain.root_key_id();
-	let _ = checker::refresh_outputs(&config, &keychain);
+	let result = checker::refresh_outputs(&config, &keychain);
 
 	// just read the wallet here, no need for a write lock
 	let _ = WalletData::read_wallet(&config.data_file_dir, |wallet_data| {
@@ -56,4 +56,8 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 			);
 		}
 	});
+
+	if let Err(e) = result {
+		println!("WARNING - Showing local data only - Wallet was unable to contact a node to update and verify the outputs shown here.");
+	}
 }


### PR DESCRIPTION
Fix for https://github.com/mimblewimble/grin/issues/239... even if unable to contact API server code was going ahead and trying to update output status from an empty set, thus marking them all spent.