### PR TITLE
[DNM] investigtion into sumtree rewind issues (duplicate commits)

### DIFF
--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -307,7 +307,7 @@ where
 		}
 
 		if let Some(rewind) = self.rewind {
-			println!("sumtree backed get: rewind exists {:?}, position {}", rewind, position);
+			println!("***** sumtree backed get: rewind exists {:?}, position {}", rewind, position);
 			if rewind.0 < position {
 				return None
 			}

--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -306,6 +306,13 @@ where
 			return None;
 		}
 
+		if let Some(rewind) = self.rewind {
+			println!("sumtree backed get: rewind exists {:?}, position {}", rewind, position);
+			if rewind.0 < position {
+				return None
+			}
+		}
+
 		// The MMR starts at 1, our binary backend starts at 0
 		let pos = position - 1;
 


### PR DESCRIPTION
See #361 for context - syncing was failing if we ever encounter a reorg and need to switch to a chain with greater difficulty.

* Make sure we go back to the pmmr to actually check for duplicate outputs and kernels (not just the index).
* Make sure the pmmr backend safely handles "out of bound" gets (cannot return results later than the rewound position).

TODO - 
- [ ] cleanup logging/debugging
- [ ] check we are doing the right thing for kernels in the pmmr
- [ ] can we compare commitments directly without hashing them?
- [ ] are there any other places we need to go look in the pmmr?

