### PR TITLE
Aggsig Serialization

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -20,6 +20,7 @@ use p2p;
 use util::secp::pedersen;
 use rest::*;
 use util;
+use util::static_secp_instance;
 
 /// The state of the current fork tip
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -285,12 +286,14 @@ pub struct TxKernelPrintable {
 
 impl TxKernelPrintable {
 	pub fn from_txkernel(k: &core::TxKernel) -> TxKernelPrintable {
+		let secp = static_secp_instance();
+		let secp = secp.lock().unwrap();
 		TxKernelPrintable {
 			features: format!("{:?}", k.features),
 			fee: k.fee,
 			lock_height: k.lock_height,
 			excess: util::to_hex(k.excess.0.to_vec()),
-			excess_sig: util::to_hex(k.excess_sig.to_vec()),
+			excess_sig: util::to_hex(k.excess_sig.serialize_compact(&secp).to_vec()),
 		}
 	}
 }

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -586,12 +586,10 @@ impl Block {
 		let msg = util::secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE])?;
 		let sig = keychain.aggsig_sign_from_key_id(&msg, &key_id).unwrap();
 
-		let excess_sig = sig.serialize_der(&secp);
-
 		let proof = TxKernel {
 			features: COINBASE_KERNEL,
 			excess: excess,
-			excess_sig: excess_sig,
+			excess_sig: sig,
 			fee: 0,
 			lock_height: 0,
 		};

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -25,7 +25,7 @@
 //! build::transaction(vec![input_rand(75), output_rand(42), output_rand(32),
 //!   with_fee(1)])
 
-use util::{secp, static_secp_instance, kernel_sig_msg};
+use util::{secp, kernel_sig_msg};
 
 use core::{Input, Output, SwitchCommitHash, Transaction, DEFAULT_OUTPUT};
 use util::LOGGER;
@@ -139,9 +139,7 @@ pub fn transaction(
 	let msg = secp::Message::from_slice(&kernel_sig_msg(tx.fee, tx.lock_height))?;
 	let sig = Keychain::aggsig_sign_with_blinding(&keychain.secp(), &msg, &blind_sum)?;
 
-	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
-	tx.excess_sig = sig.serialize_der(&secp);
+	tx.excess_sig = sig;
 
 	Ok((tx, blind_sum))
 }

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -137,10 +137,7 @@ pub fn transaction(
 	);
 	let blind_sum = ctx.keychain.blind_sum(&sum)?;
 	let msg = secp::Message::from_slice(&kernel_sig_msg(tx.fee, tx.lock_height))?;
