### PR TITLE
[testnet1] sync head & improved fork handling

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -25,7 +25,7 @@ use core::core::pmmr::{HashSum, NoSum};
 
 use core::core::{Block, BlockHeader, Output, TxKernel};
 use core::core::target::Difficulty;
-use core::core::hash::Hash;
+use core::core::hash::{Hash, Hashed};
 use grin_store::Error::NotFoundErr;
 use pipe;
 use store;
@@ -108,7 +108,8 @@ impl Chain {
 		let _ = match chain_store.get_sync_head() {
 			Ok(tip) => tip,
 			Err(NotFoundErr) => {
-				let tip = Tip::new(genesis.hash());
+				let gen = chain_store.get_header_by_height(0).unwrap();
+				let tip = Tip::new(gen.hash());
 				chain_store.save_sync_head(&tip)?;
 				tip
 			},

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -104,6 +104,23 @@ impl Chain {
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
 		};
 
+		// make sure sync_head is available for later use
+		let _ = match chain_store.get_sync_head() {
+			Ok(tip) => tip,
+			Err(NotFoundErr) => {
+				let tip = Tip::new(genesis.hash());
+				chain_store.save_sync_head(&tip)?;
+				tip
+			},
+			Err(e) => return Err(Error::StoreErr(e, "chain init sync head".to_owned())),
+		};
+
+		info!(
+			LOGGER,
+			"Chain init: {:?}",
+			head,
+		);
+
 		let store = Arc::new(chain_store);
 		let sumtrees = sumtree::SumTrees::open(db_root, store.clone())?;
 
@@ -178,19 +195,16 @@ impl Chain {
 		res.map(|tip| (tip, accepted_orphans))
 	}
 
-	/// Attempt to add a new header to the header chain. Only necessary during
-	/// sync.
-	pub fn process_block_header(
+	/// Attempt to add a new header to the header chain.
+	/// This is only ever used during sync and uses sync_head.
+	pub fn sync_block_header(
 		&self,
 		bh: &BlockHeader,
 		opts: Options,
 	) -> Result<Option<Tip>, Error> {
-		let head = self.store
-			.get_header_head()
-			.map_err(|e| Error::StoreErr(e, "chain header head".to_owned()))?;
+		let head = self.get_sync_head()?;
 		let ctx = self.ctx_from_head(head, opts);
-
-		pipe::process_block_header(bh, ctx)
+		pipe::sync_block_header(bh, ctx)
 	}
 
 	fn ctx_from_head(&self, head: Tip, opts: Options) -> pipe::BlockContext {
@@ -368,7 +382,15 @@ impl Chain {
 			.map_err(|e| Error::StoreErr(e, "chain get commitment".to_owned()))
 	}
 
-	/// Get the tip of the header chain
+	/// Get the tip of the current "sync" header chain.
+	/// This may be significantly different to current header chain.
+	pub fn get_sync_head(&self) -> Result<Tip, Error> {
+		self.store
+			.get_sync_head()
+			.map_err(|e| Error::StoreErr(e, "chain get sync head".to_owned()))
+	}
+
+	/// Get the tip of the header chain.
 	pub fn get_header_head(&self) -> Result<Tip, Error> {
 		self.store
 			.get_header_head()

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -203,9 +203,11 @@ impl Chain {
 		bh: &BlockHeader,
 		opts: Options,
 	) -> Result<Option<Tip>, Error> {
-		let head = self.get_sync_head()?;
-		let ctx = self.ctx_from_head(head, opts);
-		pipe::sync_block_header(bh, ctx)
+		let sync_head = self.get_sync_head()?;
+		let header_head = self.get_header_head()?;
+		let sync_ctx = self.ctx_from_head(sync_head, opts);
+		let header_ctx = self.ctx_from_head(header_head, opts);
+		pipe::sync_block_header(bh, sync_ctx, header_ctx)
 	}
 
 	fn ctx_from_head(&self, head: Tip, opts: Options) -> pipe::BlockContext {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -107,13 +107,13 @@ pub fn sync_block_header(
 		bh.height
 	);
 
-	// check_known(bh.hash(), &mut sync_ctx)?;
 	validate_header(&bh, &mut sync_ctx)?;
 	add_block_header(bh, &mut sync_ctx)?;
 
-	// TODO - confirm this is not needed during sync process (I don't see how it is)
+	// TODO - confirm this is needed during sync process (I don't see how it is)
+	// we do not touch the sumtrees when syncing headers
 	// just taking the shared lock
-	// let _ = ctx.sumtrees.write().unwrap();
+	let _ = header_ctx.sumtrees.write().unwrap();
 
 	// now update the header_head (if new header with most work) and the sync_head (always)
 	update_header_head(bh, &mut header_ctx);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -64,7 +64,21 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 
 	validate_header(&b.header, &mut ctx)?;
 
-	// valid header, time to take the lock on the sum trees
+	// valid header, now check we actually have the previous block in the store
+	// not just the header but the block itself
+	// we cannot assume we can use the chain head for this as we may be dealing with a fork
+	// we cannot use heights here as the fork may have jumped in height
+	match ctx.store.get_block(&b.header.previous) {
+		Ok(_) => {},
+		Err(grin_store::Error::NotFoundErr) => {
+			return Err(Error::Orphan);
+		},
+		Err(e) => {
+			return Err(Error::StoreErr(e, "pipe get previous".to_owned()));
+		}
+	};
+
+	// valid header and we have a previous block, time to take the lock on the sum trees
 	let local_sumtrees = ctx.sumtrees.clone();
 	let mut sumtrees = local_sumtrees.write().unwrap();
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -107,7 +107,7 @@ pub fn sync_block_header(
 		bh.height
 	);
 
-	check_known(bh.hash(), &mut sync_ctx)?;
+	// check_known(bh.hash(), &mut sync_ctx)?;
 	validate_header(&bh, &mut sync_ctx)?;
 	add_block_header(bh, &mut sync_ctx)?;
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -95,7 +95,11 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 
 /// Process the block header.
 /// This is only ever used during sync and uses a context based on sync_head.
-pub fn sync_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
+pub fn sync_block_header(
+	bh: &BlockHeader,
+	mut sync_ctx: BlockContext,
+	mut header_ctx: BlockContext,
+) -> Result<Option<Tip>, Error> {
 	debug!(
 		LOGGER,
 		"pipe: sync_block_header {} at {}",
@@ -103,15 +107,17 @@ pub fn sync_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Opti
 		bh.height
 	);
 
-	check_known(bh.hash(), &mut ctx)?;
-	validate_header(&bh, &mut ctx)?;
-	add_block_header(bh, &mut ctx)?;
+	check_known(bh.hash(), &mut sync_ctx)?;
+	validate_header(&bh, &mut sync_ctx)?;
+	add_block_header(bh, &mut sync_ctx)?;
 
 	// TODO - confirm this is not needed during sync process (I don't see how it is)
 	// just taking the shared lock
 	// let _ = ctx.sumtrees.write().unwrap();
 
-	update_sync_head(bh, &mut ctx)
+	// now update the header_head (if new header with most work) and the sync_head (always)
+	update_header_head(bh, &mut header_ctx);
+	update_sync_head(bh, &mut sync_ctx)
 }
 
 /// Quick in-memory check to fast-reject any block we've already handled
@@ -373,4 +379,24 @@ fn update_sync_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<T
 		bh.height,
 	);
 	Ok(Some(tip))
+}
+
+fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
+	let tip = Tip::from_block(bh);
+	debug!(LOGGER, "pipe: update_header_head {},{}", tip.total_difficulty, ctx.head.total_difficulty);
+	if tip.total_difficulty > ctx.head.total_difficulty {
+		ctx.store
+			.save_header_head(&tip)
+			.map_err(|e| Error::StoreErr(e, "pipe save header head".to_owned()))?;
+		ctx.head = tip.clone();
+		info!(
+			LOGGER,
+			"pipe: updated header head to {} at {}.",
+			bh.hash(),
+			bh.height,
+		);
+		Ok(Some(tip))
+	} else {
+		Ok(None)
+	}
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -93,22 +93,25 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 	})
 }
 
-/// Process the block header
-pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
+/// Process the block header.
+/// This is only ever used during sync and uses a context based on sync_head.
+pub fn sync_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
 	debug!(
 		LOGGER,
-		"pipe: process_header {} at {}",
+		"pipe: sync_block_header {} at {}",
 		bh.hash(),
 		bh.height
 	);
+
 	check_known(bh.hash(), &mut ctx)?;
 	validate_header(&bh, &mut ctx)?;
 	add_block_header(bh, &mut ctx)?;
 
+	// TODO - confirm this is not needed during sync process (I don't see how it is)
 	// just taking the shared lock
-	let _ = ctx.sumtrees.write().unwrap();
+	// let _ = ctx.sumtrees.write().unwrap();
 
-	update_header_head(bh, &mut ctx)
+	update_sync_head(bh, &mut ctx)
 }
 
 /// Quick in-memory check to fast-reject any block we've already handled
