### PR TITLE
base threshold for sync on difficulty of past 5 blocks

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -306,17 +306,12 @@ impl NetToChainAdapter {
 		} else {
 			if let Some(peer) = peer {
 				if let Ok(peer) = peer.try_read() {
-					let mut threshold = Difficulty::zero();
-					let last_diffs = self.chain
+					// sum the last 5 difficulties to give us the threshold
+					let threshold = self.chain
 						.difficulty_iter()
+						.filter_map(|x| x.map(|(_, x)| x).ok())
 						.take(5)
-						.collect::<Vec<_>>();
-
-					for diff in last_diffs {
-						if let Ok((_, diff)) = diff {
-							threshold = threshold + diff;
-						}
-					}
+						.fold(Difficulty::zero(), |sum, val| sum + val);
 
 					if peer.info.total_difficulty > local_diff.clone() + threshold.clone() {
 						info!(

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -39,6 +39,9 @@ pub fn run_sync(
 			let mut prev_body_sync = time::now_utc();
 			let mut prev_header_sync = prev_body_sync.clone();
 
+			// initial sleep to give us time to peer with some nodes
+			thread::sleep(Duration::from_secs(30));
+
 			loop {
 				if a_inner.is_syncing() {
 					let current_time = time::now_utc();


### PR DESCRIPTION
* Use `DifficultyIterator` to find difficulty for past 5 blocks
* Calculate sync threshold from sum of difficulties from these 5 blocks
* Add back an initial 30s sleep to sync - give us time to find some peers

Resolves #401.