### PR TITLE
pass the commitment into an AlreadySpent error

### DIFF
--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -59,7 +59,7 @@ pub enum Error {
 	/// One of the root hashes in the block is invalid
 	InvalidRoot,
 	/// One of the inputs in the block has already been spent
-	AlreadySpent,
+	AlreadySpent(Commitment),
 	/// An output with that commitment already exists (should be unique)
 	DuplicateCommitment(Commitment),
 	/// A kernel with that excess commitment already exists (should be unique)


### PR DESCRIPTION
Unrelated - cleanup the hash specific debug logging?

