### PR TITLE
less chatty Testnet1 outputs

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -53,7 +53,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 
 	info!(
 		LOGGER,
-		"Starting validation pipeline for block {} at {} with {} inputs and {} outputs.",
+		"Processing block {} at {} with {} inputs and {} outputs.",
 		b.hash(),
 		b.header.height,
 		b.inputs.len(),
@@ -96,7 +96,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
 	info!(
 		LOGGER,
-		"Starting validation pipeline for block header {} at {}.",
+		"Processing header {} at {}.",
 		bh.hash(),
 		bh.height
 	);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -51,7 +51,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 	// TODO should just take a promise for a block with a full header so we don't
  // spend resources reading the full block when its header is invalid
 
-	info!(
+	debug!(
 		LOGGER,
 		"Processing block {} at {} with {} inputs and {} outputs.",
 		b.hash(),
@@ -94,7 +94,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 
 /// Process the block header
 pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
-	info!(
+	debug!(
 		LOGGER,
 		"Processing header {} at {}.",
 		bh.hash(),

--- a/grin.toml
+++ b/grin.toml
@@ -63,7 +63,7 @@ port = 13414
 log_to_stdout = true
 
 # Log level for stdout: Critical, Error, Warning, Info, Debug, Trace
-stdout_log_level = "Debug"
+stdout_log_level = "Warning"
 
 # Whether to log to a file
 log_to_file = true

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -57,12 +57,9 @@ impl NetAdapter for NetToChainAdapter {
 			source.identifier,
 		);
 
+		let h = tx.hash();
 		if let Err(e) = self.tx_pool.write().unwrap().add_to_memory_pool(source, tx) {
-			if e.kind() == PoolError::AlreadyInPool {
-				info!(LOGGER, "Transaction rejected: {:?}", e);
-			} else {
-				error!(LOGGER, "Transaction rejected: {:?}", e);
-			}
+			debug!(LOGGER, "Transaction {} rejected: {:?}", h, e);
 		}
 	}
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -58,7 +58,11 @@ impl NetAdapter for NetToChainAdapter {
 		);
 
 		if let Err(e) = self.tx_pool.write().unwrap().add_to_memory_pool(source, tx) {
-			error!(LOGGER, "Transaction rejected: {:?}", e);
+			if e.kind() == PoolError::AlreadyInPool {
+				info!(LOGGER, "Transaction rejected: {:?}", e);
+			} else {
+				error!(LOGGER, "Transaction rejected: {:?}", e);
+			}
 		}
 	}
 


### PR DESCRIPTION
Aimed at #281

- "Starting validation pipeline for " -> "Processing "
- stdout logging default = Warning
- ERR -> INFO for "Transaction rejected: Already in pool" -- only for netadapter transaction_received, which (hopefully!) only gets tx from peers, and lots of those will be duplicates, that's good and not an error.