### PR TITLE
Allow the wallet to be queried for balances and to send a transaction…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,26 +36,46 @@ env:
 
 after_success: |
   pwd &&
-  echo "HERE" &&
   wget https://github.com/mimblewimble/kcov/archive/master.tar.gz &&
   tar xzf master.tar.gz &&
   cd kcov-master &&
-  mkdir build &&
-  cd build &&
-  cmake .. &&
-  make &&
-  sudo make install &&
+  mkdir build && cd build &&
+  cmake .. && make && mv src/kcov ../.. &&
   cd ../.. &&
   rm -rf kcov-master &&
-  cargo test --no-run &&
   cd ../
-  pwd &&
-  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_core* && 
+  cd api && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_api* &&
+  echo "Finished coverage for grin_api"
+  cd core && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_core* &&
   echo "Finished coverage for grin_core"
-  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_chain* && 
+  cd chain && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_chain* &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/mine_simple_chain* &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/store_indices* &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/test_coinbase_maturity* &&
   echo "Finished coverage for grin_chain"
-  kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/mine_simple_* &&
-  echo "Finished coverage for mine_simple"
+  cd keychain && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_keychain* &&
+  echo "Finished coverage for grin_keychain"
+  cd p2p && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_p2p* &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/peer_handshake* &&
+  echo "Finished coverage for grin_p2p"
+  cd pow && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_pow* &&
+  echo "Finished coverage for grin_pow"
+  cd store && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_store* &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/sumtree* &&
+  echo "Finished coverage for grin_store"
+  cd wallet && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_wallet* &&
+  echo "Finished coverage for grin_wallet"
+  cd util && cargo test --no-run && cd .. && rm target/debug/*.d &&
+  ./kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/grin_util* &&
+  echo "Finished coverage for grin_util"
   bash <(curl -s https://codecov.io/bash) &&
   echo "Uploaded code coverage"
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -440,13 +440,16 @@ where
 			tx.inputs.len(),
 			tx.outputs.len()
 		);
-		self.tx_pool
+	
+		let res = self.tx_pool
 			.write()
 			.unwrap()
-			.add_to_memory_pool(source, tx)
-			.map_err(|e| Error::Internal(format!("Addition to transaction pool failed: {:?}", e)))?;
+			.add_to_memory_pool(source, tx);
 
-		Ok(Response::with(status::Ok))
+		match res {
+			Ok(()) => Ok(Response::with(status::Ok)),
+			Err(e) => Err(IronError::from(Error::Argument(format!("{:?}", e))))
+		}
 	}
 }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -33,8 +33,8 @@ pub const MICRO_GRIN: u64 = MILLI_GRIN / 1_000;
 /// Nanogrin, smallest unit, takes a billion to make a grin
 pub const NANO_GRIN: u64 = 1;
 
-/// The block subsidy amount
-pub const REWARD: u64 = 50 * GRIN_BASE;
+/// The block subsidy amount, one grin per second on average
+pub const REWARD: u64 = 60 * GRIN_BASE;
 
 /// Actual block reward for a given total fee amount
 pub fn reward(fee: u64) -> u64 {

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -16,6 +16,7 @@ use std::convert::From;
 
 use api;
 use chain;
+use core::core;
 use p2p;
 use pool;
 use store;
@@ -26,6 +27,8 @@ use core::global::ChainTypes;
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]
 pub enum Error {
+	/// Error originating from the core implementation.
+	Core(core::block::Error),
 	/// Error originating from the db storage.
 	Store(store::Error),
 	/// Error originating from the blockchain implementation.
@@ -39,6 +42,11 @@ pub enum Error {
 	Cuckoo(pow::cuckoo::Error),
 }
 
+impl From<core::block::Error> for Error {
+	fn from(e: core::block::Error) -> Error {
+		Error::Core(e)
+	}
+}
 impl From<chain::Error> for Error {
 	fn from(e: chain::Error) -> Error {
 		Error::Chain(e)

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -435,7 +435,15 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			file.read_to_string(&mut contents).expect(
 				"Unable to read transaction file.",
 			);
-			wallet::receive_json_tx_str(&wallet_config, &keychain, contents.as_str()).unwrap();
+			if let Err(e) =
+				wallet::receive_json_tx_str(
+					&wallet_config, &keychain, contents.as_str()) {
+
+				println!("Error receiving transaction, the most likely reasons are:");
+				println!(" * the transaction has already been sent");
+				println!(" * your node isn't running or can't be reached");
+				println!("\nDetailed error: {:?}", e);
+			}
 		}
 		("send", Some(send_args)) => {
 			let amount = send_args.value_of("amount").expect(

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -195,11 +195,16 @@ fn main() {
 				.takes_value(true))
 
 		.subcommand(SubCommand::with_name("listen")
-			.about("Runs the wallet in listening mode waiting for transactions.")
-			.arg(Arg::with_name("port")
+			.about("Runs the wallet in listening mode waiting for transactions and operations.")
+			.arg(Arg::with_name("receiver_port")
 				.short("l")
-				.long("port")
-				.help("Port on which to run the wallet listener")
+				.long("receiver_port")
+				.help("Port on which to run the wallet receiver listener")
+				.takes_value(true))
+			.arg(Arg::with_name("operator_port")
+				.short("o")
+				.long("operator_port")
+				.help("Port on which to run the wallet operator listener")
 				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("receive")
@@ -382,7 +387,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 	let mut wallet_config = global_config.members.unwrap().wallet;
 
 	if wallet_args.is_present("external") {
-		wallet_config.api_listen_interface = "0.0.0.0".to_string();
+		wallet_config.api_receiver_listen_interface = "0.0.0.0".to_string();
 	}
 
 	if let Some(dir) = wallet_args.value_of("dir") {
@@ -423,8 +428,11 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 
 	match wallet_args.subcommand() {
 		("listen", Some(listen_args)) => {
-			if let Some(port) = listen_args.value_of("port") {
-				wallet_config.api_listen_port = port.to_string();
+			if let Some(port) = listen_args.value_of("receiver_port") {
+				wallet_config.api_receiver_listen_port = port.to_string();
+			}
+			if let Some(port) = listen_args.value_of("operator_port") {
+				wallet_config.api_operator_listen_port = port.to_string();
 			}
 			wallet::server::start_rest_apis(wallet_config, keychain);
 		}

--- a/wallet/src/handlers.rs
+++ b/wallet/src/handlers.rs
@@ -25,6 +25,10 @@ use keychain::Keychain;
 use types::*;
 use util;
 
+use checker;
+use receiver::receive_json_tx;
+use core::core::amount_to_hr_string;
+use sender::send_json_tx_str;
 
 pub struct CoinbaseHandler {
 	pub config: WalletConfig,
@@ -79,4 +83,134 @@ impl Handler for CoinbaseHandler {
 			Ok(Response::with((status::BadRequest, "")))
 		}
 	}
+}
+
+/// Component used to receive coins, implements all the receiving end of the
+/// wallet REST API as well as some of the command-line operations.
+#[derive(Clone)]
+pub struct WalletReceiverHandler {
+    pub keychain: Keychain,
+    pub config: WalletConfig,
+}
+
+impl Handler for WalletReceiverHandler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let struct_body = req.get::<bodyparser::Struct<PartialTx>>();
+
+        if let Ok(Some(partial_tx)) = struct_body {
+            receive_json_tx(&self.config, &self.keychain, &partial_tx)
+                .map_err(|e| {
+                    api::Error::Internal(
+                        format!("Error processing partial transaction: {:?}", e),
+                    )})
+                .unwrap();
+            Ok(Response::with(status::Ok))
+        } else {
+            Ok(Response::with((status::BadRequest, "")))
+        }
+    }
+}
+
+pub struct InfoHandler {
+    pub config: WalletConfig,
+    pub keychain: Keychain,
+}
+
+impl InfoHandler {
+    fn get_info(&self) -> Result<WalletInfoData, Error> {
+
+        let mut unspent_total=0;
+        let mut unspent_but_locked_total=0;
+        let mut unconfirmed_total=0;
+        let mut locked_total=0;
+
+        let _ = WalletData::read_wallet(&self.config.data_file_dir, |wallet_data| {
+            let current_height = match checker::get_tip_from_node(&self.config) {
+                Ok(tip) => tip.height,
+                Err(_) => match wallet_data.outputs.values().map(|out| out.height).max() {
+                    Some(height) => height,
+                    None => 0,
+                },
+            };
+
+            for out in wallet_data
+                .outputs
+                .values()
+                .filter(|out| out.root_key_id == self.keychain.root_key_id())
+                {
+                    if out.status == OutputStatus::Unspent {
+                        unspent_total+=out.value;
+                        if out.lock_height > current_height {
+                            unspent_but_locked_total+=out.value;
+                        }
+                    }
+                    if out.status == OutputStatus::Unconfirmed && !out.is_coinbase {
+                        unconfirmed_total+=out.value;
+                    }
+                    if out.status == OutputStatus::Locked {
+                        locked_total+=out.value;
+                    }
+                };
+
+        });
+
+        Ok(WalletInfoData {
+            unspent_total: amount_to_hr_string(unspent_total),
+            unspent_but_locked_total: amount_to_hr_string(unspent_but_locked_total),
+            unconfirmed_total: amount_to_hr_string(unconfirmed_total),
+            locked_total: amount_to_hr_string(locked_total),
+        })
+    }
+}
+
+impl Handler for InfoHandler {
+    fn handle(&self, _req: &mut Request) -> IronResult<Response> {
+        let info = self.get_info()
+            .map_err(|e| IronError::new(e, status::BadRequest))?;
+        if let Ok(json) = serde_json::to_string(&info) {
+            Ok(Response::with((status::Ok, json)))
+        } else {
+            Ok(Response::with((status::BadRequest, "")))
+        }
+    }
+}
+
+pub struct WalletSenderHandler {
+    pub keychain: Keychain,
+    pub config: WalletConfig,
+}
+
+impl WalletSenderHandler {
+    fn send_tx(&self, send_tx: &SendTx) -> Result<WalletSendResult, Error> {
+
+        send_json_tx_str(&self.config, &self.keychain, &send_tx)
+        .map_err(|e| {
+        api::Error::Internal(
+            format!("Error sending transaction : {:?}", e),
+        )})
+        .unwrap();
+
+        Ok(WalletSendResult {
+            confirmed: true,
+        })
+
+    }
+}
+
+impl Handler for WalletSenderHandler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let struct_body = req.get::<bodyparser::Struct<SendTx>>();
+
+        if let Ok(Some(send_tx)) = struct_body {
+            let result = self.send_tx(&send_tx)
+                .map_err(|e| { IronError::new(e, status::BadRequest) })?;
+            if let Ok(json) = serde_json::to_string(&result) {
+                Ok(Response::with((status::Ok, json)))
+            } else {
+                Ok(Response::with((status::BadRequest, "")))
+            }
+        } else {
+            Ok(Response::with((status::BadRequest, "")))
+        }
+    }
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -54,7 +54,8 @@ pub mod server;
 
 pub use outputs::show_outputs;
 pub use info::show_info;
-pub use receiver::{receive_json_tx, receive_json_tx_str, WalletReceiver};
+pub use receiver::{receive_json_tx, receive_json_tx_str};
+pub use handlers::{WalletReceiverHandler};
 pub use sender::{issue_burn_tx, issue_send_tx};
 pub use types::{BlockFees, CbData, Error, WalletConfig, WalletReceiveRequest, WalletSeed};
 pub use restore::restore;

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -16,10 +16,6 @@
 //! receiving money in MimbleWimble requires an interactive exchange, a
 //! wallet server that's running at all time is required in many cases.
 
-use bodyparser;
-use iron::prelude::*;
-use iron::Handler;
-use iron::status;
 use serde_json;
 
 use api;
@@ -71,33 +67,6 @@ pub fn receive_json_tx(
 		Err(Error::Node(e))
 	} else {
 		Ok(())
-	}
-}
-
-/// Component used to receive coins, implements all the receiving end of the
-/// wallet REST API as well as some of the command-line operations.
-#[derive(Clone)]
-pub struct WalletReceiver {
-	pub keychain: Keychain,
-	pub config: WalletConfig,
-}
-
-impl Handler for WalletReceiver {
-	fn handle(&self, req: &mut Request) -> IronResult<Response> {
-		let struct_body = req.get::<bodyparser::Struct<PartialTx>>();
-
-		if let Ok(Some(partial_tx)) = struct_body {
-			receive_json_tx(&self.config, &self.keychain, &partial_tx)
-				.map_err(|e| {
-					error!(LOGGER, "Problematic partial tx, looks like this: {:?}", partial_tx);
-					api::Error::Internal(
-						format!("Error processing partial transaction: {:?}", e),
-					)})
-				.unwrap();
-			Ok(Response::with(status::Ok))
-		} else {
-			Ok(Response::with((status::BadRequest, "")))
-		}
 	}
 }
 

--- a/wallet/src/server.rs
+++ b/wallet/src/server.rs
@@ -54,16 +54,14 @@ pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
 
     let send_tx_handler = WalletSenderHandler {
         config: wallet_config.clone(),
-        keychain: keychain.clone(),
     };
     let info_handler = InfoHandler {
         config: wallet_config.clone(),
-        keychain: keychain.clone(),
     };
 
     let router_wallet_operator = router!(
         send_tx: post "/send/transaction" => send_tx_handler,
-		retrieve_info: get "/info" => info_handler,
+		retrieve_info: post "/info" => info_handler,
     );
 
     let mut apis_operator = ApiServer::new("/v1".to_string());

--- a/wallet/src/server.rs
+++ b/wallet/src/server.rs
@@ -22,15 +22,11 @@ use util::LOGGER;
 pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
 	info!(
 		LOGGER,
-		"Starting the Grin wallet receiving daemon at {}...",
-		wallet_config.api_listen_addr()
+		"Starting the Grin wallet receiver daemon at {}...",
+		wallet_config.api_receiver_listen_addr()
 	);
 
 	let receive_tx_handler = WalletReceiverHandler {
-		config: wallet_config.clone(),
-		keychain: keychain.clone(),
-	};
-	let send_tx_handler = WalletSenderHandler {
 		config: wallet_config.clone(),
 		keychain: keychain.clone(),
 	};
@@ -38,21 +34,41 @@ pub fn start_rest_apis(wallet_config: WalletConfig, keychain: Keychain) {
 		config: wallet_config.clone(),
 		keychain: keychain.clone(),
 	};
-	let info_handler = InfoHandler {
-		config: wallet_config.clone(),
-		keychain: keychain.clone(),
-	};
 
-	let router = router!(
+	let router_receiver = router!(
 		receive_tx: post "/receive/transaction" => receive_tx_handler,
 		receive_coinbase: post "/receive/coinbase" => coinbase_handler,
-		send_tx: post "/send/transaction" => send_tx_handler,
-		retrieve_info: get "/info" => info_handler,
 	);
 
-	let mut apis = ApiServer::new("/v1".to_string());
-	apis.register_handler(router);
-	apis.start(wallet_config.api_listen_addr()).unwrap_or_else(|e| {
-		error!(LOGGER, "Failed to start Grin wallet listener: {}.", e);
+	let mut apis_receiver = ApiServer::new("/v1".to_string());
+	apis_receiver.register_handler(router_receiver);
+	apis_receiver.start(wallet_config.api_receiver_listen_addr()).unwrap_or_else(|e| {
+		error!(LOGGER, "Failed to start Grin wallet receiver listener: {}.", e);
 	});
+
+    info!(
+        LOGGER,
+        "Starting the Grin wallet operator daemon at {}...",
+        wallet_config.api_operator_listen_addr()
+    );
+
+    let send_tx_handler = WalletSenderHandler {
+        config: wallet_config.clone(),
+        keychain: keychain.clone(),
+    };
+    let info_handler = InfoHandler {
+        config: wallet_config.clone(),
+        keychain: keychain.clone(),
+    };
+
+    let router_wallet_operator = router!(
+        send_tx: post "/send/transaction" => send_tx_handler,
+		retrieve_info: get "/info" => info_handler,
+    );
+
+    let mut apis_operator = ApiServer::new("/v1".to_string());
+    apis_operator.register_handler(router_wallet_operator);
+    apis_operator.start(wallet_config.api_operator_listen_addr()).unwrap_or_else(|e| {
+        error!(LOGGER, "Failed to start Grin wallet operator listener: {}.", e);
+    });
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -193,7 +193,7 @@ impl WalletConfig {
 		format!("{}:{}", self.api_receiver_listen_interface, self.api_receiver_listen_port)
 	}
     pub fn api_operator_listen_addr(&self) -> String {
-        format!("{}:{}", "127.0.0.1", self.api_operator_listen_port)
+        format!("{}:{}", self.api_operator_listen_interface, self.api_operator_listen_port)
     }
 }
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -610,6 +610,16 @@ pub struct PartialTx {
 	tx: String,
 }
 
+/// Helper in serializing the information a sender requires to build a
+/// transaction.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SendTx {
+	pub amount: String,
+    pub minimum_confirmations: u64,
+    pub dest: String,
+    pub selection_strategy: String
+}
+
 /// Builds a PartialTx from data sent by a sender (not yet completed by the receiver).
 pub fn build_partial_tx(
 	receive_amount: u64,
@@ -666,4 +676,19 @@ pub struct CbData {
 	pub output: String,
 	pub kernel: String,
 	pub key_id: String,
+}
+
+/// Response to a wallet info query
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WalletInfoData {
+	pub unspent_total: String,
+	pub unspent_but_locked_total: String,
+	pub unconfirmed_total: String,
+	pub locked_total: String,
+}
+
+/// Response to a wallet send request
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WalletSendResult {
+    pub confirmed: bool,
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -159,9 +159,14 @@ pub struct WalletConfig {
 
 	// The api interface/ip_address that this api server (i.e. this wallet) will run
 	// by default this is 127.0.0.1 (and will not accept connections from external clients)
-	pub api_listen_interface: String,
-	// The port this wallet will run on
-	pub api_listen_port: String,
+	pub api_receiver_listen_interface: String,
+	// The port this wallet receiver will run on
+	pub api_receiver_listen_port: String,
+    // The api interface/ip_address that this api server (i.e. this wallet) will run
+    // by default this is 127.0.0.1 (and will not accept connections from external clients)
+    pub api_operator_listen_interface: String,
+    // The port this wallet operator will run on
+    pub api_operator_listen_port: String,
 	// The api address of a running server node against which transaction inputs
 	// will be checked during send
 	pub check_node_api_http_addr: String,
@@ -173,8 +178,10 @@ impl Default for WalletConfig {
 	fn default() -> WalletConfig {
 		WalletConfig {
 			// enable_wallet: false,
-			api_listen_interface: "127.0.0.1".to_string(),
-			api_listen_port: "13415".to_string(),
+			api_receiver_listen_interface: "127.0.0.1".to_string(),
+			api_receiver_listen_port: "13415".to_string(),
+            api_operator_listen_interface: "127.0.0.1".to_string(),
+            api_operator_listen_port: "13416".to_string(),
 			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
 			data_file_dir: ".".to_string(),
 		}
@@ -182,9 +189,12 @@ impl Default for WalletConfig {
 }
 
 impl WalletConfig {
-	pub fn api_listen_addr(&self) -> String {
-		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
+	pub fn api_receiver_listen_addr(&self) -> String {
+		format!("{}:{}", self.api_receiver_listen_interface, self.api_receiver_listen_port)
 	}
+    pub fn api_operator_listen_addr(&self) -> String {
+        format!("{}:{}", "127.0.0.1", self.api_operator_listen_port)
+    }
 }
 
 /// Status of an output that's being tracked by the wallet. Can either be

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -620,6 +620,12 @@ pub struct PartialTx {
 	tx: String,
 }
 
+/// Helper in serializing the information required to retrieve wallet information.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct InfoRequest {
+    pub passphrase: String,
+}
+
 /// Helper in serializing the information a sender requires to build a
 /// transaction.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -627,7 +633,8 @@ pub struct SendTx {
 	pub amount: String,
     pub minimum_confirmations: u64,
     pub dest: String,
-    pub selection_strategy: String
+    pub selection_strategy: String,
+    pub passphrase: String,
 }
 
 /// Builds a PartialTx from data sent by a sender (not yet completed by the receiver).


### PR DESCRIPTION
… via new handlers

Hello grin masters,

I was playing around with the idea of writing a gui wallet for grin, but I could not find any way to query the balances or send grin units to another wallet. I also am new at rust and I wanted to get familiar with it, and I would be grateful to get your remarks if any.

So I implemented two new handlers for the wallet listener :

/v1/info returns a json encoded struct containing the various balances as calculated in wallet/src/info.rs :

```
> curl http://127.0.0.1:15000/v1/info
{"unspent_total":"150.004500000","unspent_but_locked_total":"150.004500000","unconfirmed_total":"2720.003000000","locked_total":"100.000000000"}
```

/v1/send/transaction expects a json encoded struct containing the details about the transaction to send and returns a json encoded struct with a single boolean value 'confirmed' if there was no error :

```
> curl -H "Content-Type: application/json" -t":"10.000","minimum_confirmations":0,"dest":"http:\/\/127.0.0.1:35000","selection_strategy":"all"}' http://localhost:15000/v1/send/transaction
{"confirmed":true}
```

Finally I reorganized a little the sources in wallet/src so all handlers go to handlers.rs

Obviously this is very crude, and I am not sure you will think it's useful, but it would be an honor to contribute to grin and learn rust while doing that.

Thank you for your time