### PR TITLE
reset header_head and sync_head on peer ban

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 use util::secp::pedersen::{Commitment, RangeProof};
 
@@ -33,12 +34,13 @@ use sumtree;
 use types::*;
 use util::LOGGER;
 
-const MAX_ORPHANS: usize = 100;
+const MAX_ORPHAN_AGE_SECS: u64 = 30;
 
 #[derive(Debug, Clone)]
 struct Orphan {
 	block: Block,
 	opts: Options,
+	added: Instant,
 }
 
 struct OrphanBlockPool {
@@ -70,18 +72,11 @@ impl OrphanBlockPool {
 			prev_idx.insert(orphan.block.header.previous, orphan.block.hash());
 		}
 
-		if self.len() > MAX_ORPHANS {
-			let max = {
-				let orphans = self.orphans.read().unwrap();
-				orphans.values().max_by_key(|x| x.block.header.height).cloned()
-			};
-
-			if let Some(x) = max {
-				let mut orphans = self.orphans.write().unwrap();
-				let mut prev_idx = self.prev_idx.write().unwrap();
-				orphans.remove(&x.block.hash());
-				prev_idx.remove(&x.block.header.previous);
-			}
+		{
+			let mut orphans = self.orphans.write().unwrap();
+			let mut prev_idx = self.prev_idx.write().unwrap();
+			orphans.retain(|_, ref mut x| x.added.elapsed() < Duration::from_secs(MAX_ORPHAN_AGE_SECS));
+			prev_idx.retain(|_, &mut x| orphans.contains_key(&x));
 		}
 	}
 
@@ -181,13 +176,9 @@ impl Chain {
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
 		};
 
-		// Make sure we have a sync_head available for later use.
-		// We may have been tracking an invalid chain on a now banned peer
-		// so we want to reset the both sync_head and header_head on restart to handle this.
-		// TODO - handle sync_head/header_head and peer banning in a more effective way.
-		let tip = chain_store.head().unwrap();
-		chain_store.save_header_head(&tip)?;
-		chain_store.save_sync_head(&tip)?;
+		// Reset sync_head and header_head to head of current chain.
+		// Make sure sync_head is available for later use when needed.
+		chain_store.reset_head()?;
 
 		info!(
 			LOGGER,
@@ -217,7 +208,6 @@ impl Chain {
 		let head = self.store
 			.head()
 			.map_err(|e| Error::StoreErr(e, "chain load head".to_owned()))?;
-		let height = head.height;
 		let ctx = self.ctx_from_head(head, opts);
 
 		let res = pipe::process_block(&b, ctx);
@@ -259,36 +249,25 @@ impl Chain {
 				self.check_orphans(&b);
 			},
 			Err(Error::Orphan) => {
-				// TODO - Do we want to check that orphan height is > current height?
-				// TODO - Just check heights here? Or should we be checking total_difficulty as well?
 				let block_hash = b.hash();
-				if b.header.height < height + (MAX_ORPHANS as u64) {
-					let orphan = Orphan {
-						block: b.clone(),
-						opts: opts,
-					};
+				let orphan = Orphan {
+					block: b.clone(),
+					opts: opts,
+					added: Instant::now(),
+				};
 
-					// In the case of a fork - it is possible to have multiple blocks
-					// that are children of a given block.
-					// We do not handle this currently for orphans (future enhancement?).
-					// We just assume "last one wins" for now.
-					&self.orphans.add(orphan);
+				// In the case of a fork - it is possible to have multiple blocks
+				// that are children of a given block.
+				// We do not handle this currently for orphans (future enhancement?).
+				// We just assume "last one wins" for now.
+				&self.orphans.add(orphan);
 
-					debug!(
-						LOGGER,
-						"process_block: orphan: {:?}, # orphans {}",
-						block_hash,
-						self.orphans.len(),
-					);
-				} else {
-					debug!(
-						LOGGER,
-						"process_block: orphan: {:?}, (dropping, height {} vs {})",
-						block_hash,
-						b.header.height,
-						height,
-					);
-				}
+				debug!(
+					LOGGER,
+					"process_block: orphan: {:?}, # orphans {}",
+					block_hash,
+					self.orphans.len(),
+				);
 			},
 			Err(Error::Unfit(ref msg)) => {
 				debug!(
@@ -414,17 +393,6 @@ impl Chain {
 		sumtrees.roots()
 	}
 
-	/// Reset the header head to the same as the main head. When sync is running,
-	/// the header head will go ahead to try to download as many as possible.
-	/// However if a block, when fully received, is found invalid, the header
-	/// head need to backtrack to the last known valid position.
-	pub fn reset_header_head(&self) -> Result<(), Error> {
-		let head = self.head.lock().unwrap();
-		debug!(LOGGER, "Reset header head to {} at {}",
-					head.last_block_h, head.height);
-		self.store.save_header_head(&head).map_err(From::from)
-	}
-
 	/// returns the last n nodes inserted into the utxo sum tree
 	/// returns sum tree hash plus output itself (as the sum is contained
 	/// in the output anyhow)
@@ -454,6 +422,13 @@ impl Chain {
 	/// Total difficulty at the head of the chain
 	pub fn total_difficulty(&self) -> Difficulty {
 		self.head.lock().unwrap().clone().total_difficulty
+	}
+
+	/// Reset header_head and sync_head to head of current body chain
+	pub fn reset_head(&self) -> Result<(), Error> {
+		self.store
+			.reset_head()
+			.map_err(|e| Error::StoreErr(e, "chain reset_head".to_owned()))
 	}
 
 	/// Get the tip that's also the head of the chain

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -93,7 +93,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 		validate_block(b, &mut ctx, &mut extension)?;
 		debug!(
 			LOGGER,
-			"pipe: proces_block {} at {} is valid, save and append.",
+			"pipe: process_block {} at {} is valid, save and append.",
 			b.hash(),
 			b.header.height,
 		);

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -89,6 +89,13 @@ impl ChainStore for ChainKVStore {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
+	// Reset both header_head and sync_head to the current head of the body chain
+	fn reset_head(&self) -> Result<(), Error> {
+		let tip = self.head()?;
+		self.save_header_head(&tip)?;
+		self.save_sync_head(&tip)
+	}
+
 	fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())))
 	}

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -223,6 +223,9 @@ pub trait ChainStore: Send + Sync {
 	/// Save the provided tip as the current head of the sync header chain
 	fn save_sync_head(&self, t: &Tip) -> Result<(), store::Error>;
 
+	/// Reset header_head and sync_head to head of current body chain
+	fn reset_head(&self) -> Result<(), store::Error>;
+
 	/// Gets the block header at the provided height
 	fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, store::Error>;
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -79,6 +79,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		if let &Err(ref e) = &res {
 			debug!(LOGGER, "Block {} refused by chain: {:?}", bhash, e);
 			if e.is_bad_block() {
+				debug!(LOGGER, "block_received: {} is a bad block, resetting head", bhash);
+				let _ = self.chain.reset_head();
 				return false;
 			}
 		}

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -110,9 +110,9 @@ fn body_sync(peers: Peers, chain: Arc<chain::Chain>) {
 	}
 	hashes.reverse();
 
-	// if we have 5 most_work_peers then ask for 50 blocks total (peer_count * 10)
-	// max will be 80 if all 8 peers are advertising most_work
-	let peer_count = cmp::min(peers.most_work_peers().len(), 10);
+	// if we have 5 peers to sync from then ask for 50 blocks total (peer_count * 10)
+	// max will be 80 if all 8 peers are advertising more work
+	let peer_count = cmp::min(peers.more_work_peers().len(), 10);
 	let block_count = peer_count * 10;
 
 	let hashes_to_get = hashes
@@ -137,7 +137,8 @@ fn body_sync(peers: Peers, chain: Arc<chain::Chain>) {
 			);
 
 		for hash in hashes_to_get.clone() {
-			let peer = peers.most_work_peer();
+			// TODO - Is there a threshold where we sync from most_work_peer (not more_work_peer)?
+			let peer = peers.more_work_peer();
 			if let Some(peer) = peer {
 				if let Ok(peer) = peer.try_read() {
 					let _ = peer.send_block_request(hash);
@@ -209,6 +210,7 @@ pub fn needs_syncing(
 				if peer.info.total_difficulty <= local_diff {
 					info!(LOGGER, "sync: caught up on most worked chain, disabling sync");
 					currently_syncing.store(false, Ordering::Relaxed);
+					let _ = chain.reset_head();
 				}
 			}
 		} else {


### PR DESCRIPTION
* reset header_head and sync_head on receiving a bad block (we used to do this, got lost somewhere along the way)
* handle orphan blocks based on age (not fixed count)
* sync blocks from `more_work_peers` (not just `most_work_peer`)
