### PR TITLE
more robust peer handling

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -89,6 +89,12 @@ impl NetAdapter for NetToChainAdapter {
 	}
 
 	fn headers_received(&self, bhs: Vec<core::BlockHeader>) {
+		info!(
+			LOGGER,
+			"Received {} block headers",
+			bhs.len(),
+		);
+
 		// try to add each header to our header chain
 		let mut added_hs = vec![];
 		for bh in bhs {

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -140,11 +140,19 @@ impl NetAdapter for NetToChainAdapter {
 	}
 
 	fn locate_headers(&self, locator: Vec<Hash>) -> Vec<core::BlockHeader> {
+		debug!(
+			LOGGER,
+			"locate_headers: {:?}",
+			locator,
+		);
+
 		if locator.len() == 0 {
 			return vec![];
 		}
 
-		// go through the locator vector and check if we know any of these headers
+		// recursively go back through the locator vector
+		// and stop when we find a header that we recognize
+		// this will be a header shared in common between us and the peer
 		let known = self.chain.get_block_header(&locator[0]);
 		let header = match known {
 			Ok(header) => header,
@@ -156,6 +164,12 @@ impl NetAdapter for NetToChainAdapter {
 				return vec![];
 			}
 		};
+
+		debug!(
+			LOGGER,
+			"locate_headers: {:?}",
+			header,
+		);
 
 		// looks like we know one, getting as many following headers as allowed
 		let hh = header.height;
@@ -171,6 +185,13 @@ impl NetAdapter for NetToChainAdapter {
 				}
 			}
 		}
+
+		debug!(
+			LOGGER,
+			"locate_headers: returning headers: {}",
+			headers.len(),
+		);
+
 		headers
 	}
 

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -57,21 +57,6 @@ impl Seeder {
 		}
 	}
 
