### PR TITLE
[testnet1] smarter orphan block checking

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -33,7 +33,7 @@ use sumtree;
 use types::*;
 use util::LOGGER;
 
-const MAX_ORPHANS: usize = 150;
+const MAX_ORPHANS: usize = 100;
 
 #[derive(Debug, Clone)]
 struct Orphan {
@@ -93,12 +93,6 @@ impl OrphanBlockPool {
 			prev_idx.remove(&x.block.header.previous);
 		}
 		orphan
-	}
-
-	/// Get an orphan from the pool
-	fn get(&self, hash: &Hash) -> Option<Orphan> {
-		let orphans = self.orphans.read().unwrap();
-		orphans.get(hash).cloned()
 	}
 
 	/// Get an orphan from the pool indexed by the hash of its parent
@@ -362,7 +356,7 @@ impl Chain {
 		// as their "previous" block?
 		if let Some(orphan) = self.orphans.get_by_previous(&block.hash()) {
 			self.orphans.remove(&orphan.block.hash());
-			self.process_block(orphan.block, orphan.opts);
+			let _ = self.process_block(orphan.block, orphan.opts);
 		}
 	}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -346,8 +346,6 @@ impl Chain {
 	}
 
 	/// Check if hash is for a known orphan.
-	/// Note: orphans are indexed by previous hash
-	/// so we need to actually look at the values here
 	pub fn is_orphan(&self, hash: &Hash) -> bool {
 		self.orphans.contains(hash)
 	}
@@ -366,43 +364,6 @@ impl Chain {
 			self.orphans.remove(&orphan.block.hash());
 			self.process_block(orphan.block, orphan.opts);
 		}
-
-		// if self.is_orphan(&hash) {
-		// 	if let Some(orphan) = self.orphans.remove(&hash) {
-		// 		self.process_block(orphan.block, orphan.opts);
-		// 	}
-		// }
-
-
-		// first check how many we have to retry, unfort. we can't extend the lock
-		// in the loop as it needs to be freed before going in process_block
-
-
-
-        //
-		// let orphan_count;
-		// {
-		// 	let orphans = self.orphans.lock().unwrap();
-		// 	orphan_count = orphans.len();
-		// }
-		// debug!(LOGGER, "check_orphans: # orphans {}", orphan_count);
-        //
-		// // pop each orphan and retry, if still orphaned, will be pushed again
-		// let mut processed = vec![];
-		// for _ in 0..orphan_count {
-		// 	let popped;
-		// 	{
-		// 		let mut orphans = self.orphans.lock().unwrap();
-		// 		popped = orphans.pop_back();
-		// 	}
-		// 	if let Some((opts, orphan)) = popped {
-		// 		let o_hash = orphan.hash();
-		// 		if let Ok(_) = self.process_block(orphan, opts) {
-		// 			processed.push(o_hash);
-		// 		}
-		// 	}
-		// }
-		// processed
 	}
 
 	/// Gets an unspent output from its commitment. With return None if the

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -33,44 +33,88 @@ use sumtree;
 use types::*;
 use util::LOGGER;
 
