### PR TITLE
simplify sync process further - one thread for both body and header sync

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -80,12 +80,12 @@ impl NetAdapter for NetToChainAdapter {
 			// mistaken or manevolent, both of which require a ban
 			if e.is_bad_block() {
 				self.p2p_server.borrow().ban_peer(&addr);
-
-				// and if we're currently syncing, our header chain is now wrong, it
-				// needs to be reset
-				if self.is_syncing() {
-					self.chain.reset_header_head();
-				}
+			//
+			// 	// header chain should be consistent with the sync head here
+			// 	// we just banned the peer that sent a bad block so
+			// 	// sync head should resolve itself if/when we find an alternative peer
+			// 	// with more work than ourselves
+			// 	// we should not need to reset the header head here
 			}
 		}
 	}

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -88,7 +88,8 @@ impl Seeder {
 			.for_each(move |_| {
 				debug!(
 					LOGGER,
-					"monitoring peers ({} of {})",
+					"monitoring peers ({} / {} / {})",
+					p2p_server.most_work_peers().len(),
 					p2p_server.connected_peers().len(),
 					p2p_server.all_peers().len(),
 				);


### PR DESCRIPTION
* simplify sync process further - one thread, try_read on peer for robustness
* add most_work_peers() for convenience, add most_work_peers count to "monitoring peers" log msg