-	pub fn monitor_only(&self, h: reactor::Handle) {
-		// open a channel with a listener that connects every peer address sent below
-		// max peer count
-		let (tx, rx) = futures::sync::mpsc::unbounded();
-		h.spawn(self.listen_for_addrs(h.clone(), rx));
-
-		// start monitoring connections
-		let seeder = self.monitor_peers(tx.clone());
-
-		h.spawn(seeder.map(|_| ()).map_err(|e| {
-			error!(LOGGER, "Seeding or peer monitoring error: {}", e);
-			()
-		}));
-	}
-
 	pub fn connect_and_monitor(
 		&self,
 		h: reactor::Handle,
@@ -105,7 +90,7 @@ impl Seeder {
 			.interval(time::Duration::from_secs(10))
 			.for_each(move |_| {
 				debug!(LOGGER, "monitoring peers");
-				
+
 				// maintenance step first, clean up p2p server peers and mark bans
 				// if needed
 				let disconnected = p2p_server.clean_peers();

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -100,12 +100,14 @@ impl Seeder {
 		let p2p_server = self.p2p.clone();
 
 		// now spawn a new future to regularly check if we need to acquire more peers
-  // and if so, gets them from db
+		// and if so, gets them from db
 		let mon_loop = Timer::default()
 			.interval(time::Duration::from_secs(10))
 			.for_each(move |_| {
+				debug!(LOGGER, "monitoring peers");
+				
 				// maintenance step first, clean up p2p server peers and mark bans
-	// if needed
+				// if needed
 				let disconnected = p2p_server.clean_peers();
 				for p in disconnected {
 					if p.is_banned() {

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -89,7 +89,7 @@ impl Seeder {
 		let mon_loop = Timer::default()
 			.interval(time::Duration::from_secs(10))
 			.for_each(move |_| {
-				debug!(LOGGER, "monitoring peers");
+				debug!(LOGGER, "monitoring peers ({})", p2p_server.all_peers().len());
 
 				// maintenance step first, clean up p2p server peers and mark bans
 				// if needed

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -144,8 +144,7 @@ impl Server {
 			_ => {}
 		}
 
-
-		// now attempt to sync unless we have no known seeds and no known peers
+		// If we have any known seeds or peers then attempt to sync.
 		if config.seeding_type != Seeding::None || peer_store.all_peers().len() > 0 {
 			let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
 			net_adapter.start_sync(sync);

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -144,10 +144,8 @@ impl Server {
 			_ => {}
 		}
 
-		if config.seeding_type != Seeding::None {
-			let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
-			net_adapter.start_sync(sync);
-		}
+		let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
+		net_adapter.start_sync(sync);
 
 		evt_handle.spawn(p2p_server.start(evt_handle.clone()).map_err(|_| ()));
 

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -124,6 +124,7 @@ impl Server {
 					LOGGER,
 					"No seed configured, will stay solo until connected to"
 				);
+				seed.monitor_only(evt_handle.clone());
 			}
 			Seeding::List => {
 				seed.connect_and_monitor(

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -122,9 +122,12 @@ impl Server {
 			Seeding::None => {
 				warn!(
 					LOGGER,
-					"No seed configured, will stay solo until connected to"
+					"No seed(s) configured, will stay solo until connected to"
 				);
-				seed.monitor_only(evt_handle.clone());
+				seed.connect_and_monitor(
+					evt_handle.clone(),
+					seed::predefined_seeds(vec![]),
+				);
 			}
 			Seeding::List => {
 				seed.connect_and_monitor(
@@ -133,7 +136,10 @@ impl Server {
 				);
 			}
 			Seeding::WebStatic => {
-				seed.connect_and_monitor(evt_handle.clone(), seed::web_seeds(evt_handle.clone()));
+				seed.connect_and_monitor(
+					evt_handle.clone(),
+					seed::web_seeds(evt_handle.clone()),
+				);
 			}
 			_ => {}
 		}

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -144,8 +144,12 @@ impl Server {
 			_ => {}
 		}
 
-		let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
-		net_adapter.start_sync(sync);
+
+		// now attempt to sync unless we have no known seeds and no known peers
+		if config.seeding_type != Seeding::None || peer_store.all_peers().len() > 0 {
+			let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
+			net_adapter.start_sync(sync);
+		}
 
 		evt_handle.spawn(p2p_server.start(evt_handle.clone()).map_err(|_| ()));
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -71,19 +71,22 @@ impl Syncer {
 	/// syncing if required.
 	pub fn run(&self) -> Result<(), Error> {
 		info!(LOGGER, "Sync: starting sync");
+
+		// Loop for 10s waiting for some peers to potentially sync from.
 		let start = Instant::now();
 		loop {
 			let pc = self.p2p.peer_count();
 			if pc > 3 {
 				break;
 			}
-			// if pc > 0 && (Instant::now() - start > Duration::from_secs(10)) {
 			if Instant::now() - start > Duration::from_secs(10) {
 				break;
 			}
 			thread::sleep(Duration::from_millis(200));
 		}
 
+		// Now check we actually have at least one peer to sync from.
+		// If not then end the sync cleanly.
 		if self.p2p.peer_count() == 0 {
 			info!(LOGGER, "Sync: no peers to sync with, done.");
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -87,7 +87,7 @@ impl Syncer {
 		self.init_download()?;
 
 		// main syncing loop, requests more headers and bodies periodically as long
-  // as a peer with higher difficulty exists and we're not fully caught up
+		// as a peer with higher difficulty exists and we're not fully caught up
 		info!(LOGGER, "Starting sync loop.");
 		loop {
 			let tip = self.chain.get_header_head()?;

--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -44,7 +44,7 @@ use wallet::WalletConfig;
 
 /// Just removes all results from previous runs
 pub fn clean_all_output(test_name_dir: &str) {
-	let target_dir = format!("target/test_servers/{}", test_name_dir);
+	let target_dir = format!("target/{}", test_name_dir);
 	let result = fs::remove_dir_all(target_dir);
 	if let Err(e) = result {
 		println!("{}", e);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -273,16 +273,16 @@ fn simulate_full_sync() {
 	let mut servers = vec![];
 	for n in 0..2 {
 		let mut config = grin::ServerConfig {
+			api_http_addr: format!("127.0.0.1:{}", 19000 + n),
 			db_root: format!("target/{}/grin-sync-{}", test_name_dir, n),
 			p2p_config: Some(p2p::P2PConfig {
 				port: 11000 + n,
 				..p2p::P2PConfig::default()
 			}),
+			seeding_type: grin::Seeding::List,
+			seeds: Some(vec!["127.0.0.1:11000".to_string()]),
 			..Default::default()
 		};
-		if n == 1 {
-			config.seeding_type = grin::Seeding::Programmatic;
-		}
 		let s = grin::Server::future(config, &handle).unwrap();
 		servers.push(s);
 	}
@@ -290,10 +290,6 @@ fn simulate_full_sync() {
 	// mine a few blocks on server 1
 	servers[0].start_miner(miner_config);
 	thread::sleep(time::Duration::from_secs(5));
-
-	// connect 1 and 2
-	let addr = format!("{}:{}", "127.0.0.1", 11001);
-	servers[0].connect_peer(addr.parse().unwrap()).unwrap();
 
 	// 2 should get blocks
 	evtlp.run(change(&servers[1]));

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -191,7 +191,6 @@ fn a_simulate_block_propagation() {
 
 	let test_name_dir = "grin-prop";
 	framework::clean_all_output(test_name_dir);
-
 	let mut evtlp = reactor::Core::new().unwrap();
 	let handle = evtlp.handle();
 
@@ -221,6 +220,8 @@ fn a_simulate_block_propagation() {
 					port: 18000 + n,
 					..p2p::P2PConfig::default()
 				}),
+				seeding_type: grin::Seeding::List,
+				seeds: Some(vec!["127.0.0.1:18000".to_string()]),
 				..Default::default()
 			},
 			&handle,
@@ -228,23 +229,12 @@ fn a_simulate_block_propagation() {
 		servers.push(s);
 	}
 
-	// everyone connects to everyone else
-	for n in 0..5 {
-		for m in 0..5 {
-			if m == n {
-				continue;
-			}
-			let addr = format!("{}:{}", "127.0.0.1", 18000 + m);
-			servers[n].connect_peer(addr.parse().unwrap()).unwrap();
-		}
-	}
-
 	// start mining
 	servers[0].start_miner(miner_config);
 	let original_height = servers[0].head().height;
 
 	// monitor for a change of head on a different server and check whether
- // chain height has changed
+	// chain height has changed
 	evtlp.run(change(&servers[4]).and_then(|tip| {
 		assert!(tip.height == original_height + 1);
 		Ok(())

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -57,7 +57,7 @@ impl Handshake {
 		self_addr: SocketAddr,
 		conn: TcpStream,
 	) -> Box<Future<Item = (TcpStream, ProtocolV1, PeerInfo), Error = Error>> {
-		// prepare the first part of the hanshake
+		// prepare the first part of the handshake
 		let nonce = self.next_nonce();
 		let hand = Hand {
 			version: PROTOCOL_VERSION,
@@ -118,6 +118,7 @@ impl Handshake {
 						// check the nonce to see if we could be trying to connect to ourselves
 						let nonces = nonces.read().unwrap();
 						if nonces.contains(&hand.nonce) {
+							debug!(LOGGER, "***** nonce matches! Avoiding connecting to ourselves");
 							return Err(Error::Serialization(ser::Error::UnexpectedData {
 								expected: vec![],
 								received: vec![],
@@ -173,6 +174,8 @@ fn extract_ip(advertised: &SocketAddr, conn: &TcpStream) -> SocketAddr {
   match advertised {
     &SocketAddr::V4(v4sock) => {
       let ip = v4sock.ip();
+	  debug!(LOGGER, "extract_ip - {:?}, {:?}", ip, conn.peer_addr());
+
       if ip.is_loopback() || ip.is_unspecified() {
         if let Ok(addr) =  conn.peer_addr() {
           return SocketAddr::new(addr.ip(), advertised.port());

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -59,6 +59,14 @@ impl Handshake {
 	) -> Box<Future<Item = (TcpStream, ProtocolV1, PeerInfo), Error = Error>> {
 		// prepare the first part of the handshake
 		let nonce = self.next_nonce();
+		debug!(
+			LOGGER,
+			"handshake connect with nonce - {}, sender - {:?}, receiver - {:?}",
+			nonce,
+			self_addr,
+			conn.peer_addr().unwrap(),
+		);
+
 		let hand = Hand {
 			version: PROTOCOL_VERSION,
 			capabilities: capab,
@@ -117,6 +125,12 @@ impl Handshake {
 					{
 						// check the nonce to see if we could be trying to connect to ourselves
 						let nonces = nonces.read().unwrap();
+						debug!(
+							LOGGER,
+							"checking the nonce - {}, {:?}",
+							&hand.nonce,
+							nonces,
+						);
 						if nonces.contains(&hand.nonce) {
 							debug!(LOGGER, "***** nonce matches! Avoiding connecting to ourselves");
 							return Err(Error::Serialization(ser::Error::UnexpectedData {

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -62,7 +62,7 @@ impl Peer {
 		capab: Capabilities,
 		total_difficulty: Difficulty,
 		self_addr: SocketAddr,
-		hs: &Handshake,
+		hs: Arc<Handshake>,
 		na: Arc<NetAdapter>,
 	) -> Box<Future<Item = (TcpStream, Peer), Error = Error>> {
 		let connect_peer = hs.connect(capab, total_difficulty, self_addr, conn)

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -214,8 +214,6 @@ impl Server {
 	/// lost connection to or have been deemed problematic. The removed peers
 	/// are returned.
 	pub fn clean_peers(&self) -> Vec<Arc<Peer>> {
-		debug!(LOGGER, "clean_peers running");
-		
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -156,10 +156,6 @@ impl Server {
 			// if we're already connected to the addr, just return the peer
 			return Box::new(future::ok(Some(p)));
 		}
-		if self.is_self(addr) {
-			// asked to connect to ourselves
-			return Box::new(future::ok(None));
-		}
 
 		// cloneapalooza
 		let peers = self.peers.clone();
@@ -200,15 +196,9 @@ impl Server {
 		Box::new(request)
 	}
 
-	/// Check if the server already knows this peer (is already connected). In
-	/// addition we consider to know ourselves.
+	/// Check if the server already knows this peer (is already connected).
 	pub fn is_known(&self, addr: SocketAddr) -> bool {
-		self.get_peer(addr).is_some() || self.is_self(addr)
-	}
-
-	/// Whether the provided address is ourselves.
-	pub fn is_self(&self, addr: SocketAddr) -> bool {
-		addr.ip() == self.config.host && addr.port() == self.config.port
+		self.get_peer(addr).is_some()
 	}
 
 	pub fn all_peers(&self) -> Vec<Arc<Peer>> {
@@ -224,6 +214,8 @@ impl Server {
 	/// lost connection to or have been deemed problematic. The removed peers
 	/// are returned.
 	pub fn clean_peers(&self) -> Vec<Arc<Peer>> {
+		debug!(LOGGER, "clean_peers running");
+		
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -21,6 +21,7 @@ use core::ser::{self, Readable, Reader, Writeable, Writer};
 use grin_store::{self, option_to_not_found, to_key, Error};
 use msg::SockAddr;
 use types::Capabilities;
+use util::LOGGER;
 
 const STORE_SUBPATH: &'static str = "peers";
 
@@ -94,11 +95,8 @@ impl PeerStore {
 	}
 
 	pub fn save_peer(&self, p: &PeerData) -> Result<(), Error> {
-		// we want to ignore any peer without a well-defined ip
-		let ip = p.addr.ip();
-		if ip.is_unspecified() || ip.is_loopback() {
-			return Ok(());
-		}
+		debug!(LOGGER, "saving peer to store {:?}", p);
+
 		self.db.put_ser(
 			&to_key(PEER_PREFIX, &mut format!("{}", p.addr).into_bytes())[..],
 			p,

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -59,7 +59,7 @@ fn peer_handshake() {
 							p2p::UNKNOWN,
 							Difficulty::one(),
 							my_addr,
-							&p2p::handshake::Handshake::new(),
+							Arc::new(p2p::handshake::Handshake::new()),
 							net_adapter.clone(),
 						)
 					})


### PR DESCRIPTION
This PR resolves both duplicate peers and "self peers" in the `v1/peers/connected` list.
Also makes sure a seedless node monitors any peers that start talking to us.

* track connected peers in a map (avoid duplicates)
* reuse the handshake in the server (to persist nonces for self connection avoidance)
* monitor peers even in seedless mode (peers may still talk to us as a seed)
* fixup simulnet tests (seeds/peers now more robust in the tests)
* start the syncer if we know any seeds *or* peers
* exit the sync cleanly even if we cannot connect to any peers to sync with



 



