### PR TITLE
broadcast all accepted blocks, main chain or fork

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -165,8 +165,26 @@ impl Chain {
 					adapter.block_accepted(&b);
 				}
 				accepted_orphans = self.check_orphans();
-			}
-			Ok(None) => {}
+			},
+			Ok(None) => {
+				// block got accepted but we did not extend the head
+				// so its on a fork (or is the start of a new fork)
+				// broadcast the block out so everyone knows about the fork
+				//
+				// TODO - This opens us to an amplification attack on blocks
+				// mined at a low difficulty. We should suppress really old blocks
+				// or less relevant blocks somehow.
+				// We should also probably consider banning nodes that send us really old blocks.
+				//
+				if !opts.intersects(SYNC) {
+					// broadcast the block
+					let adapter = self.adapter.clone();
+					adapter.block_accepted(&b);
+				}
+				// We accepted a block here so there is a chance we can now accept
+				// one or more orphans.
+				accepted_orphans = self.check_orphans();
+			},
 			Err(Error::Orphan) => {
 				// TODO - Do we want to check that orphan height is > current height?
 				// TODO - Just check heights here? Or should we be checking total_difficulty as well?

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -50,7 +50,7 @@ pub struct BlockContext {
 /// chain head if updated.
 pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
 	// TODO should just take a promise for a block with a full header so we don't
- // spend resources reading the full block when its header is invalid
+	// spend resources reading the full block when its header is invalid
 
 	debug!(
 		LOGGER,
@@ -88,7 +88,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 		.map_err(|e| Error::StoreErr(e, "pipe reload head".to_owned()))?;
 
 	// start a chain extension unit of work dependent on the success of the
- // internal validation and saving operations
+	// internal validation and saving operations
 	sumtree::extending(&mut sumtrees, |mut extension| {
 		validate_block(b, &mut ctx, &mut extension)?;
 		debug!(
@@ -371,8 +371,9 @@ fn update_head(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> 
 		ctx.head = tip.clone();
 		info!(
 			LOGGER,
-			"Updated head to {} at {}.",
+			"pipe: update_head: {}, {} at {}",
 			b.hash(),
+			b.header.total_difficulty,
 			b.header.height
 		);
 		Ok(Some(tip))
@@ -390,8 +391,9 @@ fn update_sync_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<T
 	ctx.head = tip.clone();
 	info!(
 		LOGGER,
-		"pipe: updated sync head to {} at {}.",
+		"pipe: update_sync_head: {}, {} at {}",
 		bh.hash(),
+		bh.total_difficulty,
 		bh.height,
 	);
 	Ok(Some(tip))
@@ -399,7 +401,7 @@ fn update_sync_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<T
 
 fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	let tip = Tip::from_block(bh);
-	debug!(LOGGER, "pipe: update_header_head {},{}", tip.total_difficulty, ctx.head.total_difficulty);
+	debug!(LOGGER, "pipe: update_header_head: {}, {}", tip.total_difficulty, ctx.head.total_difficulty);
 	if tip.total_difficulty > ctx.head.total_difficulty {
 		ctx.store
 			.save_header_head(&tip)
@@ -407,8 +409,9 @@ fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option
 		ctx.head = tip.clone();
 		info!(
 			LOGGER,
-			"pipe: updated header head to {} at {}.",
+			"pipe: update_header_head: {}, {} at {}",
 			bh.hash(),
+			bh.total_difficulty,
 			bh.height,
 		);
 		Ok(Some(tip))

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -172,8 +172,9 @@ impl Peers {
 	/// if it knows the remote peer already has the block.
 	pub fn broadcast_block(&self, b: &core::Block) {
 		let peers = self.connected_peers();
+		let preferred_peers = 8;
 		let mut count = 0;
-		for p in peers.iter().take(8) {
+		for p in peers.iter().take(preferred_peers) {
 			let p = p.read().unwrap();
 			if p.is_connected() {
 				if let Err(e) = p.send_block(b) {
@@ -183,7 +184,14 @@ impl Peers {
 				}
 			}
 		}
-		debug!(LOGGER, "Broadcasted block {} to {} peers.", b.header.height, count);
+		debug!(
+			LOGGER,
+			"broadcast_block: {}, {} at {}, to {} peers",
+			b.hash(),
+			b.header.total_difficulty,
+			b.header.height,
+			count,
+		);
 	}
 
 	/// Broadcasts the provided transaction to PEER_PREFERRED_COUNT of our peers.


### PR DESCRIPTION
* broadcast all accepted blocks, main chain or fork
* tweak logging to be more consistent

See #512 for context. 
Replaces #514 (wrong approach).
