### PR TITLE
Testnet1 only: fix build warning

### DIFF
--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -38,7 +38,6 @@ extern crate tokio_timer;
 
 extern crate grin_api as api;
 extern crate grin_chain as chain;
-#[macro_use]
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_p2p as p2p;


### PR DESCRIPTION
Quick fix; this warning shows up right before a very slow-to-compile crate, and testers keep asking about it. (on master it's already fixed)