### PR TITLE
Update BlockHeaderInfo Struct

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -25,10 +25,10 @@ use util;
 pub struct Tip {
 	/// Height of the tip (max height of the fork)
 	pub height: u64,
-	// Last block pushed to the fork
-	pub last_block_pushed: String,
-	// Block previous to last
-	pub prev_block_to_last: String,
+	// Last block hash added to the chain
+	pub hash: String,
+	// Previous block hash
+	pub previous: String,
 	// Total difficulty accumulated on that fork
 	pub total_difficulty: u64,
 }
@@ -37,8 +37,8 @@ impl Tip {
 	pub fn from_tip(tip: chain::Tip) -> Tip {
 		Tip {
 			height: tip.height,
-			last_block_pushed: util::to_hex(tip.last_block_h.to_vec()),
-			prev_block_to_last: util::to_hex(tip.prev_block_h.to_vec()),
+			hash: util::to_hex(tip.last_block_h.to_vec()),
+			previous: util::to_hex(tip.prev_block_h.to_vec()),
 			total_difficulty: tip.total_difficulty.into_num(),
 		}
 	}
@@ -248,7 +248,7 @@ pub struct BlockHeaderInfo {
 	pub previous: String,
 	/// Height
 	pub height: u64,
-	/// Difficulty
+	/// Total Difficulty
 	pub total_difficulty: u64
 }
 

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -148,7 +148,7 @@ pub struct Output {
 }
 
 impl Output {
-	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader, 
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader,
 		include_proof:bool, include_switch: bool) -> Output {
 		let (output_type, lock_height) = match output.features {
 			x if x.contains(core::transaction::COINBASE_OUTPUT) => (
@@ -222,7 +222,7 @@ impl OutputPrintable {
 // As above, except just the info needed for wallet reconstruction
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OutputSwitch {
-	/// the commit 
+	/// the commit
 	pub commit: String,
 	/// switch commit hash
 	pub switch_commit_hash: [u8; core::SWITCH_COMMIT_HASH_SIZE],
@@ -247,7 +247,9 @@ pub struct BlockHeaderInfo {
 	/// Previous block hash
 	pub previous: String,
 	/// Height
-	pub height: u64
+	pub height: u64,
+	/// Difficulty
+	pub total_difficulty: u64
 }
 
 impl BlockHeaderInfo {
@@ -256,6 +258,7 @@ impl BlockHeaderInfo {
 			hash: util::to_hex(block_header.hash().to_vec()),
 			previous: util::to_hex(block_header.previous.to_vec()),
 			height: block_header.height,
+			total_difficulty: block_header.total_difficulty.into_num(),
 		}
 	}
 }


### PR DESCRIPTION
## Overview
I am not sure if is relevant although I believe that for consistency, when we return the block header we should return the same parameters in both
- `/v1/chain`
- `/v1/chain/utxos/atheight`

In case the naming was deliberately different for some reason - Please feel free to close the PR :) 

## Changes
- Added `total_difficulty` to `BlockHeaderInfo` so it can be returned by `/v1/chain/utxos/atheight`
- Inside the Tip struct I changed `last_block_pushed` to `hash` and `prev_block_to_last` to `previous` to keep the  names consistent between Apis