### PR TITLE
Genesis block for known chains, mine dev chains

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -33,7 +33,7 @@ use sumtree;
 use types::*;
 use util::LOGGER;
 
-use core::global::{MiningParameterMode, MINING_PARAMETER_MODE};
+use core::global;
 
 const MAX_ORPHANS: usize = 20;
 
@@ -184,16 +184,14 @@ impl Chain {
 	}
 
 	fn ctx_from_head(&self, head: Tip, opts: Options) -> pipe::BlockContext {
-		let opts_in = opts;
-		let param_ref = MINING_PARAMETER_MODE.read().unwrap();
-		let opts_in = match *param_ref {
-			MiningParameterMode::AutomatedTesting => opts_in | EASY_POW,
-			MiningParameterMode::UserTesting => opts_in | EASY_POW,
-			MiningParameterMode::Production => opts_in,
-		};
+		let opts = if global::is_production_mode() {
+      opts
+    } else {
+      opts | EASY_POW
+    };
 
 		pipe::BlockContext {
-			opts: opts_in,
+			opts: opts,
 			store: self.store.clone(),
 			head: head,
 			pow_verifier: self.pow_verifier,

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -30,7 +30,7 @@ use core::core::hash::Hashed;
 use core::core::target::Difficulty;
 use core::consensus;
 use core::global;
-use core::global::MiningParameterMode;
+use core::global::ChainTypes;
 
 use keychain::Keychain;
 
@@ -43,7 +43,7 @@ fn clean_output_dir(dir_name: &str) {
 fn setup(dir_name: &str) -> Chain {
 	let _ = env_logger::init();
 	clean_output_dir(dir_name);
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let mut genesis_block = None;
 	if !chain::Chain::chain_exists(dir_name.to_string()) {
 		genesis_block = pow::mine_genesis_block(None);

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -28,7 +28,7 @@ use core::core::build;
 use core::core::transaction;
 use core::consensus;
 use core::global;
-use core::global::MiningParameterMode;
+use core::global::ChainTypes;
 
 use keychain::Keychain;
 
@@ -42,7 +42,7 @@ fn clean_output_dir(dir_name: &str) {
 fn test_coinbase_maturity() {
 	let _ = env_logger::init();
 	clean_output_dir(".grin");
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let mut genesis_block = None;
 	if !chain::Chain::chain_exists(".grin".to_string()) {

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -17,18 +17,16 @@
 use time;
 
 use core;
-use consensus::MINIMUM_DIFFICULTY;
+use consensus;
 use core::target::Difficulty;
 use global;
 
-/// Genesis block definition. It has no rewards, no inputs, no outputs, no
-/// fees and a height of zero.
-pub fn genesis() -> core::Block {
-	let proof_size = global::proofsize();
-	let empty_hash = core::hash::Hash([0x0; 32]);
+/// Genesis block definition for development networks. The proof of work size
+/// is small enough to mine it on the fly, so it does not contain its own
+/// proof of work solution. Can also be easily mutated for different tests.
+pub fn genesis_dev() -> core::Block {
 	core::Block {
 		header: core::BlockHeader {
-			version: 1,
 			height: 0,
 			previous: core::hash::Hash([0xff; 32]),
 			timestamp: time::Tm {
@@ -37,13 +35,56 @@ pub fn genesis() -> core::Block {
 				tm_mday: 4,
 				..time::empty_tm()
 			},
-			difficulty: Difficulty::from_num(MINIMUM_DIFFICULTY),
-			total_difficulty: Difficulty::from_num(MINIMUM_DIFFICULTY),
-			utxo_root: empty_hash,
-			range_proof_root: empty_hash,
-			kernel_root: empty_hash,
 			nonce: global::get_genesis_nonce(),
-			pow: core::Proof::zero(proof_size), // TODO get actual PoW solution
+			..Default::default()
+		},
+		inputs: vec![],
+		outputs: vec![],
+		kernels: vec![],
+	}
+}
+
+/// First testnet genesis block, still subject to change (especially the date,
+/// will hopefully come before Christmas).
+pub fn genesis_testnet1() -> core::Block {
+	core::Block {
+		header: core::BlockHeader {
+			height: 0,
+			previous: core::hash::Hash([0xff; 32]),
+			timestamp: time::Tm {
+				tm_year: 2017 - 1900,
+				tm_mon: 12,
+				tm_mday: 25,
+				..time::empty_tm()
+			},
+			nonce: 1,
+			pow: core::Proof::zero(consensus::PROOFSIZE),
+			..Default::default()
+		},
+		inputs: vec![],
+		outputs: vec![],
+		kernels: vec![],
+	}
+}
+
+/// Placeholder for mainnet genesis block, will definitely change before
+/// release so no use trying to pre-mine it.
+pub fn genesis_main() -> core::Block {
+	core::Block {
+		header: core::BlockHeader {
+			height: 0,
+			previous: core::hash::Hash([0xff; 32]),
+			timestamp: time::Tm {
+				tm_year: 2018 - 1900,
+				tm_mon: 7,
+				tm_mday: 14,
+				..time::empty_tm()
+			},
+			difficulty: Difficulty::from_num(1000),
+			total_difficulty: Difficulty::from_num(1000),
+			nonce: global::get_genesis_nonce(),
+			pow: core::Proof::zero(consensus::PROOFSIZE),
+			..Default::default()
 		},
 		inputs: vec![],
 		outputs: vec![],

--- a/grin.toml
+++ b/grin.toml
@@ -32,13 +32,13 @@ seeding_type = "None"
 #if seeding_type = List, the list of peers to connect to.
 #seeds = ["192.168.0.1:8080","192.168.0.2:8080"]
 
-#The mining parameter mode, which defines the set of cuckoo parameters
-#used for mining. Can be:
+#The chain type, which defines the genesis block and the set of cuckoo
+#parameters used for mining. Can be:
 #AutomatedTesting - For CI builds and instant blockchain creation
 #UserTesting - For regular user testing (cuckoo 16)
-#Production - Full production cuckoo parameter (cuckoo 30)
+#Testnet1 - Full production cuckoo parameter (cuckoo 30)
 
-mining_parameter_mode = "UserTesting"
+chain_type = "UserTesting"
 
 #7 = Bit flags for FULL_NODE, this structure needs to be changed
 #internally to make it more configurable

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -21,6 +21,7 @@ use core::core::{self, Output};
 use core::core::block::BlockHeader;
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
+use core::global;
 use p2p::{self, NetAdapter, PeerData, PeerStore, Server, State};
 use pool;
 use util::secp::pedersen::Commitment;
@@ -28,7 +29,6 @@ use util::OneTime;
 use store;
 use sync;
 use util::LOGGER;
-use core::global::{MiningParameterMode, MINING_PARAMETER_MODE};
 
 /// Implementation of the NetAdapter for the blockchain. Gets notified when new
 /// blocks and transactions are received and forwards to the chain and pool
@@ -286,12 +286,11 @@ impl NetToChainAdapter {
 		} else {
 			chain::NONE
 		};
-		let param_ref = MINING_PARAMETER_MODE.read().unwrap();
-		let opts = match *param_ref {
-			MiningParameterMode::AutomatedTesting => opts | chain::EASY_POW,
-			MiningParameterMode::UserTesting => opts | chain::EASY_POW,
-			MiningParameterMode::Production => opts,
-		};
+		let opts = if global::is_production_mode() {
+      opts
+    } else {
+      opts | chain::EASY_POW
+    };
 		opts
 	}
 }

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -28,6 +28,7 @@ use tokio_timer::Timer;
 use adapters::*;
 use api;
 use chain;
+use core::{global, genesis};
 use miner;
 use p2p;
 use pool;
@@ -37,7 +38,6 @@ use types::*;
 use pow;
 use util::LOGGER;
 
-use core::global;
 
 /// Grin server holding internal structures.
 pub struct Server {
@@ -91,7 +91,12 @@ impl Server {
 
 		let mut genesis_block = None;
 		if !chain::Chain::chain_exists(config.db_root.clone()) {
-			genesis_block = pow::mine_genesis_block(config.mining_config.clone());
+      let chain_type = config.chain_type.clone().unwrap();
+      if chain_type == global::ChainTypes::Testnet1 {
+        genesis_block = Some(genesis::genesis_testnet1());
+      } else {
+			  genesis_block = pow::mine_genesis_block(config.mining_config.clone());
+      }
 		}
 
 		let shared_chain = Arc::new(chain::Chain::init(

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -21,7 +21,7 @@ use pool;
 use store;
 use pow;
 use wallet;
-use core::global::MiningParameterMode;
+use core::global::ChainTypes;
 
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]
@@ -91,8 +91,8 @@ pub struct ServerConfig {
 	/// Network address for the Rest API HTTP server.
 	pub api_http_addr: String,
 
-	/// Setup the server for tests and testnet
-	pub mining_parameter_mode: Option<MiningParameterMode>,
+	/// Setup the server for tests, testnet or mainnet
+	pub chain_type: Option<ChainTypes>,
 
 	/// Method used to get the list of seed nodes for initial bootstrap.
 	pub seeding_type: Seeding,
@@ -125,7 +125,7 @@ impl Default for ServerConfig {
 			seeds: None,
 			p2p_config: Some(p2p::P2PConfig::default()),
 			mining_config: Some(pow::types::MinerConfig::default()),
-			mining_parameter_mode: Some(MiningParameterMode::Production),
+			chain_type: Some(ChainTypes::Testnet1),
 			pool_config: pool::PoolConfig::default(),
 		}
 	}

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -41,7 +41,7 @@ use tokio_timer::Timer;
 
 use core::consensus;
 use core::global;
-use core::global::{MiningParameterMode, MINING_PARAMETER_MODE};
+use core::global::ChainTypes;
 use wallet::WalletConfig;
 
 use framework::{LocalServerContainer, LocalServerContainerConfig, LocalServerContainerPool,
@@ -51,7 +51,7 @@ use framework::{LocalServerContainer, LocalServerContainerConfig, LocalServerCon
 /// Block and mining into a wallet for a bit
 #[test]
 fn basic_genesis_mine() {
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "genesis_mine";
 	framework::clean_all_output(test_name_dir);
@@ -80,7 +80,7 @@ fn basic_genesis_mine() {
 /// messages they all end up connected.
 #[test]
 fn simulate_seeding() {
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "simulate_seeding";
 	framework::clean_all_output(test_name_dir);
@@ -133,7 +133,7 @@ fn simulate_seeding() {
 //#[test]
 #[allow(dead_code)]
 fn simulate_parallel_mining() {
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "simulate_parallel_mining";
 	// framework::clean_all_output(test_name_dir);
@@ -187,7 +187,7 @@ fn simulate_parallel_mining() {
 #[test]
 fn a_simulate_block_propagation() {
 	util::init_test_logger();
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-prop";
 	framework::clean_all_output(test_name_dir);
@@ -246,7 +246,7 @@ fn a_simulate_block_propagation() {
 #[test]
 fn simulate_full_sync() {
 	util::init_test_logger();
-	global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-sync";
 	framework::clean_all_output(test_name_dir);

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -608,7 +608,7 @@ mod tests {
 	use keychain::Keychain;
 	use std::sync::{Arc, RwLock};
 	use blake2;
-	use core::global::MiningParameterMode;
+	use core::global::ChainTypes;
 	use core::core::SwitchCommitHash;
 
 	macro_rules! expect_output_parent {
@@ -795,7 +795,7 @@ mod tests {
 
 	#[test]
 	fn test_immature_coinbase() {
-		global::set_mining_mode(MiningParameterMode::AutomatedTesting);
+		global::set_mining_mode(ChainTypes::AutomatedTesting);
 		let mut dummy_chain = DummyChainImpl::new();
 		let coinbase_output = test_coinbase_output(15);
 		dummy_chain.update_utxo_set(DummyUtxoSet::empty().with_output(coinbase_output));

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -57,7 +57,7 @@ fn start_from_config_file(mut global_config: GlobalConfig) {
 			.unwrap()
 			.server
 			.clone()
-			.mining_parameter_mode
+			.chain_type
 			.unwrap(),
 	);
 
@@ -102,7 +102,7 @@ fn main() {
 				.unwrap()
 				.server
 				.clone()
-				.mining_parameter_mode
+				.chain_type
 				.unwrap(),
 		);
 	} else {


### PR DESCRIPTION
Renamed mining parameter mode to chain type, with existing types
of CI testing, user testing, testnet1 or mainnet. The public
chains (testnet1 and mainnet) come with their fully pre-defined
genesis block.

Still need to set the nonce and cycle for testnet1 genesis.