### PR TITLE
API endpoints to browse blocks

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,8 +13,10 @@ grin_util = { path = "../util" }
 grin_p2p = { path = "../p2p" }
 hyper = "~0.10.6"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+lazy_static = "1.0"
 iron = "~0.5.1"
 router = "~0.5.1"
+regex = "0.2"
 mount = "~0.3.0"
 urlencoded = "~0.5.0"
 serde = "~1.0.8"

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -291,8 +291,9 @@ impl BlockHandler {
 	// Try to decode the string as a height or a hash address.
 	fn parse_input(&self, input: String) -> Result<Hash, Error> {
 		if let Ok(height) = input.parse() {
-			if let Ok(header) = self.chain.clone().get_header_by_height(height) {
-				return Ok(header.hash())
+			match self.chain.clone().get_header_by_height(height) {
+				Ok(header) => return Ok(header.hash()),
+				Err(_) => return Err(Error::NotFound),
 			}
 		}
     lazy_static! {

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -447,7 +447,7 @@ pub fn start_rest_apis<T>(
 
 		let route_list = vec!(
 			"get /".to_string(),
-			"get /block".to_string(),
+			"get /blocks".to_string(),
 			"get /chain".to_string(),
 			"get /chain/utxos".to_string(),
 			"get /sumtrees/roots".to_string(),
@@ -462,7 +462,7 @@ pub fn start_rest_apis<T>(
 		let index_handler = IndexHandler { list: route_list };
 		let router = router!(
 			index: get "/" => index_handler,
-			block: get "/block/*" => block_handler,
+			blocks: get "/blocks/*" => block_handler,
 			chain_tip: get "/chain" => chain_tip_handler,
 			chain_utxos: get "/chain/utxos/*" => utxo_handler,
 			sumtree_roots: get "/sumtrees/*" => sumtree_handler,

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -296,14 +296,13 @@ impl BlockHandler {
 				Err(_) => return Err(Error::NotFound),
 			}
 		}
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r"[0-9a-fA-F]{64}").unwrap();
-    }
-    if !RE.is_match(&input) {
-    	return Err(Error::Argument(
-    			String::from("Not a valid hex address or height.")))
-    }
-		let vec = util::from_hex(input).unwrap();
+		lazy_static! {
+			static ref RE: Regex = Regex::new(r"[0-9a-fA-F]{64}").unwrap();
+		}
+		if !RE.is_match(&input) {
+			return Err(Error::Argument(
+					String::from("Not a valid hex address or height.")))
+		}
 		Ok(Hash::from_vec(vec))
 	}
 }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -303,6 +303,7 @@ impl BlockHandler {
 			return Err(Error::Argument(
 					String::from("Not a valid hex address or height.")))
 		}
+		let vec = util::from_hex(input).unwrap();
 		Ok(Hash::from_vec(vec))
 	}
 }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -282,17 +282,9 @@ pub struct BlockHandler {
 }
 
 impl BlockHandler {
-	fn get_block(&self, h: &Hash) -> BlockOutputsPrintable {
+	fn get_block(&self, h: &Hash) -> BlockPrintable {
 		let block = self.chain.clone().get_block(h).unwrap();
-		let outputs = block
-			.outputs
-			.iter()
-			.map(|k|OutputPrintable::from_output(k, &block.header, true))
-			.collect();
-		BlockOutputsPrintable {
-			header: BlockHeaderInfo::from_header(&block.header),
-			outputs: outputs,
-		}
+		BlockPrintable::from_block(&block)
 	}
 
 	// Try to decode the string as a height or a hash address.

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -20,8 +20,11 @@ extern crate grin_store as store;
 extern crate grin_util as util;
 
 extern crate hyper;
+#[macro_use]
+extern crate lazy_static;
 extern crate iron;
 extern crate mount;
+extern crate regex;
 #[macro_use]
 extern crate router;
 extern crate serde;

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -148,7 +148,7 @@ pub struct Output {
 }
 
 impl Output {
-	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader, 
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader,
 		include_proof:bool, include_switch: bool) -> Output {
 		let (output_type, lock_height) = match output.features {
 			x if x.contains(core::transaction::COINBASE_OUTPUT) => (
@@ -222,7 +222,7 @@ impl OutputPrintable {
 // As above, except just the info needed for wallet reconstruction
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OutputSwitch {
-	/// the commit 
+	/// the commit
 	pub commit: String,
 	/// switch commit hash
 	pub switch_commit_hash: [u8; core::SWITCH_COMMIT_HASH_SIZE],
@@ -259,6 +259,16 @@ impl BlockHeaderInfo {
 		}
 	}
 }
+
+// Block header info with printable outputs
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockOutputsPrintable {
+	/// The block header
+	pub header: BlockHeaderInfo,
+	/// A printable version of the outputs
+	pub outputs: Vec<OutputPrintable>,
+}
+
 // For wallet reconstruction, include the header info along with the
 // transactions in the block
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -266,6 +266,8 @@ impl TxKernelPrintable {
 // Just the information required for wallet reconstruction
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockHeaderInfo {
+	// Hash
+	pub hash: String,
 	/// Version of the block
 	pub version: u16,
 	/// Height of this block since the genesis block (height 0)
@@ -291,6 +293,7 @@ pub struct BlockHeaderInfo {
 impl BlockHeaderInfo {
 	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderInfo {
 		BlockHeaderInfo {
+			hash: util::to_hex(h.hash().to_vec()),
 			version: h.version,
 			height: h.height,
 			previous: util::to_hex(h.previous.to_vec()),

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -239,6 +239,21 @@ impl OutputSwitch {
 		}
 	}
 }
+
+// Printable representation of a block
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TxKernelPrintable {
+	pub excess: String,
+}
+
+impl TxKernelPrintable {
+	pub fn from_txkernel(kernel: &core::TxKernel) -> TxKernelPrintable {
+		TxKernelPrintable {
+			excess: util::to_hex(kernel.excess.0.to_vec()),
+		}
+	}
+}
+
 // Just the information required for wallet reconstruction
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockHeaderInfo {
@@ -251,11 +266,47 @@ pub struct BlockHeaderInfo {
 }
 
 impl BlockHeaderInfo {
-	pub fn from_header(block_header: &core::BlockHeader) -> BlockHeaderInfo{
+	pub fn from_header(block_header: &core::BlockHeader) -> BlockHeaderInfo {
 		BlockHeaderInfo {
 			hash: util::to_hex(block_header.hash().to_vec()),
 			previous: util::to_hex(block_header.previous.to_vec()),
 			height: block_header.height,
+		}
+	}
+}
+
+// Printable representation of a block
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockPrintable {
+	/// The block header
+	pub header: BlockHeaderInfo,
+	// Input transactions
+	pub inputs: Vec<String>,
+	/// A printable version of the outputs
+	pub outputs: Vec<OutputPrintable>,
+	/// A printable version of the transaction kernels
+	pub kernels: Vec<TxKernelPrintable>,
+}
+
+impl BlockPrintable {
+	pub fn from_block(block: &core::Block) -> BlockPrintable {
+		let inputs = block.inputs
+			.iter()
+			.map(|input| util::to_hex((input.0).0.to_vec()))
+			.collect();
+		let outputs = block.outputs
+			.iter()
+			.map(|output| OutputPrintable::from_output(output, &block.header, true))
+			.collect();
+		let kernels = block.kernels
+			.iter()
+			.map(|kernel| TxKernelPrintable::from_txkernel(kernel))
+			.collect();
+		BlockPrintable {
+			header: BlockHeaderInfo::from_header(&block.header),
+			inputs: inputs,
+			outputs: outputs,
+			kernels: kernels,
 		}
 	}
 }

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -241,15 +241,10 @@ impl OutputSwitch {
 	}
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum KernelFeature {
-	Coinbase,
-}
-
 // Printable representation of a block
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TxKernelPrintable {
-	//pub features: String,
+	pub features: String,
 	pub fee: u64,
 	pub lock_height: u64,
 	pub excess: String,
@@ -257,12 +252,13 @@ pub struct TxKernelPrintable {
 }
 
 impl TxKernelPrintable {
-	pub fn from_txkernel(kernel: &core::TxKernel) -> TxKernelPrintable {
+	pub fn from_txkernel(k: &core::TxKernel) -> TxKernelPrintable {
 		TxKernelPrintable {
-			fee: kernel.fee,
-			lock_height: kernel.lock_height,
-			excess: util::to_hex(kernel.excess.0.to_vec()),
-			excess_sig: util::to_hex(kernel.excess_sig.to_vec())
+			features: format!("{:?}", k.features),
+			fee: k.fee,
+			lock_height: k.lock_height,
+			excess: util::to_hex(k.excess.0.to_vec()),
+			excess_sig: util::to_hex(k.excess_sig.to_vec())
 		}
 	}
 }


### PR DESCRIPTION
Added a /block endpoint to the API.  This can take either a height number or block address and return the block info.

Fixes #397 