### PR TITLE
[testnet1] relax diff check in update_head (was gt, now gte)

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -355,7 +355,7 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 		if tip.total_difficulty == ctx.head.total_difficulty {
 			debug!(
 				LOGGER,
-				"pipe: update_head: total_difficulty matches {:?} {:?} at {:?} vs. {:?} {:?} at {:?}",
+				"pipe: update_head: total_difficulty matches {}, {} at {} vs. {}, {} at {}",
 				tip.last_block_h,
 				tip.total_difficulty,
 				tip.height,
@@ -385,7 +385,7 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 		ctx.head = tip.clone();
 		info!(
 			LOGGER,
-			"pipe: update_head: updated to {} {} at {}",
+			"pipe: update_head: updated to {}, {} at {}",
 			b.hash(),
 			b.header.total_difficulty,
 			b.header.height

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -385,8 +385,9 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 		ctx.head = tip.clone();
 		info!(
 			LOGGER,
-			"pipe: update_head: updated to {} at {}",
+			"pipe: update_head: updated to {} {} at {}",
 			b.hash(),
+			b.header.total_difficulty,
 			b.header.height
 		);
 		Ok(Some(tip))


### PR DESCRIPTION
This will cover the situation where a node sees two forked blocks at same height with identical total_difficulty.
We do not now which of these two blocks will "win" the fork and it may take a couple of blocks to resolve the situation.
So - we want to handle both blocks and make sure they are both broadcast across the network.

See #512 for context/investigation.

TODO - 

- [ ] Also relax this for `update_header_head`? (Need to think this through...)
    I don't _think_ we need to - not needed during sync?
