### PR TITLE
fix chain_header_by_height error

### DIFF
--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -281,17 +281,29 @@ impl Syncer {
 
 		debug!(LOGGER, "Sync: locator heights: {:?}", heights);
 
-		let locator = heights
+		let locator:Vec<Option<Hash>> = heights
 			.into_iter()
 			.map(|h| {
-				let header = self.chain.get_header_by_height(h).unwrap();
-				header.hash()
+				trace!(LOGGER, "sync getting header: {}", h);
+				let mut header = self.chain.get_header_by_height(h);
+				if let Err(e) = header.as_mut() {
+					trace!(LOGGER, "Sync: no header in local chain \
+						at height {}, {:?}", h, e);
+					return None;
+				}
+				Some(header.unwrap().hash())
 			})
 			.collect();
 
-		debug!(LOGGER, "Sync: locator: {:?}", locator);
-
-		Ok(locator)
+		let return_loc:Vec<Hash> = locator
+			.into_iter()
+			.filter(|l| l.is_some())
+			.map(|l|{
+				l.unwrap()
+			})
+			.collect();
+		debug!(LOGGER, "Sync: locator: {:?}", return_loc);
+		Ok(return_loc)
 	}
 
 	/// Pick a random peer and ask for a block by hash


### PR DESCRIPTION
fixes `StoreErr(NotFoundErr, "chain get header by height")',` errors when trying to sync.. I think this was caused by trying to access headers in the chain that the server hasn't actually received yet.