### PR TITLE
rollback the change output in the wallet on tx failure

### DIFF
--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -488,6 +488,11 @@ impl WalletData {
 		self.outputs.insert(out.key_id.to_hex(), out.clone());
 	}
 
+	// TODO - careful with this, only for Unconfirmed (maybe Locked)?
+	pub fn delete_output(&mut self, id: &keychain::Identifier) {
+		self.outputs.remove(&id.to_hex());
+	}
+
 	/// Lock an output data.
 	/// TODO - we should track identifier on these outputs (not just n_child)
 	pub fn lock_output(&mut self, out: &OutputData) {


### PR DESCRIPTION
If we attempt to send a tx but it fails on the receiving side - we want to remove our `Unconfirmed` change output.
Also took the opportunity to clean up the user output when sending tx - pulled this out into `grin.rs` as this is part of the CLI - either on success on when it fails for various reasons.

Tested locally under various conditions - 

```
# insufficient funds to build tx
Nov 20 12:54:42.932 ERRO Tx not sent: insufficient funds (max: 449.976000000)
```

```
# error during api call to receiver
# change output is removed correctly from wallet here
Nov 20 12:55:11.530 ERRO Tx not sent: Hyper(Io(Error { repr: Os { code: 61, message: "Connection refused" } }))
```

```
# success
Nov 20 12:55:58.039 INFO Tx sent: 10.000000000 grin to http://127.0.0.1:13415 (strategy 'all')
```

Resolves #287.
