### PR TITLE
[testnet1] fix - sort tx inputs/outputs

### DIFF
--- a/chain/src/sumtree.rs
+++ b/chain/src/sumtree.rs
@@ -319,7 +319,7 @@ impl<'a> Extension<'a> {
 			LOGGER,
 			"sumtree: save_pos_index: outputs: {}, {:?}",
 			self.new_output_commits.len(),
-			self.new_output_commits,
+			self.new_output_commits.values().collect::<Vec<_>>(),
 		);
 
 		for (commit, pos) in &self.new_output_commits {
@@ -330,7 +330,7 @@ impl<'a> Extension<'a> {
 			LOGGER,
 			"sumtree: save_pos_index: kernels: {}, {:?}",
 			self.new_kernel_excesses.len(),
-			self.new_kernel_excesses,
+			self.new_kernel_excesses.values().collect::<Vec<_>>(),
 		);
 
 		for (excess, pos) in &self.new_kernel_excesses {

--- a/chain/src/sumtree.rs
+++ b/chain/src/sumtree.rs
@@ -317,7 +317,8 @@ impl<'a> Extension<'a> {
 	fn save_pos_index(&self) -> Result<(), Error> {
 		debug!(
 			LOGGER,
-			"sumtree: save_pos_index: outputs: {:?}",
+			"sumtree: save_pos_index: outputs: {}, {:?}",
+			self.new_output_commits.len(),
 			self.new_output_commits,
 		);
 
@@ -327,7 +328,8 @@ impl<'a> Extension<'a> {
 
 		debug!(
 			LOGGER,
-			"sumtree: save_pos_index: kernels: {:?}",
+			"sumtree: save_pos_index: kernels: {}, {:?}",
+			self.new_kernel_excesses.len(),
 			self.new_kernel_excesses,
 		);
 

--- a/chain/src/sumtree.rs
+++ b/chain/src/sumtree.rs
@@ -315,12 +315,26 @@ impl<'a> Extension<'a> {
 	}
 
 	fn save_pos_index(&self) -> Result<(), Error> {
+		debug!(
+			LOGGER,
+			"sumtree: save_pos_index: outputs: {:?}",
+			self.new_output_commits,
+		);
+
 		for (commit, pos) in &self.new_output_commits {
 			self.commit_index.save_output_pos(commit, *pos)?;
 		}
+
+		debug!(
+			LOGGER,
+			"sumtree: save_pos_index: kernels: {:?}",
+			self.new_kernel_excesses,
+		);
+
 		for (excess, pos) in &self.new_kernel_excesses {
 			self.commit_index.save_kernel_pos(excess, *pos)?;
 		}
+
 		Ok(())
 	}
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -22,7 +22,6 @@
 use std::fmt;
 use std::cmp::max;
 
-use ser;
 use core::target::Difficulty;
 
 /// A grin is divisible to 10^9, following the SI prefixes
@@ -132,6 +131,13 @@ pub const UPPER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW * 4 / 3;
 /// Minimum size time window used for difficulty adjustments
 pub const LOWER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW * 5 / 6;
 
+/// Consensus errors
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+	/// Inputs/outputs/kernels must be sorted lexicographically.
+	SortError,
+}
+
 /// Error when computing the next difficulty adjustment.
 #[derive(Debug, Clone)]
 pub struct TargetError(pub String);
@@ -216,10 +222,10 @@ where
 	Ok(max(difficulty, Difficulty::minimum()))
 }
 
-/// Consensus rule that collections of items are sorted lexicographically over the wire.
+/// Consensus rule that collections of items are sorted lexicographically.
 pub trait VerifySortOrder<T> {
 	/// Verify a collection of items is sorted as required.
-	fn verify_sort_order(&self) -> Result<(), ser::Error>;
+	fn verify_sort_order(&self) -> Result<(), Error>;
 }
 
 #[cfg(test)]

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -607,7 +607,7 @@ mod test {
 	use core::build::{self, input, output, with_fee};
 	use core::test::tx2i1o;
 	use keychain::{Identifier, Keychain};
-	use consensus::*;
+	use consensus::{MAX_BLOCK_WEIGHT, BLOCK_OUTPUT_WEIGHT};
 	use std::time::Instant;
 
 	use util::secp;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -326,7 +326,7 @@ impl Block {
 		kernels.push(reward_kern);
 		outputs.push(reward_out);
 
-		// now sort everything to the block is built deterministically
+		// now sort everything so the block is built deterministically
 		inputs.sort();
 		outputs.sort();
 		kernels.sort();

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -449,8 +449,14 @@ impl Block {
 		if exceeds_weight(self.inputs.len(), self.outputs.len(), self.kernels.len()) {
 			return Err(Error::WeightExceeded);
 		}
+		self.verify_sorted()?;
 		self.verify_coinbase()?;
 		self.verify_kernels(false)?;
+		Ok(())
+	}
+
+	fn verify_sorted(&self) -> Result<(), Error> {
+		// TODO - implement me
 		Ok(())
 	}
 

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -23,7 +23,7 @@ use std::convert::AsRef;
 
 use blake2::blake2b::Blake2b;
 
-use consensus::VerifySortOrder;
+use consensus;
 use ser::{self, AsFixedBytes, Error, Readable, Reader, Writeable, Writer};
 use util::LOGGER;
 
@@ -196,14 +196,14 @@ impl<W: ser::Writeable> Hashed for W {
 	}
 }
 
-impl<T: Writeable> VerifySortOrder<T> for Vec<T> {
-	fn verify_sort_order(&self) -> Result<(), ser::Error> {
+impl<T: Writeable> consensus::VerifySortOrder<T> for Vec<T> {
+	fn verify_sort_order(&self) -> Result<(), consensus::Error> {
 		match self.iter()
 			.map(|item| item.hash())
 			.collect::<Vec<_>>()
 			.windows(2)
 			.any(|pair| pair[0] > pair[1]) {
-				true => Err(ser::Error::BadlySorted),
+				true => Err(consensus::Error::SortError),
 				false => Ok(()),
 			}
 	}

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -203,8 +203,8 @@ impl<T: Writeable> VerifySortOrder<T> for Vec<T> {
 			.collect::<Vec<_>>()
 			.windows(2)
 			.any(|pair| pair[0] > pair[1]) {
-			true => Err(ser::Error::BadlySorted),
-			false => Ok(()),
-		}
+				true => Err(ser::Error::BadlySorted),
+				false => Ok(()),
+			}
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -272,6 +272,7 @@ impl Transaction {
 	pub fn with_input(self, input: Input) -> Transaction {
 		let mut new_ins = self.inputs;
 		new_ins.push(input);
+		new_ins.sort();
 		Transaction {
 			inputs: new_ins,
 			..self
@@ -283,6 +284,7 @@ impl Transaction {
 	pub fn with_output(self, output: Output) -> Transaction {
 		let mut new_outs = self.outputs;
 		new_outs.push(output);
+		new_outs.sort();
 		Transaction {
 			outputs: new_outs,
 			..self

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -420,10 +420,10 @@ where
 
 impl<T> WriteableSorted for Vec<T>
 where
-	T: Writeable + Hashed,
+	T: Writeable + Ord,
 {
 	fn write_sorted<W: Writer>(&mut self, writer: &mut W) -> Result<(), Error> {
-		self.sort_by_key(|elmt| elmt.hash());
+		self.sort();
 		for elmt in self {
 			elmt.write(writer)?;
 		}

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -23,8 +23,9 @@ use std::{cmp, error, fmt};
 use std::io::{self, Read, Write};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use keychain::{Identifier, IDENTIFIER_SIZE};
-use core::hash::Hashed;
+use consensus;
 use consensus::VerifySortOrder;
+use core::hash::Hashed;
 use core::transaction::{SWITCH_COMMIT_HASH_SIZE, SwitchCommitHash};
 use util::secp::pedersen::Commitment;
 use util::secp::pedersen::RangeProof;
@@ -46,13 +47,19 @@ pub enum Error {
 	CorruptedData,
 	/// When asked to read too much data
 	TooLargeReadErr,
-	/// Something was not sorted when consensus rules requires it to be sorted
-	BadlySorted,
+	/// Consensus rule failure (currently sort order)
+	ConsensusError(consensus::Error),
 }
 
 impl From<io::Error> for Error {
 	fn from(e: io::Error) -> Error {
 		Error::IOErr(e)
+	}
+}
+
+impl From<consensus::Error> for Error {
+	fn from(e: consensus::Error) -> Error {
+		Error::ConsensusError(e)
 	}
 }
 
@@ -66,7 +73,7 @@ impl fmt::Display for Error {
 			} => write!(f, "expected {:?}, got {:?}", e, r),
 			Error::CorruptedData => f.write_str("corrupted data"),
 			Error::TooLargeReadErr => f.write_str("too large read"),
-			Error::BadlySorted => f.write_str("badly sorted data"),
+			Error::ConsensusError(ref e) => write!(f, "consensus error {:?}", e),
 		}
 	}
 }
@@ -88,7 +95,7 @@ impl error::Error for Error {
 			} => "unexpected data",
 			Error::CorruptedData => "corrupted data",
 			Error::TooLargeReadErr => "too large read",
-			Error::BadlySorted => "badly sorted data",
+			Error::ConsensusError(_) => "consensus error (sort order)",
 		}
 	}
 }

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -112,9 +112,8 @@ fn body_sync(peers: Peers, chain: Arc<chain::Chain>) {
 
 	// if we have 5 most_work_peers then ask for 50 blocks total (peer_count * 10)
 	// max will be 80 if all 8 peers are advertising most_work
-	let peer_count = cmp::max(peers.most_work_peers().len(), 10);
+	let peer_count = cmp::min(peers.most_work_peers().len(), 10);
 	let block_count = peer_count * 10;
-
 
 	let hashes_to_get = hashes
 		.iter()


### PR DESCRIPTION
Ok initial thoughts were incorrect (see #532). 

Took the opportunity to make the following minor changes though -

1) use `sort()` in `write_sorted` to keep things DRY and consistent
2) add some debug logging in `save_pos_index`
3) keep tx inputs/outputs sorted as we add inputs & outputs

TODO - 

- [x] add explicit validation/verification to transaction and block to ensure inputs/outputs/kernels are sorted correctly
- [x] check we validate a tx before putting it in the pool (I assume we do)

