### PR TITLE
[testnet1] De-Duplicate expected responses in TimeoutConnection

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -219,6 +219,11 @@ impl Chain {
 		}
 	}
 
+	pub fn is_orphan(&self, hash: &Hash) -> bool {
+		let orphans = self.orphans.lock().unwrap();
+		orphans.iter().any(|&(_, ref x)| x.hash() == hash.clone())
+	}
+
 	/// Pop orphans out of the queue and check if we can now accept them.
 	fn check_orphans(&self) -> Vec<Hash> {
 		// first check how many we have to retry, unfort. we can't extend the lock

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -115,7 +115,7 @@ impl Seeder {
 
 				// maintenance step first, clean up p2p server peers
 				{
-					peers.clean_peers(PEER_PREFERRED_COUNT as usize);
+					peers.clean_peers(PEER_MAX_COUNT as usize);
 				}
 
 				// not enough peers, getting more from db

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -119,7 +119,11 @@ fn body_sync(peers: Peers, chain: Arc<chain::Chain>) {
 
 	let hashes_to_get = hashes
 		.iter()
-		.filter(|x| !chain.get_block(&x).is_ok())
+		.filter(|x| {
+			// only ask for blocks that we have not yet processed
+			// either successfully stored or in our orphan list
+			!chain.get_block(x).is_ok() && !chain.is_orphan(x)
+		})
 		.take(block_count)
 		.cloned()
 		.collect::<Vec<_>>();

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -236,7 +236,7 @@ impl Peers {
 	/// Iterate over the peer list and prune all peers we have
 	/// lost connection to or have been deemed problematic.
 	/// Also avoid connected peer count getting too high.
-	pub fn clean_peers(&self, desired_count: usize) {
+	pub fn clean_peers(&self, max_count: usize) {
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up
@@ -261,11 +261,10 @@ impl Peers {
 		}
 
 		// ensure we do not have too many connected peers
-		// really fighting with the double layer of rwlocks here...
 		let excess_count = {
 			let peer_count = self.peer_count().clone() as usize;
-			if peer_count > desired_count {
-				peer_count - desired_count
+			if peer_count > max_count {
+				peer_count - max_count
 			} else {
 				0
 			}


### PR DESCRIPTION
* de-dupe requests in TimeoutConnection (based on expected responses we are waiting for)
* do not request blocks that we already have in our orphan list during body_sync


TimeoutConnection already tracks "expected" responses
use this to deduplicate requests and do not ask a peer for the same thing again
(until either success or error via timeout)

Add `trace!` logging so we have some visibility into how big the "expected" list of responses is on a given connection.

This should reduce a lot of the network congestion (and backlog of requests a peer is handling) as peers attempt to request the same set of blocks repeatedly.

We were originally doing something similar in the previous `sync` process - where we tracked "in flight" block requests, only queueing up new block requests once we had received and processed previous requests.
I think its cleaner/simpler and more generic if we do this at the connection layer.

Additional benefit here - we can end up asking for the same block from a couple of different peers this way (one per connection) if the first peer takes a few seconds to respond.
So we get some redundancy here on slow connections that might slow or halt the sync process.

