### PR TITLE
[WIP] block height per output maintained in pmmr

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -70,13 +70,13 @@ impl UtxoHandler {
 			.get_unspent(&commit)
 			.map_err(|_| Error::NotFound)?;
 
-		let header = self.chain
-			.get_block_header_by_output_commit(&commit)
+		let height = self.chain
+			.block_height(&commit)
 			.map_err(|_| Error::NotFound)?;
 
 		Ok(Output::from_output(
 			&out,
-			&header,
+			height,
 			include_rp,
 			include_switch,
 		))

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use util::secp::pedersen::{Commitment, RangeProof};
+use util::secp::pedersen::Commitment;
 
 use core::core::SumCommit;
 use core::core::pmmr::{HashSum, NoSum};
@@ -379,7 +379,7 @@ impl Chain {
 		&self,
 	) -> (
 		HashSum<SumCommit>,
-		HashSum<NoSum<RangeProof>>,
+		HashSum<NoSum<WitnessData>>,
 		HashSum<NoSum<TxKernel>>,
 	) {
 		let mut sumtrees = self.sumtrees.write().unwrap();
@@ -401,7 +401,7 @@ impl Chain {
 	}
 
 	/// as above, for rangeproofs
-	pub fn get_last_n_rangeproof(&self, distance: u64) -> Vec<HashSum<NoSum<RangeProof>>> {
+	pub fn get_last_n_rangeproof(&self, distance: u64) -> Vec<HashSum<NoSum<WitnessData>>> {
 		let mut sumtrees = self.sumtrees.write().unwrap();
 		sumtrees.last_n_rangeproof(distance)
 	}

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -43,4 +43,4 @@ pub mod types;
 // Re-export the base interface
 
 pub use chain::Chain;
-pub use types::{ChainAdapter, ChainStore, Error, Options, Tip, NONE, SKIP_POW, SYNC};
+pub use types::{ChainAdapter, ChainStore, Error, Options, Tip, NONE, SKIP_POW, SYNC, WitnessData};

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -284,8 +284,9 @@ fn validate_block(
 	}
 
 	let (utxo_root, rproof_root, kernel_root) = ext.roots();
-	if utxo_root.hash != b.header.utxo_root || rproof_root.hash != b.header.range_proof_root
-		|| kernel_root.hash != b.header.kernel_root
+	if utxo_root.hash != b.header.utxo_root ||
+		rproof_root.hash != b.header.range_proof_root ||
+		kernel_root.hash != b.header.kernel_root
 	{
 		ext.dump(false);
 
@@ -309,21 +310,6 @@ fn validate_block(
 		);
 
 		return Err(Error::InvalidRoot);
-	}
-
-	// check for any outputs with lock_heights greater than current block height
-	for input in &b.inputs {
-		if let Ok(output) = ctx.store.get_output_by_commit(&input.commitment()) {
-			if output.features.contains(transaction::COINBASE_OUTPUT) {
-				if let Ok(output_header) = ctx.store
-					.get_block_header_by_output_commit(&input.commitment())
-				{
-					if b.header.height <= output_header.height + global::coinbase_maturity() {
-						return Err(Error::ImmatureCoinbase);
-					}
-				};
-			};
-		};
 	}
 
 	Ok(())

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -34,7 +34,6 @@ const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
 const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const OUTPUT_COMMIT_PREFIX: u8 = 'o' as u8;
-const HEADER_BY_OUTPUT_PREFIX: u8 = 'p' as u8;
 const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const KERNEL_POS_PREFIX: u8 = 'k' as u8;
 
@@ -129,45 +128,9 @@ impl ChainStore for ChainKVStore {
 						&mut out.commitment().as_ref().to_vec(),
 					)[..],
 					out,
-				)?
-				.put_ser(
-					&to_key(
-						HEADER_BY_OUTPUT_PREFIX,
-						&mut out.commitment().as_ref().to_vec(),
-					)[..],
-					&b.hash(),
 				)?;
 		}
 		batch.write()
-	}
-
-	// lookup the block header hash by output commitment
-	// lookup the block header based on this hash
-	// to check the chain is correct compare this block header to
-	// the block header currently indexed at the relevant block height (tbd if
-	// actually necessary)
-	//
-	// NOTE: This index is not exhaustive.
-	// This node may not have seen this full block, so may not have populated the
-	// index.
-	// Block headers older than some threshold (2 months?) will not necessarily be
-	// included
-	// in this index.
-	//
-	fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
-		let block_hash = self.db.get_ser(&to_key(
-			HEADER_BY_OUTPUT_PREFIX,
-			&mut commit.as_ref().to_vec(),
-		))?;
-
-		match block_hash {
-			Some(hash) => {
-				let block_header = self.get_block_header(&hash)?;
-				self.is_on_current_chain(&block_header)?;
-				Ok(block_header)
-			}
-			None => Err(Error::NotFoundErr),
-		}
 	}
 
 	fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Grin Developers
