### PR TITLE
introduce cpu_pool to read_msg

### DIFF
--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -16,6 +16,8 @@ use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use cpupool::CpuPool;
+
 use chain::{self, ChainAdapter};
 use core::core::{self, Output};
 use core::core::block::BlockHeader;
@@ -36,9 +38,14 @@ pub struct NetToChainAdapter {
 	p2p_server: OneTime<Arc<p2p::Server>>,
 	tx_pool: Arc<RwLock<pool::TransactionPool<PoolToChainAdapter>>>,
 	syncing: AtomicBool,
+	cpu_pool: CpuPool,
 }
 
 impl NetAdapter for NetToChainAdapter {
+	fn cpu_pool(&self) -> CpuPool {
+		self.cpu_pool.clone()
+	}
+
 	fn total_difficulty(&self) -> Difficulty {
 		self.chain.total_difficulty()
 	}
@@ -275,6 +282,7 @@ impl NetToChainAdapter {
 			p2p_server: OneTime::new(),
 			tx_pool: tx_pool,
 			syncing: AtomicBool::new(true),
+			cpu_pool: CpuPool::new(1),
 		}
 	}
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,6 +8,7 @@ workspace = ".."
 bitflags = "^0.7.0"
 byteorder = "^0.5"
 futures = "^0.1.15"
+futures-cpupool = "^0.1.3"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 net2 = "0.2.0"
 rand = "^0.3"

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -26,6 +26,8 @@ extern crate bytes;
 #[macro_use]
 extern crate enum_primitive;
 extern crate futures;
+extern crate futures_cpupool;
+
 #[macro_use]
 extern crate grin_core as core;
 extern crate grin_store;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -16,6 +16,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 
 use futures::Future;
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 
 use core::core;
@@ -221,6 +222,10 @@ impl TrackingAdapter {
 }
 
 impl NetAdapter for TrackingAdapter {
+	fn cpu_pool(&self) -> CpuPool {
+		self.adapter.cpu_pool()
+	}
+
 	fn total_difficulty(&self) -> Difficulty {
 		self.adapter.total_difficulty()
 	}

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -152,7 +152,11 @@ fn handle_payload(
 				&MsgHeader::new(Type::Pong, body_data.len() as u64),
 			));
 			data.append(&mut body_data);
-			sender.unbounded_send(data).unwrap();
+
+			if let Err(e) = sender.unbounded_send(data) {
+				debug!(LOGGER, "handle_payload: Ping, error sending: {:?}", e);
+			}
+
 			Ok(None)
 		}
 		Type::Pong => {
@@ -180,13 +184,18 @@ fn handle_payload(
 					&MsgHeader::new(Type::Block, body_data.len() as u64),
 				));
 				data.append(&mut body_data);
-				sender.unbounded_send(data).unwrap();
+				if let Err(e) = sender.unbounded_send(data) {
+					debug!(LOGGER, "handle_payload: GetBlock, error sending: {:?}", e);
+				}
 			}
 			Ok(None)
 		}
 		Type::Block => {
 			let b = ser::deserialize::<core::Block>(&mut &buf[..])?;
 			let bh = b.hash();
+
+			debug!(LOGGER, "handle_payload: Block {}", bh);
+
 			adapter.block_received(b, addr);
 			Ok(Some(bh))
 		}
@@ -207,7 +216,9 @@ fn handle_payload(
 				&MsgHeader::new(Type::Headers, body_data.len() as u64),
 			));
 			data.append(&mut body_data);
-			sender.unbounded_send(data).unwrap();
+			if let Err(e) = sender.unbounded_send(data) {
+				debug!(LOGGER, "handle_payload: GetHeaders, error sending: {:?}", e);
+			}
 
 			Ok(None)
 		}
@@ -234,7 +245,9 @@ fn handle_payload(
 				&MsgHeader::new(Type::PeerAddrs, body_data.len() as u64),
 			));
 			data.append(&mut body_data);
