### PR TITLE
first pass on better peer affinity

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -95,14 +95,10 @@ impl NetAdapter for NetToChainAdapter {
 			bhs.len(),
 			addr
 		);
-		let mut last_received_height = 0;
-		if bhs.len() > 0 {
-			last_received_height=bhs.last().unwrap().height;
-		}
 
 		// try to add each header to our header chain
 		let mut added_hs = vec![];
-		for bh in bhs {
+		for bh in bhs.clone() {
 			let res = self.chain.process_block_header(&bh, self.chain_opts());
 			match res {
 				Ok(_) => {
@@ -140,7 +136,7 @@ impl NetAdapter for NetToChainAdapter {
 		);
 
 		if self.syncing() {
-			self.syncer.borrow().headers_received(added_hs, last_received_height, addr);
+			self.syncer.borrow().headers_received(added_hs, bhs.last().unwrap(), addr);
 		}
 	}
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -95,8 +95,10 @@ impl NetAdapter for NetToChainAdapter {
 			bhs.len(),
 			addr
 		);
-
-		let last_received_height=bhs.last().unwrap().height;
+		let mut last_received_height = 0;
+		if bhs.len() > 0 {
+			last_received_height=bhs.last().unwrap().height;
+		}
 
 		// try to add each header to our header chain
 		let mut added_hs = vec![];

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -21,11 +21,14 @@
 const MAX_BODY_DOWNLOADS: usize = 8;
 
 use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
+use std::collections::HashMap;
+use std::net::SocketAddr;
 
 use core::core::hash::{Hash, Hashed};
+use core::core::BlockHeader;
 use chain;
 use p2p;
 use types::Error;
@@ -49,6 +52,10 @@ pub struct Syncer {
 	last_header_req: Mutex<Instant>,
 	blocks_to_download: Mutex<Vec<Hash>>,
 	blocks_downloading: Mutex<Vec<BlockDownload>>,
+
+	//keep a map of the last header successfully received
+	//from each peerj
+	last_headers_from_peers: Mutex<HashMap<SocketAddr, u64>>,
 }
 
 impl Syncer {
@@ -60,11 +67,46 @@ impl Syncer {
 			last_header_req: Mutex::new(Instant::now() - Duration::from_secs(2)),
 			blocks_to_download: Mutex::new(vec![]),
 			blocks_downloading: Mutex::new(vec![]),
+			last_headers_from_peers: Mutex::new(HashMap::new()),
 		}
 	}
 
 	pub fn syncing(&self) -> bool {
 		*self.sync.lock().unwrap()
+	}
+
+
+	// Tries to select the preferred peer to request headers
+	//from
+	fn select_buddy(&self, current_sync_buddy: Option<Arc<RwLock<p2p::Peer>>>)
+	-> Option<Arc<RwLock<p2p::Peer>>> {
+		//how much the work on another node should differ before we consider
+		//swapping sync buddies
+		let buddy_swap_threshold = 10_000;
+
+		//No peers at all.. problem
+		let most_work_peer = self.p2p.most_work_peer();
+		if let None = most_work_peer {
+			return None;
+		};
+
+		//If no current buddy, simply select peer with longest TD
+		if let None = current_sync_buddy {
+			return most_work_peer;
+		}
+		
+		let current_buddy_raw = current_sync_buddy.as_ref().unwrap().read().unwrap();
+		let most_work_raw = most_work_peer.as_ref().unwrap().read().unwrap();
+		let current_buddy_td = current_buddy_raw.info.total_difficulty.into_num();
+		let most_work_td = most_work_raw.info.total_difficulty.into_num();
+
+		let td_difference = most_work_td-current_buddy_td;
+		if td_difference > buddy_swap_threshold {
+			info!(LOGGER, "Swapping sync buddy to: {}", most_work_raw.info.addr);
+			most_work_peer.clone()
+		} else {
+			current_sync_buddy.clone()
+		}
 	}
 
 	/// Checks the local chain state, comparing it with our peers and triggers
@@ -99,18 +141,33 @@ impl Syncer {
 		// check if we have missing full blocks for which we already have a header
 		self.init_download()?;
 
-		// main syncing loop, requests more headers and bodies periodically as long
+	//Keep track of which peer we're currently syncing with
+	let current_sync_buddy = None; 
+
+	//keep a map of the latest header each peer has given us
+	//(so we can swap from one to the next while still
+	//providing a relevant set of locators
+	//let last_headers_from_peers = HashMap::new();
+
 		// as a peer with higher difficulty exists and we're not fully caught up
 		info!(LOGGER, "Sync: Starting loop.");
 		loop {
 			let tip = self.chain.get_header_head()?;
 
-			// TODO do something better (like trying to get more) if we lose peers
-			let peer = self.p2p.most_work_peer().expect("No peers available for sync.");
-			let peer = peer.read().unwrap();
+			// select the best peer to be peering with
+			let current_sync_buddy=self.select_buddy(current_sync_buddy.clone());
+			if let None = current_sync_buddy.clone(){
+				error!(LOGGER, "No peers to sync headers with. Done.");
+				break;
+			}
+
+			let current_sync_buddy = current_sync_buddy.unwrap();
+			let peer=current_sync_buddy.read().unwrap();
+
+			trace!(LOGGER, "Buddy peer is: {:?}",peer.info);
 			debug!(
 				LOGGER,
-				"Sync: peer {} vs us {}",
+				"Sync: buddy peer {} vs us {}",
 				peer.info.total_difficulty,
 				tip.total_difficulty
 			);
@@ -127,13 +184,14 @@ impl Syncer {
 				);
 				blocks_to_download.len() > 0 || blocks_downloading.len() > 0
 			};
-
+			trace!(LOGGER, "Requesting headers.");
 			{
 				let last_header_req = self.last_header_req.lock().unwrap().clone();
 				if more_headers || (Instant::now() - Duration::from_secs(30) > last_header_req) {
-					self.request_headers()?;
+					self.request_headers(&peer)?;
 				}
 			}
+			trace!(LOGGER, "Requesting bodies.");
 			if more_bodies {
 				self.request_bodies();
 			}
@@ -236,38 +294,55 @@ impl Syncer {
 	}
 
 	/// Request some block headers from a peer to advance us
-	fn request_headers(&self) -> Result<(), Error> {
+	fn request_headers(&self, peer: &p2p::Peer) -> Result<(), Error> {
 		{
 			let mut last_header_req = self.last_header_req.lock().unwrap();
 			*last_header_req = Instant::now();
 		}
 
-		let tip = self.chain.get_header_head()?;
-		let peer = self.p2p.most_work_peer();
-		let locator = self.get_locator(&tip)?;
-		if let Some(p) = peer {
-			let p = p.read().unwrap();
+		//Get the height of current sync buddy, which we'll use to build locators
+		{
+			let buddy_locator_height= {
+				let last_headers_from_peers = self.last_headers_from_peers.lock().unwrap();
+				let result = last_headers_from_peers.get(&peer.info.addr);
+				match result {
+					Some(r) => *r,
+					None => 0,
+				}
+			};
+			
+			let locator = self.get_locator(buddy_locator_height)?;
 			debug!(
 				LOGGER,
 				"Sync: Asking peer {} for more block headers, locator: {:?}",
-				p.info.addr,
+				peer.info.addr,
 				locator,
 			);
-			if let Err(e) = p.send_header_request(locator) {
+			if let Err(_) = peer.send_header_request(locator) {
 				debug!(LOGGER, "Sync: peer error, will retry");
+			} else {
+				//warn!(LOGGER, "Sync: Could not get most worked peer to request headers.");
 			}
-		} else {
-			warn!(LOGGER, "Sync: Could not get most worked peer to request headers.");
 		}
 		Ok(())
 	}
 
 	/// We added a header, add it to the full block download list
-	pub fn headers_received(&self, bhs: Vec<Hash>) {
+	pub fn headers_received(&self, bhs: Vec<BlockHeader>, last_received_height: u64, addr: SocketAddr) {
+		debug!(LOGGER, "Headers received from : {}", addr);
 		let mut blocks_to_download = self.blocks_to_download.lock().unwrap();
 		for h in bhs {
 			// enlist for full block download
-			blocks_to_download.insert(0, h);
+			blocks_to_download.insert(0, h.hash());
+		}
+
+		let mut last_headers_from_peers = self.last_headers_from_peers.lock().unwrap();
+		let last_stored_height = match last_headers_from_peers.get(&addr) {
+			None => 0,
+			Some(h) => *h,
+		};
+		if last_received_height > last_stored_height {
+			last_headers_from_peers.insert(addr, last_received_height);
 		}
 
 		// we may still have more headers to retrieve but the main loop
@@ -276,16 +351,16 @@ impl Syncer {
 
 	/// Builds a vector of block hashes that should help the remote peer sending
 	/// us the right block headers.
-	fn get_locator(&self, tip: &chain::Tip) -> Result<Vec<Hash>, Error> {
+	fn get_locator(&self, height: u64) -> Result<Vec<Hash>, Error> {
 		// Prepare the heights we want as the latests height minus increasing powers
 		// of 2 up to max.
-		let mut heights = vec![tip.height];
+		let mut heights = vec![height];
 		let mut tail = (1..p2p::MAX_LOCATORS)
 			.map(|n| 2u64.pow(n))
-			.filter_map(|n| if n > tip.height {
+			.filter_map(|n| if n > height {
 				None
 			} else {
-				Some(tip.height - n)
+				Some(height - n)
 			})
 			.collect::<Vec<_>>();
 		heights.append(&mut tail);
@@ -294,21 +369,17 @@ impl Syncer {
 		// both nodes share at least one common header hash in the locator
 		heights.push(0);
 
-		debug!(LOGGER, "Sync: Loc heights: {:?}", heights);
+		debug!(LOGGER, "Sync: Locator heights (from sync buddy): {:?}", heights);
 
-		// Iteratively travel the header chain back from our head and retain the
+		// Iteratively travel the header chain back from peer's head and retain the
 		// headers at the wanted heights.
-		let mut header = self.chain.get_block_header(&tip.last_block_h)?;
-		let mut locator = vec![];
-		while heights.len() > 0 {
-			if header.height == heights[0] {
-				heights = heights[1..].to_vec();
-				locator.push(header.hash());
-			}
-			if header.height > 0 {
-				header = self.chain.get_block_header(&header.previous)?;
-			}
-		}
+	let locator = heights
+		.into_iter()
+		.map(|h| self.chain.get_header_by_height(h))
+			.filter(|h| h.is_ok())
+			.map(|h| h.unwrap().hash())
+			.collect();
+		debug!(LOGGER, "Sync: locator: {:?}", locator);
 		Ok(locator)
 	}
 

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -229,8 +229,8 @@ impl NetAdapter for TrackingAdapter {
 		self.adapter.block_received(b)
 	}
 
-	fn headers_received(&self, bh: Vec<core::BlockHeader>) {
-		self.adapter.headers_received(bh)
+	fn headers_received(&self, bh: Vec<core::BlockHeader>, addr: SocketAddr) {
+		self.adapter.headers_received(bh, addr)
 	}
 
 	fn locate_headers(&self, locator: Vec<Hash>) -> Vec<core::BlockHeader> {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -211,7 +211,7 @@ fn handle_payload(
 		}
 		Type::Headers => {
 			let headers = ser::deserialize::<Headers>(&mut &buf[..])?;
-			adapter.headers_received(headers.headers);
+			adapter.headers_received(headers.headers, addr);
 			Ok(None)
 		}
 		Type::GetPeerAddrs => {

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -45,7 +45,7 @@ impl NetAdapter for DummyAdapter {
 	}
 	fn transaction_received(&self, _: core::Transaction) {}
 	fn block_received(&self, _: core::Block) {}
-	fn headers_received(&self, _: Vec<core::BlockHeader>) {}
+	fn headers_received(&self, _: Vec<core::BlockHeader>, _:SocketAddr) {}
 	fn locate_headers(&self, _: Vec<Hash>) -> Vec<core::BlockHeader> {
 		vec![]
 	}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -161,7 +161,7 @@ pub trait NetAdapter: Sync + Send {
 	/// A set of block header has been received, typically in response to a
 	/// block
 	/// header request.
-	fn headers_received(&self, bh: Vec<core::BlockHeader>);
+	fn headers_received(&self, bh: Vec<core::BlockHeader>, addr: SocketAddr);
 
 	/// Finds a list of block headers based on the provided locator. Tries to
 	/// identify the common chain and gets the headers that follow it


### PR DESCRIPTION
Updated with changes discussed yesterday:

-Select a peer with the longest work and stick to it, changing only when a longer peer becomes available.
-Use the last valid block height a particular peer gave you to derive the locator, as opposed to your own locator
-Keep track of the last height given to you by each peer separately, to enable flopping back and forth if needed.

MOSTLY there, it would seem, only there remains an issue whereby when you get a new set of headers from your peer because you validated far enough up the chain, you seem to keep repeatedly requesting blocks you already have. (Restart fixes, but I'm sick of restarting).

If you want to merge and cherrypick as is @ignopeverell , then run with the block issue, (it's probably something minor, I'm just running out of time now) go ahead. It's feeling very near to being able to properly sync.

