### PR TITLE
reset sync_head on restart 

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -183,9 +183,10 @@ impl Chain {
 
 		// Make sure we have a sync_head available for later use.
 		// We may have been tracking an invalid chain on a now banned peer
-		// so we want to reset the sync_head on restart to handle this.
-		// TODO - handle sync_head and peer banning in a more effective way.
+		// so we want to reset the both sync_head and header_head on restart to handle this.
+		// TODO - handle sync_head/header_head and peer banning in a more effective way.
 		let tip = chain_store.head().unwrap();
+		chain_store.save_header_head(&tip)?;
 		chain_store.save_sync_head(&tip)?;
 
 		info!(

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -181,16 +181,12 @@ impl Chain {
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
 		};
 
-		// make sure sync_head is available for later use
-		let _ = match chain_store.get_sync_head() {
-			Ok(tip) => tip,
-			Err(NotFoundErr) => {
-				let tip = chain_store.head().unwrap();
-				chain_store.save_sync_head(&tip)?;
-				tip
-			},
-			Err(e) => return Err(Error::StoreErr(e, "chain init sync head".to_owned())),
-		};
+		// Make sure we have a sync_head available for later use.
+		// We may have been tracking an invalid chain on a now banned peer
+		// so we want to reset the sync_head on restart to handle this.
+		// TODO - handle sync_head and peer banning in a more effective way.
+		let tip = chain_store.head().unwrap();
+		chain_store.save_sync_head(&tip)?;
 
 		info!(
 			LOGGER,

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -154,6 +154,7 @@ pub fn header_sync(peers: Peers, chain: Arc<chain::Chain>) {
 		if let Some(peer) = peers.most_work_peer() {
 			if let Ok(p) = peer.try_read() {
 				let peer_difficulty = p.info.total_difficulty.clone();
+				debug!(LOGGER, "sync: header_sync: {}, {}", difficulty, peer_difficulty);
 				if peer_difficulty > difficulty {
 					let _ = request_headers(
 						peer.clone(),


### PR DESCRIPTION
This should handle the case where we have been following a bad chain from a now banned peer.
We need to restart the node, but doing so will now reset the `sync_head` so we have a chance to reconsider which chain we want to sync against (and look at currently unbanned peers to do this).
