### PR TITLE
don't update local wallet status until 200 returned from receiver

### DIFF
--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -74,6 +74,7 @@ fn single_send_partial_tx(url: &str, partial_tx: &PartialTx) -> Result<(), Error
 			info!(LOGGER, "Transaction sent successfully");
 		} else {
 			error!(LOGGER, "Error sending transaction - status: {}", res.status());
+			return Err(hyper::Error::Status);
 		}
 		Ok(())
 	})?;


### PR DESCRIPTION
Quick and dirty fix for testnet, it's not elegant )returning all the values required to update the wallet.dat in a massive tuple), but this entire section needs rework anyhow, so I don't think there's any harm.

This obviously doesn't fix the issue permanently, as we need to handle cases where it's received but the receiver decides not to do anything with it, but it should make testnet1 a lot more usable for the time being.