### PR TITLE
Added --release flag to build documentation.

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -38,7 +38,7 @@ In order to compile and run Grin on your machine, you should have installed:
     cd grin
     #if running a testnet1 node, check out the correct branch:
     git checkout milestone/testnet1 
-    cargo build
+    cargo build --release
 ```
 
 ### Cuckoo-Miner considerations


### PR DESCRIPTION
The `--release` build creates significanltly faster binaries, which is
what probably most people want.