### PR TITLE
Daemonize server with proper working directory.

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -34,6 +34,7 @@ use std::thread;
 use std::io::Read;
 use std::fs::File;
 use std::time::Duration;
+use std::env::current_dir;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use daemonize::Daemonize;
@@ -333,6 +334,7 @@ fn server_command(server_args: &ArgMatches, global_config: GlobalConfig) {
 			let daemonize = Daemonize::new()
 				.pid_file("/tmp/grin.pid")
 				.chown_pid_file(true)
+				.working_directory(current_dir().unwrap())
 				.privileged_action(move || {
 					grin::Server::start(server_config.clone()).unwrap();
 					loop {


### PR DESCRIPTION
Resolves #282.

`daemonize`'s default working directory for daemons that it spawns is the full path `/`<sup>[1](#footnote1)</sup>, rendering the daemonized server unable to write to the `.grin` relative path as it would be resolved to the full path `/.grin` (which is usually not writeable).

<a name="footnote1">1</a>: https://github.com/knsd/daemonize/blob/0.2.3/src/lib.rs#L228