-	let sig = Keychain::aggsig_sign_with_blinding(&keychain.secp(), &msg, &blind_sum)?;
-
-	tx.excess_sig = sig;
-
+	tx.excess_sig = Keychain::aggsig_sign_with_blinding(&keychain.secp(), &msg, &blind_sum)?;
 	Ok((tx, blind_sum))
 }
 

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -260,8 +260,9 @@ mod test {
 		let tx = tx2i1o();
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &tx).expect("serialized failed");
-		assert!(vec.len() > 5360);
-		assert!(vec.len() < 5380);
+		println!("{}", vec.len());
+		assert!(vec.len() > 5340);
+		assert!(vec.len() < 5370);
 	}
 
 	#[test]

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -255,12 +255,10 @@ impl Default for Transaction {
 impl Transaction {
 	/// Creates a new empty transaction (no inputs or outputs, zero fee).
 	pub fn empty() -> Transaction {
-		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
 		Transaction {
 			fee: 0,
 			lock_height: 0,
-			excess_sig: Signature::from_compact(&secp, &[0;64]).unwrap(),
+			excess_sig: Signature::from_raw_data(&[0;64]).unwrap(),
 			inputs: vec![],
 			outputs: vec![],
 		}
@@ -274,12 +272,10 @@ impl Transaction {
 		fee: u64,
 		lock_height: u64,
 	) -> Transaction {
-		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
 		Transaction {
 			fee: fee,
 			lock_height: lock_height,
-			excess_sig: Signature::from_compact(&secp, &[0;64]).unwrap(),
+			excess_sig: Signature::from_raw_data(&[0;64]).unwrap(),
 			inputs: inputs,
 			outputs: outputs,
 		}
@@ -663,7 +659,7 @@ mod test {
 		let commit = keychain.commit(5, &key_id).unwrap();
 
 		// just some bytes for testing ser/deser
-		let sig = secp::Signature::from_compact(&keychain.secp(), &[0;64]).unwrap();
+		let sig = secp::Signature::from_raw_data(&[0;64]).unwrap();
 
 		let kernel = TxKernel {
 			features: DEFAULT_KERNEL,

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -75,16 +75,18 @@ macro_rules! try_to_o {
 }
 
 /// Eliminate some of the boilerplate of deserialization (package ser) by
-/// passing just the list of reader function.
+/// passing just the list of reader function (with optional single param)
 /// Example before:
 ///   let foo = try!(reader.read_u64());
 ///   let bar = try!(reader.read_u32());
+///   let fixed_byte_var = try!(reader.read_fixed_bytes(64));
 /// Example after:
-///   let (foo, bar) = ser_multiread!(reader, read_u64, read_u32);
+///   let (foo, bar, fixed_byte_var) = ser_multiread!(reader, read_u64, read_u32,
+///   read_fixed_bytes(64));
 #[macro_export]
 macro_rules! ser_multiread {
-  ($rdr:ident, $($read_call:ident),*) => {
-    ( $(try!($rdr.$read_call())),* )
+  ($rdr:ident, $($read_call:ident $(($val:expr)),*),*) => {
+    ( $(try!($rdr.$read_call($($val),*))),* )
   }
 }
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -29,7 +29,8 @@ use core::hash::Hashed;
 use core::transaction::{SWITCH_COMMIT_HASH_SIZE, SwitchCommitHash};
 use util::secp::pedersen::Commitment;
 use util::secp::pedersen::RangeProof;
-use util::secp::constants::{MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE};
+use util::secp::Signature;
+use util::secp::constants::{MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE, AGG_SIGNATURE_SIZE};
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Debug)]
@@ -352,6 +353,24 @@ impl Readable for RangeProof {
 		})
 	}
 }
+
+impl Readable for Signature {
+	fn read(reader: &mut Reader) -> Result<Signature, Error> {
+		let a = try!(reader.read_fixed_bytes(AGG_SIGNATURE_SIZE));
+		let mut c = [0; AGG_SIGNATURE_SIZE];
+		for i in 0..AGG_SIGNATURE_SIZE {
+			c[i] = a[i];
+		}
+		Ok(Signature::from_raw_data(&c).unwrap())
+	}
+}
+
+impl Writeable for Signature {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		writer.write_fixed_bytes(self)
+	}
+}
+
 
 /// Utility wrapper for an underlying byte Writer. Defines higher level methods
 /// to write numbers, byte vectors, hashes, etc.

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -14,6 +14,6 @@ byteorder = "^0.5"
 rand = "0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_6" }
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_7" }
 #secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -344,7 +344,7 @@ fn build_final_transaction(
 		keychain,
 	)?;
 
-	final_tx.excess_sig = excess_sig.serialize_der(&keychain.secp());
+	final_tx.excess_sig = excess_sig.clone();
 
 	// make sure the resulting transaction is valid (could have been lied to on
  // excess).


### PR DESCRIPTION
For #613, creates read/write serialization functions for ffi::Signature struct (which can now hold aggsigs as well,) and change TxKernel/Transaction structs to use it. Sigs will now be serialized as [u8;64]

Note I've also modified the ser_multiread macro to allow for calling `as_fixed_bytes(arg)` with an argument, though I didn't end up using it. Might be handle to keep there.

