### PR TITLE
rename JSONPartialTx -> PartialTx

### DIFF
--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -55,11 +55,11 @@ where
 	Ok(res)
 }
 
-pub fn send_partial_tx(url: &str, partial_tx: &JSONPartialTx) -> Result<(), Error> {
+pub fn send_partial_tx(url: &str, partial_tx: &PartialTx) -> Result<(), Error> {
 	single_send_partial_tx(url, partial_tx)
 }
 
-fn single_send_partial_tx(url: &str, partial_tx: &JSONPartialTx) -> Result<(), Error> {
+fn single_send_partial_tx(url: &str, partial_tx: &PartialTx) -> Result<(), Error> {
 	let mut core = reactor::Core::new()?;
 	let client = hyper::Client::new(&core.handle());
 

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -52,7 +52,7 @@ pub fn receive_json_tx_str(
 pub fn receive_json_tx(
 	config: &WalletConfig,
 	keychain: &Keychain,
-	partial_tx: &JSONPartialTx,
+	partial_tx: &PartialTx,
 ) -> Result<(), Error> {
 	let (amount, blinding, tx) = read_partial_tx(keychain, partial_tx)?;
 	let final_tx = receive_transaction(config, keychain, amount, blinding, tx)?;
@@ -74,7 +74,7 @@ pub struct WalletReceiver {
 
 impl Handler for WalletReceiver {
 	fn handle(&self, req: &mut Request) -> IronResult<Response> {
-		let struct_body = req.get::<bodyparser::Struct<JSONPartialTx>>();
+		let struct_body = req.get::<bodyparser::Struct<PartialTx>>();
 
 		if let Ok(Some(partial_tx)) = struct_body {
 			receive_json_tx(&self.config, &self.keychain, &partial_tx)


### PR DESCRIPTION
`JSONPartialTx` is a hold-over from when we passed json representations around in the ApiEndpoint. We're now consistently using serde for json serialization/deserialization.
Rename to `PartialTx` to keep things clean.

