### PR TITLE
generate locator heights all the way down to 0 by powers of 2

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -55,5 +55,5 @@ mod types;
 pub use server::{DummyAdapter, Server};
 pub use peer::Peer;
 pub use types::{Capabilities, Error, NetAdapter, P2PConfig, PeerInfo, FULL_HIST, FULL_NODE,
-                MAX_BLOCK_HEADERS, MAX_LOCATORS, MAX_PEER_ADDRS, UNKNOWN};
+                MAX_BLOCK_HEADERS, MAX_PEER_ADDRS, UNKNOWN};
 pub use store::{PeerData, PeerStore, State};

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -26,9 +26,6 @@ use core::core::hash::Hash;
 use core::core::target::Difficulty;
 use core::ser;
 
-/// Maximum number of hashes in a block header locator request
-pub const MAX_LOCATORS: u32 = 10;
-
 /// Maximum number of block headers a peer should ever send
 pub const MAX_BLOCK_HEADERS: u32 = 512;
 


### PR DESCRIPTION
Resolves #366 
Add some basic tests to make sure `get_locator_heights` does something reasonable.

For 10,000 headers the locator is only length 14 - 

```
# locator heights for 10,000 headers -
[10000, 9998, 9994, 9986, 9970, 9938, 9874, 9746, 9490, 8978, 7954, 5906, 1810, 0]
```

So I think we're safe removing the max length of 10.