-			sender.unbounded_send(data).unwrap();
+			if let Err(e) = sender.unbounded_send(data) {
+				debug!(LOGGER, "handle_payload: GetPeerAddrs, error sending: {:?}", e);
+			}
 
 			Ok(None)
 		}

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -50,7 +50,8 @@ impl Protocol for ProtocolV1 {
 		adapter: Arc<NetAdapter>,
 		addr: SocketAddr,
 	) -> Box<Future<Item = (), Error = Error>> {
-		let (conn, listener) = TimeoutConnection::listen(conn, move |sender, header, data| {
+		let pool = adapter.cpu_pool();
+		let (conn, listener) = TimeoutConnection::listen(conn, pool, move |sender, header, data| {
 			let adapt = adapter.as_ref();
 			handle_payload(adapt, sender, header, data, addr)
 		});

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -40,10 +40,12 @@ use types::*;
 use util::LOGGER;
 
 /// A no-op network adapter used for testing.
-pub struct DummyAdapter {}
+pub struct DummyAdapter {
+	cpu_pool: CpuPool,
+}
 impl NetAdapter for DummyAdapter {
 	fn cpu_pool(&self) -> CpuPool {
-		panic!("not implemented in dummy adapter");
+		self.cpu_pool.clone()
 	}
 	fn total_difficulty(&self) -> Difficulty {
 		Difficulty::one()

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use futures;
 use futures::{Future, Stream};
 use futures::future::{self, IntoFuture};
+use futures_cpupool::CpuPool;
 use rand::{thread_rng, Rng};
 use tokio_core::net::{TcpListener, TcpStream};
 use tokio_core::reactor;
@@ -41,6 +42,9 @@ use util::LOGGER;
 /// A no-op network adapter used for testing.
 pub struct DummyAdapter {}
 impl NetAdapter for DummyAdapter {
+	fn cpu_pool(&self) -> CpuPool {
+		panic!("not implemented in dummy adapter");
+	}
 	fn total_difficulty(&self) -> Difficulty {
 		Difficulty::one()
 	}

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -43,6 +43,15 @@ use util::LOGGER;
 pub struct DummyAdapter {
 	cpu_pool: CpuPool,
 }
+
+impl DummyAdapter {
+	pub fn new() -> DummyAdapter {
+		DummyAdapter {
+			cpu_pool: CpuPool::new(1),
+		}
+	}
+}
+
 impl NetAdapter for DummyAdapter {
 	fn cpu_pool(&self) -> CpuPool {
 		self.cpu_pool.clone()

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -18,6 +18,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use futures::Future;
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_timer::TimerError;
 
@@ -197,4 +198,7 @@ pub trait NetAdapter: Sync + Send {
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
 	fn peer_difficulty(&self, SocketAddr, Difficulty);
+
+	/// Central threadpool that we can use to handle requests from all our peers.
+	fn cpu_pool(&self) -> CpuPool;
 }

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time;
 
 use futures::future::Future;
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{self, Core};
 
@@ -36,7 +37,9 @@ fn peer_handshake() {
 	let mut evtlp = Core::new().unwrap();
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
-	let net_adapter = Arc::new(p2p::DummyAdapter {});
+	let net_adapter = Arc::new(p2p::DummyAdapter {
+		cpu_pool: CpuPool::new(1),
+	});
 	let server = p2p::Server::new(
 		".grin".to_owned(),
 		p2p::UNKNOWN,

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate futures;
+extern crate futures_cpupool;
 extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate tokio_core;
@@ -22,7 +23,6 @@ use std::sync::Arc;
 use std::time;
 
 use futures::future::Future;
-use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{self, Core};
 
@@ -37,9 +37,7 @@ fn peer_handshake() {
 	let mut evtlp = Core::new().unwrap();
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
-	let net_adapter = Arc::new(p2p::DummyAdapter {
-		cpu_pool: CpuPool::new(1),
-	});
+	let net_adapter = Arc::new(p2p::DummyAdapter::new());
 	let server = p2p::Server::new(
 		".grin".to_owned(),
 		p2p::UNKNOWN,


### PR DESCRIPTION
This PR attempts to allow `read_msg` and `write_msg` to run at a more granular level.
We should be able to write msg back to a peer as soon as we have read the msg and handled it.
We should not wait for 10 GetBlock msgs to be processed before we start returning blocks to the peer requesting them for example.

--------------

TODO -
- [x] look into passing a single cpu_pool into the various peer connections we set up
- [x] failing tests (related to DummyAdaptor)

------------



* introduce `cpu_pool` to `read_msg`
    * `handler.handle()` off main loop now
* add `buffered(1)` adaptor to the "infinite iterator" in `read_msg`
    * ensures `fold()` runs on every msg to be read and does not keep going until stream is empty
* add some `trace!` logging to see what's going on when reading/writing msgs

We are now seeing interleaved `read_msg/write_msg` in the logs.
We are no longer waiting for all the `GetBlock` handlers to run for a given peer before starting to return data to the peer.

```
Dec 13 09:44:40.657 TRCE read_msg: start
Dec 13 09:44:40.657 DEBG locate_headers: [545b137e, 222b4104, 634195cd, 2f0a8880, b83053b4]
Dec 13 09:44:40.657 DEBG locate_headers: common header: 545b137e
Dec 13 09:44:40.657 DEBG locate_headers: returning headers: 1
Dec 13 09:44:40.657 TRCE read_msg: done (via cpu_pool)
Dec 13 09:44:40.658 TRCE read_msg: count (per buffered fold): 21
Dec 13 09:44:40.658 TRCE write_msg: start
Dec 13 09:44:40.658 TRCE write_msg: done
Dec 13 09:44:40.659 TRCE read_msg: start
Dec 13 09:44:40.660 DEBG handle_payload: GetBlock 050179b4
Dec 13 09:44:40.660 TRCE read_msg: done (via cpu_pool)
Dec 13 09:44:40.661 TRCE read_msg: count (per buffered fold): 22
Dec 13 09:44:40.661 TRCE read_msg: start
Dec 13 09:44:40.661 TRCE write_msg: start
Dec 13 09:44:40.661 TRCE write_msg: done
Dec 13 09:44:40.662 DEBG handle_payload: GetBlock 634195cd
Dec 13 09:44:40.662 TRCE read_msg: done (via cpu_pool)
Dec 13 09:44:40.662 TRCE read_msg: count (per buffered fold): 23
Dec 13 09:44:40.663 TRCE read_msg: start
Dec 13 09:44:40.663 TRCE write_msg: start
Dec 13 09:44:40.663 TRCE write_msg: done
Dec 13 09:44:40.670 DEBG handle_payload: GetBlock 74459b4d
Dec 13 09:44:40.670 TRCE read_msg: done (via cpu_pool)
Dec 13 09:44:40.670 TRCE read_msg: count (per buffered fold): 24
Dec 13 09:44:40.670 TRCE read_msg: start
Dec 13 09:44:40.670 TRCE write_msg: start
Dec 13 09:44:40.670 TRCE write_msg: done
Dec 13 09:44:40.670 DEBG handle_payload: GetBlock 17412fd7
Dec 13 09:44:40.670 TRCE read_msg: done (via cpu_pool)
Dec 13 09:44:40.670 TRCE read_msg: count (per buffered fold): 25
Dec 13 09:44:40.670 TRCE read_msg: start
Dec 13 09:44:40.671 TRCE write_msg: start
Dec 13 09:44:40.671 TRCE write_msg: done
Dec 13 09:44:40.671 DEBG handle_payload: GetBlock c1ee31ee
Dec 13 09:44:40.671 TRCE read_msg: done (via cpu_pool)
```
