### PR TITLE
Revert BlockHeaderInfo struct to contain only the fields needed for w…

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -275,8 +275,8 @@ impl Handler for ChainHandler {
 	}
 }
 
-// Gets block details given either a hex address or height.
-// GET /v1/block/<address>
+// Gets block details given either a hash or height.
+// GET /v1/block/<hash>
 // GET /v1/block/<height>
 pub struct BlockHandler {
 	pub chain: Arc<chain::Chain>,
@@ -288,7 +288,7 @@ impl BlockHandler {
 		Ok(BlockPrintable::from_block(&block))
 	}
 
-	// Try to decode the string as a height or a hash address.
+	// Try to decode the string as a height or a hash.
 	fn parse_input(&self, input: String) -> Result<Hash, Error> {
 		if let Ok(height) = input.parse() {
 			match self.chain.clone().get_header_by_height(height) {
@@ -301,7 +301,7 @@ impl BlockHandler {
 		}
 		if !RE.is_match(&input) {
 			return Err(Error::Argument(
-					String::from("Not a valid hex address or height.")))
+					String::from("Not a valid hash or height.")))
 		}
 		let vec = util::from_hex(input).unwrap();
 		Ok(Hash::from_vec(vec))

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -267,6 +267,26 @@ impl TxKernelPrintable {
 pub struct BlockHeaderInfo {
 	// Hash
 	pub hash: String,
+	/// Height of this block since the genesis block (height 0)
+	pub height: u64,
+	/// Hash of the block previous to this in the chain.
+	pub previous: String,
+}
+
+impl BlockHeaderInfo {
+	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderInfo {
+		BlockHeaderInfo {
+			hash: util::to_hex(h.hash().to_vec()),
+			height: h.height,
+			previous: util::to_hex(h.previous.to_vec()),
+		}
+	}
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockHeaderPrintable {
+	// Hash
+	pub hash: String,
 	/// Version of the block
 	pub version: u16,
 	/// Height of this block since the genesis block (height 0)
@@ -289,9 +309,9 @@ pub struct BlockHeaderInfo {
 	pub total_difficulty: u64,
 }
 
-impl BlockHeaderInfo {
-	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderInfo {
-		BlockHeaderInfo {
+impl BlockHeaderPrintable {
+	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderPrintable {
+		BlockHeaderPrintable {
 			hash: util::to_hex(h.hash().to_vec()),
 			version: h.version,
 			height: h.height,
@@ -311,7 +331,7 @@ impl BlockHeaderInfo {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockPrintable {
 	/// The block header
-	pub header: BlockHeaderInfo,
+	pub header: BlockHeaderPrintable,
 	// Input transactions
 	pub inputs: Vec<String>,
 	/// A printable version of the outputs
@@ -335,7 +355,7 @@ impl BlockPrintable {
 			.map(|kernel| TxKernelPrintable::from_txkernel(kernel))
 			.collect();
 		BlockPrintable {
-			header: BlockHeaderInfo::from_header(&block.header),
+			header: BlockHeaderPrintable::from_header(&block.header),
 			inputs: inputs,
 			outputs: outputs,
 			kernels: kernels,


### PR DESCRIPTION
…allet reconstruction.  Create a new struct for use in the /blocks api.

address @yeastplume comments which further resolves #397.  