### PR TITLE
[DNM] introduce new sync_head for tracking header chain during sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -99,6 +99,17 @@ impl Chain {
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
 		};
 
+		// make sure sync_head is available for later use
+		let _ = match chain_store.get_sync_head() {
+			Ok(tip) => tip,
+			Err(NotFoundErr) => {
+				let tip = Tip::new(genesis.hash());
+				chain_store.save_sync_head(&tip)?;
+				tip
+			},
+			Err(e) => return Err(Error::StoreErr(e, "chain init sync head".to_owned())),
+		};
+
 		info!(
 			LOGGER,
 			"Chain init: {:?}",
@@ -176,19 +187,16 @@ impl Chain {
 		res
 	}
 
-	/// Attempt to add a new header to the header chain. Only necessary during
-	/// sync.
-	pub fn process_block_header(
+	/// Attempt to add a new header to the header chain.
+	/// This is only ever used during sync and uses sync_head.
+	pub fn sync_block_header(
 		&self,
 		bh: &BlockHeader,
 		opts: Options,
 	) -> Result<Option<Tip>, Error> {
-		let head = self.store
-			.get_header_head()
-			.map_err(|e| Error::StoreErr(e, "chain header head".to_owned()))?;
+		let head = self.get_sync_head()?;
 		let ctx = self.ctx_from_head(head, opts);
-
-		pipe::process_block_header(bh, ctx)
+		pipe::sync_block_header(bh, ctx)
 	}
 
 	fn ctx_from_head(&self, head: Tip, opts: Options) -> pipe::BlockContext {
@@ -350,7 +358,15 @@ impl Chain {
 			.map_err(|e| Error::StoreErr(e, "chain get commitment".to_owned()))
 	}
 
-	/// Get the tip of the header chain
+	/// Get the tip of the current "sync" header chain.
+	/// This may be significantly different to current header chain.
+	pub fn get_sync_head(&self) -> Result<Tip, Error> {
+		self.store
+			.get_sync_head()
+			.map_err(|e| Error::StoreErr(e, "chain get sync head".to_owned()))
+	}
+
+	/// Get the tip of the header chain.
 	pub fn get_header_head(&self) -> Result<Tip, Error> {
 		self.store
 			.get_header_head()

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -194,9 +194,11 @@ impl Chain {
 		bh: &BlockHeader,
 		opts: Options,
 	) -> Result<Option<Tip>, Error> {
-		let head = self.get_sync_head()?;
-		let ctx = self.ctx_from_head(head, opts);
-		pipe::sync_block_header(bh, ctx)
+		let sync_head = self.get_sync_head()?;
+		let header_head = self.get_header_head()?;
+		let sync_ctx = self.ctx_from_head(sync_head, opts);
+		let header_ctx = self.ctx_from_head(header_head, opts);
+		pipe::sync_block_header(bh, sync_ctx, header_ctx)
 	}
 
 	fn ctx_from_head(&self, head: Tip, opts: Options) -> pipe::BlockContext {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -31,6 +31,7 @@ const BLOCK_HEADER_PREFIX: u8 = 'h' as u8;
 const BLOCK_PREFIX: u8 = 'b' as u8;
 const HEAD_PREFIX: u8 = 'H' as u8;
 const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
+const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const OUTPUT_COMMIT_PREFIX: u8 = 'o' as u8;
 const HEADER_BY_OUTPUT_PREFIX: u8 = 'p' as u8;
@@ -80,14 +81,21 @@ impl ChainStore for ChainKVStore {
 		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)
 	}
 
+	fn get_sync_head(&self) -> Result<Tip, Error> {
+		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]))
+	}
+
+	fn save_sync_head(&self, t: &Tip) -> Result<(), Error> {
+		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
+	}
+
 	fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())))
 	}
 
 	fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
