### PR TITLE
[WIP] Syncer keeps running in background

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -81,13 +81,13 @@ impl NetAdapter for NetToChainAdapter {
 		}
 
 		// TODO - revisit the logic here around initial sync
-		if self.initial_syncing() {
+		// if self.initial_syncing() {
 			match res {
 				Ok(_) => self.syncer.borrow().block_received(bhash),
 				Err(chain::Error::Unfit(_)) => self.syncer.borrow().block_received(bhash),
 				Err(_) => {}
 			}
-		}
+		// }
 	}
 
 	fn headers_received(&self, bhs: Vec<core::BlockHeader>) {
@@ -136,9 +136,9 @@ impl NetAdapter for NetToChainAdapter {
 			added_hs.len()
 		);
 
-		if self.initial_syncing() {
+		// if self.initial_syncing() {
 			self.syncer.borrow().headers_received(added_hs);
-		}
+		// }
 	}
 
 	fn locate_headers(&self, locator: Vec<Hash>) -> Vec<core::BlockHeader> {
@@ -302,16 +302,15 @@ impl NetToChainAdapter {
 		self.syncer.borrow().initial_syncing()
 	}
 
+	/// TODO - Right now SYNC is for initial sync (but sync always runs)
 	/// Prepare options for the chain pipeline
 	fn chain_opts(&self) -> chain::Options {
-		chain::SYNC
-
-		// let opts = if self.syncing() {
-		// 	chain::SYNC
-		// } else {
-		// 	chain::NONE
-		// };
-		// opts
+		let opts = if self.initial_syncing() {
+			chain::SYNC
+		} else {
+			chain::NONE
+		};
+		opts
 	}
 }
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -80,7 +80,8 @@ impl NetAdapter for NetToChainAdapter {
 			debug!(LOGGER, "Block {} refused by chain: {:?}", bhash, e);
 		}
 