@@ -356,27 +359,18 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 	}
 }
 
-/// Directly updates the head if we've just appended a new block to it or handle
-/// the situation where we've just added enough work to have a fork with more
-/// work than the head.
-fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
-	// if we made a fork with more work than the head (which should also be true
-	// when extending the head), update it
+/// Update the sync head so we can keep syncing from where we left off.
+fn update_sync_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	let tip = Tip::from_block(bh);
-	if tip.total_difficulty > ctx.head.total_difficulty {
-		ctx.store
-			.save_header_head(&tip)
-			.map_err(|e| Error::StoreErr(e, "pipe save header head".to_owned()))?;
-
-		ctx.head = tip.clone();
-		info!(
-			LOGGER,
-			"Updated block header head to {} at {}.",
-			bh.hash(),
-			bh.height
-			);
-		Ok(Some(tip))
-	} else {
-		Ok(None)
-	}
+	ctx.store
+		.save_sync_head(&tip)
+		.map_err(|e| Error::StoreErr(e, "pipe save sync head".to_owned()))?;
+	ctx.head = tip.clone();
+	info!(
+		LOGGER,
+		"pipe: updated sync head to {} at {}.",
+		bh.hash(),
+		bh.height,
+	);
+	Ok(Some(tip))
 }

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -31,6 +31,7 @@ const BLOCK_HEADER_PREFIX: u8 = 'h' as u8;
 const BLOCK_PREFIX: u8 = 'b' as u8;
 const HEAD_PREFIX: u8 = 'H' as u8;
 const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
