### PR TITLE
[WIP] stateful syncer tracking in_flight blocks

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -286,7 +286,7 @@ impl NetToChainAdapter {
 	/// Whether we're currently syncing the chain or we're fully caught up and
 	/// just receiving blocks through gossip.
 	pub fn is_syncing(&self) -> bool {
-		syncer.is_syncing()
+		self.syncer.is_syncing()
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -14,7 +14,6 @@
 
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use chain::{self, ChainAdapter};
 use core::core::{self, Output};
@@ -23,10 +22,10 @@ use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use p2p::{self, NetAdapter, PeerData, State};
 use pool;
-use util::secp::pedersen::Commitment;
-use util::OneTime;
 use store;
-use util::LOGGER;
+use sync;
+use util::secp::pedersen::Commitment;
+use util::{LOGGER, OneTime};
 
 /// Implementation of the NetAdapter for the blockchain. Gets notified when new
 /// blocks and transactions are received and forwards to the chain and pool
@@ -35,7 +34,7 @@ pub struct NetToChainAdapter {
 	chain: Arc<chain::Chain>,
 	p2p_server: OneTime<Arc<p2p::Server>>,
 	tx_pool: Arc<RwLock<pool::TransactionPool<PoolToChainAdapter>>>,
-	syncing: AtomicBool,
+	syncer: Arc<sync::Syncer>,
 }
 
 impl NetAdapter for NetToChainAdapter {
@@ -269,12 +268,13 @@ impl NetToChainAdapter {
 	pub fn new(
 		chain_ref: Arc<chain::Chain>,
 		tx_pool: Arc<RwLock<pool::TransactionPool<PoolToChainAdapter>>>,
+		syncer: Arc<sync::Syncer>,
 	) -> NetToChainAdapter {
 		NetToChainAdapter {
 			chain: chain_ref,
 			p2p_server: OneTime::new(),
 			tx_pool: tx_pool,
-			syncing: AtomicBool::new(true),
+			syncer: syncer,
 		}
 	}
 
@@ -286,47 +286,7 @@ impl NetToChainAdapter {
 	/// Whether we're currently syncing the chain or we're fully caught up and
 	/// just receiving blocks through gossip.
 	pub fn is_syncing(&self) -> bool {
-		let local_diff = self.total_difficulty();
-		let peer = self.p2p_server.borrow().most_work_peer();
-
-		// if we're already syncing, we're caught up if no peer has a higher
-		// difficulty than us
-		if self.syncing.load(Ordering::Relaxed) {
-			if let Some(peer) = peer {
-				if let Ok(peer) = peer.try_read() {
-					if peer.info.total_difficulty <= local_diff {
-						info!(LOGGER, "sync: caught up on most worked chain, disabling sync");
-						self.syncing.store(false, Ordering::Relaxed);
-					}
-				}
-			} else {
-				info!(LOGGER, "sync: no peers available, disabling sync");
-				self.syncing.store(false, Ordering::Relaxed);
-			}
-		} else {
-			if let Some(peer) = peer {
-				if let Ok(peer) = peer.try_read() {
-					// sum the last 5 difficulties to give us the threshold
-					let threshold = self.chain
-						.difficulty_iter()
-						.filter_map(|x| x.map(|(_, x)| x).ok())
-						.take(5)
-						.fold(Difficulty::zero(), |sum, val| sum + val);
-
-					if peer.info.total_difficulty > local_diff.clone() + threshold.clone() {
-						info!(
-							LOGGER,
-							"sync: total_difficulty {}, peer_difficulty {}, threshold {} (last 5 blocks), enabling sync",
-							local_diff,
-							peer.info.total_difficulty,
-							threshold,
-						);
-						self.syncing.store(true, Ordering::Relaxed);
-					}
-				}
-			}
-		}
-		self.syncing.load(Ordering::Relaxed)
+		syncer.is_syncing()
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -158,7 +158,7 @@ impl Server {
 			_ => {}
 		}
 
-		syncer.run_sync();
+		sync::run_sync(syncer);
 
 		evt_handle.spawn(p2p_server.start(evt_handle.clone()).map_err(|_| ()));
 


### PR DESCRIPTION
Bringing back the state to track "in flight" blocks.
We have scenarios where we start to see timeouts during the `body_sync` with the syncer repeatedly asking for the same blocks from the same peer.
I suspect we're causing a lot of backlog with this and get into a situation where these are timing out because we have queued up so many block requests that we cannot get through them fast enough.

Tracking "in flight" block requests will let us avoid asking for the same blocks again and again.

~Battling with lifetimes though in rust right now...~

See #454 for more info.