### PR TITLE
miner timing resolution

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -150,7 +150,7 @@ burn_reward = false
 #slower.
 [[mining.cuckoo_miner_plugin_config]]
 type_filter = "mean_compat_cpu"
-parameter_list = {NUM_THREADS=4, NUM_TRIMS=68}
+parameter_list = {NUM_THREADS=1, NUM_TRIMS=68}
 
 #note lean_cpu currently has a bug which prevents it from
 #working with threads > 1

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -207,7 +207,7 @@ impl Miner {
 					let stats = job_handle.get_stats(i);
 					if let Ok(stat_vec) = stats {
 						for s in stat_vec {
-							let last_solution_time_secs = s.last_solution_time as f64 / 1000.0;
+							let last_solution_time_secs = s.last_solution_time as f64 / 1000000000.0;
 							let last_hashes_per_sec = 1.0 / last_solution_time_secs;
 							debug!(
 								LOGGER,
@@ -299,7 +299,7 @@ impl Miner {
 			if time::get_time().sec >= next_stat_check {
 				let stats_vec = plugin_miner.get_stats(0).unwrap();
 				for s in stats_vec.into_iter() {
-					let last_solution_time_secs = s.last_solution_time as f64 / 1000.0;
+					let last_solution_time_secs = s.last_solution_time as f64 / 1000000000.0;
 					let last_hashes_per_sec = 1.0 / last_solution_time_secs;
 					debug!(
 						LOGGER,

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,7 +18,7 @@ grin_util = { path = "../util" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="grin_integration_15"
+tag="grin_integration_16"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]


### PR DESCRIPTION
Miner debug output timing makes more sense, and changing default threads in grin.toml to 1 instead of 4.