### PR TITLE
reset sync_head on restart 

### DIFF
--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -154,6 +154,7 @@ pub fn header_sync(peers: Peers, chain: Arc<chain::Chain>) {
 		if let Some(peer) = peers.most_work_peer() {
 			if let Ok(p) = peer.try_read() {
 				let peer_difficulty = p.info.total_difficulty.clone();
+				debug!(LOGGER, "sync: header_sync: {}, {}", difficulty, peer_difficulty);
 				if peer_difficulty > difficulty {
 					let _ = request_headers(
 						peer.clone(),


### PR DESCRIPTION
cherry-pick from testnet1 
* reset sync_head on restart (handle banned peers and sync against invalid chain)
* reset both sync_head and header_head on restart