-const MAX_ORPHANS: usize = 50;
+const MAX_ORPHANS: usize = 150;
+
+#[derive(Debug, Clone)]
+struct Orphan {
+	block: Block,
+	opts: Options,
+}
 
 struct OrphanBlockPool {
 	// blocks indexed by their hash
-	orphans: RwLock<HashMap<Hash, (Options, Block)>>,
+	orphans: RwLock<HashMap<Hash, Orphan>>,
 	// additional index of previous -> hash
 	// so we can efficiently identify a child block (ex-orphan) after processing a block
 	prev_idx: RwLock<HashMap<Hash, Hash>>,
 }
 
 impl OrphanBlockPool {
-	// API here could take previous accepted block
-	// and remove and return the now non-orphan, ready for processing
-	// or None if nothing we can do
-	fn foo() {
-
+	fn new() -> OrphanBlockPool {
+		OrphanBlockPool {
+			orphans: RwLock::new(HashMap::new()),
+			prev_idx: RwLock::new(HashMap::new()),
+		}
 	}
 
-	fn add(block: &Block) {
-
+	fn len(&self) -> usize {
+		let orphans = self.orphans.read().unwrap();
+		orphans.len()
 	}
 
-	fn remove(hash: &Hash) -> Option<Block> {
+	fn add(&self, orphan: Orphan) {
+		{
+			let mut orphans = self.orphans.write().unwrap();
+			let mut prev_idx = self.prev_idx.write().unwrap();
+			orphans.insert(orphan.block.hash(), orphan.clone());
+			prev_idx.insert(orphan.block.header.previous, orphan.block.hash());
+		}
 
+		if self.len() > MAX_ORPHANS {
+			let max = {
+				let orphans = self.orphans.read().unwrap();
+				orphans.values().max_by_key(|x| x.block.header.height).cloned()
+			};
+
+			if let Some(x) = max {
+				let mut orphans = self.orphans.write().unwrap();
+				let mut prev_idx = self.prev_idx.write().unwrap();
+				orphans.remove(&x.block.hash());
+				prev_idx.remove(&x.block.header.previous);
+			}
+		}
+	}
+
+	fn remove(&self, hash: &Hash) -> Option<Orphan> {
+		let mut orphans = self.orphans.write().unwrap();
+		let mut prev_idx = self.prev_idx.write().unwrap();
+		let orphan = orphans.remove(hash);
+		if let Some(x) = orphan.clone() {
+			prev_idx.remove(&x.block.header.previous);
+		}
+		orphan
 	}
 
 	/// Get an orphan from the pool
-	fn get(hash: &Hash) -> Option<&Block> {
-
+	fn get(&self, hash: &Hash) -> Option<Orphan> {
+		let orphans = self.orphans.read().unwrap();
+		orphans.get(hash).cloned()
 	}
 
 	/// Get an orphan from the pool indexed by the hash of its parent
-	fn get_by_previous(hash: &Hash) -> Option<&Block> {
-
+	fn get_by_previous(&self, hash: &Hash) -> Option<Orphan> {
+		let orphans = self.orphans.read().unwrap();
+		let prev_idx = self.prev_idx.read().unwrap();
+		if let Some(hash) = prev_idx.get(hash) {
+			orphans.get(hash).cloned()
+		} else {
+			None
+		}
 	}
 
-	fn contains(hash: &Hash) -> bool {
-
+	fn contains(&self, hash: &Hash) -> bool {
+		let orphans = self.orphans.read().unwrap();
+		orphans.contains_key(hash)
 	}
 }
 
@@ -228,22 +272,22 @@ impl Chain {
 				// TODO - Just check heights here? Or should we be checking total_difficulty as well?
 				let block_hash = b.hash();
 				if b.header.height < height + (MAX_ORPHANS as u64) {
-					let mut orphans = self.orphans.write().unwrap();
+					let orphan = Orphan {
+						block: b.clone(),
+						opts: opts,
+					};
 
 					// In the case of a fork - it is possible to have multiple blocks
 					// that are children of a given block.
 					// We do not handle this currently for orphans (future enhancement?).
 					// We just assume "last one wins" for now.
-					orphans.insert(b.header.previous, (opts, b));
-
-					// TODO - how to "truncate" orphans here
-					// orphans.truncate(MAX_ORPHANS);
+					&self.orphans.add(orphan);
 
 					debug!(
 						LOGGER,
 						"process_block: orphan: {:?}, # orphans {}",
 						block_hash,
-						orphans.len(),
+						self.orphans.len(),
 					);
 				} else {
 					debug!(
@@ -309,20 +353,25 @@ impl Chain {
 	}
 
 	fn check_orphans(&self, block: &Block) {
-		let hash = block.hash();
+		debug!(
+			LOGGER,
+			"chain: check_orphans: # orphans {}",
+			self.orphans.len(),
+		);
 
 		// Is there an orphan in our orphans that we can now process?
 		// We just processed the given block, are there any orphans that have this block
 		// as their "previous" block?
-		if self.is_orphan(&hash) {
-			{
-				let mut orphans = self.orphans
-					.write()
-					.expect("attempting to get write lock on orphans");
-				orphans.remove(&hash);
-			}
-			self.process_block(candidate, opts);
+		if let Some(orphan) = self.orphans.get_by_previous(&block.hash()) {
+			self.orphans.remove(&orphan.block.hash());
+			self.process_block(orphan.block, orphan.opts);
 		}
+
+		// if self.is_orphan(&hash) {
+		// 	if let Some(orphan) = self.orphans.remove(&hash) {
+		// 		self.process_block(orphan.block, orphan.opts);
+		// 	}
+		// }
 
 
 		// first check how many we have to retry, unfort. we can't extend the lock

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -15,7 +15,7 @@
 //! Facade and handler for the rest of the blockchain implementation
 //! and mostly the chain pipeline.
 
-use std::collections::VecDeque;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
 use util::secp::pedersen::{Commitment, RangeProof};
@@ -35,6 +35,45 @@ use util::LOGGER;
 
 const MAX_ORPHANS: usize = 50;
 
+struct OrphanBlockPool {
+	// blocks indexed by their hash
+	orphans: RwLock<HashMap<Hash, (Options, Block)>>,
+	// additional index of previous -> hash
+	// so we can efficiently identify a child block (ex-orphan) after processing a block
+	prev_idx: RwLock<HashMap<Hash, Hash>>,
+}
+
+impl OrphanBlockPool {
+	// API here could take previous accepted block
+	// and remove and return the now non-orphan, ready for processing
+	// or None if nothing we can do
+	fn foo() {
+
+	}
+
+	fn add(block: &Block) {
+
+	}
+
+	fn remove(hash: &Hash) -> Option<Block> {
+
+	}
+
+	/// Get an orphan from the pool
+	fn get(hash: &Hash) -> Option<&Block> {
+
+	}
+
+	/// Get an orphan from the pool indexed by the hash of its parent
+	fn get_by_previous(hash: &Hash) -> Option<&Block> {
+
+	}
+
+	fn contains(hash: &Hash) -> bool {
+
+	}
+}
+
 /// Facade to the blockchain block processing pipeline and storage. Provides
 /// the current view of the UTXO set according to the chain state. Also
 /// maintains locking for the pipeline to avoid conflicting processing.
@@ -43,7 +82,7 @@ pub struct Chain {
 	adapter: Arc<ChainAdapter>,
 
 	head: Arc<Mutex<Tip>>,
-	orphans: Arc<Mutex<VecDeque<(Options, Block)>>>,
+	orphans: Arc<OrphanBlockPool>,
 	sumtrees: Arc<RwLock<sumtree::SumTrees>>,
 
 	// POW verification function
@@ -128,7 +167,7 @@ impl Chain {
 			store: store,
 			adapter: adapter,
 			head: Arc::new(Mutex::new(head)),
-			orphans: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_ORPHANS + 1))),
+			orphans: Arc::new(OrphanBlockPool::new()),
 			sumtrees: Arc::new(RwLock::new(sumtrees)),
 			pow_verifier: pow_verifier,
 		})
@@ -138,8 +177,8 @@ impl Chain {
 	/// has been added to the longest chain, None if it's added to an (as of
 	/// now) orphan chain.
 	pub fn process_block(&self, b: Block, opts: Options)
-		-> Result<(Option<Tip>, Vec<Hash>), Error> {
-
+		-> Result<Option<Tip>, Error>
+	{
 		let head = self.store
 			.head()
 			.map_err(|e| Error::StoreErr(e, "chain load head".to_owned()))?;
@@ -148,7 +187,6 @@ impl Chain {
 
 		let res = pipe::process_block(&b, ctx);
 
-		let mut accepted_orphans = vec![];
 		match res {
 			Ok(Some(ref tip)) => {
 				// block got accepted and extended the head, updating our head
@@ -164,7 +202,8 @@ impl Chain {
 					let adapter = self.adapter.clone();
 					adapter.block_accepted(&b);
 				}
-				accepted_orphans = self.check_orphans();
+				// We just accepted a block so see if we can now accept any orphan(s)
+				self.check_orphans(&b);
 			},
 			Ok(None) => {
 				// block got accepted but we did not extend the head
@@ -181,18 +220,25 @@ impl Chain {
 					let adapter = self.adapter.clone();
 					adapter.block_accepted(&b);
 				}
-				// We accepted a block here so there is a chance we can now accept
-				// one or more orphans.
-				accepted_orphans = self.check_orphans();
+				// We just accepted a block so see if we can now accept any orphan(s)
+				self.check_orphans(&b);
 			},
 			Err(Error::Orphan) => {
 				// TODO - Do we want to check that orphan height is > current height?
 				// TODO - Just check heights here? Or should we be checking total_difficulty as well?
 				let block_hash = b.hash();
 				if b.header.height < height + (MAX_ORPHANS as u64) {
-					let mut orphans = self.orphans.lock().unwrap();
-					orphans.push_front((opts, b));
-					orphans.truncate(MAX_ORPHANS);
+					let mut orphans = self.orphans.write().unwrap();
+
+					// In the case of a fork - it is possible to have multiple blocks
+					// that are children of a given block.
+					// We do not handle this currently for orphans (future enhancement?).
+					// We just assume "last one wins" for now.
+					orphans.insert(b.header.previous, (opts, b));
+
+					// TODO - how to "truncate" orphans here
+					// orphans.truncate(MAX_ORPHANS);
+
 					debug!(
 						LOGGER,
 						"process_block: orphan: {:?}, # orphans {}",
@@ -228,8 +274,7 @@ impl Chain {
 				);
 			}
 		}
-
-		res.map(|tip| (tip, accepted_orphans))
+		res
 	}
 
 	/// Attempt to add a new header to the header chain.
@@ -257,38 +302,58 @@ impl Chain {
 	}
 
 	/// Check if hash is for a known orphan.
+	/// Note: orphans are indexed by previous hash
+	/// so we need to actually look at the values here
 	pub fn is_orphan(&self, hash: &Hash) -> bool {
-		let orphans = self.orphans.lock().unwrap();
-		orphans.iter().any(|&(_, ref x)| x.hash() == hash.clone())
+		self.orphans.contains(hash)
 	}
 
-	/// Pop orphans out of the queue and check if we can now accept them.
-	fn check_orphans(&self) -> Vec<Hash> {
+	fn check_orphans(&self, block: &Block) {
+		let hash = block.hash();
+
+		// Is there an orphan in our orphans that we can now process?
+		// We just processed the given block, are there any orphans that have this block
+		// as their "previous" block?
+		if self.is_orphan(&hash) {
+			{
+				let mut orphans = self.orphans
+					.write()
+					.expect("attempting to get write lock on orphans");
+				orphans.remove(&hash);
+			}
+			self.process_block(candidate, opts);
+		}
+
+
 		// first check how many we have to retry, unfort. we can't extend the lock
 		// in the loop as it needs to be freed before going in process_block
-		let orphan_count;
-		{
-			let orphans = self.orphans.lock().unwrap();
-			orphan_count = orphans.len();
-		}
-		debug!(LOGGER, "check_orphans: # orphans {}", orphan_count);
 
-		// pop each orphan and retry, if still orphaned, will be pushed again
-		let mut processed = vec![];
-		for _ in 0..orphan_count {
-			let popped;
-			{
-				let mut orphans = self.orphans.lock().unwrap();
-				popped = orphans.pop_back();
-			}
-			if let Some((opts, orphan)) = popped {
-				let o_hash = orphan.hash();
-				if let Ok(_) = self.process_block(orphan, opts) {
-					processed.push(o_hash);
-				}
-			}
-		}
-		processed
+
+
+        //
+		// let orphan_count;
+		// {
+		// 	let orphans = self.orphans.lock().unwrap();
+		// 	orphan_count = orphans.len();
+		// }
+		// debug!(LOGGER, "check_orphans: # orphans {}", orphan_count);
+        //
+		// // pop each orphan and retry, if still orphaned, will be pushed again
+		// let mut processed = vec![];
+		// for _ in 0..orphan_count {
+		// 	let popped;
+		// 	{
+		// 		let mut orphans = self.orphans.lock().unwrap();
+		// 		popped = orphans.pop_back();
+		// 	}
+		// 	if let Some((opts, orphan)) = popped {
+		// 		let o_hash = orphan.hash();
+		// 		if let Ok(_) = self.process_block(orphan, opts) {
+		// 			processed.push(o_hash);
+		// 		}
+		// 	}
+		// }
+		// processed
 	}
 
 	/// Gets an unspent output from its commitment. With return None if the

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::thread;
+use std::{cmp, thread};
 use std::time::Duration;
 use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -112,10 +112,9 @@ fn body_sync(peers: Peers, chain: Arc<chain::Chain>) {
 
 	// if we have 5 most_work_peers then ask for 50 blocks total (peer_count * 10)
 	// max will be 80 if all 8 peers are advertising most_work
-	let peer_count = {
-		peers.most_work_peers().len()
-	};
+	let peer_count = cmp::max(peers.most_work_peers().len(), 10);
 	let block_count = peer_count * 10;
+
 
 	let hashes_to_get = hashes
 		.iter()


### PR DESCRIPTION
We spend a _lot_ of time checking orphans during sync.
The orphans are maintained as a ring buffer and we brute force check all the orphans in the buffer every time we accept a new block.

This PR introduces an in memory "pool" of orphan blocks, stored in a HashMap, keyed by block hash.
Additionally we maintain an index by "previous" hash.
This additional index allows to quickly identify an orphan that can now be processed based on the block we just accepted (it needs to have a previous hash matching the new block).

If we find an ex-orphan that can be processed then we remove it from the orphan pool and process it. 
This will recursively check the remaining orphans to see if we can now process the next one.

Resolves #521.

