### PR TITLE
Minimal client implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["Ignotus Peverell <igno.peverell@protonmail.com>"]
 exclude = ["**/*.grin", "**/*.grin2"]
 
 [workspace]
-members = ["api", "chain", "config", "core", "grin", "keychain", "p2p", "store", "util", "pool", "wallet"]
+members = ["api", "chain", "client", "config", "core", "grin", "keychain", "p2p", "store", "util", "pool", "wallet"]
 
 [dependencies]
 grin_api = { path = "./api" }
 grin_wallet = { path = "./wallet" }
 grin_keychain = { path = "./keychain" }
 grin_grin = { path = "./grin" }
+grin_client = {path = "./client"}
 grin_config = { path = "./config" }
 grin_core = { path = "./core" }
 grin_pow = { path = "./pow"}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "grin_client"
+version = "0.1.0"
+authors = ["Quentin Le Sceller <q.lesceller@gmail.com>"]
+workspace = ".."

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,3 +3,7 @@ name = "grin_client"
 version = "0.1.0"
 authors = ["Quentin Le Sceller <q.lesceller@gmail.com>"]
 workspace = ".."
+
+[dependencies]
+term = "~0.4.6"
+grin_p2p = { path = "../p2p" }

--- a/client/rustfmt.toml
+++ b/client/rustfmt.toml
@@ -1,0 +1,3 @@
+hard_tabs = true
+wrap_comments = true
+write_mode = "Overwrite"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate grin_p2p as p2p;
+
+extern crate term;
+
 mod status;
 
 pub use status::show_status;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod status;
+
+pub use status::show_status;

--- a/client/src/status.rs
+++ b/client/src/status.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn show_status() {
+    println!("status info...");
+}

--- a/client/src/status.rs
+++ b/client/src/status.rs
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use p2p::msg::{PROTOCOL_VERSION, USER_AGENT};
+use term;
+
 pub fn show_status() {
-    println!("status info...");
+    println!();
+    let title=format!("Grin Server Status ");
+    let mut t = term::stdout().unwrap();
+    let mut e = term::stdout().unwrap();
+    t.fg(term::color::MAGENTA).unwrap();
+    writeln!(t, "{}", title).unwrap();
+    writeln!(t, "--------------------------").unwrap();
+    t.reset().unwrap();
+    writeln!(e, "Protocol version: {}", PROTOCOL_VERSION).unwrap();
+    writeln!(e, "User agent: {}", USER_AGENT).unwrap();
+    e.reset().unwrap();
+    println!();
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -47,7 +47,7 @@ extern crate tokio_timer;
 mod conn;
 pub mod handshake;
 mod rate_limit;
-mod msg;
+pub mod msg;
 mod peer;
 mod peers;
 mod protocol;

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -25,6 +25,7 @@ extern crate slog;
 extern crate grin_api as api;
 extern crate grin_config as config;
 extern crate grin_core as core;
+extern crate grin_client as client;
 extern crate grin_grin as grin;
 extern crate grin_keychain as keychain;
 extern crate grin_util as util;
@@ -271,12 +272,7 @@ fn main() {
 
 		// client commands and options
 		("client", Some(client_args)) => {
-			match client_args.subcommand() {
-				("status", _) => {
-					println!("status info...");
-				}
-				_ => panic!("Unknown client command, use 'grin help client' for details"),
-			}
+			client_command(client_args);
 		}
 
 		// client commands and options
@@ -365,6 +361,15 @@ fn server_command(server_args: &ArgMatches, global_config: GlobalConfig) {
 				cmd
 			);
 		}
+	}
+}
+
+fn client_command(client_args: &ArgMatches) {
+	match client_args.subcommand() {
+		("status", Some(_)) => {
+			client::show_status();
+		}
+		_ => panic!("Unknown client command, use 'grin help client' for details"),
 	}
 }
 


### PR DESCRIPTION
This PR is a very minimal implementation of the ```grin client```/```grin client status```. 
For now, it only displays the protocol version and the user agent based on the content of  [p2p/src/msg.rs](https://github.com/mimblewimble/grin/blob/master/p2p/src/msg.rs). 
Later modifications will display chain eight using the REST API and uptime of the server.