### PR TITLE
[testnet1] cpu_pool and buffered fold in read_msg

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,6 +8,7 @@ workspace = ".."
 bitflags = "^0.7.0"
 byteorder = "^0.5"
 futures = "^0.1.15"
+futures-cpupool = "^0.1.3"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 net2 = "0.2.0"
 rand = "^0.3"

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -21,9 +21,9 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures;
-use futures::{Future, Stream};
-use futures::stream;
+use futures::{Future, Stream, stream};
 use futures::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::{read_exact, write_all};
@@ -94,6 +94,7 @@ impl Connection {
 	/// itself.
 	pub fn listen<F>(
 		conn: TcpStream,
+		pool: CpuPool,
 		handler: F,
 	) -> (Connection, Box<Future<Item = (), Error = Error>>)
 	where
@@ -124,10 +125,10 @@ impl Connection {
 		};
 
 		// setup the reading future, getting messages from the peer and processing them
-		let read_msg = me.read_msg(tx, reader, handler).map(|_| ());
+		let read_msg = me.read_msg(tx, reader, handler, pool).map(|_| ());
 
-		// setting the writing future, getting messages from our system and sending
-  // them out
+		// setting the writing future
+		// getting messages from our system and sending them out
 		let write_msg = me.write_msg(rx, writer).map(|_| ());
 
 		// select between our different futures and return them
@@ -154,16 +155,20 @@ impl Connection {
 		let sent_bytes = self.sent_bytes.clone();
 		let send_data = rx
 			.map_err(|_| Error::ConnectionClose)
-      .map(move |data| {
-        // add the count of bytes sent
+			.map(move |data| {
+				trace!(LOGGER, "write_msg: start");
+				// add the count of bytes sent
 				let mut sent_bytes = sent_bytes.lock().unwrap();
 				*sent_bytes += data.len() as u64;
 				data
 			})
-      // write the data and make sure the future returns the right types
+			// write the data and make sure the future returns the right types
 			.fold(writer, |writer, data| {
-        write_all(writer, data).map_err(|e| Error::Connection(e)).map(|(writer, _)| writer)
-      });
+				write_all(writer, data).map_err(|e| Error::Connection(e)).map(|(writer, _)| {
+					trace!(LOGGER, "write_msg: done");
+					writer
+				})
+			});
 		Box::new(send_data)
 	}
 
@@ -174,28 +179,37 @@ impl Connection {
 		sender: UnboundedSender<Vec<u8>>,
 		reader: R,
 		handler: F,
+		pool: CpuPool,
 	) -> Box<Future<Item = R, Error = Error>>
 	where
 		F: Handler + 'static,
-		R: AsyncRead + 'static,
+		R: AsyncRead + Send + 'static,
 	{
 		// infinite iterator stream so we repeat the message reading logic until the
-  // peer is stopped
+		// peer is stopped
 		let iter = stream::iter_ok(iter::repeat(()).map(Ok::<(), Error>));
 
 		// setup the reading future, getting messages from the peer and processing them
 		let recv_bytes = self.received_bytes.clone();
 		let handler = Arc::new(handler);
 
-		let read_msg = iter.fold(reader, move |reader, _| {
+		let mut count = 0;
+
+		let read_msg = iter.buffered(1).fold(reader, move |reader, _| {
+			count += 1;
+			trace!(LOGGER, "read_msg: count (per buffered fold): {}", count);
+
 			let recv_bytes = recv_bytes.clone();
 			let handler = handler.clone();
 			let sender_inner = sender.clone();
+			let pool = pool.clone();
 
 			// first read the message header
 			read_exact(reader, vec![0u8; HEADER_LEN as usize])
 				.from_err()
 				.and_then(move |(reader, buf)| {
+					trace!(LOGGER, "read_msg: start");
+
 					let header = try!(ser::deserialize::<MsgHeader>(&mut &buf[..]));
 					Ok((reader, header))
 				})
@@ -210,14 +224,16 @@ impl Connection {
 					let mut recv_bytes = recv_bytes.lock().unwrap();
 					*recv_bytes += header.serialized_len() + header.msg_len;
 
-					// and handle the different message types
-					let msg_type = header.msg_type;
-					if let Err(e) = handler.handle(sender_inner.clone(), header, buf) {
-						debug!(LOGGER, "Invalid {:?} message: {}", msg_type, e);
-						return Err(Error::Serialization(e));
-					}
+					pool.spawn_fn(move || {
+						let msg_type = header.msg_type;
+						if let Err(e) = handler.handle(sender_inner.clone(), header, buf) {
+							debug!(LOGGER, "Invalid {:?} message: {}", msg_type, e);
+							return Err(Error::Serialization(e));
+						}
 
-					Ok(reader)
+						trace!(LOGGER, "read_msg: done (via cpu_pool)");
+						Ok(reader)
+					})
 				})
 		});
 		Box::new(read_msg)
@@ -260,6 +276,7 @@ impl TimeoutConnection {
 	/// Same as Connection
 	pub fn listen<F>(
 		conn: TcpStream,
+		pool: CpuPool,
 		handler: F,
 	) -> (TimeoutConnection, Box<Future<Item = (), Error = Error>>)
 	where
@@ -270,7 +287,7 @@ impl TimeoutConnection {
 		// Decorates the handler to remove the "subscription" from the expected
 		// responses. We got our replies, so no timeout should occur.
 		let exp = expects.clone();
-		let (conn, fut) = Connection::listen(conn, move |sender, header: MsgHeader, data| {
+		let (conn, fut) = Connection::listen(conn, pool, move |sender, header: MsgHeader, data| {
 			let msg_type = header.msg_type;
 			let recv_h = try!(handler.handle(sender, header, data));
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -26,6 +26,8 @@ extern crate bytes;
 #[macro_use]
 extern crate enum_primitive;
 extern crate futures;
+extern crate futures_cpupool;
+
 #[macro_use]
 extern crate grin_core as core;
 extern crate grin_store;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -90,12 +90,11 @@ impl Peer {
 
 	/// Main peer loop listening for messages and forwarding to the rest of the
 	/// system.
-	pub fn run(&self, conn: TcpStream) -> Box<Future<Item = (), Error = Error>> {
+	pub fn run(&self, conn: TcpStream, pool: CpuPool) -> Box<Future<Item = (), Error = Error>> {
 		let addr = self.info.addr;
 		let state = self.state.clone();
 		let adapter = Arc::new(self.tracking_adapter.clone());
-		let pool = CpuPool::new(1);
-		
+
 		Box::new(self.proto.handle(conn, adapter, addr, pool).then(move |res| {
 			// handle disconnection, standard disconnections aren't considered an error
 			let mut state = state.write().unwrap();
@@ -256,10 +255,6 @@ impl ChainAdapter for TrackingAdapter {
 }
 
 impl NetAdapter for TrackingAdapter {
-	// fn cpu_pool(&self) -> CpuPool {
-	// 	self.adapter.cpu_pool()
-	// }
-
 	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {
 		self.adapter.find_peer_addrs(capab)
 	}

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -330,6 +330,10 @@ impl ChainAdapter for Peers {
 }
 
 impl NetAdapter for Peers {
+	// fn cpu_pool(&self) -> CpuPool {
+	// 	self.adapter.cpu_pool()
+	// }
+
 	/// Find good peers we know with the provided capability and return their
 	/// addresses.
 	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -330,10 +330,6 @@ impl ChainAdapter for Peers {
 }
 
 impl NetAdapter for Peers {
-	// fn cpu_pool(&self) -> CpuPool {
-	// 	self.adapter.cpu_pool()
-	// }
-
 	/// Find good peers we know with the provided capability and return their
 	/// addresses.
 	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -39,6 +39,7 @@ use util::LOGGER;
 
 /// A no-op network adapter used for testing.
 pub struct DummyAdapter {}
+
 impl ChainAdapter for DummyAdapter {
 	fn total_difficulty(&self) -> Difficulty {
 		Difficulty::one()
@@ -56,7 +57,11 @@ impl ChainAdapter for DummyAdapter {
 		None
 	}
 }
+
 impl NetAdapter for DummyAdapter {
+	// fn cpu_pool(&self) -> CpuPool {
+	// 	self.cpu_pool.clone()
+	// }
 	fn find_peer_addrs(&self, _: Capabilities) -> Vec<SocketAddr> {
 		vec![]
 	}
@@ -268,7 +273,7 @@ impl Server {
 }
 
 // Adds the peer built by the provided future in the peers map
-fn add_to_peers<A>(peers: Peers, peer_fut: A) 
+fn add_to_peers<A>(peers: Peers, peer_fut: A)
 	-> Box<Future<Item = Result<(TcpStream, Arc<RwLock<Peer>>), ()>, Error = Error>>
 	where A: IntoFuture<Item = (TcpStream, Peer), Error = Error> + 'static {
 
@@ -301,4 +306,3 @@ fn with_timeout<T: 'static>(
 		});
 	Box::new(timed)
 }
-

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -199,7 +199,4 @@ pub trait NetAdapter: ChainAdapter {
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
 	fn peer_difficulty(&self, SocketAddr, Difficulty, u64);
-
-	// Central threadpool that we can use to handle requests from all our peers.
-	// fn cpu_pool(&self) -> CpuPool;
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -18,6 +18,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use futures::Future;
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_timer::TimerError;
 
@@ -125,7 +126,7 @@ pub trait Protocol {
 	/// be  known already, usually passed during construction. Will typically
 	/// block so needs to be called withing a coroutine. Should also be called
 	/// only once.
-	fn handle(&self, conn: TcpStream, na: Arc<NetAdapter>, addr: SocketAddr)
+	fn handle(&self, conn: TcpStream, na: Arc<NetAdapter>, addr: SocketAddr, pool: CpuPool)
 		-> Box<Future<Item = (), Error = Error>>;
 
 	/// Sends a ping message to the remote peer.
@@ -198,4 +199,7 @@ pub trait NetAdapter: ChainAdapter {
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
 	fn peer_difficulty(&self, SocketAddr, Difficulty, u64);
+
+	// Central threadpool that we can use to handle requests from all our peers.
+	// fn cpu_pool(&self) -> CpuPool;
 }

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 extern crate futures;
-extern crate futures_cpupool;
 extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate tokio_core;
@@ -36,7 +35,7 @@ fn peer_handshake() {
 	let mut evtlp = Core::new().unwrap();
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
-	let net_adapter = Arc::new(p2p::DummyAdapter::new());
+	let net_adapter = Arc::new(p2p::DummyAdapter {});
 	let server = p2p::Server::new(
 		".".to_owned(),
 		p2p::UNKNOWN,

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate futures;
+extern crate futures_cpupool;
 extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate tokio_core;
@@ -35,7 +36,7 @@ fn peer_handshake() {
 	let mut evtlp = Core::new().unwrap();
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
-	let net_adapter = Arc::new(p2p::DummyAdapter {});
+	let net_adapter = Arc::new(p2p::DummyAdapter::new());
 	let server = p2p::Server::new(
 		".".to_owned(),
 		p2p::UNKNOWN,

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate futures;
+extern crate futures_cpupool;
 extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate tokio_core;
@@ -22,6 +23,7 @@ use std::sync::Arc;
 use std::time;
 
 use futures::future::Future;
+use futures_cpupool::CpuPool;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{self, Core};
 
@@ -36,11 +38,13 @@ fn peer_handshake() {
 	let handle = evtlp.handle();
 	let p2p_conf = p2p::P2PConfig::default();
 	let net_adapter = Arc::new(p2p::DummyAdapter {});
+	let pool = CpuPool::new(1);
 	let server = p2p::Server::new(
-		".".to_owned(),
+		".grin".to_owned(),
 		p2p::UNKNOWN,
 		p2p_conf,
 		net_adapter.clone(),
+		pool.clone(),
 	).unwrap();
 	let run_server = server.start(handle.clone());
 	let my_addr = "127.0.0.1:5000".parse().unwrap();
@@ -69,7 +73,7 @@ fn peer_handshake() {
 						)
 					})
 					.and_then(move |(socket, peer)| {
-						rhandle.spawn(peer.run(socket).map_err(|e| {
+						rhandle.spawn(peer.run(socket, pool).map_err(|e| {
 							panic!("Client run failed: {:?}", e);
 						}));
 						peer.send_ping(Difficulty::one(), 0).unwrap();


### PR DESCRIPTION
* use a `cpu_pool` in `read_msg` for running `handler.handle()`
* add `buffered` adapter to the infinite interator in read_msg (so we fold over one msg at a time)

Related - #454.
Related - #466.
Original (master) - #477 (reverted and will be reapplied once master is consistent with testnet1)