### PR TITLE
port across "simple_sync" changes from testnet1 branch

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -229,12 +229,12 @@ impl Handler for SumTreeHandler {
 }
 
 pub struct PeersAllHandler {
-	pub peer_store: Arc<p2p::PeerStore>,
+	pub p2p_server: Arc<p2p::Server>,
 }
 
 impl Handler for PeersAllHandler {
 	fn handle(&self, _req: &mut Request) -> IronResult<Response> {
-		let peers = &self.peer_store.all_peers();
+		let peers = &self.p2p_server.all_peers();
 		json_response_pretty(&peers)
 	}
 }
@@ -246,7 +246,7 @@ pub struct PeersConnectedHandler {
 impl Handler for PeersConnectedHandler {
 	fn handle(&self, _req: &mut Request) -> IronResult<Response> {
 		let mut peers = vec![];
-		for p in &self.p2p_server.all_peers() {
+		for p in &self.p2p_server.connected_peers() {
 			let p = p.read().unwrap();
 			let peer_info = p.info.clone();
 			peers.push(peer_info);
@@ -374,7 +374,6 @@ pub fn start_rest_apis<T>(
 	chain: Arc<chain::Chain>,
 	tx_pool: Arc<RwLock<pool::TransactionPool<T>>>,
 	p2p_server: Arc<p2p::Server>,
-	peer_store: Arc<p2p::PeerStore>,
 ) where
 	T: pool::BlockChain + Send + Sync + 'static,
 {
@@ -396,7 +395,7 @@ pub fn start_rest_apis<T>(
 			tx_pool: tx_pool.clone(),
 		};
 		let peers_all_handler = PeersAllHandler {
-			peer_store: peer_store.clone(),
+			p2p_server: p2p_server.clone(),
 		};
 		let peers_connected_handler = PeersConnectedHandler {
 			p2p_server: p2p_server.clone(),

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -53,7 +53,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 
 	debug!(
 		LOGGER,
-		"Processing block {} at {} with {} inputs and {} outputs.",
+		"pipe: process_block {} at {} with {} inputs and {} outputs.",
 		b.hash(),
 		b.header.height,
 		b.inputs.len(),
@@ -78,9 +78,9 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 		validate_block(b, &mut ctx, &mut extension)?;
 		debug!(
 			LOGGER,
-			"Block at {} with hash {} is valid, going to save and append.",
+			"pipe: proces_block {} at {} is valid, save and append.",
+			b.hash(),
 			b.header.height,
-			b.hash()
 		);
 
 		add_block(b, &mut ctx)?;
@@ -96,7 +96,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
 	debug!(
 		LOGGER,
-		"Processing header {} at {}.",
+		"pipe: process_header {} at {}",
 		bh.hash(),
 		bh.height
 	);
@@ -119,7 +119,7 @@ fn check_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
 	}
 	if let Ok(b) = ctx.store.get_block(&bh) {
 		// there is a window where a block can be saved but the chain head not
-  // updated yet, we plug that window here by re-accepting the block
+		// updated yet, we plug that window here by re-accepting the block
 		if b.header.total_difficulty <= ctx.head.total_difficulty {
 			return Err(Error::Unfit("already in store".to_string()));
 		}
@@ -157,7 +157,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 	if !ctx.opts.intersects(SKIP_POW) {
 		let cycle_size = global::sizeshift();
 
-		debug!(LOGGER, "Validating block with cuckoo size {}", cycle_size);
+		debug!(LOGGER, "pipe: validate_header cuckoo size {}", cycle_size);
 		if !(ctx.pow_verifier)(header, cycle_size as u32) {
 			return Err(Error::InvalidPow);
 		}
@@ -220,7 +220,7 @@ fn validate_block(
 		ext.apply_block(b)?;
 	} else {
 		// extending a fork, first identify the block where forking occurred
-  // keeping the hashes of blocks along the fork
+		// keeping the hashes of blocks along the fork
 		let mut current = b.header.previous;
 		let mut hashes = vec![];
 		loop {
@@ -290,7 +290,7 @@ fn validate_block(
 					.get_block_header_by_output_commit(&input.commitment())
 				{
 					// TODO - make sure we are not off-by-1 here vs. the equivalent tansaction
-	 // validation rule
+					// validation rule
 					if b.header.height <= output_header.height + global::coinbase_maturity() {
 						return Err(Error::ImmatureCoinbase);
 					}
@@ -321,7 +321,7 @@ fn add_block_header(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Erro
 /// work than the head.
 fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	// if we made a fork with more work than the head (which should also be true
- // when extending the head), update it
+	// when extending the head), update it
 	let tip = Tip::from_block(&b.header);
 	if tip.total_difficulty > ctx.head.total_difficulty {
 		// update the block height index
@@ -330,8 +330,8 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 			.map_err(|e| Error::StoreErr(e, "pipe setup height".to_owned()))?;
 
 		// in sync mode, only update the "body chain", otherwise update both the
-  // "header chain" and "body chain", updating the header chain in sync resets
-  // all additional "future" headers we've received
+		// "header chain" and "body chain", updating the header chain in sync resets
+		// all additional "future" headers we've received
 		if ctx.opts.intersects(SYNC) {
 			ctx.store
 				.save_body_head(&tip)
@@ -359,7 +359,7 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 /// work than the head.
 fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	// if we made a fork with more work than the head (which should also be true
- // when extending the head), update it
+	// when extending the head), update it
 	let tip = Tip::from_block(bh);
 	if tip.total_difficulty > ctx.head.total_difficulty {
 		ctx.store
@@ -372,7 +372,7 @@ fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option
 			"Updated block header head to {} at {}.",
 			bh.hash(),
 			bh.height
-		);
+			);
 		Ok(Some(tip))
 	} else {
 		Ok(None)

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -39,7 +39,6 @@ const PEER_PREFERRED_COUNT: u32 = 8;
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
 
 pub struct Seeder {
-	peer_store: Arc<p2p::PeerStore>,
 	p2p: Arc<p2p::Server>,
 
 	capabilities: p2p::Capabilities,
@@ -48,11 +47,9 @@ pub struct Seeder {
 impl Seeder {
 	pub fn new(
 		capabilities: p2p::Capabilities,
-		peer_store: Arc<p2p::PeerStore>,
 		p2p: Arc<p2p::Server>,
 	) -> Seeder {
 		Seeder {
-			peer_store: peer_store,
 			p2p: p2p,
 			capabilities: capabilities,
 		}
@@ -82,7 +79,6 @@ impl Seeder {
 		&self,
 		tx: mpsc::UnboundedSender<SocketAddr>,
 	) -> Box<Future<Item = (), Error = String>> {
-		let peer_store = self.peer_store.clone();
 		let p2p_server = self.p2p.clone();
 
 		// now spawn a new future to regularly check if we need to acquire more peers
@@ -100,7 +96,7 @@ impl Seeder {
 					if p.is_banned() {
 						debug!(LOGGER, "Marking peer {} as banned.", p.info.addr);
 						let update_result =
-							peer_store.update_state(p.info.addr, p2p::State::Banned);
+							p2p_server.update_state(p.info.addr, p2p::State::Banned);
 						match update_result {
 							Ok(()) => {}
 							Err(_) => {}
@@ -110,12 +106,12 @@ impl Seeder {
 
 				// we don't have enough peers, getting more from db
 				if p2p_server.peer_count() < PEER_PREFERRED_COUNT {
-					let mut peers = peer_store.find_peers(
+					let mut peers = p2p_server.find_peers(
 						p2p::State::Healthy,
 						p2p::UNKNOWN,
 						(2 * PEER_MAX_COUNT) as usize,
 					);
-					peers.retain(|p| !p2p_server.is_known(p.addr));
+					peers.retain(|p| !p2p_server.is_known(&p.addr));
 					if peers.len() > 0 {
 						debug!(
 							LOGGER,
@@ -137,21 +133,21 @@ impl Seeder {
 	}
 
 	// Check if we have any pre-existing peer in db. If so, start with those,
- // otherwise use the seeds provided.
+	// otherwise use the seeds provided.
 	fn connect_to_seeds(
 		&self,
 		tx: mpsc::UnboundedSender<SocketAddr>,
 		seed_list: Box<Future<Item = Vec<SocketAddr>, Error = String>>,
 	) -> Box<Future<Item = (), Error = String>> {
-		let peer_store = self.peer_store.clone();
 
 		// a thread pool is required so we don't block the event loop with a
-  // db query
+		// db query
 		let thread_pool = cpupool::CpuPool::new(1);
+		let p2p_server = self.p2p.clone();
 		let seeder = thread_pool
 			.spawn_fn(move || {
 				// check if we have some peers in db
-				let peers = peer_store.find_peers(
+				let peers = p2p_server.find_peers(
 					p2p::State::Healthy,
 					p2p::FULL_HIST,
 					(2 * PEER_MAX_COUNT) as usize,
@@ -192,7 +188,6 @@ impl Seeder {
 		rx: mpsc::UnboundedReceiver<SocketAddr>,
 	) -> Box<Future<Item = (), Error = ()>> {
 		let capab = self.capabilities;
-		let p2p_store = self.peer_store.clone();
 		let p2p_server = self.p2p.clone();
 
 		let listener = rx.for_each(move |peer_addr| {
@@ -202,7 +197,6 @@ impl Seeder {
 				h.spawn(
 					connect_and_req(
 						capab,
-						p2p_store.clone(),
 						p2p_server.clone(),
 						inner_h,
 						peer_addr,
@@ -271,7 +265,6 @@ pub fn predefined_seeds(
 
 fn connect_and_req(
 	capab: p2p::Capabilities,
-	peer_store: Arc<p2p::PeerStore>,
 	p2p: Arc<p2p::Server>,
 	h: reactor::Handle,
 	addr: SocketAddr,
@@ -279,6 +272,7 @@ fn connect_and_req(
 	let connect_peer = p2p.connect_peer(addr, h).map_err(|_| ());
 	let timer = Timer::default();
 	let timeout = timer.timeout(connect_peer, Duration::from_secs(5));
+	let p2p_server = p2p.clone();
 
 	let fut = timeout.then(move |p| {
 		match p {
@@ -291,7 +285,7 @@ fn connect_and_req(
 				}
 			}
 			Err(_) => {
-				let update_result = peer_store.update_state(addr, p2p::State::Defunct);
+				let update_result = p2p_server.update_state(addr, p2p::State::Defunct);
 				match update_result {
 					Ok(()) => {}
 					Err(_) => {}

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -86,7 +86,7 @@ impl Seeder {
 		let mon_loop = Timer::default()
 			.interval(time::Duration::from_secs(10))
 			.for_each(move |_| {
-				debug!(LOGGER, "monitoring peers ({})", p2p_server.all_peers().len());
+				debug!(LOGGER, "monitoring peers ({})", p2p_server.connected_peers().len());
 
 				// maintenance step first, clean up p2p server peers and mark bans
 				// if needed

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Grin Developers
+// Copyright 2017 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,294 +12,182 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Synchronization of the local blockchain with the rest of the network. Used
-//! either on a brand new node or when a node is late based on others' heads.
-//! Always starts by downloading the header chain before asking either for full
-//! blocks or a full UTXO set with related information.
-
-/// How many block bodies to download in parallel
-const MAX_BODY_DOWNLOADS: usize = 8;
-
-use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::sync::{Arc, RwLock};
 
-use core::core::hash::{Hash, Hashed};
+use adapters::NetToChainAdapter;
 use chain;
-use p2p;
+use core::core::hash::{Hash, Hashed};
+use p2p::{self, Peer, NetAdapter};
 use types::Error;
 use util::LOGGER;
 
-#[derive(Debug)]
-struct BlockDownload {
-	hash: Hash,
-	start_time: Instant,
-	retries: u8,
-}
-
-/// Manages syncing the local chain with other peers. Needs both a head chain
-/// and a full block chain to operate. First tries to advance the header
-/// chain as much as possible, then downloads the full blocks by batches.
-pub struct Syncer {
+/// Starts the syncing loop, just spawns two threads that loop forever
+pub fn run_sync(
+	adapter: Arc<NetToChainAdapter>,
+	p2p_server: Arc<p2p::Server>,
 	chain: Arc<chain::Chain>,
-	p2p: Arc<p2p::Server>,
-
-	sync: Mutex<bool>,
-	last_header_req: Mutex<Instant>,
-	blocks_to_download: Mutex<Vec<Hash>>,
-	blocks_downloading: Mutex<Vec<BlockDownload>>,
-}
-
-impl Syncer {
-	pub fn new(chain_ref: Arc<chain::Chain>, p2p: Arc<p2p::Server>) -> Syncer {
-		Syncer {
-			chain: chain_ref,
-			p2p: p2p,
-			sync: Mutex::new(true),
-			last_header_req: Mutex::new(Instant::now() - Duration::from_secs(2)),
-			blocks_to_download: Mutex::new(vec![]),
-			blocks_downloading: Mutex::new(vec![]),
-		}
-	}
-
-	pub fn syncing(&self) -> bool {
-		*self.sync.lock().unwrap()
-	}
-
-	/// Checks the local chain state, comparing it with our peers and triggers
-	/// syncing if required.
-	pub fn run(&self) -> Result<(), Error> {
-		info!(LOGGER, "Sync: starting sync");
-
-		// Loop for 10s waiting for some peers to potentially sync from.
-		let start = Instant::now();
-		loop {
-			let pc = self.p2p.peer_count();
-			if pc > 3 {
-				break;
-			}
-			if Instant::now() - start > Duration::from_secs(10) {
-				break;
-			}
-			thread::sleep(Duration::from_millis(200));
-		}
-
-		// Now check we actually have at least one peer to sync from.
-		// If not then end the sync cleanly.
-		if self.p2p.peer_count() == 0 {
-			info!(LOGGER, "Sync: no peers to sync with, done.");
-
-			let mut sync = self.sync.lock().unwrap();
-			*sync = false;
-
-			return Ok(())
-		}
-
-		// check if we have missing full blocks for which we already have a header
-		self.init_download()?;
-
-		// main syncing loop, requests more headers and bodies periodically as long
-		// as a peer with higher difficulty exists and we're not fully caught up
-		info!(LOGGER, "Sync: Starting loop.");
-		loop {
-			let tip = self.chain.get_header_head()?;
-
-			// TODO do something better (like trying to get more) if we lose peers
-			let peer = self.p2p.most_work_peer().expect("No peers available for sync.");
-			let peer = peer.read().unwrap();
-			debug!(
-				LOGGER,
-				"Sync: peer {} vs us {}",
-				peer.info.total_difficulty,
-				tip.total_difficulty
-			);
-
-			let more_headers = peer.info.total_difficulty > tip.total_difficulty;
-			let more_bodies = {
-				let blocks_to_download = self.blocks_to_download.lock().unwrap();
-				let blocks_downloading = self.blocks_downloading.lock().unwrap();
-				debug!(
-					LOGGER,
-					"Sync: blocks to download {}, block downloading {}",
-					blocks_to_download.len(),
-					blocks_downloading.len(),
-				);
-				blocks_to_download.len() > 0 || blocks_downloading.len() > 0
-			};
-
-			{
-				let last_header_req = self.last_header_req.lock().unwrap().clone();
-				if more_headers || (Instant::now() - Duration::from_secs(30) > last_header_req) {
-					self.request_headers()?;
+) {
+	let a_inner = adapter.clone();
+	let p2p_inner = p2p_server.clone();
+	let c_inner = chain.clone();
+	let _ = thread::Builder::new()
+		.name("body_sync".to_string())
+		.spawn(move || {
+			loop {
+				if a_inner.is_syncing() {
+					body_sync(p2p_inner.clone(), c_inner.clone());
+				} else {
+					thread::sleep(Duration::from_secs(5));
 				}
 			}
-			if more_bodies {
-				self.request_bodies();
+		});
+	let _ = thread::Builder::new()
+		.name("header_sync".to_string())
+		.spawn(move || {
+			loop {
+				if adapter.is_syncing() {
+					header_sync(adapter.clone(), p2p_server.clone(), chain.clone());
+				} else {
+					thread::sleep(Duration::from_secs(5));
+				}
 			}
-			if !more_headers && !more_bodies {
-				// TODO check we haven't been lied to on the total work
-				let mut sync = self.sync.lock().unwrap();
-				*sync = false;
+		});
+}
+
+fn body_sync(
+	p2p_server: Arc<p2p::Server>,
+	chain: Arc<chain::Chain>,
+) {
+	debug!(LOGGER, "block_sync: loop");
+
+	let header_head = chain.get_header_head().unwrap();
+	let block_header = chain.head_header().unwrap();
+	let mut hashes = vec![];
+
+	if header_head.total_difficulty > block_header.total_difficulty {
+		let mut current = chain.get_block_header(&header_head.last_block_h);
+		while let Ok(header) = current {
+			if header.hash() == block_header.hash() {
 				break;
 			}
-
-			thread::sleep(Duration::from_secs(2));
+			hashes.push(header.hash());
+			current = chain.get_block_header(&header.previous);
 		}
-		info!(LOGGER, "Sync: done.");
-		Ok(())
 	}
+	hashes.reverse();
 
-	/// Checks the gap between the header chain and the full block chain and
-	/// initializes the blocks_to_download structure with the missing full
-	/// blocks
-	fn init_download(&self) -> Result<(), Error> {
-		// compare the header's head to the full one to see what we're missing
-		let header_head = self.chain.get_header_head()?;
-		let full_head = self.chain.head()?;
-		let mut blocks_to_download = self.blocks_to_download.lock().unwrap();
+	let hashes_to_get = hashes
+		.iter()
+		.filter(|x| !chain.get_block(&x).is_ok())
+		.take(10)
+		.cloned()
+		.collect::<Vec<_>>();
 
-		// go back the chain and insert for download all blocks we only have the
-		// head for
-		let mut prev_h = header_head.last_block_h;
-		while prev_h != full_head.last_block_h {
-			let header = self.chain.get_block_header(&prev_h)?;
-			if header.height < full_head.height {
-				break;
-			}
-			blocks_to_download.push(header.hash());
-			prev_h = header.previous;
-		}
-
+	if hashes_to_get.len() > 0 {
 		debug!(
 			LOGGER,
-			"Sync: Added {} full block hashes to download.",
-			blocks_to_download.len()
-		);
-		Ok(())
-	}
+			"block_sync: requesting blocks ({}/{}), {:?}",
+			block_header.height,
+			header_head.height,
+			hashes_to_get,
+			);
 
-	/// Asks for the blocks we haven't downloaded yet and place them in the
-	/// downloading structure.
-	fn request_bodies(&self) {
-		let mut blocks_to_download = self.blocks_to_download.lock().unwrap();
-		let mut blocks_downloading = self.blocks_downloading.lock().unwrap();
-
-		// retry blocks not downloading
-		let now = Instant::now();
-		for download in blocks_downloading.deref_mut() {
-			let elapsed = (now - download.start_time).as_secs();
-			if download.retries >= 12 {
-				panic!("Failed to download required block {}", download.hash);
-			}
-			if download.retries < (elapsed / 5) as u8 {
-				debug!(
-					LOGGER,
-					"Sync: Retry {} on block {}",
-					download.retries,
-					download.hash
-				);
-				self.request_block(download.hash);
-				download.retries += 1;
+		for hash in hashes_to_get.clone() {
+			let peer = if hashes_to_get.len() < 100 {
+				p2p_server.most_work_peer()
+			} else {
+				p2p_server.random_peer()
+			};
+			if let Some(peer) = peer {
+				let peer = peer.read().unwrap();
+				if let Err(e) = peer.send_block_request(hash) {
+					debug!(LOGGER, "block_sync: error requesting block: {:?}, {:?}", hash, e);
+				}
 			}
 		}
-
-		// consume hashes from blocks to download, place them in downloading and
-		// request them from the network
-		let mut count = 0;
-		while blocks_to_download.len() > 0 && blocks_downloading.len() < MAX_BODY_DOWNLOADS {
-			let h = blocks_to_download.pop().unwrap();
-			self.request_block(h);
-			count += 1;
-			blocks_downloading.push(BlockDownload {
-				hash: h,
-				start_time: Instant::now(),
-				retries: 0,
-			});
-		}
-		debug!(
-			LOGGER,
-			"Sync: Requested {} full blocks to download, total left: {}. Current list: {:?}.",
-			count,
-			blocks_to_download.len(),
-			blocks_downloading.deref(),
-		);
+		thread::sleep(Duration::from_secs(1));
+	} else {
+		thread::sleep(Duration::from_secs(5));
 	}
+}
 
-	/// We added a block, clean up the downloading structure
-	pub fn block_received(&self, bh: Hash) {
-		// just clean up the downloading list
-		let mut bds = self.blocks_downloading.lock().unwrap();
-		bds.iter()
-			.position(|ref h| h.hash == bh)
-			.map(|n| bds.remove(n));
-	}
+pub fn header_sync(
+	adapter: Arc<NetToChainAdapter>,
+	p2p_server: Arc<p2p::Server>,
+	chain: Arc<chain::Chain>,
+	) {
+	debug!(LOGGER, "header_sync: loop");
 
-	/// Request some block headers from a peer to advance us
-	fn request_headers(&self) -> Result<(), Error> {
-		{
-			let mut last_header_req = self.last_header_req.lock().unwrap();
-			*last_header_req = Instant::now();
-		}
+	let difficulty = adapter.total_difficulty();
 
-		let tip = self.chain.get_header_head()?;
-		let peer = self.p2p.most_work_peer();
-		let locator = self.get_locator(&tip)?;
-		if let Some(p) = peer {
-			let p = p.read().unwrap();
+	if let Some(peer) = p2p_server.most_work_peer() {
+		let peer = peer.clone();
+		let p = peer.read().unwrap();
+		let peer_difficulty = p.info.total_difficulty.clone();
+
+		if peer_difficulty > difficulty {
 			debug!(
 				LOGGER,
-				"Sync: Asking peer {} for more block headers, locator: {:?}",
-				p.info.addr,
-				locator,
-			);
-			if let Err(e) = p.send_header_request(locator) {
-				debug!(LOGGER, "Sync: peer error, will retry");
-			}
-		} else {
-			warn!(LOGGER, "Sync: Could not get most worked peer to request headers.");
-		}
-		Ok(())
-	}
+				"header_sync: difficulty {} vs {}",
+				peer_difficulty,
+				difficulty,
+				);
 
-	/// We added a header, add it to the full block download list
-	pub fn headers_received(&self, bhs: Vec<Hash>) {
-		let mut blocks_to_download = self.blocks_to_download.lock().unwrap();
-		for h in bhs {
-			// enlist for full block download
-			blocks_to_download.insert(0, h);
-		}
-
-		// we may still have more headers to retrieve but the main loop
-		// will take care of this for us
-	}
-
-	/// Builds a vector of block hashes that should help the remote peer sending
-	/// us the right block headers.
-	fn get_locator(&self, tip: &chain::Tip) -> Result<Vec<Hash>, Error> {
-		let heights = get_locator_heights(tip.height);
-
-		debug!(LOGGER, "Sync: locator heights: {:?}", heights);
-
-		let locator = heights
-			.into_iter()
-			.map(|h| self.chain.get_header_by_height(h))
-			.filter(|h| h.is_ok())
-			.map(|h| h.unwrap().hash())
-			.collect();
-		debug!(LOGGER, "Sync: locator: {:?}", locator);
-		Ok(locator)
-	}
-
-	/// Pick a random peer and ask for a block by hash
-	fn request_block(&self, h: Hash) {
-		if let Some(peer) = self.p2p.random_peer() {
-			let peer = peer.read().unwrap();
-			if let Err(e) = peer.send_block_request(h) {
-				debug!(LOGGER, "Sync: Error requesting block: {:?}", e);
-			}
+			let _ = request_headers(
+				peer.clone(),
+				chain.clone(),
+				);
 		}
 	}
+
+	thread::sleep(Duration::from_secs(30));
+}
+
+/// Request some block headers from a peer to advance us
+fn request_headers(
+	peer: Arc<RwLock<Peer>>,
+	chain: Arc<chain::Chain>,
+) -> Result<(), Error> {
+	let locator = get_locator(chain)?;
+	let peer = peer.read().unwrap();
+	debug!(
+		LOGGER,
+		"Sync: Asking peer {} for more block headers, locator: {:?}",
+		peer.info.addr,
+		locator,
+	);
+	let _ = peer.send_header_request(locator);
+	Ok(())
+}
+
+fn get_locator(chain: Arc<chain::Chain>) -> Result<Vec<Hash>, Error> {
+	let tip = chain.get_header_head()?;
+
+	// TODO - is this necessary?
+	// go back to earlier header height to ensure we do not miss a header
+	let height = if tip.height > 5 {
+		tip.height - 5
+	} else {
+		0
+	};
+	let heights = get_locator_heights(height);
+
+	debug!(LOGGER, "Sync: locator heights: {:?}", heights);
+
+	let mut locator = vec![];
+	let mut current = chain.get_block_header(&tip.last_block_h);
+	while let Ok(header) = current {
+		if heights.contains(&header.height) {
+			locator.push(header.hash());
+		}
+		current = chain.get_block_header(&header.previous);
+	}
+
+	debug!(LOGGER, "Sync: locator: {:?}", locator);
+
+	Ok(locator)
 }
 
 // current height back to 0 decreasing in powers of 2

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -55,5 +55,5 @@ mod types;
 pub use server::{DummyAdapter, Server};
 pub use peer::Peer;
 pub use types::{Capabilities, Error, NetAdapter, P2PConfig, PeerInfo, FULL_HIST, FULL_NODE,
-                MAX_BLOCK_HEADERS, MAX_PEER_ADDRS, UNKNOWN};
-pub use store::{PeerData, PeerStore, State};
+				MAX_BLOCK_HEADERS, MAX_PEER_ADDRS, UNKNOWN};
+pub use store::{PeerData, State};

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -229,8 +229,8 @@ impl NetAdapter for TrackingAdapter {
 		self.adapter.block_received(b)
 	}
 
-	fn headers_received(&self, bh: Vec<core::BlockHeader>) {
-		self.adapter.headers_received(bh)
+	fn headers_received(&self, bh: Vec<core::BlockHeader>, addr: SocketAddr) {
+		self.adapter.headers_received(bh, addr)
 	}
 
 	fn locate_headers(&self, locator: Vec<Hash>) -> Vec<core::BlockHeader> {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -211,7 +211,7 @@ fn handle_payload(
 		}
 		Type::Headers => {
 			let headers = ser::deserialize::<Headers>(&mut &buf[..])?;
-			adapter.headers_received(headers.headers);
+			adapter.headers_received(headers.headers, addr);
 			Ok(None)
 		}
 		Type::GetPeerAddrs => {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -25,6 +25,7 @@ use core::core;
 use core::core::hash::Hash;
 use core::core::target::Difficulty;
 use core::ser;
+use grin_store;
 
 /// Maximum number of block headers a peer should ever send
 pub const MAX_BLOCK_HEADERS: u32 = 512;
@@ -42,6 +43,7 @@ pub enum Error {
 	Connection(io::Error),
 	ConnectionClose,
 	Timeout,
+	Store(grin_store::Error),
 	PeerWithSelf,
 	ProtocolMismatch {
 		us: u32,
@@ -56,6 +58,11 @@ pub enum Error {
 impl From<ser::Error> for Error {
 	fn from(e: ser::Error) -> Error {
 		Error::Serialization(e)
+	}
+}
+impl From<grin_store::Error> for Error {
+	fn from(e: grin_store::Error) -> Error {
+		Error::Store(e)
 	}
 }
 impl From<io::Error> for Error {
@@ -167,7 +174,7 @@ pub trait NetAdapter: Sync + Send {
 	/// A set of block header has been received, typically in response to a
 	/// block
 	/// header request.
-	fn headers_received(&self, bh: Vec<core::BlockHeader>);
+	fn headers_received(&self, bh: Vec<core::BlockHeader>, addr: SocketAddr);
 
 	/// Finds a list of block headers based on the provided locator. Tries to
 	/// identify the common chain and gets the headers that follow it

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -17,9 +17,8 @@ extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate tokio_core;
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time;
 
 use futures::future::Future;
@@ -38,14 +37,13 @@ fn peer_handshake() {
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
 	let net_adapter = Arc::new(p2p::DummyAdapter {});
-	let connected_peers = Arc::new(RwLock::new(HashMap::new()));
 	let server = p2p::Server::new(
+		".grin".to_owned(),
 		p2p::UNKNOWN,
 		p2p_conf,
-		connected_peers,
 		net_adapter.clone(),
 		Hash::from_vec(vec![]),
-	);
+	).unwrap();
 	let run_server = server.start(handle.clone());
 	let my_addr = "127.0.0.1:5000".parse().unwrap();
 


### PR DESCRIPTION
Cleanup direct refs to peer map or peer store
P2P server acts as a facade, handling the list of connected peers
and the storage of their information. Everything else goes through
the p2p server instead of having a peer map reference or going
straight to the store.
Fix p2p tests