### PR TITLE
Bump RocksDB to ^0.8.0

### DIFF
--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -10,7 +10,7 @@ env_logger="^0.3.5"
 slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 libc = "^0.2"
 memmap = { git = "https://github.com/danburkert/memmap-rs", tag="0.6.0" }
-rocksdb = "^0.7.0"
+rocksdb = "^0.8.0"
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }


### PR DESCRIPTION
Fix to https://github.com/mimblewimble/grin/issues/554.
However, I have no idea if this update breaks something in Grin storage.