### PR TITLE
rework WalletData and OutputData serialization 

### DIFF
--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -74,7 +74,7 @@ impl error::Error for Error {
 	}
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Ord, Hash, PartialOrd)]
 pub struct Identifier([u8; IDENTIFIER_SIZE]);
 
 impl ser::Serialize for Identifier {

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -64,7 +64,7 @@ fn refresh_missing_block_hashes(config: &WalletConfig, keychain: &Keychain) -> R
 			.values()
 			.filter(|x| {
 				x.root_key_id == keychain.root_key_id() &&
-				x.block_hash == Hash::zero() &&
+				x.block.hash() == Hash::zero() &&
 				x.status == OutputStatus::Unspent
 			})
 		{
@@ -139,7 +139,7 @@ fn refresh_missing_block_hashes(config: &WalletConfig, keychain: &Keychain) -> R
 			if let Entry::Occupied(mut output) = wallet_data.outputs.entry(id.to_hex()) {
 				if let Some(b) = api_blocks.get(&commit) {
 					let output = output.get_mut();
-					output.block_hash = Hash::from_hex(&b.hash).unwrap();
+					output.block = BlockIdentifier::from_str(&b.hash).unwrap();
 					output.height = b.height;
 				}
 			}

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -25,7 +25,6 @@ use serde_json;
 use api;
 use core::consensus::reward;
 use core::core::{build, Block, Output, Transaction, TxKernel, amount_to_hr_string};
-use core::core::hash::Hash;
 use core::{global, ser};
 use keychain::{Identifier, Keychain};
 use types::*;
@@ -97,7 +96,7 @@ fn handle_sender_initiation(
 			height: 0,
 			lock_height: 0,
 			is_coinbase: false,
-			block_hash: Hash::zero(),
+			block: BlockIdentifier::zero(),
 		});
 
 		key_id
@@ -282,7 +281,7 @@ pub fn receive_coinbase(
 			height: height,
 			lock_height: lock_height,
 			is_coinbase: true,
-			block_hash: Hash::zero(),
+			block: BlockIdentifier::zero(),
 		});
 
 		(key_id, derivation)
@@ -363,7 +362,7 @@ fn build_final_transaction(
 			height: 0,
 			lock_height: 0,
 			is_coinbase: false,
-			block_hash: Hash::zero(),
+			block: BlockIdentifier::zero(),
 		});
 
 		(key_id, derivation)

--- a/wallet/src/restore.rs
+++ b/wallet/src/restore.rs
@@ -18,9 +18,8 @@ use util::secp::pedersen;
 use api;
 use core::global;
 use core::core::{Output, SwitchCommitHash};
-use core::core::hash::Hash;
 use core::core::transaction::{COINBASE_OUTPUT, DEFAULT_OUTPUT};
-use types::{WalletConfig, WalletData, OutputData, OutputStatus, Error};
+use types::{BlockIdentifier, WalletConfig, WalletData, OutputData, OutputStatus, Error};
 use byteorder::{BigEndian, ByteOrder};
 
 
@@ -311,7 +310,7 @@ pub fn restore(
 							height: output.4,
 							lock_height: output.5,
 							is_coinbase: output.6,
-							block_hash: Hash::zero(),
+							block: BlockIdentifier::zero(),
 						});
 					};
 				}

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -16,7 +16,6 @@ use api;
 use client;
 use checker;
 use core::core::{build, Transaction, amount_to_hr_string};
-use core::core::hash::Hash;
 use core::ser;
 use keychain::{BlindingFactor, Identifier, Keychain};
 use receiver::TxWrapper;
@@ -267,9 +266,9 @@ fn inputs_and_change(
 	for coin in coins {
 		let key_id = keychain.derive_key_id(coin.n_child)?;
 		if coin.is_coinbase {
-			parts.push(build::coinbase_input(coin.value, coin.block_hash, key_id));
+			parts.push(build::coinbase_input(coin.value, coin.block.hash(), key_id));
 		} else {
-			parts.push(build::input(coin.value, coin.block_hash, key_id));
+			parts.push(build::input(coin.value, coin.block.hash(), key_id));
 		}
 	}
 
@@ -288,7 +287,7 @@ fn inputs_and_change(
 			height: 0,
 			lock_height: 0,
 			is_coinbase: false,
-			block_hash: Hash::zero(),
+			block: BlockIdentifier::zero(),
 		});
 
 		change_key


### PR DESCRIPTION
* serialize block hashes cleanly in wallet.dat (as hex string, not a vec of byte values)
* persist vec of values (and not the full map) in wallet.dat
  * this lets us sort it so we can diff the file more easily

```
[
  {
    "root_key_id": "a028f7f87c10b785203e",
    "key_id": "21536a327cc884e164f2",
    "n_child": 8,
    "value": 60004000000,
    "status": "Unspent",
    "height": 6,
    "lock_height": 9,
    "is_coinbase": true,
    "block": "daa87aa69d0bdfac87f4494f9fec797a815dbba03d0312173efb95c64fdd7a1f"
  },
  ...
]
```