+// Copyright 2018 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 use std::io;
 
-use util::secp::pedersen::Commitment;
+use util::secp::pedersen::{Commitment, RangeProof};
 
 use grin_store as store;
 use core::core::{block, Block, BlockHeader, Output};
@@ -177,6 +177,19 @@ impl ser::Readable for Tip {
 			prev_block_h: prev,
 			total_difficulty: diff,
 		})
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct WitnessData {
+	pub range_proof: RangeProof,
+	pub block_height: u64,
+}
+
+impl ser::Writeable for WitnessData {
+	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		self.range_proof.write(writer)?;
+		writer.write_u64(self.block_height)
 	}
 }
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -110,13 +110,6 @@ fn mine_empty_chain() {
 		// now check the block height index
 		let header_by_height = chain.get_header_by_height(n).unwrap();
 		assert_eq!(header_by_height.hash(), bhash);
-
-		// now check the header output index
-		let output = block.outputs[0];
-		let header_by_output_commit = chain
-			.get_block_header_by_output_commit(&output.commitment())
-			.unwrap();
-		assert_eq!(header_by_output_commit.hash(), bhash);
 	}
 }
 

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -59,9 +59,4 @@ fn test_various_store_indices() {
 
 	let block_header = chain_store.get_header_by_height(1).unwrap();
 	assert_eq!(block_header.hash(), block_hash);
-
-	let block_header = chain_store
-		.get_block_header_by_output_commit(&commit)
-		.unwrap();
-	assert_eq!(block_header.hash(), block_hash);
 }

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -343,14 +343,15 @@ impl pool::BlockChain for PoolToChainAdapter {
 			})
 	}
 
