### PR TITLE
body_sync every 5s, but request 10*most_work_peers blocks at a time

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -33,7 +33,7 @@ use sumtree;
 use types::*;
 use util::LOGGER;
 
-const MAX_ORPHANS: usize = 20;
+const MAX_ORPHANS: usize = 50;
 
 /// Facade to the blockchain block processing pipeline and storage. Provides
 /// the current view of the UTXO set according to the chain state. Also


### PR DESCRIPTION
* body_sync every `5s`
* request `10*most_work_peers` each time
* increase `MAX_ORPHANS = 50` (to handle larger number of blocks at a time)
* header_sync every `10s`

Sync will be slower if the network is not in a particularly stable state (few peers advertising most work) but faster once network starts to converge (multiple peers advertising most work).

Resolves #447.