+const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const OUTPUT_COMMIT_PREFIX: u8 = 'o' as u8;
 const HEADER_BY_OUTPUT_PREFIX: u8 = 'p' as u8;
@@ -80,14 +81,21 @@ impl ChainStore for ChainKVStore {
 		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)
 	}
 
+	fn get_sync_head(&self) -> Result<Tip, Error> {
+		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]))
+	}
+
+	fn save_sync_head(&self, t: &Tip) -> Result<(), Error> {
+		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
+	}
+
 	fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())))
 	}
 
 	fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
-			self.db
-				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
+			self.db.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 		)
 	}
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -217,6 +217,12 @@ pub trait ChainStore: Send + Sync {
 	/// Save the provided tip as the current head of the block header chain
 	fn save_header_head(&self, t: &Tip) -> Result<(), store::Error>;
 
+	/// Get the tip of the current sync header chain
+	fn get_sync_head(&self) -> Result<Tip, store::Error>;
+
+	/// Save the provided tip as the current head of the sync header chain
+	fn save_sync_head(&self, t: &Tip) -> Result<(), store::Error>;
+
 	/// Gets the block header at the provided height
 	fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, store::Error>;
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -97,7 +97,7 @@ impl NetAdapter for NetToChainAdapter {
 	fn headers_received(&self, bhs: Vec<core::BlockHeader>, addr: SocketAddr) {
 		debug!(
 			LOGGER,
-			"Received block headers {:?} from {}",
+			"adapter: received block headers {:?} from {}",
 			bhs.iter().map(|x| x.hash()).collect::<Vec<_>>(),
 			addr
 		);
@@ -105,7 +105,7 @@ impl NetAdapter for NetToChainAdapter {
 		// try to add each header to our header chain
 		let mut added_hs = vec![];
 		for bh in bhs.clone() {
-			let res = self.chain.process_block_header(&bh, self.chain_opts());
+			let res = self.chain.sync_block_header(&bh, self.chain_opts());
 			match res {
 				Ok(_) => {
 					added_hs.push(bh);
@@ -306,7 +306,7 @@ impl NetToChainAdapter {
 		}
 		self.syncing.load(Ordering::Relaxed)
 	}
-	
+
 	// recursively go back through the locator vector and stop when we find
 	// a header that we recognize this will be a header shared in common
 	// between us and the peer

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -95,23 +95,23 @@ impl NetAdapter for NetToChainAdapter {
 	}
 
 	fn headers_received(&self, bhs: Vec<core::BlockHeader>, addr: SocketAddr) {
-		debug!(
+		info!(
 			LOGGER,
-			"adapter: received block headers {:?} from {}",
+			"Received block headers {:?} from {}",
 			bhs.iter().map(|x| x.hash()).collect::<Vec<_>>(),
-			addr
+			addr,
 		);
 
 		// try to add each header to our header chain
 		let mut added_hs = vec![];
-		for bh in bhs.clone() {
+		for bh in bhs {
 			let res = self.chain.sync_block_header(&bh, self.chain_opts());
 			match res {
 				Ok(_) => {
-					added_hs.push(bh);
+					added_hs.push(bh.hash());
 				}
 				Err(chain::Error::Unfit(s)) => {
-					debug!(
+					info!(
 						LOGGER,
 						"Received unfit block header {} at {}: {}.",
 						bh.hash(),
@@ -135,9 +135,9 @@ impl NetAdapter for NetToChainAdapter {
 				}
 			}
 		}
-		debug!(
+		info!(
 			LOGGER,
-			"Received {} headers for the header chain.",
+			"Added {} headers to the header chain.",
 			added_hs.len()
 		);
 	}
@@ -149,9 +149,23 @@ impl NetAdapter for NetToChainAdapter {
 			locator,
 		);
 
-		let header = match self.find_common_header(locator) {
-			Some(header) => header,
-			None => return vec![],
+		if locator.len() == 0 {
+			return vec![];
+		}
+
+		// recursively go back through the locator vector
+		// and stop when we find a header that we recognize
+		// this will be a header shared in common between us and the peer
+		let known = self.chain.get_block_header(&locator[0]);
+		let header = match known {
+			Ok(header) => header,
+			Err(chain::Error::StoreErr(store::Error::NotFoundErr, _)) => {
+				return self.locate_headers(locator[1..].to_vec());
+			}
+			Err(e) => {
+				error!(LOGGER, "Could not build header locator: {:?}", e);
+				return vec![];
+			}
 		};
 
 		debug!(
@@ -241,7 +255,7 @@ impl NetAdapter for NetToChainAdapter {
 		debug!(
 			LOGGER,
 			"peer total_diff @ height (ping/pong): {}: {} @ {} \
-				 vs us: {} @ {}",
+			vs us: {} @ {}",
 			addr,
 			diff,
 			height,
@@ -249,7 +263,7 @@ impl NetAdapter for NetToChainAdapter {
 			self.total_height()
 		);
 
-		if self.p2p_server.is_initialized() {
+		if diff.into_num() > 0 {
 			if let Some(peer) = self.p2p_server.borrow().get_peer(&addr) {
 				let mut peer = peer.write().unwrap();
 				peer.info.total_difficulty = diff;
@@ -305,40 +319,6 @@ impl NetToChainAdapter {
 			}
 		}
 		self.syncing.load(Ordering::Relaxed)
-	}
-
-	// recursively go back through the locator vector and stop when we find
-	// a header that we recognize this will be a header shared in common
-	// between us and the peer
-	fn find_common_header(&self, locator: Vec<Hash>) -> Option<BlockHeader> {
-		if locator.len() == 0 {
-			return None;
-		}
-
-		let known = self.chain.get_block_header(&locator[0]);
-
-		match known {
-			Ok(header) => {
-				// even if we know the block, it may not be on our winning chain
-				let known_winning = self.chain.get_header_by_height(header.height);
-				if let Ok(known_winning) = known_winning {
-					if known_winning.hash() != header.hash() {
-						self.find_common_header(locator[1..].to_vec())
-					} else {
-						Some(header)
-					}
-				} else {
-					self.find_common_header(locator[1..].to_vec())
-				}
-			},
-			Err(chain::Error::StoreErr(store::Error::NotFoundErr, _)) => {
-				self.find_common_header(locator[1..].to_vec())
-			},
-			Err(e) => {
-				error!(LOGGER, "Could not build header locator: {:?}", e);
-				None
-			}
-		}
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -86,7 +86,12 @@ impl Seeder {
 		let mon_loop = Timer::default()
 			.interval(time::Duration::from_secs(10))
 			.for_each(move |_| {
-				debug!(LOGGER, "monitoring peers ({})", p2p_server.all_peers().len());
+				debug!(
+					LOGGER,
+					"monitoring peers ({} of {})", 
+					p2p_server.connected_peers().len(),
+					p2p_server.all_peers().len(),
+				);
 
 				// maintenance step first, clean up p2p server peers
 				let _ = p2p_server.clean_peers();

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -60,16 +60,18 @@ fn body_sync(
 	p2p_server: Arc<p2p::Server>,
 	chain: Arc<chain::Chain>,
 ) {
-	debug!(LOGGER, "block_sync: loop");
+	debug!(LOGGER, "body_sync: loop");
 
 	let header_head = chain.get_header_head().unwrap();
-	let block_header = chain.head_header().unwrap();
+	let sync_head = chain.get_sync_head().unwrap();
 	let mut hashes = vec![];
 
-	if header_head.total_difficulty > block_header.total_difficulty {
-		let mut current = chain.get_block_header(&header_head.last_block_h);
+	if sync_head.total_difficulty > header_head.total_difficulty {
+		let mut current = chain.get_block_header(&sync_head.last_block_h);
 		while let Ok(header) = current {
-			if header.hash() == block_header.hash() {
+			// TODO we need a smarter condition here (this only works on a non-fork sync)
+			// although I think it still works (just inefficient as we go all the way back to genesis block...)
+			if header.hash() == header_head.hash() {
 				break;
 			}
 			hashes.push(header.hash());
@@ -89,12 +91,13 @@ fn body_sync(
 		debug!(
 			LOGGER,
 			"block_sync: requesting blocks ({}/{}), {:?}",
-			block_header.height,
 			header_head.height,
+			sync_head.height,
 			hashes_to_get,
 			);
 
 		for hash in hashes_to_get.clone() {
+			// TODO - what condition should we choose most_work_peer v random_peer (if any?)
 			let peer = if hashes_to_get.len() < 100 {
 				p2p_server.most_work_peer()
 			} else {
@@ -128,24 +131,17 @@ pub fn header_sync(
 		let peer_difficulty = p.info.total_difficulty.clone();
 
 		if peer_difficulty > difficulty {
-			debug!(
-				LOGGER,
-				"header_sync: difficulty {} vs {}",
-				peer_difficulty,
-				difficulty,
-				);
-
 			let _ = request_headers(
 				peer.clone(),
 				chain.clone(),
-				);
+			);
 		}
 	}
 
 	thread::sleep(Duration::from_secs(30));
 }
 
-/// Request some block headers from a peer to advance us
+/// Request some block headers from a peer to advance us.
 fn request_headers(
 	peer: Arc<RwLock<Peer>>,
 	chain: Arc<chain::Chain>,
@@ -154,7 +150,7 @@ fn request_headers(
 	let peer = peer.read().unwrap();
 	debug!(
 		LOGGER,
-		"Sync: Asking peer {} for more block headers, locator: {:?}",
+		"sync: asking {} for headers, locator: {:?}",
 		peer.info.addr,
 		locator,
 	);
@@ -162,18 +158,14 @@ fn request_headers(
 	Ok(())
 }
 
+/// We build a locator based on sync_head.
+/// Even if sync_head is significantly out of date we will "reset" it once we start getting
+/// headers back from a peer.
 fn get_locator(chain: Arc<chain::Chain>) -> Result<Vec<Hash>, Error> {
-	let tip = chain.get_header_head()?;
+	let tip = chain.get_sync_head()?;
+	let heights = get_locator_heights(tip.height);
 
-	// go back to earlier header height to ensure we do not miss a header
-	let height = if tip.height > 5 {
-		tip.height - 5
-	} else {
-		0
-	};
-	let heights = get_locator_heights(height);
-
-	debug!(LOGGER, "Sync: locator heights: {:?}", heights);
+	debug!(LOGGER, "sync: locator heights: {:?}", heights);
 
 	let mut locator = vec![];
 	let mut current = chain.get_block_header(&tip.last_block_h);
@@ -184,7 +176,7 @@ fn get_locator(chain: Arc<chain::Chain>) -> Result<Vec<Hash>, Error> {
 		current = chain.get_block_header(&header.previous);
 	}
 
-	debug!(LOGGER, "Sync: locator: {:?}", locator);
+	debug!(LOGGER, "sync: locator: {:?}", locator);
 
 	Ok(locator)
 }

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -80,11 +80,18 @@ fn body_sync(
 	if sync_head.total_difficulty > body_head.total_difficulty {
 		let mut current = chain.get_block_header(&sync_head.last_block_h);
 		while let Ok(header) = current {
-			// TODO we need a smarter condition here (this only works on a non-fork sync)
-			// although I think it still works (just inefficient as we go all the way back to genesis block...)
-			if header.hash() == body_head.hash() {
-				break;
+
+			// look back through the sync chain until we find a header
+			// that is consistent with the height index (we know this is in the real chain)
+			match chain.get_header_by_height(header.height) {
+				Ok(height_header) => {
+					if header.hash() == height_header.hash() {
+						break;
+					}
+				},
+				Err(_) => {},
 			}
+
 			hashes.push(header.hash());
 			current = chain.get_block_header(&header.previous);
 		}

--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -205,6 +205,7 @@ impl LocalServerContainer {
 				}),
 				seeds: Some(seeds),
 				seeding_type: seeding_type,
+				chain_type: core::global::ChainTypes::AutomatedTesting,
 				..Default::default()
 			},
 			&event_loop.handle(),

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -189,8 +189,8 @@ fn a_simulate_block_propagation() {
 	util::init_test_logger();
 
 	// we actually set the chain_type in the ServerConfig below
-	// the global mining mode is effectively ignored
-	// global::set_mining_mode(ChainTypes::AutomatedTesting);
+	// TODO - avoid needing to set it in two places?
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-prop";
 	framework::clean_all_output(test_name_dir);
@@ -252,8 +252,8 @@ fn simulate_full_sync() {
 	util::init_test_logger();
 
 	// we actually set the chain_type in the ServerConfig below
-	// the global mining mode is effectively ignored
-	// global::set_mining_mode(ChainTypes::AutomatedTesting);
+	// TODO - avoid needing to set it in two places?
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-sync";
 	framework::clean_all_output(test_name_dir);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -187,7 +187,10 @@ fn simulate_parallel_mining() {
 #[test]
 fn a_simulate_block_propagation() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+
+	// we actually set the chain_type in the ServerConfig below
+	// the global mining mode is effectively ignored
+	// global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-prop";
 	framework::clean_all_output(test_name_dir);
@@ -222,6 +225,7 @@ fn a_simulate_block_propagation() {
 				}),
 				seeding_type: grin::Seeding::List,
 				seeds: Some(vec!["127.0.0.1:18000".to_string()]),
+				chain_type: core::global::ChainTypes::AutomatedTesting,
 				..Default::default()
 			},
 			&handle,
@@ -246,7 +250,10 @@ fn a_simulate_block_propagation() {
 #[test]
 fn simulate_full_sync() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+
+	// we actually set the chain_type in the ServerConfig below
+	// the global mining mode is effectively ignored
+	// global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-sync";
 	framework::clean_all_output(test_name_dir);
@@ -281,6 +288,7 @@ fn simulate_full_sync() {
 			}),
 			seeding_type: grin::Seeding::List,
 			seeds: Some(vec!["127.0.0.1:11000".to_string()]),
+			chain_type: core::global::ChainTypes::AutomatedTesting,
 			..Default::default()
 		};
 		let s = grin::Server::future(config, &handle).unwrap();


### PR DESCRIPTION
* introduces the new `sync_head` that we use to track the longest fork on the peer with most work
* remove assumption that a new fork will never by `>height+1` based on current head (see #402 for discussion)
* don't call `check_known` in `sync_block_header` - we always want to (re)-process headers when syncing as we can jump from fork to fork depending on connected peers
* don't check heights as first step in `validate_block` (height may jump across forks)
* in `validate_block` 
  * check for NotFound in `get_header_by_height` (height may jump across forks)
* in `setup_height` 
  * check for NotFound (height may jump across forks)
  * make it recursive for clarity

