### PR TITLE
Add 'sent' to wallet info output (#288)

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -25,6 +25,7 @@ tokio-retry="~0.1.0"
 router = "~0.5.1"
 prettytable-rs = "^0.6"
 term = "~0.4.6"
+time = "^0.1"
 grin_api = { path = "../api" }
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -23,6 +23,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate slog;
+extern crate time;
 #[macro_use]
 extern crate prettytable;
 extern crate term;

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -226,5 +226,24 @@ fn receive_transaction(
 		derivation,
 	);
 
+	// append transfer record of received coins into stats.dat
+	// only if the transaction is completed.
+	StatsData::append(&config.data_file_dir, |stats_data| {
+		let current_time_sec = get_transfer_timestamp();
+		let (ins, outs) = get_transfer_inouts(&tx_final);
+		let port = config.api_listen_port.to_string();
+		let addr = format!("{}:{}", "localhost".to_string(), port);
+		stats_data.add_transfer(
+			StatsTransferData {
+				amount: amount,
+				receiving_wallet_address: addr,
+				tx_type: StatsTransferType::Received,
+				inputs: ins,
+				outputs: outs,
+				sent_or_received_at: current_time_sec,
+			}
+		);
+	})?;
+
 	Ok(tx_final)
 }


### PR DESCRIPTION
The wallet info shows all transfers of successful sending and receiving. Please note that the current enhancement does not include recording local coinbase transactions. The timestamps of "Sent or Received At" is automatically generated by the wallet when each transfer is being processed.

![screen shot 2018-01-03 at 12 22 57 am](https://user-images.githubusercontent.com/17690691/34547610-39d7b1fc-f0b1-11e7-9876-2b6b952513bf.png)
![screen shot 2018-01-03 at 12 24 21 am](https://user-images.githubusercontent.com/17690691/34547611-39ed6632-f0b1-11e7-8bdf-917c57c6644a.png)
