### PR TITLE
Display chain status with grin client status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ grin_grin = { path = "./grin" }
 grin_config = { path = "./config" }
 grin_core = { path = "./core" }
 grin_pow = { path = "./pow"}
+grin_p2p = { path = "./p2p"}
 grin_util = { path = "./util"}
 secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 blake2-rfc = "~0.2.17"
@@ -24,6 +25,7 @@ serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.7"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+term = "~0.4.6"
 
 # TODO - once "patch" is available we should be able to clean up the workspace dependencies
 # [patch.crate-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ exclude = ["**/*.grin", "**/*.grin2"]
 [workspace]
 members = ["api", "chain", "config", "core", "grin", "keychain", "p2p", "store", "util", "pool", "wallet"]
 
+[[bin]]
+name = "grin"
+path = "src/bin/grin.rs"
+
 [dependencies]
 grin_api = { path = "./api" }
 grin_wallet = { path = "./wallet" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ grin_core = { path = "./core" }
 grin_pow = { path = "./pow"}
 grin_p2p = { path = "./p2p"}
 grin_util = { path = "./util"}
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 blake2-rfc = "~0.2.17"
 clap = "^2.23.3"
 daemonize = "^0.2.3"

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -47,7 +47,7 @@ extern crate tokio_timer;
 mod conn;
 pub mod handshake;
 mod rate_limit;
-mod msg;
+pub mod msg;
 mod peer;
 mod peers;
 mod protocol;

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -15,7 +15,10 @@
 extern crate grin_p2p as p2p;
 extern crate term;
 
-pub fn show_status() {
+use api;
+use grin::ServerConfig;
+
+pub fn show_status(config: &ServerConfig) {
     println!();
     let title=format!("Grin Server Status ");
     let mut t = term::stdout().unwrap();
@@ -26,6 +29,22 @@ pub fn show_status() {
     t.reset().unwrap();
     writeln!(e, "Protocol version: {}", p2p::msg::PROTOCOL_VERSION).unwrap();
     writeln!(e, "User agent: {}", p2p::msg::USER_AGENT).unwrap();
+    match get_tip_from_node(config) {
+        Ok(tip) => writeln!(e, "Chain height: {}", tip.height).unwrap(),
+        Err(_) => writeln!(e, "WARNING: Client failed to get data. Is your `grin server` offline or broken?").unwrap()
+    };
     e.reset().unwrap();
     println!();
+}
+
+fn get_tip_from_node(config: &ServerConfig) -> Result<api::Tip, Error> {
+	let url = format!("http://{}/v1/chain", config.api_http_addr);
+	api::client::get::<api::Tip>(url.as_str()).map_err(|e| Error::API(e))
+}
+
+/// Error type wrapping underlying module errors.
+#[derive(Debug)]
+enum Error {
+	/// Error originating from HTTP API calls.
+	API(api::Error)
 }

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate grin_p2p as p2p;
+extern crate term;
+
+pub fn show_status() {
+    println!();
+    let title=format!("Grin Server Status ");
+    let mut t = term::stdout().unwrap();
+    let mut e = term::stdout().unwrap();
+    t.fg(term::color::MAGENTA).unwrap();
+    writeln!(t, "{}", title).unwrap();
+    writeln!(t, "--------------------------").unwrap();
+    t.reset().unwrap();
+    writeln!(e, "Protocol version: {}", p2p::msg::PROTOCOL_VERSION).unwrap();
+    writeln!(e, "User agent: {}", p2p::msg::USER_AGENT).unwrap();
+    e.reset().unwrap();
+    println!();
+}

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -30,7 +30,11 @@ pub fn show_status(config: &ServerConfig) {
     writeln!(e, "Protocol version: {}", p2p::msg::PROTOCOL_VERSION).unwrap();
     writeln!(e, "User agent: {}", p2p::msg::USER_AGENT).unwrap();
     match get_tip_from_node(config) {
-        Ok(tip) => writeln!(e, "Chain height: {}", tip.height).unwrap(),
+        Ok(tip) => {
+            writeln!(e, "Chain height: {}", tip.height).unwrap();
+            writeln!(e, "Total difficulty: {}", tip.total_difficulty).unwrap();
+            writeln!(e, "Last block pushed: {}", tip.last_block_pushed).unwrap()
+        }
         Err(_) => writeln!(e, "WARNING: Client failed to get data. Is your `grin server` offline or broken?").unwrap()
     };
     e.reset().unwrap();

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -273,7 +273,7 @@ fn main() {
 
 		// client commands and options
 		("client", Some(client_args)) => {
-			client_command(client_args);
+			client_command(client_args, global_config);
 		}
 
 		// client commands and options
@@ -365,10 +365,13 @@ fn server_command(server_args: &ArgMatches, global_config: GlobalConfig) {
 	}
 }
 
-fn client_command(client_args: &ArgMatches) {
+fn client_command(client_args: &ArgMatches, global_config: GlobalConfig) {
+	// just get defaults from the global config
+	let server_config = global_config.members.unwrap().server;
+
 	match client_args.subcommand() {
 		("status", Some(_)) => {
-			client::show_status();
+			client::show_status(&server_config);
 		}
 		_ => panic!("Unknown client command, use 'grin help client' for details"),
 	}

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -30,6 +30,8 @@ extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 
+mod client;
+
 use std::thread;
 use std::io::Read;
 use std::fs::File;
@@ -271,12 +273,7 @@ fn main() {
 
 		// client commands and options
 		("client", Some(client_args)) => {
-			match client_args.subcommand() {
-				("status", _) => {
-					println!("status info...");
-				}
-				_ => panic!("Unknown client command, use 'grin help client' for details"),
-			}
+			client_command(client_args);
 		}
 
 		// client commands and options
@@ -365,6 +362,15 @@ fn server_command(server_args: &ArgMatches, global_config: GlobalConfig) {
 				cmd
 			);
 		}
+	}
+}
+
+fn client_command(client_args: &ArgMatches) {
+	match client_args.subcommand() {
+		("status", Some(_)) => {
+			client::show_status();
+		}
+		_ => panic!("Unknown client command, use 'grin help client' for details"),
 	}
 }
 


### PR DESCRIPTION
Based on https://github.com/mimblewimble/grin/pull/541.
Display current chain height, total difficulty and last block pushed.
Will not work with milestone/testnet1 since the format of Tip has changed.