### PR TITLE
[DNM] Remove header by output commit index (very slow but consistent)

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -81,14 +81,23 @@ pub struct SumTreeNode {
 
 impl SumTreeNode {
 	pub fn get_last_n_utxo(chain: Arc<chain::Chain>, distance: u64) -> Vec<SumTreeNode> {
+		let tip = chain.head().unwrap();
 		let mut return_vec = Vec::new();
 		let last_n = chain.get_last_n_utxo(distance);
 		for elem_output in last_n {
 			let header = chain
-				.get_block_header_by_output_commit(&elem_output.1.commit)
-				.map_err(|_| Error::NotFound);
+				.get_block_header_by_output_commit(
+					&elem_output.1.commit,
+					&tip.last_block_h,
+				)
+				.map_err(|_| Error::Internal(format!("failed to get block header for output")));
+
 			// Need to call further method to check if output is spent
-			let mut output = OutputPrintable::from_output(&elem_output.1, &header.unwrap(),true);
+			let mut output = OutputPrintable::from_output(
+				&elem_output.1,
+				&header.unwrap(),
+				true,
+			);
 			if let Ok(_) = chain.get_unspent(&elem_output.1.commit) {
 				output.spent = false;
 			}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -233,8 +233,8 @@ impl Chain {
 			Ok(None) => {
 				// block got accepted but we did not extend the head
 				// so its on a fork (or is the start of a new fork)
-				// broadcast the block out so everyone knows about the fork
-				//
+
+				// Broadcast the block out so everyone knows about the fork.
 				// TODO - This opens us to an amplification attack on blocks
 				// mined at a low difficulty. We should suppress really old blocks
 				// or less relevant blocks somehow.
@@ -245,6 +245,7 @@ impl Chain {
 					let adapter = self.adapter.clone();
 					adapter.block_accepted(&b);
 				}
+
 				// We just accepted a block so see if we can now accept any orphan(s)
 				self.check_orphans(&b);
 			},
@@ -483,10 +484,11 @@ impl Chain {
 	pub fn get_block_header_by_output_commit(
 		&self,
 		commit: &Commitment,
+		bhash: &Hash,
 	) -> Result<BlockHeader, Error> {
 		self.store
-			.get_block_header_by_output_commit(commit)
-			.map_err(|e| Error::StoreErr(e, "chain get commitment".to_owned()))
+			.get_block_header_by_output_commit(commit, bhash)
+			.map_err(|e| Error::StoreErr(e, "chain get header by commitment".to_owned()))
 	}
 
 	/// Get the tip of the current "sync" header chain.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -312,11 +312,15 @@ fn validate_block(
 	}
 
 	// check for any outputs with lock_heights greater than current block height
+	let bhash = b.header.previous;
 	for input in &b.inputs {
 		if let Ok(output) = ctx.store.get_output_by_commit(&input.commitment()) {
 			if output.features.contains(transaction::COINBASE_OUTPUT) {
 				if let Ok(output_header) = ctx.store
-					.get_block_header_by_output_commit(&input.commitment())
+					.get_block_header_by_output_commit(
+						&input.commitment(),
+						&bhash,
+					)
 				{
 					if b.header.height <= output_header.height + global::coinbase_maturity() {
 						return Err(Error::ImmatureCoinbase);

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -35,7 +35,6 @@ const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
 const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const OUTPUT_COMMIT_PREFIX: u8 = 'o' as u8;
-const HEADER_BY_OUTPUT_PREFIX: u8 = 'p' as u8;
 const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const KERNEL_POS_PREFIX: u8 = 'k' as u8;
 
@@ -130,45 +129,26 @@ impl ChainStore for ChainKVStore {
 						&mut out.commitment().as_ref().to_vec(),
 					)[..],
 					out,
-				)?
-				.put_ser(
-					&to_key(
-						HEADER_BY_OUTPUT_PREFIX,
-						&mut out.commitment().as_ref().to_vec(),
-					)[..],
-					&b.hash(),
 				)?;
 		}
 		batch.write()
 	}
 
-	// lookup the block header hash by output commitment
-	// lookup the block header based on this hash
-	// to check the chain is correct compare this block header to
-	// the block header currently indexed at the relevant block height (tbd if
-	// actually necessary)
-	//
-	// NOTE: This index is not exhaustive.
-	// This node may not have seen this full block, so may not have populated the
-	// index.
-	// Block headers older than some threshold (2 months?) will not necessarily be
-	// included
-	// in this index.
-	//
-	fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
-		let block_hash = self.db.get_ser(&to_key(
-			HEADER_BY_OUTPUT_PREFIX,
-			&mut commit.as_ref().to_vec(),
-		))?;
-
-		match block_hash {
-			Some(hash) => {
-				let block_header = self.get_block_header(&hash)?;
-				self.is_on_current_chain(&block_header)?;
-				Ok(block_header)
+	fn get_block_header_by_output_commit(
+		&self,
+		commit: &Commitment,
+		bhash: &Hash,
+	) -> Result<BlockHeader, Error> {
+		let mut bhash = bhash.clone();
+		while let Ok(block) = self.get_block(&bhash) {
+			if block.header.height == 0 {
+				return Err(Error::NotFoundErr);
+			} else if block.outputs.iter().any(|x| x.commitment() == *commit) {
+				return Ok(block.header);
 			}
-			None => Err(Error::NotFoundErr),
+			bhash = block.header.previous;
 		}
+		Err(Error::NotFoundErr)
 	}
 
 	fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -144,7 +144,7 @@ impl Tip {
 		}
 	}
 
-	/// Append a new block to this tip, returning a new updated tip.
+	/// Convert a block_header to a chain "tip".
 	pub fn from_block(bh: &BlockHeader) -> Tip {
 		Tip {
 			height: bh.height,
@@ -240,9 +240,11 @@ pub trait ChainStore: Send + Sync {
 	fn get_output_by_commit(&self, commit: &Commitment) -> Result<Output, store::Error>;
 
 	/// Gets a block_header for the given input commit
+	/// looking back through the chain from the given chain tip (may be a fork).
 	fn get_block_header_by_output_commit(
 		&self,
 		commit: &Commitment,
+		bhash: &Hash,
 	) -> Result<BlockHeader, store::Error>;
 
 	/// Saves the position of an output, represented by its commitment, in the

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -346,10 +346,11 @@ impl pool::BlockChain for PoolToChainAdapter {
 	fn get_block_header_by_output_commit(
 		&self,
 		commit: &Commitment,
+		bhash: &Hash,
 	) -> Result<BlockHeader, pool::PoolError> {
 		self.chain
 			.borrow()
-			.get_block_header_by_output_commit(commit)
+			.get_block_header_by_output_commit(commit, bhash)
 			.map_err(|_| pool::PoolError::GenericPoolError)
 	}
 

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -32,9 +32,10 @@ impl DummyBlockHeaderIndex {
 
 	pub fn get_block_header_by_output_commit(
 		&self,
-		commit: Commitment,
+		commit: &Commitment,
+		_: &hash::Hash,
 	) -> Result<&block::BlockHeader, PoolError> {
-		match self.block_headers.get(&commit) {
+		match self.block_headers.get(commit) {
 			Some(h) => Ok(h),
 			None => Err(PoolError::GenericPoolError),
 		}
@@ -139,11 +140,12 @@ impl BlockChain for DummyChainImpl {
 	fn get_block_header_by_output_commit(
 		&self,
 		commit: &Commitment,
+		bhash: &hash::Hash,
 	) -> Result<block::BlockHeader, PoolError> {
 		match self.block_headers
 			.read()
 			.unwrap()
-			.get_block_header_by_output_commit(*commit)
+			.get_block_header_by_output_commit(commit, bhash)
 		{
 			Ok(h) => Ok(h.clone()),
 			Err(e) => Err(e),

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -20,6 +20,7 @@ pub use graph;
 use core::core::transaction;
 use core::core::block;
 use core::core::hash;
+use core::core::hash::Hashed;
 use core::global;
 
 use util::secp::pedersen::Commitment;
@@ -186,7 +187,10 @@ where
 					// TODO - pull this out into a separate function?
 					if output.features.contains(transaction::COINBASE_OUTPUT) {
 						if let Ok(out_header) = self.blockchain
-							.get_block_header_by_output_commit(&output.commitment())
+							.get_block_header_by_output_commit(
+								&output.commitment(),
+								&head_header.hash(),
+							)
 						{
 							let lock_height = out_header.height + global::coinbase_maturity();
 							if head_header.height < lock_height {

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -162,6 +162,7 @@ pub trait BlockChain {
 	fn get_block_header_by_output_commit(
 		&self,
 		commit: &Commitment,
+		bhash: &hash::Hash,
 	) -> Result<block::BlockHeader, PoolError>;
 
 	/// Get the block header at the head


### PR DESCRIPTION
[Do Not Merge]

Experimental approach removing the index so we are always consistent with the blocks themselves.
Mainly so we can verify the problem is with the index itself (and not the UTXO set).

* remove the header by output commit index
* lookup headers by traversing the chain each time (very slow for early outputs)

See #559 for context.

TODO - 
- [ ] reintroduce the index but allow multiple entries per commitment (multiple blocks, different forks)
- [ ] when we read the index we need to - 
    - [ ] check what chain/fork we should be on? We can check heights for main chain?
    - [ ] Is this even possible? Do we have a way to know if a given block is on the "right" fork?
- [ ] Can this be done without needing something like the output pmmr (but for heights?)
