### PR TITLE
use consensus rule that minimum difficulty is 10

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -22,6 +22,7 @@ use time;
 use core::consensus;
 use core::core::hash::{Hash, Hashed};
 use core::core::{Block, BlockHeader};
+use core::core::target::Difficulty;
 use core::core::transaction;
 use types::*;
 use store;
@@ -182,6 +183,12 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 
 	if !ctx.opts.intersects(SKIP_POW) {
 		// verify the proof of work and related parameters
+
+		// explicit check to ensure we are not below the minimum difficulty
+		// we will also check difficulty based on next_difficulty later on
+		if header.difficulty < Difficulty::minimum() {
+			return Err(Error::DifficultyTooLow);
+		}
 
 		if header.total_difficulty != prev.total_difficulty.clone() + prev.pow.to_difficulty() {
 			return Err(Error::WrongTotalDifficulty);

--- a/core/src/core/target.rs
+++ b/core/src/core/target.rs
@@ -25,6 +25,7 @@ use std::ops::{Add, Div, Mul, Sub};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use byteorder::{BigEndian, ByteOrder};
 
+use consensus;
 use core::hash::Hash;
 use ser::{self, Readable, Reader, Writeable, Writer};
 
@@ -38,7 +39,7 @@ pub struct Difficulty {
 }
 
 impl Difficulty {
-	/// Difficulty of zero, which is practically invalid (not target can be
+	/// Difficulty of zero, which is invalid (no target can be
 	/// calculated from it) but very useful as a start for additions.
 	pub fn zero() -> Difficulty {
 		Difficulty { num: 0 }
@@ -46,8 +47,14 @@ impl Difficulty {
 
 	/// Difficulty of one, which is the minumum difficulty (when the hash
 	/// equals the max target)
+	/// TODO - is this the minimum dificulty or is consensus::MINIMUM_DIFFICULTY the minimum?
 	pub fn one() -> Difficulty {
 		Difficulty { num: 1 }
+	}
+
+	/// Minimum difficulty according to our consensus rules.
+	pub fn minimum() -> Difficulty {
+		Difficulty { num: consensus::MINIMUM_DIFFICULTY }
 	}
 
 	/// Convert a `u32` into a `Difficulty`


### PR DESCRIPTION
See #243 for a mining node apparently dropping to `difficulty==0` and then getting jammed on sumtree rollbacking.

This PR ensure `next_difficulty` never returns anything lower than `MINIMUM_DIFFICULTY`.
