### PR TITLE
[testnet1] more aggressive peering

### DIFF
--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -132,6 +132,11 @@ impl Seeder {
 								p.info.addr,
 							);
 							let _ = p.send_peer_request(capabilities);
+						} else {
+							warn!(
+								LOGGER,
+								"monitor_peers: failed to get read lock on peer",
+							);
 						}
 					}
 

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -311,10 +311,10 @@ fn connect_and_req(
 				}
 			},
 			Ok(None) => {
-				error!(LOGGER, "connect_and_req: ok but none inner (what does this mean?), {}", addr);
+				debug!(LOGGER, "connect_and_req: ok but none inner (what does this mean?), {}", addr);
 			},
 			Err(e) => {
-				error!(LOGGER, "connect_and_req: err - {:?}, {}, flagging as defunct", e, addr);
+				debug!(LOGGER, "connect_and_req: err - {:?}, {}, flagging as defunct", e, addr);
 				let _ = p2p_server.update_state(addr, p2p::State::Defunct);
 			},
 		}

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -106,12 +106,14 @@ fn body_sync(
 	}
 	hashes.reverse();
 
-	// let peer_count = p2p_server.most_work_peers().len();
+	let peer_count = {
+		p2p_server.most_work_peers().len()
+	};
+
 	let hashes_to_get = hashes
 		.iter()
 		.filter(|x| !chain.get_block(&x).is_ok())
-		.take(10)
-		// .take(peer_count * 2)
+		.take(peer_count * 2)
 		.cloned()
 		.collect::<Vec<_>>();
 
@@ -172,7 +174,7 @@ fn request_headers(
 		let _ = peer.send_header_request(locator);
 	} else {
 		// not much we can do here, log and try again next time
-		warn!(
+		debug!(
 			LOGGER,
 			"sync: request_headers: failed to get read lock on peer",
 		);

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -162,26 +162,22 @@ fn request_headers(
 	chain: Arc<chain::Chain>,
 ) -> Result<(), Error> {
 	let locator = get_locator(chain)?;
-	match peer.try_read() {
-		Ok(peer) => {
-			debug!(
-				LOGGER,
-				"sync: request_headers: asking {} for headers, {:?}",
-				peer.info.addr,
-				locator,
-			);
-			let _ = peer.send_header_request(locator);
-			Ok(())
-		},
-		Err(_) => {
-			// not much we can do here, log and try again next time
-			warn!(
-				LOGGER,
-				"sync: request_headers: failed to get read lock on peer",
-			);
-			Ok(())
-		},
+	if let Ok(peer) = peer.try_read() {
+		debug!(
+			LOGGER,
+			"sync: request_headers: asking {} for headers, {:?}",
+			peer.info.addr,
+			locator,
+		);
+		let _ = peer.send_header_request(locator);
+	} else {
+		// not much we can do here, log and try again next time
+		warn!(
+			LOGGER,
+			"sync: request_headers: failed to get read lock on peer",
+		);
 	}
+	Ok(())
 }
 
 /// We build a locator based on sync_head.

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -130,14 +130,7 @@ impl Handshake {
 					{
 						// check the nonce to see if we could be trying to connect to ourselves
 						let nonces = nonces.read().unwrap();
-						debug!(
-							LOGGER,
-							"checking the nonce - {}, {:?}",
-							&hand.nonce,
-							nonces,
-						);
 						if nonces.contains(&hand.nonce) {
-							debug!(LOGGER, "***** nonce matches! Avoiding connecting to ourselves");
 							return Err(Error::Serialization(ser::Error::UnexpectedData {
 								expected: vec![],
 								received: vec![],

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -237,7 +237,7 @@ impl Server {
 			TcpStream::connect(&addr, &h),
 			Duration::from_secs(5),
 		).map_err(|e| {
-			error!(LOGGER, "connect_peer: socket connect error - {:?}", e);
+			debug!(LOGGER, "connect_peer: socket connect error - {:?}", e);
 			Error::Connection(e)
 		});
 
@@ -533,11 +533,11 @@ fn with_timeout<T: 'static>(
 				Ok(inner)
 			},
 			Ok((Err(inner), _accept)) => {
-				error!(LOGGER, "with_timeout: ok but nested - {:?} (treating this as timeout)", inner);
+				debug!(LOGGER, "with_timeout: ok but nested - {:?} (treating this as timeout)", inner);
 				Err(Error::Timeout)
 			},
 			Err((e, _other)) => {
-				error!(LOGGER, "with_timeout: err - {:?} (treating this as an error)", e);
+				debug!(LOGGER, "with_timeout: err - {:?} (treating this as an error)", e);
 				Err(e)
 			},
 		});


### PR DESCRIPTION
[WIP] looking into why so many peers get marked as defunct (do we do this too quickly?)

* attempt to peer 100 addrs at a time
* if we end up with too many then prune the connected peers down to preferred count
* rework timeout handling in `connect_and_req`
    * push timeout logic into `connect_peer` (timeout/connection error handling)
* request peer list from our conected peers when we are low on peers
    * peers that have connected to our peers may be worth trying to connect to

Resolves #437.

If this gets _really_ noisy at the network level we can revisit this but I think this is worth a shot now to see if it improves network stability.

