### PR TITLE
reset header_head and sync_head on peer ban

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -93,7 +93,7 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 		validate_block(b, &mut ctx, &mut extension)?;
 		debug!(
 			LOGGER,
-			"pipe: proces_block {} at {} is valid, save and append.",
+			"pipe: process_block {} at {} is valid, save and append.",
 			b.hash(),
 			b.header.height,
 		);

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -89,6 +89,13 @@ impl ChainStore for ChainKVStore {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
+	// Reset both header_head and sync_head to the current head of the body chain
+	fn reset_head(&self) -> Result<(), Error> {
+		let tip = self.head()?;
+		self.save_header_head(&tip)?;
+		self.save_sync_head(&tip)
+	}
+
 	fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())))
 	}

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -223,6 +223,9 @@ pub trait ChainStore: Send + Sync {
 	/// Save the provided tip as the current head of the sync header chain
 	fn save_sync_head(&self, t: &Tip) -> Result<(), store::Error>;
 
+	/// Reset header_head and sync_head to head of current body chain
+	fn reset_head(&self) -> Result<(), store::Error>;
+
 	/// Gets the block header at the provided height
 	fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, store::Error>;
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -79,11 +79,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		if let &Err(ref e) = &res {
 			debug!(LOGGER, "Block {} refused by chain: {:?}", bhash, e);
 			if e.is_bad_block() {
-			 	// header chain should be consistent with the sync head here
-			 	// we just banned the peer that sent a bad block so
-			 	// sync head should resolve itself if/when we find an alternative peer
-			 	// with more work than ourselves
-			 	// we should not need to reset the header head here
+				debug!(LOGGER, "block_received: {} is a bad block, resetting head", bhash);
+				let _ = self.chain.reset_head();
 				return false;
 			}
 		}


### PR DESCRIPTION
cherrypick from #551 on testnet1

* reset header_head and sync_head on peer ban
* handle orphan blocks based on age (not fixed count)