### PR TITLE
bad case of trying to rewind to block header height 0

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -237,8 +237,6 @@ fn validate_block(
 			}
 		}
 
-		// rewind the sum trees up to the forking block, providing the height of the
-		// forked block and the last commitment we want to rewind to
 		let forked_block = ctx.store.get_block(&current)?;
 
 		debug!(
@@ -248,13 +246,8 @@ fn validate_block(
 			forked_block.header.height,
 		);
 
-		if forked_block.header.height > 0 {
-			let last_output = &forked_block.outputs.last().unwrap();
-			let last_kernel = &forked_block.kernels.last().unwrap();
-			ext.rewind(forked_block.header.height, last_output, last_kernel)?;
-		} else {
-			ext.rewind_to_genesis()?;
-		}
+		// rewind the sum trees up to the forking block
+		ext.rewind(&forked_block)?;
 
 		// apply all forked blocks, including this new one
 		for h in hashes {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -249,13 +249,11 @@ fn validate_block(
 		);
 
 		if forked_block.header.height > 0 {
-			let last_output = &forked_block.outputs[forked_block.outputs.len() - 1];
-			let last_kernel = &forked_block.kernels[forked_block.kernels.len() - 1];
+			let last_output = &forked_block.outputs.last().unwrap();
+			let last_kernel = &forked_block.kernels.last().unwrap();
 			ext.rewind(forked_block.header.height, last_output, last_kernel)?;
 		} else {
-			// TODO - what needs to happen here?
-			// here we need to rewind all the way to the genesis block - is this possible?
-			// there is no last_output and no last_kernel
+			ext.rewind_to_genesis()?;
 		}
 
 		// apply all forked blocks, including this new one

--- a/chain/src/sumtree.rs
+++ b/chain/src/sumtree.rs
@@ -295,13 +295,44 @@ impl<'a> Extension<'a> {
 		Ok(())
 	}
 
+	pub fn rewind_to_genesis(&mut self) -> Result<(), Error> {
+		debug!(
+			LOGGER,
+			"Rewind sumtrees to genesis (hold onto your wizard hat)",
+		);
+
+		self.output_pmmr
+			.rewind(0, 0)
+			.map_err(&Error::SumTreeErr)?;
+		self.rproof_pmmr
+			.rewind(0, 0)
+			.map_err(&Error::SumTreeErr)?;
+		self.kernel_pmmr
+			.rewind(0, 0)
+			.map_err(&Error::SumTreeErr)?;
+
+		self.dump(true);
+		Ok(())
+	}
+
 	/// Rewinds the MMRs to the provided position, given the last output and
 	/// last kernel of the block we want to rewind to.
 	pub fn rewind(&mut self, height: u64, output: &Output, kernel: &TxKernel) -> Result<(), Error> {
+		debug!(
+			LOGGER,
+			"Rewind sumtrees to height: {}",
+			height,
+		);
+
 		let out_pos_rew = self.commit_index.get_output_pos(&output.commitment())?;
 		let kern_pos_rew = self.commit_index.get_kernel_pos(&kernel.excess)?;
 
-		debug!(LOGGER, "Rewind sumtrees to {}", out_pos_rew);
+		debug!(
+			LOGGER,
+			"Rewind sumtrees to output pos: {}, kernel pos: {}",
+			out_pos_rew,
+			kern_pos_rew,
+		);
 		self.output_pmmr
 			.rewind(out_pos_rew, height as u32)
 			.map_err(&Error::SumTreeErr)?;
@@ -311,6 +342,7 @@ impl<'a> Extension<'a> {
 		self.kernel_pmmr
 			.rewind(kern_pos_rew, height as u32)
 			.map_err(&Error::SumTreeErr)?;
+
 		self.dump(true);
 		Ok(())
 	}

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -167,8 +167,8 @@ impl NetAdapter for NetToChainAdapter {
 
 		debug!(
 			LOGGER,
-			"locate_headers: {:?}",
-			header,
+			"locate_headers: common header: {:?}",
+			header.hash(),
 		);
 
 		// looks like we know one, getting as many following headers as allowed

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -288,7 +288,7 @@ impl Syncer {
 			.collect::<Vec<_>>();
 		heights.append(&mut tail);
 
-		// Include the genesis block (height 0) here as a fallback to guarentee
+		// Include the genesis block (height 0) here as a fallback to guarantee
 		// both nodes share at least one common header hash in the locator
 		heights.push(0);
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -247,10 +247,9 @@ impl Syncer {
 		if let Some(p) = peer {
 			debug!(
 				LOGGER,
-				"Asking peer {} for more block headers starting from {} at {}.",
+				"Asking peer {} for more block headers, locator: {:?}",
 				p.info.addr,
-				tip.last_block_h,
-				tip.height
+				locator,
 			);
 			p.send_header_request(locator)?;
 		} else {
@@ -277,7 +276,7 @@ impl Syncer {
 	/// us the right block headers.
 	fn get_locator(&self, tip: &chain::Tip) -> Result<Vec<Hash>, Error> {
 		// Prepare the heights we want as the latests height minus increasing powers
-  // of 2 up to max.
+		// of 2 up to max.
 		let mut heights = vec![tip.height];
 		let mut tail = (1..p2p::MAX_LOCATORS)
 			.map(|n| 2u64.pow(n))
@@ -288,10 +287,15 @@ impl Syncer {
 			})
 			.collect::<Vec<_>>();
 		heights.append(&mut tail);
+
+		// Include the genesis block (height 0) here as a fallback to guarentee
+		// both nodes share at least one common header hash in the locator
+		heights.push(0);
+
 		debug!(LOGGER, "Loc heights: {:?}", heights);
 
 		// Iteratively travel the header chain back from our head and retain the
-  // headers at the wanted heights.
+		// headers at the wanted heights.
 		let mut header = self.chain.get_block_header(&tip.last_block_h)?;
 		let mut locator = vec![];
 		while heights.len() > 0 {


### PR DESCRIPTION
* Always include height 0 (genesis) in the locator (to guarantee at least one header hash in common between the nodes)
* `ext.rewind` now takes a block (so we can handle it being empty if necessary)


To reproduce the issue - 
1) mine two completely independent chains 
    * clear out .grin dirs for miner1 and miner2
    * run miner1 for a couple of blocks
    * stop miner1
    * run miner2 for a couple of blocks
2) then try and sync them up (start them both up, may need to restart one with less total work)

See related - #264
