### PR TITLE
notify syncer on every block received (including orphans)

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -81,11 +81,10 @@ impl NetAdapter for NetToChainAdapter {
 		}
 
 		if self.syncing() {
-			match res {
-				Ok(_) => self.syncer.borrow().block_received(bhash),
-				Err(chain::Error::Unfit(_)) => self.syncer.borrow().block_received(bhash),
-				Err(_) => {}
-			}
+			// always notify the syncer we received a block
+			// otherwise we jam up the 8 download slots with orphans
+			debug!(LOGGER, "adapter: notifying syncer: received block {:?}", bhash);
+			self.syncer.borrow().block_received(bhash);
 		}
 	}
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -265,15 +265,13 @@ impl Syncer {
 	/// We added a header, add it to the full block download list
 	pub fn headers_received(&self, bhs: Vec<Hash>) {
 		let mut blocks_to_download = self.blocks_to_download.lock().unwrap();
-		let hs_len = bhs.len();
 		for h in bhs {
 			// enlist for full block download
 			blocks_to_download.insert(0, h);
 		}
-		// ask for more headers if we got as many as required
-		if hs_len == (p2p::MAX_BLOCK_HEADERS as usize) {
-			self.request_headers().unwrap();
-		}
+
+		// we may still have more headers to retrieve but the main loop
+		// will take care of this for us
 	}
 
 	/// Builds a vector of block hashes that should help the remote peer sending
@@ -316,10 +314,11 @@ impl Syncer {
 
 	/// Pick a random peer and ask for a block by hash
 	fn request_block(&self, h: Hash) {
-		let peer = self.p2p.random_peer().expect("No connected peer.");
-		let peer = peer.read().unwrap();
-		if let Err(e) = peer.send_block_request(h) {
-			debug!(LOGGER, "Sync: Error requesting block: {:?}", e);
+		if let Some(peer) = self.p2p.random_peer() {
+			let peer = peer.read().unwrap();
+			if let Err(e) = peer.send_block_request(h) {
+				debug!(LOGGER, "Sync: Error requesting block: {:?}", e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a bunch of issues that emerged during testing - 

* we now notify the syncer when we successfully download a block that turns out to be an orphan
    (we were previously not notifying the syncer and it clogged up one of our 8 download slots)
* prefer a random peer with more difficulty than us when requesting a block
* do not expect/panic when requesting a block and we have no connected peers
* avoid getting into a loop asking for the same headers over and over

