### PR TITLE
 dry up how we check if a header is on the current chain 

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -25,7 +25,7 @@ use core::core::pmmr::{HashSum, NoSum};
 
 use core::core::{Block, BlockHeader, Output, TxKernel};
 use core::core::target::Difficulty;
-use core::core::hash::{Hash, Hashed};
+use core::core::hash::Hash;
 use grin_store::Error::NotFoundErr;
 use pipe;
 use store;
@@ -103,8 +103,7 @@ impl Chain {
 		let _ = match chain_store.get_sync_head() {
 			Ok(tip) => tip,
 			Err(NotFoundErr) => {
-				let gen = chain_store.get_header_by_height(0).unwrap();
-				let tip = Tip::new(gen.hash());
+				let tip = chain_store.head().unwrap();
 				chain_store.save_sync_head(&tip)?;
 				tip
 			},
@@ -359,6 +358,14 @@ impl Chain {
 	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
 		self.store.get_header_by_height(height).map_err(|e| {
 			Error::StoreErr(e, "chain get header by height".to_owned())
+		})
+	}
+
+	/// Verifies the given block header is actually on the current chain.
+	/// Checks the header_by_height index to verify the header is where we say it is
+	pub fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {
+		self.store.is_on_current_chain(header).map_err(|e| {
+			Error::StoreErr(e, "chain is_on_current_chain".to_owned())
 		})
 	}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -245,22 +245,12 @@ fn validate_block(
 		let mut hashes = vec![];
 		loop {
 			let curr_header = ctx.store.get_block_header(&current)?;
-			match ctx.store.get_header_by_height(curr_header.height) {
-				Ok(height_header) => {
-					if curr_header.hash() != height_header.hash() {
-						hashes.insert(0, curr_header.hash());
-						current = curr_header.previous;
-					} else {
-						break;
-					}
-				},
-				Err(grin_store::Error::NotFoundErr) => {
-					hashes.insert(0, curr_header.hash());
-					current = curr_header.previous;
-				},
-				Err(e) => {
-					return Err(Error::StoreErr(e, format!("header by height lookup failed")));
-				}
+
+			if let Ok(_) = ctx.store.is_on_current_chain(&curr_header) {
+				break;
+			} else {
+				hashes.insert(0, curr_header.hash());
+				current = curr_header.previous;
 			}
 		}
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -226,6 +226,10 @@ pub trait ChainStore: Send + Sync {
 	/// Gets the block header at the provided height
 	fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, store::Error>;
 
+	/// Is the block header on the current chain?
+	/// Use the header_by_height index to verify the block header is where we think it is.
+	fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), store::Error>;
+
 	/// Gets an output by its commitment
 	fn get_output_by_commit(&self, commit: &Commitment) -> Result<Output, store::Error>;
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -94,15 +94,10 @@ fn body_sync(
 		let mut current = chain.get_block_header(&header_head.last_block_h);
 		while let Ok(header) = current {
 
-			// look back through the sync chain until we find a header
-			// that is consistent with the height index (we know this is in the real chain)
-			match chain.get_header_by_height(header.height) {
-				Ok(height_header) => {
-					if header.hash() == height_header.hash() {
-						break;
-					}
-				},
-				Err(_) => {},
+			// break out of the while loop when we find a header common
+			// between the this chain and the current chain
+			if let Ok(_) = chain.is_on_current_chain(&header) {
+				break;
 			}
 
 			hashes.push(header.hash());


### PR DESCRIPTION
We were doing similar (but slightly different) things to check the header by hash and then header by height and comparing the hashes to see if the header was on the current chain.

This PR pulls this logic out into `is_on_current_chain()` to DRY this up.

Unrelated (probably should have been in a separate PR) - initial sync_head is set to `head` now and not manually setting to the header on the genesis block.