-	fn get_block_header_by_output_commit(
-		&self,
-		commit: &Commitment,
-	) -> Result<BlockHeader, pool::PoolError> {
+	fn block_height(&self, output_ref: &Commitment) -> Result<u64, pool::PoolError> {
 		self.chain
 			.borrow()
-			.get_block_header_by_output_commit(commit)
-			.map_err(|_| pool::PoolError::GenericPoolError)
+			.block_height(output_ref)
+			.map_err(|e| match e {
+				chain::types::Error::OutputNotFound => pool::PoolError::OutputNotFound,
+				chain::types::Error::OutputSpent => pool::PoolError::OutputSpent,
+				_ => pool::PoolError::GenericPoolError,
+			})
 	}
 
 	fn head_header(&self) -> Result<BlockHeader, pool::PoolError> {

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -585,7 +585,7 @@ impl Miner {
 		b.header.difficulty = difficulty;
 		b.header.timestamp = time::at_utc(time::Timespec::new(now_sec, 0));
 		trace!(LOGGER, "Block: {:?}", b);
-		let result=self.chain.set_sumtree_roots(&mut b);
+		let result = self.chain.set_sumtree_roots(&mut b);
 		match result {
 			Ok(_) => Ok((b, block_fees)),
 			//If it's a duplicate commitment, it's likely trying to use

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -29,16 +29,6 @@ impl DummyBlockHeaderIndex {
 	pub fn insert(&mut self, commit: Commitment, block_header: block::BlockHeader) {
 		self.block_headers.insert(commit, block_header);
 	}
-
-	pub fn get_block_header_by_output_commit(
-		&self,
-		commit: Commitment,
-	) -> Result<&block::BlockHeader, PoolError> {
-		match self.block_headers.get(&commit) {
-			Some(h) => Ok(h),
-			None => Err(PoolError::GenericPoolError),
-		}
-	}
 }
 
 /// A DummyUtxoSet for mocking up the chain
@@ -136,18 +126,8 @@ impl BlockChain for DummyChainImpl {
 		}
 	}
 
-	fn get_block_header_by_output_commit(
-		&self,
-		commit: &Commitment,
-	) -> Result<block::BlockHeader, PoolError> {
-		match self.block_headers
-			.read()
-			.unwrap()
-			.get_block_header_by_output_commit(*commit)
-		{
-			Ok(h) => Ok(h.clone()),
-			Err(e) => Err(e),
-		}
+	fn block_height(&self, output_ref: &Commitment) -> Result<u64, PoolError> {
+		panic!("not yet implemented...");
 	}
 
 	fn head_header(&self) -> Result<block::BlockHeader, PoolError> {
@@ -167,16 +147,6 @@ impl DummyChain for DummyChainImpl {
 	fn apply_block(&self, b: &block::Block) {
 		self.utxo.write().unwrap().with_block(b);
 	}
-	fn store_header_by_output_commitment(
-		&self,
-		commitment: Commitment,
-		block_header: &block::BlockHeader,
-	) {
-		self.block_headers
-			.write()
-			.unwrap()
-			.insert(commitment, block_header.clone());
-	}
 	fn store_head_header(&self, block_header: &block::BlockHeader) {
 		let mut h = self.head_header.write().unwrap();
 		h.clear();
@@ -187,10 +157,5 @@ impl DummyChain for DummyChainImpl {
 pub trait DummyChain: BlockChain {
 	fn update_utxo_set(&mut self, new_utxo: DummyUtxoSet);
 	fn apply_block(&self, b: &block::Block);
-	fn store_header_by_output_commitment(
-		&self,
-		commitment: Commitment,
-		block_header: &block::BlockHeader,
-	);
 	fn store_head_header(&self, block_header: &block::BlockHeader);
 }

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -20,20 +20,10 @@ use std::sync::RwLock;
 
 use types::{BlockChain, PoolError};
 
-#[derive(Debug)]
-pub struct DummyBlockHeaderIndex {
-	block_headers: HashMap<Commitment, block::BlockHeader>,
-}
-
-impl DummyBlockHeaderIndex {
-	pub fn insert(&mut self, commit: Commitment, block_header: block::BlockHeader) {
-		self.block_headers.insert(commit, block_header);
-	}
-}
-
 /// A DummyUtxoSet for mocking up the chain
 pub struct DummyUtxoSet {
 	outputs: HashMap<Commitment, transaction::Output>,
+	heights: HashMap<Commitment, u64>,
 }
 
 #[allow(dead_code)]
@@ -41,55 +31,73 @@ impl DummyUtxoSet {
 	pub fn empty() -> DummyUtxoSet {
 		DummyUtxoSet {
 			outputs: HashMap::new(),
+			heights: HashMap::new(),
 		}
 	}
+
 	pub fn root(&self) -> hash::Hash {
 		hash::ZERO_HASH
 	}
+
 	pub fn apply(&self, b: &block::Block) -> DummyUtxoSet {
-		let mut new_hashmap = self.outputs.clone();
+		let mut new_outputs = self.outputs.clone();
+		let mut new_heights = self.heights.clone();
+
 		for input in &b.inputs {
-			new_hashmap.remove(&input.commitment());
+			new_outputs.remove(&input.commitment());
 		}
 		for output in &b.outputs {
-			new_hashmap.insert(output.commitment(), output.clone());
+			new_outputs.insert(output.commitment(), output.clone());
+			new_heights.insert(output.commitment(), b.header.height);
 		}
 		DummyUtxoSet {
-			outputs: new_hashmap,
+			outputs: new_outputs,
+			heights: new_heights,
 		}
 	}
+
 	pub fn with_block(&mut self, b: &block::Block) {
 		for input in &b.inputs {
 			self.outputs.remove(&input.commitment());
 		}
 		for output in &b.outputs {
 			self.outputs.insert(output.commitment(), output.clone());
+			self.heights.insert(output.commitment(), b.header.height);
 		}
 	}
+
 	pub fn rewind(&self, _: &block::Block) -> DummyUtxoSet {
 		DummyUtxoSet {
 			outputs: HashMap::new(),
+			heights: HashMap::new(),
 		}
 	}
+
 	pub fn get_output(&self, output_ref: &Commitment) -> Option<&transaction::Output> {
 		self.outputs.get(output_ref)
+	}
+
+	pub fn get_height(&self, output_ref: &Commitment) -> Option<&u64> {
+		self.heights.get(output_ref)
 	}
 
 	fn clone(&self) -> DummyUtxoSet {
 		DummyUtxoSet {
 			outputs: self.outputs.clone(),
+			heights: self.heights.clone(),
 		}
 	}
 
 	// only for testing: add an output to the map
-	pub fn add_output(&mut self, output: transaction::Output) {
-		self.outputs.insert(output.commitment(), output);
-	}
-	// like above, but doesn't modify in-place so no mut ref needed
-	pub fn with_output(&self, output: transaction::Output) -> DummyUtxoSet {
-		let mut new_map = self.outputs.clone();
-		new_map.insert(output.commitment(), output);
-		DummyUtxoSet { outputs: new_map }
+	pub fn with_output(&self, output: transaction::Output, height: u64) -> DummyUtxoSet {
+		let mut new_outputs = self.outputs.clone();
+		let mut new_heights = self.heights.clone();
+		new_outputs.insert(output.commitment(), output);
+		new_heights.insert(output.commitment(), height);
+		DummyUtxoSet {
+			outputs: new_outputs,
+			heights: new_heights,
+		}
 	}
 }
 
@@ -98,7 +106,6 @@ impl DummyUtxoSet {
 #[allow(dead_code)]
 pub struct DummyChainImpl {
 	utxo: RwLock<DummyUtxoSet>,
-	block_headers: RwLock<DummyBlockHeaderIndex>,
 	head_header: RwLock<Vec<block::BlockHeader>>,
 }
 
@@ -108,9 +115,7 @@ impl DummyChainImpl {
 		DummyChainImpl {
 			utxo: RwLock::new(DummyUtxoSet {
 				outputs: HashMap::new(),
-			}),
-			block_headers: RwLock::new(DummyBlockHeaderIndex {
-				block_headers: HashMap::new(),
+				heights: HashMap::new(),
 			}),
 			head_header: RwLock::new(vec![]),
 		}
@@ -118,8 +123,8 @@ impl DummyChainImpl {
 }
 
 impl BlockChain for DummyChainImpl {
-	fn get_unspent(&self, commitment: &Commitment) -> Result<transaction::Output, PoolError> {
-		let output = self.utxo.read().unwrap().get_output(commitment).cloned();
+	fn get_unspent(&self, output_ref: &Commitment) -> Result<transaction::Output, PoolError> {
+		let output = self.utxo.read().unwrap().get_output(output_ref).cloned();
 		match output {
 			Some(o) => Ok(o),
 			None => Err(PoolError::GenericPoolError),
@@ -127,7 +132,11 @@ impl BlockChain for DummyChainImpl {
 	}
 
 	fn block_height(&self, output_ref: &Commitment) -> Result<u64, PoolError> {
-		panic!("not yet implemented...");
+		let height = self.utxo.read().unwrap().get_height(output_ref).cloned();
+		match height {
+			Some(x) => Ok(x),
+			None => Err(PoolError::GenericPoolError),
+		}
 	}
 
 	fn head_header(&self) -> Result<block::BlockHeader, PoolError> {
@@ -144,9 +153,11 @@ impl DummyChain for DummyChainImpl {
 	fn update_utxo_set(&mut self, new_utxo: DummyUtxoSet) {
 		self.utxo = RwLock::new(new_utxo);
 	}
+
 	fn apply_block(&self, b: &block::Block) {
 		self.utxo.write().unwrap().with_block(b);
 	}
+
 	fn store_head_header(&self, block_header: &block::BlockHeader) {
 		let mut h = self.head_header.write().unwrap();
 		h.clear();

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -638,10 +638,10 @@ mod tests {
 		let parent_transaction = test_transaction(vec![5, 6, 7], vec![11, 3]);
 		// We want this transaction to be rooted in the blockchain.
 		let new_utxo = DummyUtxoSet::empty()
-			.with_output(test_output(5))
-			.with_output(test_output(6))
-			.with_output(test_output(7))
-			.with_output(test_output(8));
+			.with_output(test_output(5), 1)
+			.with_output(test_output(6), 1)
+			.with_output(test_output(7), 1)
+			.with_output(test_output(8), 1);
 
 		// Prepare a second transaction, connected to the first.
 		let child_transaction = test_transaction(vec![11, 3], vec![12]);
@@ -697,9 +697,9 @@ mod tests {
 		dummy_chain.store_head_header(&head_header);
 
 		let new_utxo = DummyUtxoSet::empty()
-			.with_output(test_output(5))
-			.with_output(test_output(6))
-			.with_output(test_output(7));
+			.with_output(test_output(5), 1)
+			.with_output(test_output(6), 1)
+			.with_output(test_output(7), 1);
 
 		dummy_chain.update_utxo_set(new_utxo);
 
@@ -797,7 +797,7 @@ mod tests {
 		global::set_mining_mode(ChainTypes::AutomatedTesting);
 		let mut dummy_chain = DummyChainImpl::new();
 		let coinbase_output = test_coinbase_output(15);
-		dummy_chain.update_utxo_set(DummyUtxoSet::empty().with_output(coinbase_output));
+		dummy_chain.update_utxo_set(DummyUtxoSet::empty().with_output(coinbase_output, 1));
 
 		let chain_ref = Arc::new(dummy_chain);
 		let pool = RwLock::new(test_setup(&chain_ref));
@@ -809,6 +809,8 @@ mod tests {
 				height: 1,
 				..block::BlockHeader::default()
 			};
+			chain_ref.store_head_header(&coinbase_header);
+
 			let head_header = block::BlockHeader {
 				height: 2,
 				..block::BlockHeader::default()
@@ -819,7 +821,8 @@ mod tests {
 			let result = write_pool.add_to_memory_pool(test_source(), txn);
 			match result {
 				Err(PoolError::ImmatureCoinbase {
-					header: _,
+					height: _,
+					lock_height: _,
 					output: out,
 				}) => {
 					assert_eq!(out, coinbase_output.commitment());
@@ -837,7 +840,8 @@ mod tests {
 			let result = write_pool.add_to_memory_pool(test_source(), txn);
 			match result {
 				Err(PoolError::ImmatureCoinbase {
-					header: _,
+					height: _,
+					lock_height: _,
 					output: out,
 				}) => {
 					assert_eq!(out, coinbase_output.commitment());
@@ -876,7 +880,7 @@ mod tests {
 		dummy_chain.store_head_header(&head_header);
 
 		// single UTXO
-		let new_utxo = DummyUtxoSet::empty().with_output(test_output(100));
+		let new_utxo = DummyUtxoSet::empty().with_output(test_output(100), 1);
 
 		dummy_chain.update_utxo_set(new_utxo);
 		let chain_ref = Arc::new(dummy_chain);
@@ -953,10 +957,10 @@ mod tests {
 		dummy_chain.store_head_header(&head_header);
 
 		let new_utxo = DummyUtxoSet::empty()
-			.with_output(test_output(10))
-			.with_output(test_output(20))
-			.with_output(test_output(30))
-			.with_output(test_output(40));
+			.with_output(test_output(10), 1)
+			.with_output(test_output(20), 1)
+			.with_output(test_output(30), 1)
+			.with_output(test_output(40), 1);
 
 		dummy_chain.update_utxo_set(new_utxo);
 
@@ -1107,10 +1111,10 @@ mod tests {
 		dummy_chain.store_head_header(&head_header);
 
 		let new_utxo = DummyUtxoSet::empty()
-			.with_output(test_output(10))
-			.with_output(test_output(20))
-			.with_output(test_output(30))
-			.with_output(test_output(40));
+			.with_output(test_output(10), 1)
+			.with_output(test_output(20), 1)
+			.with_output(test_output(30), 1)
+			.with_output(test_output(40), 1);
 
 		dummy_chain.update_utxo_set(new_utxo);
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -185,13 +185,12 @@ where
 				Parent::BlockTransaction { output } => {
 					// TODO - pull this out into a separate function?
 					if output.features.contains(transaction::COINBASE_OUTPUT) {
-						if let Ok(out_header) = self.blockchain
-							.get_block_header_by_output_commit(&output.commitment())
-						{
-							let lock_height = out_header.height + global::coinbase_maturity();
+						if let Ok(h) = self.blockchain.block_height(&output.commitment()) {
+							let lock_height = h + global::coinbase_maturity();
 							if head_header.height < lock_height {
 								return Err(PoolError::ImmatureCoinbase {
-									header: out_header,
+									height: head_header.height,
+									lock_height: lock_height,
 									output: output.commitment(),
 								});
 							};
@@ -810,9 +809,6 @@ mod tests {
 				height: 1,
 				..block::BlockHeader::default()
 			};
-			chain_ref
-				.store_header_by_output_commitment(coinbase_output.commitment(), &coinbase_header);
-
 			let head_header = block::BlockHeader {
 				height: 2,
 				..block::BlockHeader::default()

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -123,8 +123,10 @@ pub enum PoolError {
 	/// Attempt to spend an output before it matures
 	/// lock_height must not exceed current block height
 	ImmatureCoinbase {
-		/// The block header of the block containing the output
-		header: block::BlockHeader,
+		/// The current height of the chain
+		height: u64,
+		/// The height at which the coinbase output can be spent
+		lock_height: u64,
 		/// The unspent output
 		output: Commitment,
 	},
@@ -157,12 +159,7 @@ pub trait BlockChain {
 	/// orphans, etc.
 	fn get_unspent(&self, output_ref: &Commitment) -> Result<transaction::Output, PoolError>;
 
-	/// Get the block header by output commitment (needed for spending coinbase
-	/// after n blocks)
-	fn get_block_header_by_output_commit(
-		&self,
-		commit: &Commitment,
-	) -> Result<block::BlockHeader, PoolError>;
+	fn block_height(&self, output_ref: &Commitment) -> Result<u64, PoolError>;
 
 	/// Get the block header at the head
 	fn head_header(&self) -> Result<block::BlockHeader, PoolError>;


### PR DESCRIPTION
Alternative approach to solving the "coinbase maturity needs to be fork aware" issue in #559.

#215 attempts to solve this by committing to lock_heights in outputs (and revealing lock_heights in inputs).
The problem with this is discussed in #215. tl;dr introduces something like "output malleability" where a commitment can refer to multiple different output versions (on different forks).

This PR attempts to solve the issue by taking a step back and maintaining block heights in one of the sumtree pmmrs, specifically the rproof_pmmr (referred to as "witness data" here).

The rangeproof pmmr (I'm calling this witness data here, but this may not be technically correct for height info) was originally storing `NullSum` sum values (we had no need to sum anything).
We can use the sums here to store block heights.
The block height for an individual output is the height of the block that produced the output.
A sum of block heights is a range, represented by `[lower_height ... upper_height]` so any non-leaf node in the pmmr maintains the range of block heights for all nodes below it.
It is not immediately clear to me that this is a useful sum value. We only really care about heights for leaf nodes (outputs). But knowing the range of block heights _might_ be useful for something for subsets of the pmmr?

To find the height of the block producing an output for a given commitment we can simply look in the rproof_pmmr at the same pos and retrieve the sum.

This has the benefit of being fully compatible with multiple forks. Whenever we rewind a pmmr and reapply blocks we rebuild the rproof_pmmr and reconstruct the necessary block heights in memory in the sumtree extension mechanism.
The block heights for the current chain are persisted in the pmmr to disk.

Summary of changes - 
* get rid of the "header by output" index entirely
* store block heights as sum values in the rproof_pmmr
* wrap rproof and block_height up in `WitnessData` in the pmmr
* for current chain look heights up via sumtree
* for applying new blocks use the pmmr via the sumtree extension (fork aware)
* moved coinbase maturity validation from pipeline to sumtree.apply_block
* fixup DummyChain to more closely resemble what we are doing with heights

TODO - 
- [ ] lots of cleanup and renaming

This is exploratory - mainly to see if we _could_ leverage the sumtree/pmmr to include useful information in the sum values.
I'm not taking a position on whether we _should_...

Thoughts? @ignopeverell @yeastplume