-		if self.syncing() {
+		// TODO - revisit the logic here around initial sync
+		if self.initial_syncing() {
 			match res {
 				Ok(_) => self.syncer.borrow().block_received(bhash),
 				Err(chain::Error::Unfit(_)) => self.syncer.borrow().block_received(bhash),
@@ -135,7 +136,7 @@ impl NetAdapter for NetToChainAdapter {
 			added_hs.len()
 		);
 
-		if self.syncing() {
+		if self.initial_syncing() {
 			self.syncer.borrow().headers_received(added_hs);
 		}
 	}
@@ -296,18 +297,21 @@ impl NetToChainAdapter {
 			});
 	}
 
-	pub fn syncing(&self) -> bool {
-		self.syncer.is_initialized() && self.syncer.borrow().syncing()
+	pub fn initial_syncing(&self) -> bool {
+		// self.syncer.is_initialized() && self.syncer.borrow().initial_syncing()
+		self.syncer.borrow().initial_syncing()
 	}
 
 	/// Prepare options for the chain pipeline
 	fn chain_opts(&self) -> chain::Options {
-		let opts = if self.syncing() {
-			chain::SYNC
-		} else {
-			chain::NONE
-		};
-		opts
+		chain::SYNC
+
+		// let opts = if self.syncing() {
+		// 	chain::SYNC
+		// } else {
+		// 	chain::NONE
+		// };
+		// opts
 	}
 }
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -38,7 +38,7 @@ pub struct NetToChainAdapter {
 	peer_store: Arc<PeerStore>,
 	connected_peers: Arc<RwLock<HashMap<SocketAddr, Arc<RwLock<Peer>>>>>,
 	tx_pool: Arc<RwLock<pool::TransactionPool<PoolToChainAdapter>>>,
-	syncer: OneTime<Arc<sync::Syncer>>,
+	pub syncer: Option<Arc<RwLock<sync::Syncer>>>,
 }
 
 impl NetAdapter for NetToChainAdapter {
@@ -83,8 +83,18 @@ impl NetAdapter for NetToChainAdapter {
 		// TODO - revisit the logic here around initial sync
 		if self.initial_syncing() {
 			match res {
-				Ok(_) => self.syncer.borrow().block_received(bhash),
-				Err(chain::Error::Unfit(_)) => self.syncer.borrow().block_received(bhash),
+				Ok(_) => {
+					if let Some(ref syncer) = self.syncer {
+						let syncer = syncer.read().unwrap();
+						syncer.block_received(bhash)
+					}
+				},
+				Err(chain::Error::Unfit(_)) => {
+					if let Some(ref syncer) = self.syncer {
+						let syncer = syncer.read().unwrap();
+						syncer.block_received(bhash)
+					}
+				},
 				Err(_) => {}
 			}
 		}
@@ -137,7 +147,10 @@ impl NetAdapter for NetToChainAdapter {
 		);
 
 		if self.initial_syncing() {
-			self.syncer.borrow().headers_received(added_hs);
+			if let Some(ref syncer) = self.syncer {
+				let syncer = syncer.read().unwrap();
+				syncer.headers_received(added_hs);
+			}
 		}
 	}
 
@@ -281,25 +294,34 @@ impl NetToChainAdapter {
 			peer_store: peer_store,
 			connected_peers: connected_peers,
 			tx_pool: tx_pool,
-			syncer: OneTime::new(),
+			syncer: None,
 		}
 	}
 
 	/// Start syncing the chain by instantiating and running the Syncer in the
 	/// background (a new thread is created).
-	pub fn start_sync(&self, sync: sync::Syncer) {
-		let arc_sync = Arc::new(sync);
-		self.syncer.init(arc_sync.clone());
-		let _ = thread::Builder::new()
-			.name("syncer".to_string())
-			.spawn(move || {
-				let _ = arc_sync.run();
-			});
+	pub fn start_sync(&self) {
+		if let Some(ref syncer) = self.syncer {
+			let syncer = syncer.clone();
+
+			let _ = thread::Builder::new()
+				.name("syncer".to_string())
+				.spawn(move || {
+					let _ = syncer.read().unwrap().run();
+				});
+		}
 	}
 
 	pub fn initial_syncing(&self) -> bool {
 		// self.syncer.is_initialized() && self.syncer.borrow().initial_syncing()
-		self.syncer.borrow().initial_syncing()
+		// self.syncer.borrow().initial_syncing()
+
+		if let Some(ref syncer) = self.syncer {
+			let syncer = syncer.read().unwrap();
+			syncer.initial_syncing()
+		} else {
+			false
+		}
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -215,7 +215,8 @@ impl Server {
 		miner.set_debug_output_id(format!("Port {}", self.config.p2p_config.unwrap().port));
 		thread::spawn(move || {
 			let secs_5 = time::Duration::from_secs(5);
-			while net_adapter.syncing() {
+			while net_adapter.initial_syncing() {
+				debug!(LOGGER, "miner waiting for initial sync to complete");
 				thread::sleep(secs_5);
 			}
 			miner.run_loop(config.clone(), cuckoo_size as u32, proof_size);

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -160,11 +160,8 @@ impl Server {
 
 		// If we have any known seeds or peers then attempt to sync.
 		if config.seeding_type != Seeding::None || peer_store.all_peers().len() > 0 {
-			let syncer = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
-			if let Ok(mut net_adapter) = Arc::try_unwrap(net_adapter.clone()) {
-				net_adapter.syncer = Some(Arc::new(RwLock::new(syncer)));
-				net_adapter.start_sync()
-			}
+			let sync = sync::Syncer::new(shared_chain.clone(), p2p_server.clone());
+			net_adapter.start_sync(sync);
 		}
 
 		evt_handle.spawn(p2p_server.start(evt_handle.clone()).map_err(|_| ()));
@@ -186,7 +183,7 @@ impl Server {
 			p2p: p2p_server,
 			chain: shared_chain,
 			tx_pool: tx_pool,
-			net_adapter: net_adapter.clone(),
+			net_adapter: net_adapter,
 		})
 	}
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -85,21 +85,6 @@ impl Syncer {
 			thread::sleep(Duration::from_millis(200));
 		}
 
-		// // Now check we actually have at least one peer to sync from.
-		// // If not then end the sync cleanly.
-		// if self.p2p.peer_count() == 0 {
-		// 	info!(LOGGER, "Sync: no peers to sync with, done.");
-        //
-		// 	let mut sync = self.sync.lock().unwrap();
-		// 	*sync = false;
-        //
-		// 	return Ok(())
-		// }
-
-		// if let Some(_) = self.p2p.most_work_peer() {
-		// 	self.init_download()?;
-		// }
-
 		// main syncing loop, requests more headers and bodies periodically as long
 		// as a peer with higher difficulty exists and we're not fully caught up
 		info!(LOGGER, "Starting sync loop.");
@@ -108,7 +93,7 @@ impl Syncer {
 
 			if let Some(peer) = self.p2p.most_work_peer() {
 				// TODO - is it a bad idea to do this within the loop?
-				// self.init_download()?;
+				self.init_download()?;
 
 				let peer = peer.read().unwrap();
 				debug!(

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -45,7 +45,7 @@ pub struct Syncer {
 	chain: Arc<chain::Chain>,
 	p2p: Arc<p2p::Server>,
 	initial_sync: Mutex<bool>,
-	last_header_req: Mutex<Instant>,
+	// last_header_req: Mutex<Instant>,
 	blocks_to_download: Mutex<Vec<Hash>>,
 	blocks_downloading: Mutex<Vec<BlockDownload>>,
 }
@@ -56,7 +56,7 @@ impl Syncer {
 			chain: chain_ref,
 			p2p: p2p,
 			initial_sync: Mutex::new(true),
-			last_header_req: Mutex::new(Instant::now() - Duration::from_secs(2)),
+			// last_header_req: Mutex::new(Instant::now() - Duration::from_secs(2)),
 			blocks_to_download: Mutex::new(vec![]),
 			blocks_downloading: Mutex::new(vec![]),
 		}
@@ -96,6 +96,10 @@ impl Syncer {
 		// 	return Ok(())
 		// }
 
+		// if let Some(_) = self.p2p.most_work_peer() {
+		// 	self.init_download()?;
+		// }
+
 		// main syncing loop, requests more headers and bodies periodically as long
 		// as a peer with higher difficulty exists and we're not fully caught up
 		info!(LOGGER, "Starting sync loop.");
@@ -104,7 +108,7 @@ impl Syncer {
 
 			if let Some(peer) = self.p2p.most_work_peer() {
 				// TODO - is it a bad idea to do this within the loop?
-				self.init_download()?;
+				// self.init_download()?;
 
 				let peer = peer.read().unwrap();
 				debug!(
@@ -132,7 +136,7 @@ impl Syncer {
 
 				{
 					// TODO - do we need this timing complexity?
-					let last_header_req = self.last_header_req.lock().unwrap().clone();
+					// let last_header_req = self.last_header_req.lock().unwrap().clone();
 					// if more_headers || (Instant::now() - Duration::from_secs(30) > last_header_req) {
 					if more_headers {
 						self.request_headers()?;
@@ -255,10 +259,10 @@ impl Syncer {
 
 	/// Request some block headers from a peer to advance us
 	fn request_headers(&self) -> Result<(), Error> {
-		{
-			let mut last_header_req = self.last_header_req.lock().unwrap();
-			*last_header_req = Instant::now();
-		}
+		// {
+		// 	let mut last_header_req = self.last_header_req.lock().unwrap();
+		// 	*last_header_req = Instant::now();
+		// }
 
 		let tip = self.chain.get_header_head()?;
 		let peer = self.p2p.most_work_peer();


### PR DESCRIPTION
First attempt at getting `syncer` to run in the background and stay running ever after successful first sync.

Some observations - 
* the syncer in the net_adapter is lazily instantiated (but the OneTime never returns now)
* the syncer is not futures aware (and feels like it doesn't fit cleanly with rest of the server)
* there's a big circular dependency between syncer <-> net_adapter <-> grin server (hence the lazy instantiation of syncer?)
* we run `init_download` within the sync loop and this causes `blocks_to_download` to grow as we are not checking if we are asking for duplicate blocks
* chain_opts is not handled correctly - SYNC vs. NONE (just realized this)

That last commit that I reverted was an attempt to to "simplify" and replace the OneTime wrapping the syncer with an Arc<RwLock<>> but I think it went off the rails...

