### PR TITLE
use the static secp instance everywhere (except the wallet)

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -16,7 +16,6 @@
 
 use std::sync::{Arc, RwLock};
 
-use util::secp;
 use time;
 
 use core::consensus;
@@ -209,8 +208,7 @@ fn validate_block(
 	}
 
 	// main isolated block validation, checks all commitment sums and sigs
-	let curve = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-	try!(b.validate(&curve).map_err(&Error::InvalidBlockProof));
+	try!(b.validate().map_err(&Error::InvalidBlockProof));
 
 	// apply the new block to the MMR trees and check the new root hashes
 	if b.header.previous == ctx.head.last_block_h {

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -37,7 +37,6 @@ use util::LOGGER;
 use types::Error;
 
 use chain;
-use util::secp;
 use pool;
 use util;
 use keychain::{Identifier, Keychain};
@@ -574,8 +573,7 @@ impl Miner {
 		);
 
 		// making sure we're not spending time mining a useless block
-		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-		b.validate(&secp).expect("Built an invalid block!");
+		b.validate().expect("Built an invalid block!");
 
 		let mut rng = rand::OsRng::new().unwrap();
 		b.header.nonce = rng.gen();

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -100,7 +100,7 @@ impl Keychain {
 		}
 
 		trace!(LOGGER, "Derived Key key_id: {}", key_id);
-		
+
 		if let Some(n) = n_child{
 			let extkey = self.extkey.derive(&self.secp, n)?;
 			return Ok(extkey.key);
@@ -222,8 +222,8 @@ mod test {
 
 	#[test]
 	fn test_key_derivation() {
-		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 		let keychain = Keychain::from_random_seed().unwrap();
+		let secp = keychain.secp();
 
 		// use the keychain to derive a "key_id" based on the underlying seed
 		let key_id = keychain.derive_key_id(1).unwrap();

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -22,7 +22,6 @@ use core::core::block;
 use core::core::hash;
 use core::global;
 
-use util::secp;
 use util::secp::pedersen::Commitment;
 
 use std::sync::Arc;
@@ -145,8 +144,7 @@ where
 		}
 
 		// Making sure the transaction is valid before anything else.
-		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-		tx.validate(&secp).map_err(|_e| PoolError::Invalid)?;
+		tx.validate().map_err(|_e| PoolError::Invalid)?;
 
 		// The first check involves ensuring that an identical transaction is
   // not already in the pool's transaction set.

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -205,7 +205,7 @@ fn receive_transaction(
 
 	// make sure the resulting transaction is valid (could have been lied to on
  // excess).
-	tx_final.validate(&keychain.secp())?;
+	tx_final.validate()?;
 
 	// operate within a lock on wallet data
 	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -135,7 +135,7 @@ pub fn issue_burn_tx(
 
 	// finalize the burn transaction and send
 	let (tx_burn, _) = build::transaction(parts, &keychain)?;
-	tx_burn.validate(&keychain.secp())?;
+	tx_burn.validate()?;
 
 	let tx_hex = util::to_hex(ser::ser_vec(&tx_burn).unwrap());
 	let url = format!("{}/v1/pool/push", config.check_node_api_http_addr.as_str());


### PR DESCRIPTION
We were creating new instances of `secp` in various places via 
```
Secp256k1::with_caps(secp::ContextFlag::Commit);
```

This PR replaces these with calls to -
```
let secp = static_secp_instance();
let secp = secp.lock().unwrap();
```

Also wraps some usage up in code blocks to limit how long we keep the lock for secp access.
And we can simplify a lot of the code by not passing around raw instances of `secp` into `verify` etc.

Note: we are trading the overhead of re-initializing secp against some added complexity around needing to manage locks and contention for access to the static secp instance.
We may want to consider making these threadlocal (or possibly a pool of instances) at some point if we do see contention.
