### PR TITLE
[WIP] Aggsig Transactions

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -335,7 +335,10 @@ fn prepare_fork_block_tx(kc: &Keychain, prev: &BlockHeader, chain: &Chain, diff:
 fn prepare_block_nosum(kc: &Keychain, prev: &BlockHeader, diff: u64, txs: Vec<&Transaction>) -> Block {
 	let key_id = kc.derive_key_id(diff as u32).unwrap();
 
-	let mut b = core::core::Block::new(prev, txs, kc, &key_id).unwrap();
+	let mut b = match core::core::Block::new(prev, txs, kc, &key_id) {
+		Err(e) => panic!("{:?}",e),
+		Ok(b) => b
+	};
 	b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 	b.header.total_difficulty = Difficulty::from_num(diff);
 	b

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -341,7 +341,6 @@ impl Block {
 		kernels.sort();
 
 		// calculate the overall Merkle tree and fees (todo?)
-
 		Ok(
 			Block {
 				header: BlockHeader {
@@ -585,7 +584,7 @@ impl Block {
 		let excess = secp.commit_sum(vec![out_commit], vec![over_commit])?;
 
 		let msg = util::secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE])?;
-		let sig = keychain.sign(&msg, &key_id)?;
+		let sig = keychain.aggsig_sign_from_key_id(&msg, &key_id).unwrap();
 
 		let excess_sig = sig.serialize_der(&secp);
 

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -137,7 +137,7 @@ pub fn transaction(
 	);
 	let blind_sum = ctx.keychain.blind_sum(&sum)?;
 	let msg = secp::Message::from_slice(&kernel_sig_msg(tx.fee, tx.lock_height))?;
-	let sig = ctx.keychain.sign_with_blinding(&msg, &blind_sum)?;
+	let sig = Keychain::aggsig_sign_with_blinding(&keychain.secp(), &msg, &blind_sum)?;
 
 	let secp = static_secp_instance();
 	let secp = secp.lock().unwrap();

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -25,10 +25,9 @@
 //! build::transaction(vec![input_rand(75), output_rand(42), output_rand(32),
 //!   with_fee(1)])
 
-use util::{secp, static_secp_instance};
+use util::{secp, static_secp_instance, kernel_sig_msg};
 
 use core::{Input, Output, SwitchCommitHash, Transaction, DEFAULT_OUTPUT};
-use core::transaction::kernel_sig_msg;
 use util::LOGGER;
 use keychain;
 use keychain::{BlindSum, BlindingFactor, Identifier, Keychain};

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -156,16 +156,7 @@ impl TxKernel {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
 		let sig = try!(Signature::from_der(&secp, &self.excess_sig));
-		// Extract the pubkey, unfortunately we need this hack for now, (we just hope one is valid)
-		// TODO: Create better secp256k1 API to do this
-		let pubkeys = self.excess.to_two_pubkeys(&secp);
-		let mut valid=false;
-		for i in 0..pubkeys.len() {
-			valid=secp::aggsig::verify_single(&secp, &sig, &msg, None, &pubkeys[i], false);
-			if valid {
-				break;
-			}
-		}
+		let valid = Keychain::aggsig_verify_single_from_commit(&secp, &sig, &msg, &self.excess);
 		if !valid{
 			return Err(secp::Error::IncorrectSignature);
 		}
@@ -333,19 +324,9 @@ impl Transaction {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
 		let sig = Signature::from_der(&secp, &self.excess_sig)?;
-		// Extract the pubkey, unfortunately we need this hack for now, (we just hope one is valid)
-		// TODO: Create better secp256k1 API to do this
-		let pubkeys = rsum.to_two_pubkeys(&secp);
-
 		// pretend the sum is a public key (which it is, being of the form r.G) and
 		// verify the transaction sig with it
-		let mut valid=false;
-		for i in 0..pubkeys.len() {
-			valid=secp::aggsig::verify_single(&secp, &sig, &msg, None, &pubkeys[i], false);
-			if valid {
-				break;
-			}
-		}
+		let valid = Keychain::aggsig_verify_single_from_commit(&secp, &sig, &msg, &rsum);
 		if !valid{
 			return Err(secp::Error::IncorrectSignature);
 		}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 //! Transactions
-
-use byteorder::{BigEndian, ByteOrder};
 use blake2::blake2b::blake2b;
 use util::secp::{self, Message, Signature};
-use util::static_secp_instance;
+use util::{static_secp_instance, kernel_sig_msg};
 use util::secp::pedersen::{Commitment, RangeProof};
 use std::cmp::Ordering;
 use std::ops;
@@ -90,14 +88,6 @@ impl From<consensus::Error> for Error {
 	fn from(e: consensus::Error) -> Error {
 		Error::ConsensusError(e)
 	}
-}
-
-/// Construct msg bytes from tx fee and lock_height
-pub fn kernel_sig_msg(fee: u64, lock_height: u64) -> [u8; 32] {
-	let mut bytes = [0; 32];
-	BigEndian::write_u64(&mut bytes[16..24], fee);
-	BigEndian::write_u64(&mut bytes[24..], lock_height);
-	bytes
 }
 
 /// A proof that a transaction sums to zero. Includes both the transaction's

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -32,3 +32,4 @@ itertools = "~0.6.0"
 
 [dev_dependencies]
 blake2-rfc = "~0.2.17"
+grin_config = { path = "../config" }

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -38,7 +38,6 @@ extern crate tokio_timer;
 
 extern crate grin_api as api;
 extern crate grin_chain as chain;
-#[macro_use]
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_p2p as p2p;

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -161,10 +161,16 @@ impl Server {
 			_ => {}
 		}
 
+		let skip_sync_wait = match config.skip_sync_wait {
+			None => false,
+			Some(b) => b,
+		};
+
 		sync::run_sync(
 			currently_syncing.clone(),
 			p2p_server.peers.clone(),
 			shared_chain.clone(),
+			skip_sync_wait,
 			);
 
 		evt_handle.spawn(p2p_server.start(evt_handle.clone()).map_err(|_| ()));

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -30,6 +30,7 @@ pub fn run_sync(
 	currently_syncing: Arc<AtomicBool>,
 	peers: p2p::Peers,
 	chain: Arc<chain::Chain>,
+	skip_sync_wait: bool,
 ) {
 
 	let chain = chain.clone();
@@ -40,7 +41,9 @@ pub fn run_sync(
 			let mut prev_header_sync = prev_body_sync.clone();
 
 			// initial sleep to give us time to peer with some nodes
-			thread::sleep(Duration::from_secs(30));
+			if !skip_sync_wait {
+				thread::sleep(Duration::from_secs(30));
+			}
 
 			loop {
 				let syncing = needs_syncing(

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -128,6 +128,10 @@ pub struct ServerConfig {
 	/// Transaction pool configuration
 	#[serde(default)]
 	pub pool_config: pool::PoolConfig,
+
+	/// Whether to skip the sync timeout on startup
+	/// (To assist testing on solo chains)
+	pub skip_sync_wait: Option<bool>,
 }
 
 impl Default for ServerConfig {
@@ -142,6 +146,7 @@ impl Default for ServerConfig {
 			mining_config: Some(pow::types::MinerConfig::default()),
 			chain_type: ChainTypes::default(),
 			pool_config: pool::PoolConfig::default(),
+			skip_sync_wait: Some(true),
 		}
 	}
 }

--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -34,12 +34,9 @@ use std::default::Default;
 use std::fs;
 use std::sync::{Arc, Mutex};
 
-use tokio_core::reactor;
-use tokio_timer::Timer;
+use self::tokio_core::reactor;
+use self::tokio_timer::Timer;
 
-use util::secp::Secp256k1;
-// TODO - why does this need self here? Missing something somewhere.
-use self::keychain::Keychain;
 use wallet::WalletConfig;
 
 /// Just removes all results from previous runs
@@ -158,7 +155,10 @@ pub struct LocalServerContainer {
 	pub peer_list: Vec<String>,
 
 	// base directory for the server instance
-	working_dir: String,
+	pub working_dir: String,
+
+	// Wallet configuration
+	pub wallet_config:WalletConfig,
 }
 
 impl LocalServerContainer {
@@ -168,6 +168,11 @@ impl LocalServerContainer {
 
 	pub fn new(config: LocalServerContainerConfig) -> Result<LocalServerContainer, Error> {
 		let working_dir = format!("target/test_servers/{}", config.name);
+		let mut wallet_config = WalletConfig::default();
+
+		wallet_config.api_listen_port = format!("{}", config.wallet_port);
+		wallet_config.check_node_api_http_addr = config.wallet_validating_node_url.clone();
+		wallet_config.data_file_dir = working_dir.clone();
 		Ok(
 			(LocalServerContainer {
 				config: config,
@@ -178,6 +183,7 @@ impl LocalServerContainer {
 				wallet_is_running: false,
 				working_dir: working_dir,
 				peer_list: Vec::new(),
+				wallet_config:wallet_config,
 			}),
 		)
 	}
@@ -206,6 +212,7 @@ impl LocalServerContainer {
 				seeds: Some(seeds),
 				seeding_type: seeding_type,
 				chain_type: core::global::ChainTypes::AutomatedTesting,
+				skip_sync_wait:Some(true),
 				..Default::default()
 			},
 			&event_loop.handle(),
@@ -260,52 +267,92 @@ impl LocalServerContainer {
 	/// Starts a wallet daemon to receive and returns the
 	/// listening server url
 
-	pub fn run_wallet(&mut self, _duration_in_seconds: u64) {
+	pub fn run_wallet(&mut self, _duration_in_mills: u64) {
 		// URL on which to start the wallet listener (i.e. api server)
-		let url = format!("{}:{}", self.config.base_addr, self.config.wallet_port);
+		let _url = format!("{}:{}", self.config.base_addr, self.config.wallet_port);
 
 		// Just use the name of the server for a seed for now
 		let seed = format!("{}", self.config.name);
 
-		let seed = blake2::blake2b::blake2b(32, &[], seed.as_bytes());
+		let _seed = blake2::blake2b::blake2b(32, &[], seed.as_bytes());
 
-		// TODO - just use from_random_seed here?
-		let keychain =
-			Keychain::from_seed(seed.as_bytes()).expect("Error initializing keychain from seed");
 
 		println!(
 			"Starting the Grin wallet receiving daemon on {} ",
 			self.config.wallet_port
 		);
 
-		let mut wallet_config = WalletConfig::default();
+		self.wallet_config = WalletConfig::default();
 
-		wallet_config.api_listen_port = format!("{}", self.config.wallet_port);
-		wallet_config.check_node_api_http_addr = self.config.wallet_validating_node_url.clone();
-		wallet_config.data_file_dir = self.working_dir.clone();
+		self.wallet_config.api_listen_port = format!("{}", self.config.wallet_port);
+		self.wallet_config.check_node_api_http_addr = self.config.wallet_validating_node_url.clone();
+		self.wallet_config.data_file_dir = self.working_dir.clone();
 
-		let receive_tx_handler = wallet::WalletReceiver {
-			config: wallet_config.clone(),
-			keychain: keychain.clone(),
-		};
-		let router = router!(
-			receive_tx: get "/receive/transaction" => receive_tx_handler,
+		let _=fs::create_dir_all(self.wallet_config.clone().data_file_dir);
+		wallet::WalletSeed::init_file(&self.wallet_config);
+
+		let wallet_seed =
+			wallet::WalletSeed::from_file(&self.wallet_config).expect("Failed to read wallet seed file.");
+
+		let keychain = wallet_seed.derive_keychain("grin_test").expect(
+			"Failed to derive keychain from seed file and passphrase.",
 		);
 
-		let mut api_server = api::ApiServer::new("/v1".to_string());
-		api_server.register_handler(router);
-		api_server.start(url).unwrap_or_else(|e| {
-			println!("Failed to start Grin wallet receiver: {}.", e);
-		});
-
-		self.api_server = Some(api_server);
+		wallet::server::start_rest_apis(self.wallet_config.clone(), keychain);
 		self.wallet_is_running = true;
 	}
 
-	/// Stops the running wallet server
 
+	pub fn send_amount_to(config: &WalletConfig,
+		amount:&str,
+		minimum_confirmations: u64,
+		selection_strategy:&str,
+		dest: &str){
+
+		let amount = core::core::amount_from_hr_string(amount).expect(
+			"Could not parse amount as a number with optional decimal point.",
+		);
+
+		let wallet_seed =
+			wallet::WalletSeed::from_file(config).expect("Failed to read wallet seed file.");
+
+		let mut keychain = wallet_seed.derive_keychain("grin_test").expect(
+			"Failed to derive keychain from seed file and passphrase.",
+		);
+		let max_outputs = 500;
+		let result = wallet::issue_send_tx(
+			config,
+			&mut keychain,
+			amount,
+			minimum_confirmations,
+			dest.to_string(),
+			max_outputs,
+			(selection_strategy == "all"),
+			);
+		match result {
+			Ok(_) => {
+				println!(
+					"Tx sent: {} grin to {} (strategy '{}')",
+					core::core::amount_to_hr_string(amount),
+					dest,
+					selection_strategy,
+				)
+			}
+			Err(wallet::Error::NotEnoughFunds(available)) => {
+				println!(
+					"Tx not sent: insufficient funds (max: {})",
+					core::core::amount_to_hr_string(available),
+				);
+			}
+			Err(e) => {
+				println!("Tx not sent to {}: {:?}", dest, e);
+			}
+		};
+	}
+ 
+	/// Stops the running wallet server
 	pub fn stop_wallet(&mut self) {
-		let mut api_server = self.api_server.as_mut().unwrap();
+		let api_server = self.api_server.as_mut().unwrap();
 		api_server.stop();
 	}
 
@@ -497,8 +544,8 @@ impl LocalServerContainerPool {
 	}
 
 	pub fn connect_all_peers(&mut self) {
-		/// just pull out all currently active servers, build a list,
-		/// and feed into all servers
+		// just pull out all currently active servers, build a list,
+		// and feed into all servers
 		let mut server_addresses: Vec<String> = Vec::new();
 		for s in &self.server_containers {
 			let server_address = format!("{}:{}", s.config.base_addr, s.config.p2p_server_port);

--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -352,6 +352,7 @@ impl LocalServerContainer {
  
 	/// Stops the running wallet server
 	pub fn stop_wallet(&mut self) {
+		println!("Stop wallet!");
 		let api_server = self.api_server.as_mut().unwrap();
 		api_server.stop();
 	}

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -45,6 +45,7 @@ use framework::{LocalServerContainerConfig, LocalServerContainerPool,
 /// Block and mining into a wallet for a bit
 #[test]
 fn basic_genesis_mine() {
+	util::init_test_logger();
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "genesis_mine";
@@ -64,7 +65,8 @@ fn basic_genesis_mine() {
 	// Create a server to add into the pool
 	let mut server_config = LocalServerContainerConfig::default();
 	server_config.start_miner = true;
-	server_config.start_wallet = true;
+	server_config.start_wallet = false;
+	server_config.burn_mining_rewards = true;
 
 	pool.create_server(&mut server_config);
 	pool.run_all_servers();

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -96,7 +96,8 @@ fn simulate_seeding() {
 	// Create a first seed server to add into the pool
 	let mut server_config = LocalServerContainerConfig::default();
 	// server_config.start_miner = true;
-	server_config.start_wallet = true;
+	server_config.start_wallet = false;
+	server_config.burn_mining_rewards = true;
 	server_config.is_seeding = true;
 
 	pool.create_server(&mut server_config);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate router;
-
 extern crate grin_api as api;
 extern crate grin_chain as chain;
 extern crate grin_core as core;
@@ -37,14 +34,11 @@ use std::default::Default;
 use futures::{Async, Future, Poll};
 use futures::task::current;
 use tokio_core::reactor;
-use tokio_timer::Timer;
 
-use core::consensus;
 use core::global;
 use core::global::ChainTypes;
-use wallet::WalletConfig;
 
-use framework::{LocalServerContainer, LocalServerContainerConfig, LocalServerContainerPool,
+use framework::{LocalServerContainerConfig, LocalServerContainerPool,
                 LocalServerContainerPoolConfig};
 
 /// Testing the frameworks by starting a fresh server, creating a genesis

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -273,7 +273,7 @@ fn simulate_full_sync() {
 	// instantiates 2 servers on different ports
 	let mut servers = vec![];
 	for n in 0..2 {
-		let mut config = grin::ServerConfig {
+		let config = grin::ServerConfig {
 			api_http_addr: format!("127.0.0.1:{}", 19000 + n),
 			db_root: format!("target/{}/grin-sync-{}", test_name_dir, n),
 			p2p_config: Some(p2p::P2PConfig {

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -95,7 +95,7 @@ fn basic_wallet_transactions() {
 	});
 
 	//Wait for chain to build
-	thread::sleep(time::Duration::from_millis(3000));
+	thread::sleep(time::Duration::from_millis(5000));
 	warn!(LOGGER, "Sending 50 Grins to recipient wallet");
 	LocalServerContainer::send_amount_to(&coinbase_wallet_config, "50.00", 1, "all", "http://127.0.0.1:20002");
 

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -70,6 +70,9 @@ fn basic_wallet_transactions() {
 	recp_config.wallet_port = 20002;
 	let target_wallet = Arc::new(Mutex::new(LocalServerContainer::new(recp_config).unwrap()));
 	let target_wallet_cloned = target_wallet.clone();
+	let mut recp_wallet_config = {
+		target_wallet.lock().unwrap().wallet_config.clone()
+	};
 
 	//Start up a second wallet, to receive
 	let _ = thread::spawn(move || {
@@ -99,7 +102,11 @@ fn basic_wallet_transactions() {
 	warn!(LOGGER, "Sending 50 Grins to recipient wallet");
 	LocalServerContainer::send_amount_to(&coinbase_wallet_config, "50.00", 1, "all", "http://127.0.0.1:20002");
 
-	//Wait for request to finish
-	//thread::sleep(time::Duration::from_millis(1000));
+	//let some more mining happen, make sure nothing pukes
+	thread::sleep(time::Duration::from_millis(5000));
+
+	//send some cash right back
+	LocalServerContainer::send_amount_to(&recp_wallet_config, "25.00", 1, "all", "http://127.0.0.1:10002");
+	thread::sleep(time::Duration::from_millis(5000));
 }
 

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -55,7 +55,7 @@ fn basic_wallet_transactions() {
 	coinbase_config.wallet_validating_node_url=String::from("http://127.0.0.1:30001");
 	coinbase_config.wallet_port = 10002;
 	let coinbase_wallet = Arc::new(Mutex::new(LocalServerContainer::new(coinbase_config).unwrap()));
-	let mut coinbase_wallet_config = {
+	let coinbase_wallet_config = {
 		coinbase_wallet.lock().unwrap().wallet_config.clone()
 	};
 
@@ -70,7 +70,7 @@ fn basic_wallet_transactions() {
 	recp_config.wallet_port = 20002;
 	let target_wallet = Arc::new(Mutex::new(LocalServerContainer::new(recp_config).unwrap()));
 	let target_wallet_cloned = target_wallet.clone();
-	let mut recp_wallet_config = {
+	let recp_wallet_config = {
 		target_wallet.lock().unwrap().wallet_config.clone()
 	};
 

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -47,7 +47,8 @@ fn basic_wallet_transactions() {
 	let mut log_config = util::LoggingConfig::default();
 	//log_config.stdout_log_level = util::LogLevel::Trace;
 	log_config.stdout_log_level = util::LogLevel::Info;
-	init_logger(Some(log_config));
+	//init_logger(Some(log_config));
+	util::init_test_logger();
 
 	// Run a separate coinbase wallet for coinbase transactions
 	let mut coinbase_config = LocalServerContainerConfig::default();

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -32,8 +32,8 @@ mod framework;
 use std::{thread, time};
 use std::sync::{Arc, Mutex};
 use framework::{LocalServerContainer,
-								LocalServerContainerConfig,
-								LocalServerContainerPoolConfig};
+	LocalServerContainerConfig,
+	LocalServerContainerPoolConfig};
 
 use util::{init_logger, LOGGER};
 

--- a/grin/tests/wallet.rs
+++ b/grin/tests/wallet.rs
@@ -1,0 +1,105 @@
+// Copyright 2017 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate router;
+#[macro_use]
+extern crate slog;
+
+extern crate grin_api as api;
+extern crate grin_chain as chain;
+extern crate grin_core as core;
+extern crate grin_grin as grin;
+extern crate grin_p2p as p2p;
+extern crate grin_pow as pow;
+extern crate grin_util as util;
+extern crate grin_wallet as wallet;
+extern crate grin_config as config;
+
+mod framework;
+
+use std::{thread, time};
+use std::sync::{Arc, Mutex};
+use framework::{LocalServerContainer,
+								LocalServerContainerConfig,
+								LocalServerContainerPoolConfig};
+
+use util::{init_logger, LOGGER};
+
+/// Start 1 node mining and two wallets, then send a few
+/// transactions from one to the other
+#[test]
+fn basic_wallet_transactions() {
+	let test_name_dir = "test_servers";
+	core::global::set_mining_mode(core::global::ChainTypes::AutomatedTesting);
+	framework::clean_all_output(test_name_dir);
+	let mut log_config = util::LoggingConfig::default();
+	//log_config.stdout_log_level = util::LogLevel::Trace;
+	log_config.stdout_log_level = util::LogLevel::Info;
+	init_logger(Some(log_config));
+
+	// Run a separate coinbase wallet for coinbase transactions
+	let mut coinbase_config = LocalServerContainerConfig::default();
+	coinbase_config.name = String::from("coinbase_wallet");
+	coinbase_config.wallet_validating_node_url=String::from("http://127.0.0.1:30001");
+	coinbase_config.wallet_port = 10002;
+	let coinbase_wallet = Arc::new(Mutex::new(LocalServerContainer::new(coinbase_config).unwrap()));
+	let mut coinbase_wallet_config = {
+		coinbase_wallet.lock().unwrap().wallet_config.clone()
+	};
+
+	let _ = thread::spawn(move || {
+		let mut w = coinbase_wallet.lock().unwrap();
+		w.run_wallet(0);
+	});
+
+	let mut recp_config = LocalServerContainerConfig::default();
+	recp_config.name = String::from("target_wallet");
+	recp_config.wallet_validating_node_url=String::from("http://127.0.0.1:30001");
+	recp_config.wallet_port = 20002;
+	let target_wallet = Arc::new(Mutex::new(LocalServerContainer::new(recp_config).unwrap()));
+	let target_wallet_cloned = target_wallet.clone();
+
+	//Start up a second wallet, to receive
+	let _ = thread::spawn(move || {
+		let mut w = target_wallet_cloned.lock().unwrap();
+		w.run_wallet(0);
+	});
+
+	// Spawn server and let it run for a bit
+	let _ = thread::spawn(move || {
+		let mut server_config = LocalServerContainerConfig::default();
+		server_config.name = String::from("server_one");
+		server_config.p2p_server_port = 30000;
+		server_config.api_server_port = 30001;
+		server_config.start_miner = true;
+		server_config.start_wallet = false;
+		server_config.coinbase_wallet_address = String::from(format!(
+			"http://{}:{}",
+			server_config.base_addr,
+			10002
+		));
+		let mut server_one = LocalServerContainer::new(server_config).unwrap();
+		server_one.run_server(120);
+	});
+
+	//Wait for chain to build
+	thread::sleep(time::Duration::from_millis(3000));
+	warn!(LOGGER, "Sending 50 Grins to recipient wallet");
+	LocalServerContainer::send_amount_to(&coinbase_wallet_config, "50.00", 1, "all", "http://127.0.0.1:20002");
+
+	//Wait for request to finish
+	//thread::sleep(time::Duration::from_millis(1000));
+}
+

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -277,7 +277,7 @@ impl Keychain {
 		let context = self.aggsig_context.clone();
 		let context_read=context.read().unwrap();
 		let agg_context=context_read.as_ref().unwrap();
-		let sig = aggsig::sign_single(&self.secp, msg, &agg_context.sec_key, secnonce, pubnonce)?;
+		let sig = aggsig::sign_single(&self.secp, msg, &agg_context.sec_key, secnonce, pubnonce, None)?;
 		Ok(sig)
 	}
 
@@ -287,7 +287,7 @@ impl Keychain {
 	}
 
 	//Verifies other party's sig corresponds with what we're expecting
-	pub fn aggsig_verify_partial_sig_build_msg(&self, sig: &Signature, pubkey: &PublicKey, fee: u64, lock_height:u64) -> bool {
+	pub fn aggsig_verify_final_sig_build_msg(&self, sig: &Signature, pubkey: &PublicKey, fee: u64, lock_height:u64) -> bool {
 		let msg = secp::Message::from_slice(&kernel_sig_msg(fee, lock_height)).unwrap();
 		self.aggsig_verify_single(sig, &msg, None, pubkey)
 	}

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -31,4 +31,4 @@ mod extkey;
 pub use blind::{BlindSum, BlindingFactor};
 pub use extkey::{ExtendedKey, Identifier, IDENTIFIER_SIZE};
 pub mod keychain;
-pub use keychain::{Error, Keychain};
+pub use keychain::{Error, Keychain, AggSigTxContext};

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -737,7 +737,7 @@ mod tests {
    // a valid transaction.
 			let valid_transaction = test_transaction(vec![5, 6], vec![9]);
 
-			match write_pool.add_to_memory_pool(test_source(), valid_transaction) {
+			match write_pool.add_to_memory_pool(test_source(), valid_transaction.clone()) {
 				Ok(_) => {}
 				Err(x) => panic!("Unexpected error while adding a valid transaction: {:?}", x),
 			};
@@ -764,9 +764,15 @@ mod tests {
 				}
 			};
 
-			let already_in_pool = test_transaction(vec![5, 6], vec![9]);
+			// Note, this used to work as expected, but after aggsig implementation
+			// creating another transaction with the same inputs/outputs doesn't create
+			// the same hash ID due to the random nonces in an aggsig. This
+			// will instead throw a (correct as well) Already spent error. An AlreadyInPool
+			// error can only come up in the case of the exact same transaction being
+			// added
+			//let already_in_pool = test_transaction(vec![5, 6], vec![9]);
 
-			match write_pool.add_to_memory_pool(test_source(), already_in_pool) {
+			match write_pool.add_to_memory_pool(test_source(), valid_transaction) {
 				Ok(_) => panic!("Expected error when adding already in pool, got Ok"),
 				Err(x) => {
 					match x {

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -408,7 +408,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 	let passphrase = wallet_args.value_of("pass").expect(
 		"Failed to read passphrase.",
 	);
-	let keychain = wallet_seed.derive_keychain(&passphrase).expect(
+	let mut keychain = wallet_seed.derive_keychain(&passphrase).expect(
 		"Failed to derive keychain from seed file and passphrase.",
 	);
 
@@ -451,7 +451,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			let max_outputs = 500;
 			let result = wallet::issue_send_tx(
 				&wallet_config,
-				&keychain,
+				&mut keychain,
 				amount,
 				minimum_confirmations,
 				dest.to_string(),

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -33,8 +33,6 @@ extern crate grin_wallet as wallet;
 mod client;
 
 use std::thread;
-use std::io::Read;
-use std::fs::File;
 use std::time::Duration;
 use std::env::current_dir;
 
@@ -211,10 +209,8 @@ fn main() {
 				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("send")
-			.about("Builds a transaction to send someone some coins. By default, \
-				the transaction will just be printed to stdout. If a destination is \
-				provided, the command will attempt to contact the receiver at that \
-				address and send the transaction directly.")
+			.about("Builds a transaction to send coins and sends it to the specified \
+			 listener directly.")
 			.arg(Arg::with_name("amount")
 				.help("Number of coins to send with optional fraction, e.g. 12.423")
 				.index(1))
@@ -428,7 +424,9 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			}
 			wallet::server::start_rest_apis(wallet_config, keychain);
 		}
-		("receive", Some(receive_args)) => {
+		// The following is gone for now, as a result of aggsig transactions
+		// being implemented
+		/*("receive", Some(receive_args)) => {
 			let input = receive_args.value_of("input").expect("Input file required");
 			let mut file = File::open(input).expect("Unable to open transaction file.");
 			let mut contents = String::new();
@@ -444,7 +442,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 				println!(" * your node isn't running or can't be reached");
 				println!("\nDetailed error: {:?}", e);
 			}
-		}
+		}*/
 		("send", Some(send_args)) => {
 			let amount = send_args.value_of("amount").expect(
 				"Amount to send required",
@@ -461,10 +459,9 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			let selection_strategy = send_args.value_of("selection_strategy").expect(
 				"Selection strategy required",
 			);
-			let mut dest = "stdout";
-			if let Some(d) = send_args.value_of("dest") {
-				dest = d;
-			}
+			let dest =  send_args.value_of("dest").expect(
+				"Destination wallet address required",
+			);
 			let max_outputs = 500;
 			let result = wallet::issue_send_tx(
 				&wallet_config,

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -14,6 +14,6 @@ byteorder = "^0.5"
 rand = "0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-#secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_3" }
-secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_5" }
+#secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -14,6 +14,6 @@ byteorder = "^0.5"
 rand = "0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_3" }
-#secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
+#secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_3" }
+secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,8 +10,10 @@ slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_
 slog-term = "^2.2.0"
 slog-async = "^2.1.0"
 lazy_static = "~0.2.8"
+byteorder = "^0.5"
 rand = "0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_2" }
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_3" }
+#secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -14,6 +14,6 @@ byteorder = "^0.5"
 rand = "0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_5" }
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_6" }
 #secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -25,7 +25,7 @@
 extern crate slog;
 extern crate slog_async;
 extern crate slog_term;
-
+extern crate byteorder;
 extern crate rand;
 
 #[macro_use]
@@ -54,6 +54,7 @@ pub use types::LoggingConfig;
 use std::cell::{Ref, RefCell};
 #[allow(unused_imports)]
 use std::ops::Deref;
+use byteorder::{BigEndian, ByteOrder};
 
 mod hex;
 pub use hex::*;
@@ -97,4 +98,12 @@ impl<T> OneTime<T> {
 	pub fn borrow(&self) -> Ref<T> {
 		Ref::map(self.inner.borrow(), |o| o.as_ref().unwrap())
 	}
+}
+
+/// Construct msg bytes from tx fee and lock_height
+pub fn kernel_sig_msg(fee: u64, lock_height: u64) -> [u8; 32] {
+	let mut bytes = [0; 32];
+	BigEndian::write_u64(&mut bytes[16..24], fee);
+	BigEndian::write_u64(&mut bytes[24..], lock_height);
+	bytes
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -48,7 +48,7 @@ pub mod secp_static;
 pub use secp_static::static_secp_instance;
 
 pub mod types;
-pub use types::LoggingConfig;
+pub use types::{LoggingConfig, LogLevel};
 
 // other utils
 use std::cell::{Ref, RefCell};

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -54,7 +54,7 @@ pub mod server;
 
 pub use outputs::show_outputs;
 pub use info::show_info;
-pub use receiver::{receive_json_tx, receive_json_tx_str, WalletReceiver};
+pub use receiver::{WalletReceiver};
 pub use sender::{issue_burn_tx, issue_send_tx};
 pub use types::{BlockFees, CbData, Error, WalletConfig, WalletReceiveRequest, WalletSeed};
 pub use restore::restore;

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -106,17 +106,7 @@ fn handle_sender_initiation(
 	// this will create a new blinding sum and nonce, and store them
 	keychain.aggsig_create_context(blind_sum.secret_key());
 
-	// Add public nonces kR*G + kS*G 
-	let (pub_excess, _) = keychain.aggsig_get_public_keys();
-	let (_, sec_nonce) = keychain.aggsig_get_private_keys();
-	let mut nonce_sum = sender_pub_nonce.clone();
-  let _ = nonce_sum.add_exp_assign(keychain.secp(), &sec_nonce);
-
-	//Now calculate signature using message M=fee, nonce=nonce_sum
-
-
-	// Calculate sR
-	//keychain.aggsig_sign_single();
+	let sig_part=keychain.aggsig_calculate_partial_sig(&sender_pub_nonce, fee, tx.lock_height).unwrap();
 
 	//let final_tx = receive_transaction(config, keychain, amount, sender_pub_blinding, tx)?;
 	//let tx_hex = util::to_hex(ser::ser_vec(&final_tx).unwrap());

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -54,8 +54,8 @@ pub fn receive_json_tx(
 	keychain: &Keychain,
 	partial_tx: &PartialTx,
 ) -> Result<(), Error> {
-	let (amount, blinding, tx) = read_partial_tx(keychain, partial_tx)?;
-	let final_tx = receive_transaction(config, keychain, amount, blinding, tx)?;
+	let (amount, sender_pub_blinding, _sender_pub_nonce, tx) = read_partial_tx(keychain, partial_tx)?;
+	let final_tx = receive_transaction(config, keychain, amount, sender_pub_blinding, tx)?;
 	let tx_hex = util::to_hex(ser::ser_vec(&final_tx).unwrap());
 
 	let url = format!("{}/v1/pool/push", config.check_node_api_http_addr.as_str());

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -153,7 +153,7 @@ fn handle_sender_confirmation(
 	println!("Final Pubkey: {:?}", final_pubkey);
 
 	//Check our final transaction verifies
-	let res = keychain.aggsig_verify_partial_sig_build_msg(&final_sig, &final_pubkey, tx.fee, tx.lock_height);
+	let res = keychain.aggsig_verify_final_sig_build_msg(&final_sig, &final_pubkey, tx.fee, tx.lock_height);
 
 	println!("Final result.....: {}", res);
 	if !res {

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Grin Developers
+// Copyright 2018 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use serde_json;
 
 use api;
 use client;

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -61,7 +61,7 @@ pub fn issue_send_tx(
 	// Create a new aggsig context
 	keychain.aggsig_create_context(blind_sum.secret_key());
 
-	let partial_tx = build_partial_tx(keychain, amount, tx);
+	let partial_tx = build_partial_tx(keychain, amount, None, tx);
 
 	// Closure to acquire wallet lock and lock the coins being spent
 	// so we avoid accidental double spend attempt.
@@ -84,15 +84,16 @@ pub fn issue_send_tx(
 	} else if &dest[..4] == "http" {
 		let url = format!("{}/v1/receive/transaction", &dest);
 		debug!(LOGGER, "Posting partial transaction to {}", url);
+		println!("Sender init partial tx: {:?}", partial_tx);
 		let res = client::send_partial_tx(&url, &partial_tx);
 		match res {
 			Err(_) => {
 				error!(LOGGER, "Communication with receiver failed. Aborting transaction");
 				rollback_wallet()?;
-				return res;
 			}
-			Ok(_) => {
-				update_wallet()?;
+			Ok(r) => {
+				println!("Partial response: {:?}", r);
+				//update_wallet()?;
 			}
 		}
 	} else {

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -32,7 +32,7 @@ use util;
 
 pub fn issue_send_tx(
 	config: &WalletConfig,
-	keychain: &mut Keychain,
+	keychain: &Keychain,
 	amount: u64,
 	minimum_confirmations: u64,
 	dest: String,
@@ -58,10 +58,10 @@ pub fn issue_send_tx(
 		selection_strategy,
 	)?;
 
-	// Create a new aggsig context (that we'll have to hold onto somehow throughout the transaction)
-	keychain.create_aggsig_context(blind_sum.secret_key());
+	// Create a new aggsig context
+	keychain.aggsig_create_context(blind_sum.secret_key());
 
-	let partial_tx = build_partial_tx_sender_initiation(keychain, amount, tx);
+	let partial_tx = build_partial_tx(keychain, amount, tx);
 
 	// Closure to acquire wallet lock and lock the coins being spent
 	// so we avoid accidental double spend attempt.


### PR DESCRIPTION
See https://github.com/mimblewimble/grin/issues/399 for context

https://github.com/mimblewimble/rust-secp256k1-zkp/blob/master/src/aggsig.rs for latest state of rust aggsig API (still very subject to change)

- [X] Integrate existing aggsig work into mimblewimble secp fork
- [X] creation of single-sig version of API based on existing work
- [X] Additions to single-sig API to support encoding different nonces within schnorr 'e' message (to support @tromp's additive signature scheme)
- [X] Additions to single-sig API to support simple addition of two signatures
- [X] (FIXED) The implementation I have doesn't verify the individual signatures AND the aggregated signature consistently, at the moment I can consistently validate one or the other, but not both. They should both work, and I'm currently working through the maths to figure out what the issue is.
- [X] (Framework done) Automated testing to exercise this (at the moment, there are no tests in the wallet whatsover.. integration tests need to be added, probably a separate file) in grin/tests
- [X] Updating transaction workflow between client and receiver as needed, with approach to keeping state between calls
- [X] Updating validation
- [x] Updating all automated tests

Note that stdout transactions are gone (as we don't have a strategy to handle them now that this is an exchange instead of a single send)

Also, I've added an optional config parameter to turn off waiting for peers on startup (which was slowing down automated testing immensely)

  
  
  
  
  