### PR TITLE
compare genesis during peering handshake

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -44,10 +44,7 @@ fn setup(dir_name: &str) -> Chain {
 	let _ = env_logger::init();
 	clean_output_dir(dir_name);
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
-	let mut genesis_block = None;
-	if !chain::Chain::chain_exists(dir_name.to_string()) {
-		genesis_block = pow::mine_genesis_block(None);
-	}
+	let genesis_block = pow::mine_genesis_block(None).unwrap();
 	chain::Chain::init(
 		dir_name.to_string(),
 		Arc::new(NoopAdapter {}),

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -44,10 +44,8 @@ fn test_coinbase_maturity() {
 	clean_output_dir(".grin");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
-	let mut genesis_block = None;
-	if !chain::Chain::chain_exists(".grin".to_string()) {
-		genesis_block = pow::mine_genesis_block(None);
-	}
+	let genesis_block = pow::mine_genesis_block(None).unwrap();
+
 	let chain = chain::Chain::init(
 		".grin".to_string(),
 		Arc::new(NoopAdapter {}),

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -36,6 +36,7 @@ pub enum Error {
 	API(api::Error),
 	/// Error originating from wallet API.
 	Wallet(wallet::Error),
+	Cuckoo(pow::cuckoo::Error),
 }
 
 impl From<chain::Error> for Error {
@@ -47,6 +48,12 @@ impl From<chain::Error> for Error {
 impl From<p2p::Error> for Error {
 	fn from(e: p2p::Error) -> Error {
 		Error::P2P(e)
+	}
+}
+
+impl From<pow::cuckoo::Error> for Error {
+	fn from(e: pow::cuckoo::Error) -> Error {
+		Error::Cuckoo(e)
 	}
 }
 

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -107,6 +107,7 @@ impl Handshake {
 						};
 
 						info!(LOGGER, "Connected to peer {:?}", peer_info);
+
 						// when more than one protocol version is supported, choosing should go here
 						Ok((conn, ProtocolV1::new(), peer_info))
 					}
@@ -166,7 +167,7 @@ impl Handshake {
 				.and_then(|(conn, shake, peer_info)| {
 					debug!(LOGGER, "Success handshake with {}.", peer_info.addr);
 					write_msg(conn, shake, Type::Shake)
-				  // when more than one protocol version is supported, choosing should go here
+					// when more than one protocol version is supported, choosing should go here
 					.map(|conn| (conn, ProtocolV1::new(), peer_info))
 				}),
 		)

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -131,7 +131,7 @@ pub struct MsgHeader {
 	magic: [u8; 2],
 	/// Type of the message.
 	pub msg_type: Type,
-	/// Tota length of the message in bytes.
+	/// Total length of the message in bytes.
 	pub msg_len: u64,
 }
 
@@ -210,24 +210,25 @@ impl Writeable for Hand {
 			[write_u32, self.capabilities.bits()],
 			[write_u64, self.nonce]
 		);
-		self.genesis.write(writer).unwrap();
 		self.total_difficulty.write(writer).unwrap();
 		self.sender_addr.write(writer).unwrap();
 		self.receiver_addr.write(writer).unwrap();
-		writer.write_bytes(&self.user_agent)
+		writer.write_bytes(&self.user_agent).unwrap();
+		self.genesis.write(writer).unwrap();
+		Ok(())
 	}
 }
 
 impl Readable for Hand {
 	fn read(reader: &mut Reader) -> Result<Hand, ser::Error> {
 		let (version, capab, nonce) = ser_multiread!(reader, read_u32, read_u32, read_u64);
-		let genesis = try!(Hash::read(reader));
+		let capabilities = try!(Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData,));
 		let total_diff = try!(Difficulty::read(reader));
 		let sender_addr = try!(SockAddr::read(reader));
 		let receiver_addr = try!(SockAddr::read(reader));
 		let ua = try!(reader.read_vec());
 		let user_agent = try!(String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData));
-		let capabilities = try!(Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData,));
+		let genesis = try!(Hash::read(reader));
 		Ok(Hand {
 			version: version,
 			capabilities: capabilities,
@@ -264,9 +265,9 @@ impl Writeable for Shake {
 			[write_u32, self.version],
 			[write_u32, self.capabilities.bits()]
 		);
-		self.genesis.write(writer).unwrap();
 		self.total_difficulty.write(writer).unwrap();
 		writer.write_bytes(&self.user_agent).unwrap();
+		self.genesis.write(writer).unwrap();
 		Ok(())
 	}
 }
@@ -274,11 +275,11 @@ impl Writeable for Shake {
 impl Readable for Shake {
 	fn read(reader: &mut Reader) -> Result<Shake, ser::Error> {
 		let (version, capab) = ser_multiread!(reader, read_u32, read_u32);
-		let genesis = try!(Hash::read(reader));
+		let capabilities = try!(Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData,));
 		let total_diff = try!(Difficulty::read(reader));
 		let ua = try!(reader.read_vec());
 		let user_agent = try!(String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData));
-		let capabilities = try!(Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData,));
+		let genesis = try!(Hash::read(reader));
 		Ok(Shake {
 			version: version,
 			capabilities: capabilities,

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -169,8 +169,6 @@ impl Server {
 		let capab = self.capabilities.clone();
 		let self_addr = SocketAddr::new(self.config.host, self.config.port);
 
-		debug!(LOGGER, "{} connecting to {}", self_addr, addr);
-
 		let socket = TcpStream::connect(&addr, &h).map_err(|e| Error::Connection(e));
 		let h2 = h.clone();
 		let request = socket

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -76,12 +76,17 @@ unsafe impl Send for Server {}
 // TODO TLS
 impl Server {
 	/// Creates a new idle p2p server with no peers
-	pub fn new(capab: Capabilities, config: P2PConfig, adapter: Arc<NetAdapter>) -> Server {
+	pub fn new(
+		capab: Capabilities,
+		config: P2PConfig,
+		adapter: Arc<NetAdapter>,
+		genesis: Hash,
+	) -> Server {
 		Server {
 			config: config,
 			capabilities: capab,
 			peers: Arc::new(RwLock::new(HashMap::new())),
-			handshake: Arc::new(Handshake::new()),
+			handshake: Arc::new(Handshake::new(genesis)),
 			adapter: adapter,
 			stop: RefCell::new(None),
 		}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -45,6 +45,7 @@ pub enum Error {
 	Connection(io::Error),
 	ConnectionClose,
 	Timeout,
+	PeerWithSelf,
 }
 
 impl From<ser::Error> for Error {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -46,6 +46,14 @@ pub enum Error {
 	ConnectionClose,
 	Timeout,
 	PeerWithSelf,
+	ProtocolMismatch {
+		us: u32,
+		peer: u32,
+	},
+	GenesisMismatch {
+		us: Hash,
+		peer: Hash,
+	},
 }
 
 impl From<ser::Error> for Error {

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -26,6 +26,7 @@ use tokio_core::net::TcpStream;
 use tokio_core::reactor::{self, Core};
 
 use core::core::target::Difficulty;
+use core::core::hash::Hash;
 use p2p::Peer;
 
 // Starts a server and connects a client peer to it to check handshake,
@@ -36,7 +37,12 @@ fn peer_handshake() {
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
 	let net_adapter = Arc::new(p2p::DummyAdapter {});
-	let server = p2p::Server::new(p2p::UNKNOWN, p2p_conf, net_adapter.clone());
+	let server = p2p::Server::new(
+		p2p::UNKNOWN,
+		p2p_conf,
+		net_adapter.clone(),
+		Hash::from_vec(vec![]),
+	);
 	let run_server = server.start(handle.clone());
 	let my_addr = "127.0.0.1:5000".parse().unwrap();
 
@@ -59,7 +65,7 @@ fn peer_handshake() {
 							p2p::UNKNOWN,
 							Difficulty::one(),
 							my_addr,
-							Arc::new(p2p::handshake::Handshake::new()),
+							Arc::new(p2p::handshake::Handshake::new(Hash::from_vec(vec![]))),
 							net_adapter.clone(),
 						)
 					})

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -95,8 +95,9 @@ pub fn pow20<T: MiningWorker>(
 
 /// Mines a genesis block, using the config specified miner if specified.
 /// Otherwise, uses the internal miner
-pub fn mine_genesis_block(miner_config: Option<types::MinerConfig>) -> Option<core::core::Block> {
-	info!(util::LOGGER, "Genesis block not found, initializing...");
+pub fn mine_genesis_block(
+	miner_config: Option<types::MinerConfig>,
+) -> Result<core::core::Block, Error> {
 	let mut gen = genesis::genesis_dev();
 	let diff = gen.header.difficulty.clone();
 
@@ -114,7 +115,7 @@ pub fn mine_genesis_block(miner_config: Option<types::MinerConfig>) -> Option<co
 		None => Box::new(cuckoo::Miner::new(consensus::EASINESS, sz, proof_size)),
 	};
 	pow_size(&mut *miner, &mut gen.header, diff, sz as u32).unwrap();
-	Some(gen)
+	Ok(gen)
 }
 
 /// Runs a proof of work computation over the provided block using the provided


### PR DESCRIPTION
- [x] make sure we have genesis when setting up the handshake
- [x] pass genesis in `hand ->`
- [x] pass genesis in `shake <-`
- [x] check genesis for mismatch and `Defunct` the peer
- [x] test this is "backward compatible" by not breaking existing nodes (handshake ser/deser changed)

This will split the network - see comment below.
"old" and "new" nodes will not peer successfully with each other.

