### PR TITLE
Add another rocksdb compile error fix to FAQ entry

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -44,6 +44,7 @@ Run `cargo update` to fix this
 ## Build error: Panic during rocksdb compilation.
 This is caused by missing Linux headers. Install the development headers with
 your favorite package manager (usually they are called `linux-headers`).
+On some platforms, installing `clang` is also required.
 
 # Short term plans
 ## Transaction types


### PR DESCRIPTION
On Fedora, Linux headers aren't enough to build `rocksdb`, as suggested in #549. `clang` is also required. Adds note to troubleshooting to help with this.