### PR TITLE
[CONSENSUS] Limit number of inputs in a block #261

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -87,7 +87,7 @@ pub const MAX_BLOCK_WEIGHT: usize = 80_000;
 
 /// Maximum inputs for a block (issue#261)
 /// Hundreds of inputs + 1 output might be slow to validate (issue#258)
-pub const MAX_BLOCK_INPUTS: usize = 40_000; // soft fork down when too_high
+pub const MAX_BLOCK_INPUTS: usize = 300_000; // soft fork down when too_high
 
 /// Whether a block exceeds the maximum acceptable weight
 pub fn exceeds_weight(input_len: usize, output_len: usize, kernel_len: usize) -> bool {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -85,10 +85,15 @@ pub const BLOCK_KERNEL_WEIGHT: usize = 2;
 /// Total maximum block weight
 pub const MAX_BLOCK_WEIGHT: usize = 80_000;
 
+/// Maximum inputs for a block (issue#261)
+/// Hundreds of inputs + 1 output might be slow to validate (issue#258)
+pub const MAX_BLOCK_INPUTS: usize = 40_000; // soft fork down when too_high
+
 /// Whether a block exceeds the maximum acceptable weight
 pub fn exceeds_weight(input_len: usize, output_len: usize, kernel_len: usize) -> bool {
 	input_len * BLOCK_INPUT_WEIGHT + output_len * BLOCK_OUTPUT_WEIGHT
 		+ kernel_len * BLOCK_KERNEL_WEIGHT > MAX_BLOCK_WEIGHT
+		|| input_len > MAX_BLOCK_INPUTS
 }
 
 /// Fork every 250,000 blocks for first 2 years, simple number and just a

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -346,7 +346,6 @@ impl Transaction {
 	/// Validates all relevant parts of a fully built transaction. Checks the
 	/// excess value against the signature as well as range proofs for each
 	/// output.
-	// TODO: this is Consensus critical code. Move to consensus.rs ?
 	pub fn validate(&self) -> Result<Commitment, Error> {
 		if self.fee & 1 != 0 {
 			return Err(Error::OddFee);


### PR DESCRIPTION
Add a consensus rule to limit about of inputs in a block (and also for each individual transaction, so we don't create a transaction that is invalid to ever be in a block!)

consensus::MAX_BLOCK_INPUTS.

Actual number should start out too high, since it can be softforked down but not up. Highest possible would be MAX_BLOCK_WEIGHT / BLOCK_INPUT_WEIGHT I guess? Ignoring the weight of a single output.

- Q: Can a "crafty" miner make a 40000 inputs transaction with a single kernel and a single output, or are there other consensus rules that could block that?