-			self.db
-				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
+			self.db.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 		)
 	}
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -200,6 +200,12 @@ pub trait ChainStore: Send + Sync {
 	/// Save the provided tip as the current head of the block header chain
 	fn save_header_head(&self, t: &Tip) -> Result<(), store::Error>;
 
+	/// Get the tip of the current sync header chain
+	fn get_sync_head(&self) -> Result<Tip, store::Error>;
+
+	/// Save the provided tip as the current head of the sync header chain
+	fn save_sync_head(&self, t: &Tip) -> Result<(), store::Error>;
+
 	/// Gets the block header at the provided height
 	fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, store::Error>;
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -81,7 +81,7 @@ impl NetAdapter for NetToChainAdapter {
 	fn headers_received(&self, bhs: Vec<core::BlockHeader>, addr: SocketAddr) {
 		info!(
 			LOGGER,
-			"Received block headers {:?} from {}",
+			"adapter: received block headers {:?} from {}",
 			bhs.iter().map(|x| x.hash()).collect::<Vec<_>>(),
 			addr,
 		);
@@ -89,7 +89,7 @@ impl NetAdapter for NetToChainAdapter {
 		// try to add each header to our header chain
 		let mut added_hs = vec![];
 		for bh in bhs {
-			let res = self.chain.process_block_header(&bh, self.chain_opts());
+			let res = self.chain.sync_block_header(&bh, self.chain_opts());
 			match res {
 				Ok(_) => {
 					added_hs.push(bh.hash());

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -60,16 +60,18 @@ fn body_sync(
 	p2p_server: Arc<p2p::Server>,
 	chain: Arc<chain::Chain>,
 ) {
-	debug!(LOGGER, "block_sync: loop");
+	debug!(LOGGER, "body_sync: loop");
 
 	let header_head = chain.get_header_head().unwrap();
-	let block_header = chain.head_header().unwrap();
+	let sync_head = chain.get_sync_head().unwrap();
 	let mut hashes = vec![];
 
-	if header_head.total_difficulty > block_header.total_difficulty {
-		let mut current = chain.get_block_header(&header_head.last_block_h);
+	if sync_head.total_difficulty > header_head.total_difficulty {
+		let mut current = chain.get_block_header(&sync_head.last_block_h);
 		while let Ok(header) = current {
-			if header.hash() == block_header.hash() {
+			// TODO we need a smarter condition here (this only works on a non-fork sync)
+			// although I think it still works (just inefficient as we go all the way back to genesis block...)
+			if header.hash() == header_head.hash() {
 				break;
 			}
 			hashes.push(header.hash());
@@ -89,12 +91,13 @@ fn body_sync(
 		debug!(
 			LOGGER,
 			"block_sync: requesting blocks ({}/{}), {:?}",
-			block_header.height,
 			header_head.height,
+			sync_head.height,
 			hashes_to_get,
 			);
 
 		for hash in hashes_to_get.clone() {
+			// TODO - what condition should we choose most_work_peer v random_peer (if any?)
 			let peer = if hashes_to_get.len() < 100 {
 				p2p_server.most_work_peer()
 			} else {
@@ -128,24 +131,17 @@ pub fn header_sync(
 		let peer_difficulty = p.info.total_difficulty.clone();
 
 		if peer_difficulty > difficulty {
-			debug!(
-				LOGGER,
-				"header_sync: difficulty {} vs {}",
-				peer_difficulty,
-				difficulty,
-				);
-
 			let _ = request_headers(
 				peer.clone(),
 				chain.clone(),
-				);
+			);
 		}
 	}
 
 	thread::sleep(Duration::from_secs(30));
 }
 
-/// Request some block headers from a peer to advance us
+/// Request some block headers from a peer to advance us.
 fn request_headers(
 	peer: Arc<RwLock<Peer>>,
 	chain: Arc<chain::Chain>,
@@ -154,7 +150,7 @@ fn request_headers(
 	let peer = peer.read().unwrap();
 	debug!(
 		LOGGER,
-		"Sync: Asking peer {} for more block headers, locator: {:?}",
+		"sync: asking {} for headers, locator: {:?}",
 		peer.info.addr,
 		locator,
 	);
@@ -162,19 +158,14 @@ fn request_headers(
 	Ok(())
 }
 
+/// We build a locator based on sync_head.
+/// Even if sync_head is significantly out of date we will "reset" it once we start getting
+/// headers back from a peer.
 fn get_locator(chain: Arc<chain::Chain>) -> Result<Vec<Hash>, Error> {
-	let tip = chain.get_header_head()?;
+	let tip = chain.get_sync_head()?;
+	let heights = get_locator_heights(tip.height);
 
-	// TODO - is this necessary?
-	// go back to earlier header height to ensure we do not miss a header
-	let height = if tip.height > 5 {
-		tip.height - 5
-	} else {
-		0
-	};
-	let heights = get_locator_heights(height);
-
-	debug!(LOGGER, "Sync: locator heights: {:?}", heights);
+	debug!(LOGGER, "sync: locator heights: {:?}", heights);
 
 	let mut locator = vec![];
 	let mut current = chain.get_block_header(&tip.last_block_h);
@@ -185,7 +176,7 @@ fn get_locator(chain: Arc<chain::Chain>) -> Result<Vec<Hash>, Error> {
 		current = chain.get_block_header(&header.previous);
 	}
 
-	debug!(LOGGER, "Sync: locator: {:?}", locator);
+	debug!(LOGGER, "sync: locator: {:?}", locator);
 
 	Ok(locator)
 }


### PR DESCRIPTION
#413 was just merged onto testnet1 branch and contains some additional changes.
I'll port these across, either here or on another PR to replace this one.

* init sync_head during chain init
* rename `process_block_header` to `sync_block_header` (more explicit that this is sync only)
* in `sync` use `sync_header` to track the header chain that we are syncing to
* update `sync_head` as we process headers during the sync
* update `header_head` during sync when processing headers if new header is now the one with most work
* pass in 2x ctxs (sync and header) to `sync_block_header` to maintain both head states

Resolves #402.
