### PR TITLE
Wallet Restore feature

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -25,6 +25,7 @@ use serde_json;
 
 use chain;
 use core::core::Transaction;
+use core::core::hash::Hashed;
 use core::ser;
 use pool;
 use p2p;
@@ -36,8 +37,9 @@ use util::LOGGER;
 
 
 // Supports retrieval of multiple outputs in a single request -
-// GET /v1/chain/utxos?id=xxx,yyy,zzz
-// GET /v1/chain/utxos?id=xxx&id=yyy&id=zzz
+// GET /v1/chain/utxos/byids?id=xxx,yyy,zzz
+// GET /v1/chain/utxos/byids?id=xxx&id=yyy&id=zzz
+// GET /v1/chain/utxos/byheight?height=n
 struct UtxoHandler {
 	chain: Arc<chain::Chain>,
 }
@@ -60,10 +62,8 @@ impl UtxoHandler {
 
 		Ok(Output::from_output(&out, &header, false))
 	}
-}
 
-impl Handler for UtxoHandler {
-	fn handle(&self, req: &mut Request) -> IronResult<Response> {
+	fn utxos_by_ids(&self, req: &mut Request)->Vec<Output> {
 		let mut commitments: Vec<&str> = vec![];
 		if let Ok(params) = req.get_ref::<UrlEncodedQuery>() {
 			if let Some(ids) = params.get("id") {
@@ -74,14 +74,64 @@ impl Handler for UtxoHandler {
 				}
 			}
 		}
-
 		let mut utxos: Vec<Output> = vec![];
 		for commit in commitments {
 			if let Ok(out) = self.get_utxo(commit) {
 				utxos.push(out);
 			}
 		}
-		json_response(&utxos)
+		utxos
+	}
+
+	fn utxos_at_height(&self, block_height: u64)->BlockOutputs{
+		let header=self.chain.clone().get_header_by_height(block_height).unwrap();
+		let block=self.chain.clone().get_block(&header.hash()).unwrap();
+		let outputs=block.outputs
+			.iter()
+			.map(|k| OutputSwitch::from_output(k, &header))
+			.collect();
+		BlockOutputs{
+			header : BlockHeaderInfo::from_header(&header),
+			outputs: outputs
+		}
+	}
+
+	//returns utxos for a specified range of blocks
+	fn utxo_block_batch(&self, req: &mut Request) -> Vec<BlockOutputs> {
+		let mut start_height = 1;
+		let mut end_height = 1;
+		if let Ok(params) = req.get_ref::<UrlEncodedQuery>() {
+			if let Some(heights) = params.get("start_height") {
+				for height in heights {
+					start_height=height.parse().unwrap();
+				}
+			}
+			if let Some(heights) = params.get("end_height") {
+				for height in heights {
+					end_height=height.parse().unwrap();
+				}
+			}
+		}
+		let mut return_vec = vec![];
+		for i in start_height..end_height+1 {
+			return_vec.push(self.utxos_at_height(i));
+		}
+		return_vec
+	}
+}
+
+impl Handler for UtxoHandler {
+	fn handle(&self, req: &mut Request) -> IronResult<Response> {
+		let url = req.url.clone();
+		let mut path_elems = url.path();
+		if *path_elems.last().unwrap() == "" {
+			path_elems.pop();
+		}
+	match *path_elems.last().unwrap() {
+			"byids" => json_response(&self.utxos_by_ids(req)),
+			"atheight" => json_response(&self.utxo_block_batch(req)),
+			_ => Ok(Response::with((status::BadRequest, ""))),
+		}
 	}
 }
 
@@ -319,7 +369,7 @@ pub fn start_rest_apis<T>(
 
 		let router = router!(
 			chain_tip: get "/chain" => chain_tip_handler,
-			chain_utxos: get "/chain/utxos" => utxo_handler,
+			chain_utxos: get "/chain/utxos/*" => utxo_handler,
 			sumtree_roots: get "/sumtrees/*" => sumtree_handler,
 			pool_info: get "/pool" => pool_info_handler,
 			pool_push: post "/pool/push" => pool_push_handler,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -225,7 +225,7 @@ pub struct OutputSwitch {
 	/// the commit 
 	pub commit: String,
 	/// switch commit hash
-	pub switch_commit_hash: String,
+	pub switch_commit_hash: [u8; core::SWITCH_COMMIT_HASH_SIZE],
 	/// The height of the block creating this output
 	pub height: u64,
 }
@@ -234,7 +234,7 @@ impl OutputSwitch {
 	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader) -> OutputSwitch {
 		OutputSwitch {
 			commit: util::to_hex(output.commit.0.to_vec()),
-			switch_commit_hash: util::to_hex(output.switch_commit_hash.hash.to_vec()),
+			switch_commit_hash: output.switch_commit_hash.hash,
 			height: block_header.height,
 		}
 	}

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -138,8 +138,7 @@ pub struct Output {
 	/// The homomorphic commitment representing the output's amount
 	pub commit: pedersen::Commitment,
 	/// switch commit hash
-	//leave out for now, to optimise wallet info time
-	//pub switch_commit_hash: core::SwitchCommitHash,
+	pub switch_commit_hash: Option<core::SwitchCommitHash>,
 	/// A proof that the commitment is in the right range
 	pub proof: Option<pedersen::RangeProof>,
 	/// The height of the block creating this output
@@ -149,7 +148,8 @@ pub struct Output {
 }
 
 impl Output {
-	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader, include_proof:bool) -> Output {
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader, 
+		include_proof:bool, include_switch: bool) -> Output {
 		let (output_type, lock_height) = match output.features {
 			x if x.contains(core::transaction::COINBASE_OUTPUT) => (
 				OutputType::Coinbase,
@@ -161,7 +161,10 @@ impl Output {
 		Output {
 			output_type: output_type,
 			commit: output.commit,
-			//switch_commit_hash: output.switch_commit_hash,
+			switch_commit_hash: match include_switch {
+				true => Some(output.switch_commit_hash),
+				false => None,
+			},
 			proof: match include_proof {
 				true => Some(output.proof),
 				false => None,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -88,7 +88,7 @@ impl SumTreeNode {
 				.get_block_header_by_output_commit(&elem_output.1.commit)
 				.map_err(|_| Error::NotFound);
 			// Need to call further method to check if output is spent
-			let mut output = OutputPrintable::from_output(&elem_output.1, &header.unwrap());
+			let mut output = OutputPrintable::from_output(&elem_output.1, &header.unwrap(),true);
 			if let Ok(_) = chain.get_unspent(&elem_output.1.commit) {
 				output.spent = false;
 			}
@@ -137,6 +137,9 @@ pub struct Output {
 	pub output_type: OutputType,
 	/// The homomorphic commitment representing the output's amount
 	pub commit: pedersen::Commitment,
+	/// switch commit hash
+	//leave out for now, to optimise wallet info time
+	//pub switch_commit_hash: core::SwitchCommitHash,
 	/// A proof that the commitment is in the right range
 	pub proof: Option<pedersen::RangeProof>,
 	/// The height of the block creating this output
@@ -158,6 +161,7 @@ impl Output {
 		Output {
 			output_type: output_type,
 			commit: output.commit,
+			//switch_commit_hash: output.switch_commit_hash,
 			proof: match include_proof {
 				true => Some(output.proof),
 				false => None,
@@ -176,6 +180,8 @@ pub struct OutputPrintable {
 	/// The homomorphic commitment representing the output's amount (as hex
 	/// string)
 	pub commit: String,
+	/// switch commit hash
+	pub switch_commit_hash: String,
 	/// The height of the block creating this output
 	pub height: u64,
 	/// The lock height (earliest block this output can be spent)
@@ -183,11 +189,11 @@ pub struct OutputPrintable {
 	/// Whether the output has been spent
 	pub spent: bool,
 	/// Rangeproof hash  (as hex string)
-	pub proof_hash: String,
+	pub proof_hash: Option<String>,
 }
 
 impl OutputPrintable {
-	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader) -> OutputPrintable {
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader, include_proof_hash:bool) -> OutputPrintable {
 		let (output_type, lock_height) = match output.features {
 			x if x.contains(core::transaction::COINBASE_OUTPUT) => (
 				OutputType::Coinbase,
@@ -198,12 +204,66 @@ impl OutputPrintable {
 		OutputPrintable {
 			output_type: output_type,
 			commit: util::to_hex(output.commit.0.to_vec()),
+			switch_commit_hash: util::to_hex(output.switch_commit_hash.hash.to_vec()),
 			height: block_header.height,
 			lock_height: lock_height,
 			spent: true,
-			proof_hash: util::to_hex(output.proof.hash().to_vec()),
+			proof_hash: match include_proof_hash {
+				true => Some(util::to_hex(output.proof.hash().to_vec())),
+				false => None,
+			}
 		}
 	}
+}
+
+// As above, except just the info needed for wallet reconstruction
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OutputSwitch {
+	/// the commit 
+	pub commit: String,
+	/// switch commit hash
+	pub switch_commit_hash: String,
+	/// The height of the block creating this output
+	pub height: u64,
+}
+
+impl OutputSwitch {
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader) -> OutputSwitch {
+		OutputSwitch {
+			commit: util::to_hex(output.commit.0.to_vec()),
+			switch_commit_hash: util::to_hex(output.switch_commit_hash.hash.to_vec()),
+			height: block_header.height,
+		}
+	}
+}
+// Just the information required for wallet reconstruction
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockHeaderInfo {
+	/// Hash
+	pub hash: String,
+	/// Previous block hash
+	pub previous: String,
+	/// Height
+	pub height: u64
+}
+
+impl BlockHeaderInfo {
+	pub fn from_header(block_header: &core::BlockHeader) -> BlockHeaderInfo{
+		BlockHeaderInfo {
+			hash: util::to_hex(block_header.hash().to_vec()),
+			previous: util::to_hex(block_header.previous.to_vec()),
+			height: block_header.height,
+		}
+	}
+}
+// For wallet reconstruction, include the header info along with the
+// transactions in the block
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockOutputs {
+	/// The block header
+	pub header: BlockHeaderInfo,
+	/// A printable version of the outputs
+	pub outputs: Vec<OutputSwitch>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -401,7 +401,8 @@ bitflags! {
 /// Definition of the switch commitment hash
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SwitchCommitHash {
-	hash: [u8; SWITCH_COMMIT_HASH_SIZE],
+	/// simple hash
+	pub hash: [u8; SWITCH_COMMIT_HASH_SIZE],
 }
 
 /// Implementation of Writeable for a switch commitment hash

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -172,6 +172,14 @@ impl Keychain {
 		Ok(commit)
 	}
 
+	pub fn switch_commit_from_index(&self, index:u32) -> Result<Commitment, Error> {
+		//just do this directly, because cache seems really slow for wallet reconstruct
+		let skey = self.extkey.derive(&self.secp, index)?;
+		let skey = skey.key;
+		let commit = self.secp.switch_commit(skey)?;
+		Ok(commit)
+	}
+
 	pub fn range_proof(
 		&self,
 		amount: u64,

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -247,7 +247,10 @@ fn main() {
 			.about("basic wallet contents summary"))
 
 		.subcommand(SubCommand::with_name("init")
-			.about("Initialize a new wallet seed file.")))
+			.about("Initialize a new wallet seed file."))
+
+		.subcommand(SubCommand::with_name("restore")
+			.about("Attempt to restore wallet contents from the chain using seed and password.")))
 
 	.get_matches();
 
@@ -465,6 +468,9 @@ fn wallet_command(wallet_args: &ArgMatches) {
 		}
 		("outputs", Some(_)) => {
 			wallet::show_outputs(&wallet_config, &keychain, show_spent);
+		}
+		("restore", Some(_)) => {
+			wallet::restore(&wallet_config, &keychain);
 		}
 		_ => panic!("Unknown wallet command, use 'grin help wallet' for details"),
 	}

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -188,7 +188,14 @@ fn main() {
 			.long("api_server_address")
 			.help("Api address of running node on which to check inputs and post transactions")
 			.takes_value(true))
-
+		.arg(Arg::with_name("key_derivations")
+				.help("The number of keys possiblities to search for each output. \
+				Ideally, set this to a number greater than the number of outputs \
+				you believe should belong to this seed/password. (Default 500)")
+				.short("k")
+				.long("key_derivations")
+				.default_value("1000")
+				.takes_value(true))
 		.subcommand(SubCommand::with_name("listen")
 			.about("Run the wallet in listening mode. If an input file is \
 				provided, will process it, otherwise runs in server mode waiting \
@@ -254,7 +261,7 @@ fn main() {
 
 		.subcommand(SubCommand::with_name("restore")
 			.about("Attempt to restore wallet contents from the chain using seed and password.")))
-
+			
 	.get_matches();
 
 	match args.subcommand() {
@@ -379,6 +386,11 @@ fn wallet_command(wallet_args: &ArgMatches) {
 		wallet_config.check_node_api_http_addr = sa.to_string().clone();
 	}
 
+	let mut key_derivations:u32=1000;
+	if let Some(kd) = wallet_args.value_of("key_derivations") {
+		key_derivations=kd.parse().unwrap();
+	}
+
 	let mut show_spent=false;
 	if wallet_args.is_present("show_spent") {
 		show_spent=true;
@@ -473,7 +485,7 @@ fn wallet_command(wallet_args: &ArgMatches) {
 			wallet::show_outputs(&wallet_config, &keychain, show_spent);
 		}
 		("restore", Some(_)) => {
-			let _=wallet::restore(&wallet_config, &keychain);
+			let _=wallet::restore(&wallet_config, &keychain, key_derivations);
 		}
 		("receive", Some(_)) => {
 			panic!("Command 'receive' is depreciated, use 'listen' instead");

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -84,7 +84,7 @@ pub fn refresh_outputs(config: &WalletConfig, keychain: &Keychain) -> Result<(),
 	let query_string = query_params.join("&");
 
 	let url = format!(
-		"{}/v1/chain/utxos?{}",
+		"{}/v1/chain/utxos/byids?{}",
 		config.check_node_api_http_addr,
 		query_string,
 	);

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -48,6 +48,7 @@ mod info;
 mod receiver;
 mod sender;
 mod types;
+mod restore;
 pub mod client;
 pub mod server;
 
@@ -56,3 +57,4 @@ pub use info::show_info;
 pub use receiver::{receive_json_tx, receive_json_tx_str, WalletReceiver};
 pub use sender::{issue_burn_tx, issue_send_tx};
 pub use types::{BlockFees, CbData, Error, WalletConfig, WalletReceiveRequest, WalletSeed};
+pub use restore::restore;

--- a/wallet/src/restore.rs
+++ b/wallet/src/restore.rs
@@ -1,0 +1,139 @@
+// Copyright 2017 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use keychain::{Keychain, Identifier};
+use util::{LOGGER, to_hex, from_hex};
+use util::secp::pedersen;
+use api;
+use core::core::SwitchCommitHash;
+use types::{WalletConfig, WalletData, OutputData, OutputStatus, Error};
+use byteorder::{BigEndian, ByteOrder};
+
+pub fn get_chain_height(config: &WalletConfig)->
+	Result<u64, Error>{
+	let url = format!(
+		"{}/v1/chain",
+		config.check_node_api_http_addr
+	);
+
+	match api::client::get::<api::Tip>(url.as_str()) {
+		Ok(tip) => {
+			Ok(tip.height)
+		},
+		Err(e) => {
+			// if we got anything other than 200 back from server, bye
+			error!(LOGGER, "Restore failed... unable to contact node: {}", e);
+			Err(Error::Node(e))
+		}
+	}
+}
+
+pub fn utxos_batch_block(config: &WalletConfig, start_height: u64, end_height:u64)->
+	Result<Vec<api::BlockOutputs>, Error>{
+	// build the necessary query param -
+	// ?height=x
+	let query_param= format!("start_height={}&end_height={}", start_height, end_height);
+
+	let url = format!(
+		"{}/v1/chain/utxos/atheight?{}",
+		config.check_node_api_http_addr,
+		query_param,
+	);
+
+	match api::client::get::<Vec<api::BlockOutputs>>(url.as_str()) {
+		Ok(outputs) => Ok(outputs),
+		Err(e) => {
+			// if we got anything other than 200 back from server, bye
+			error!(LOGGER, "Restore failed... unable to contact node: {}", e);
+			Err(Error::Node(e))
+		}
+	}
+}
+
+fn find_utxos_with_key(keychain: &Keychain,
+	block_outputs:api::BlockOutputs, key_iterations: u64) 
+	-> Vec<(pedersen::Commitment, Identifier, u32)> {
+	//let key_id = keychain.clone().root_key_id();
+	let mut wallet_outputs: Vec<(pedersen::Commitment, Identifier, u32)> = Vec::new();
+
+	info!(LOGGER, "Scanning block {}", block_outputs.header.height);
+	for output in block_outputs.outputs {
+		for i in 1..key_iterations+1 {
+			let key_id = keychain.derive_key_id(i as u32).unwrap();
+			let switch_commit = keychain.switch_commit(&key_id).unwrap();
+			let switch_commit_hash = SwitchCommitHash::from_switch_commit(switch_commit);
+			//println!("switch commit hash: {:?}", switch_commit_hash);
+			let compare_string=to_hex(switch_commit_hash.hash.to_vec());
+			if compare_string==output.switch_commit_hash {
+				info!(LOGGER, "Output found: {:?}", output.switch_commit_hash);
+				//add it to result set here
+				let commit = keychain.commit_with_key_index(BigEndian::read_u64(&from_hex(output.commit).unwrap()), i as u32).unwrap();
+				wallet_outputs.push((commit, key_id.clone(), i as u32));
+				break;
+			}
+		}
+	}
+	wallet_outputs
+}
+
+pub fn restore(config: &WalletConfig, keychain: &Keychain) ->
+	Result<(), Error>{
+	// Don't proceed if wallet.dat has anything in it
+	let is_empty = WalletData::read_wallet(&config.data_file_dir, |wallet_data| {
+		wallet_data.outputs.len() ==  0
+	})?;
+	if !is_empty {
+		error!(LOGGER, "Not restoring. Please back up and remove existing wallet.dat first.");
+		return Ok(())
+	}
+
+// Get height of chain from node (we'll check again when done)
+	let chain_height = get_chain_height(config)?;
+	debug!(LOGGER, "Restore: Chain height is {}", chain_height);
+
+	let mut batch_size=100;
+	let key_iterations=1000;
+	for h in 1..chain_height+1 {
+		if h % batch_size != 0 && h!=chain_height{
+			continue;
+		}
+		if h==chain_height {
+			batch_size=h%batch_size;
+		}
+		let blocks = utxos_batch_block(config, h-batch_size+1, h)?;
+		for block in blocks{
+			let result_vec=find_utxos_with_key(keychain, block, key_iterations);
+			if result_vec.len() > 0 {
+				for output in result_vec.clone() {
+					let _ = WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
+						let root_key_id = keychain.root_key_id();
+						debug!(LOGGER, "{:?}", result_vec);
+						//Just plonk it in for now, and refresh actual values via wallet info command later 
+						wallet_data.add_output(OutputData {
+							root_key_id: root_key_id.clone(),
+							key_id: output.1.clone(),
+							n_child: output.2,
+							value: 0,
+							status: OutputStatus::Unconfirmed,
+							height: 0,
+							lock_height: 0,
+							is_coinbase: false,
+						});
+					});
+				}
+			}
+		}
+	}
+	Ok(())
+}


### PR DESCRIPTION
This adds a wallet restore command, which works as follows:

grin wallet -p password -k [max_key_derivations] restore

The max key derivations should be a number a bit larger than the number of outputs you think you have in your wallet, or set larger if you no longer have the older wallet.bak file. The restore feature works a bit faster than I'd thought it would at this stage, so setting this to a relatively high number like 10000 is okay.. it'll just take a moment to build a potential switch commitment cache at the start, but then go through outputs from the entire chain in linear time.

Note the wallet utxo endpoints have changed, split into chain/utxos/byids and chain/utxos/byheight

First pass for now, so will contain issues, however it won't overwrite a wallet.dat file (it insists it be empty before starting), so should be non-descructive for now. It's restored all of my testnet wallets that had been corrupted through failed transactions earlier.

Will also submit similar PR for testnet1 branch.
