### PR TITLE
Removed delete_peer because unused

### DIFF
--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -109,10 +109,6 @@ impl PeerStore {
 		self.db.exists(&peer_key(peer_addr)[..])
 	}
 
-	pub fn delete_peer(&self, peer_addr: SocketAddr) -> Result<(), Error> {
-		self.db.delete(&peer_key(peer_addr)[..])
-	}
-
 	pub fn find_peers(&self, state: State, cap: Capabilities, count: usize) -> Vec<PeerData> {
 		let mut peers = self.db
 			.iter::<PeerData>(&to_key(PEER_PREFIX, &mut "".to_string().into_bytes()))

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -177,12 +177,6 @@ pub trait PoolAdapter: Send + Sync {
 	fn tx_accepted(&self, tx: &transaction::Transaction);
 }
 
-/// Dummy adapter used as a placeholder for real implementations
-pub struct NoopAdapter {}
-impl PoolAdapter for NoopAdapter {
-	fn tx_accepted(&self, _: &transaction::Transaction) {}
-}
-
 /// Pool contains the elements of the graph that are connected, in full, to
 /// the blockchain.
 /// Reservations of outputs by orphan transactions (not fully connected) are


### PR DESCRIPTION
# Overview

Removed unused methods that were rising warnings during the build

```
warning: method is never used: `delete_peer`
   --> p2p/src/store.rs:112:2
    |
112 |  pub fn delete_peer(&self, peer_addr: SocketAddr) -> Result<(), Error> {
    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(dead_code)] on by default

   Compiling grin_pool v0.1.0 (file:///Users/mtanzi/Projects/mimblewimble/grin/pool)
warning: struct is never used: `NoopAdapter`
   --> pool/src/types.rs:181:1
    |
181 | pub struct NoopAdapter {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(dead_code)] on by default
```