### PR TITLE
Add kcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 after_success: |
   pwd &&
   echo "HERE" &&
-  wget https://github.com/percytheprefect/kcov/archive/master.tar.gz &&
+  wget https://github.com/mimblewimble/kcov/archive/master.tar.gz &&
   tar xzf master.tar.gz &&
   cd kcov-master &&
   mkdir build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ addons:
     packages:
       - g++-5
       - cmake
-
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev 
 env:
   global:
     - RUST_BACKTRACE="1"
@@ -28,5 +33,30 @@ env:
     - TEST_DIR=keychain
     - TEST_DIR=core
     - TEST_DIR=util
+
+after_success: |
+  pwd &&
+  echo "HERE" &&
+  wget https://github.com/percytheprefect/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  cargo test --no-run &&
+  cd ../
+  pwd &&
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_core* && 
+  echo "Finished coverage for grin_core"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_chain* && 
+  echo "Finished coverage for grin_chain"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/mine_simple_* &&
+  echo "Finished coverage for mine_simple"
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"
 
 script: cd $TEST_DIR && cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mimblewimble/grin.svg?branch=master)](https://travis-ci.org/mimblewimble/grin) [![Gitter chat](https://badges.gitter.im/grin_community/Lobby.png)](https://gitter.im/grin_community/Lobby)
+[![Build Status](https://travis-ci.org/mimblewimble/grin.svg?branch=master)](https://travis-ci.org/mimblewimble/grin) [![Gitter chat](https://badges.gitter.im/grin_community/Lobby.png)](https://gitter.im/grin_community/Lobby) [![Codecov coverage status](https://codecov.io/gh/mimblewimble/kcov/branch/master/graph/badge.svg)](https://codecov.io/gh/mimblewimble/kcov)
 
 # Grin
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mimblewimble/grin.svg?branch=master)](https://travis-ci.org/mimblewimble/grin) [![Gitter chat](https://badges.gitter.im/grin_community/Lobby.png)](https://gitter.im/grin_community/Lobby) [![Codecov coverage status](https://codecov.io/gh/mimblewimble/kcov/branch/master/graph/badge.svg)](https://codecov.io/gh/mimblewimble/kcov)
+[![Build Status](https://travis-ci.org/mimblewimble/grin.svg?branch=master)](https://travis-ci.org/mimblewimble/grin) [![Gitter chat](https://badges.gitter.im/grin_community/Lobby.png)](https://gitter.im/grin_community/Lobby) [![Codecov coverage status](https://codecov.io/gh/mimblewimble/grin/branch/master/graph/badge.svg)](https://codecov.io/gh/mimblewimble/grin)
 
 # Grin
 


### PR DESCRIPTION
Adds code coverage and a badge.  Continuation of @percytheprefect's work in #115.

Next Steps:
- [x] A `mimblewimble` org admin forks [`SimonKagstrom/kcov`](https://github.com/SimonKagstrom/kcov)

No other changes are needed.  I haven't used codecov before so not certain on this, but according to their site we don't need to do anything to set up open source projects. 
>No repository activation required. Simply upload a report and the project activates automatically.

All reports are viewable in the `mimblewimble/grin` dashboard, [here](https://codecov.io/gh/mimblewimble/grin).
