### PR TITLE
[wip] [experimental] include block hash in output identifier

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use core::{core, ser};
-use core::core::hash::Hashed;
+use core::core::hash::{Hash, Hashed};
 use core::core::SumCommit;
 use chain;
 use p2p;
@@ -183,6 +183,7 @@ pub struct OutputPrintable {
 impl OutputPrintable {
 	pub fn from_output(
 		output: &core::Output,
+		block: Hash,
 		chain: Arc<chain::Chain>,
 		include_proof: bool,
 	) -> OutputPrintable {
@@ -193,7 +194,7 @@ impl OutputPrintable {
 				OutputType::Transaction
 			};
 
-		let out_id = core::OutputIdentifier::from_output(&output);
+		let out_id = core::OutputIdentifier::from_output(&output, &block);
 		let spent = chain.is_unspent(&out_id).is_err();
 
 		let proof = if include_proof {
@@ -351,7 +352,12 @@ impl BlockPrintable {
 		let outputs = block
 			.outputs
 			.iter()
-			.map(|output| OutputPrintable::from_output(output, chain.clone(), include_proof))
+			.map(|output| OutputPrintable::from_output(
+				output,
+				block.hash(),
+				chain.clone(),
+				include_proof,
+			))
 			.collect();
 		let kernels = block
 			.kernels

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -20,7 +20,7 @@ use util::secp::pedersen::Commitment;
 
 use types::*;
 use core::core::hash::{Hash, Hashed};
-use core::core::{Block, BlockHeader};
+use core::core::{Block, BlockHeader, OutputIdentifier};
 use core::consensus::TargetError;
 use core::core::target::Difficulty;
 use grin_store::{self, option_to_not_found, to_key, Error, u64_to_key};
@@ -143,17 +143,17 @@ impl ChainStore for ChainKVStore {
 		self.db.delete(&u64_to_key(HEADER_HEIGHT_PREFIX, height))
 	}
 
-	fn save_output_pos(&self, commit: &Commitment, pos: u64) -> Result<(), Error> {
+	fn save_output_pos(&self, output: &OutputIdentifier, pos: u64) -> Result<(), Error> {
 		self.db.put_ser(
-			&to_key(COMMIT_POS_PREFIX, &mut commit.as_ref().to_vec())[..],
+			&to_key(COMMIT_POS_PREFIX, &mut output.commit.as_ref().to_vec())[..],
 			&pos,
 		)
 	}
 
-	fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
+	fn get_output_pos(&self, output: &OutputIdentifier) -> Result<u64, Error> {
 		option_to_not_found(
 			self.db
-				.get_ser(&to_key(COMMIT_POS_PREFIX, &mut commit.as_ref().to_vec())),
+				.get_ser(&to_key(COMMIT_POS_PREFIX, &mut output.commit.as_ref().to_vec())),
 		)
 	}
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -145,7 +145,7 @@ impl ChainStore for ChainKVStore {
 
 	fn save_output_pos(&self, output: &OutputIdentifier, pos: u64) -> Result<(), Error> {
 		self.db.put_ser(
-			&to_key(COMMIT_POS_PREFIX, &mut output.commit.as_ref().to_vec())[..],
+			&to_key(COMMIT_POS_PREFIX, &mut output.hash().to_vec()),
 			&pos,
 		)
 	}
@@ -153,7 +153,7 @@ impl ChainStore for ChainKVStore {
 	fn get_output_pos(&self, output: &OutputIdentifier) -> Result<u64, Error> {
 		option_to_not_found(
 			self.db
-				.get_ser(&to_key(COMMIT_POS_PREFIX, &mut output.commit.as_ref().to_vec())),
+				.get_ser(&to_key(COMMIT_POS_PREFIX, &mut output.hash().to_vec())),
 		)
 	}
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -19,7 +19,7 @@ use std::io;
 use util::secp::pedersen::Commitment;
 
 use grin_store as store;
-use core::core::{Block, BlockHeader, block, transaction};
+use core::core::{Block, BlockHeader, OutputIdentifier, block, transaction};
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use core::ser;
@@ -245,11 +245,11 @@ pub trait ChainStore: Send + Sync {
 
 	/// Saves the position of an output, represented by its commitment, in the
 	/// UTXO MMR. Used as an index for spending and pruning.
-	fn save_output_pos(&self, commit: &Commitment, pos: u64) -> Result<(), store::Error>;
+	fn save_output_pos(&self, output: &OutputIdentifier, pos: u64) -> Result<(), store::Error>;
 
 	/// Gets the position of an output, represented by its commitment, in the
 	/// UTXO MMR. Used as an index for spending and pruning.
-	fn get_output_pos(&self, commit: &Commitment) -> Result<u64, store::Error>;
+	fn get_output_pos(&self, output: &OutputIdentifier) -> Result<u64, store::Error>;
 
 	/// Saves the position of a kernel, represented by its excess, in the
 	/// UTXO MMR. Used as an index for spending and pruning.

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -600,7 +600,7 @@ impl Block {
 
 		if let Some(_) = self.outputs
 			.iter()
-			.find(|x| OutputIdentifier::from_output(&x) == output)
+			.find(|x| OutputIdentifier::from_output(&x, &self.hash()) == output)
 		{
 			let lock_height = self.header.height + global::coinbase_maturity();
 			if lock_height > height {

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -47,7 +47,7 @@ pub type Append = for<'a> Fn(&'a mut Context, (Transaction, BlindSum)) -> (Trans
 fn build_input(
 	value: u64,
 	features: OutputFeatures,
-	out_block: Option<Hash>,
+	out_block: Hash,
 	key_id: Identifier,
 ) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
@@ -69,7 +69,7 @@ pub fn input(
 	key_id: Identifier,
 ) -> Box<Append> {
 	debug!(LOGGER, "Building input (spending regular output): {}, {}", value, key_id);
-	build_input(value, DEFAULT_OUTPUT, Some(out_block), key_id)
+	build_input(value, DEFAULT_OUTPUT, out_block, key_id)
 }
 
 /// Adds a coinbase input spending a coinbase output.
@@ -80,7 +80,7 @@ pub fn coinbase_input(
 	key_id: Identifier,
 ) -> Box<Append> {
 	debug!(LOGGER, "Building input (spending coinbase): {}, {}", value, key_id);
-	build_input(value, COINBASE_OUTPUT, Some(out_block), key_id)
+	build_input(value, COINBASE_OUTPUT, out_block, key_id)
 }
 
 /// Adds an output with the provided value and key identifier from the

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -117,7 +117,7 @@ impl BlockChain for DummyChainImpl {
 		if !input.features.contains(COINBASE_OUTPUT) {
 			return Ok(());
 		}
-		let block_hash = input.out_block.expect("requires a block hash");
+		let block_hash = input.out_block;
 		let headers = self.block_headers.read().unwrap();
 		if let Some(h) = headers
 			.iter()

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -67,8 +67,7 @@ pub struct Edge {
 	source: Option<core::hash::Hash>,
 	destination: Option<core::hash::Hash>,
 
-	// Output is the output hash which this input/output pairing corresponds
-	// to.
+	// Output that this input/output pairing corresponds to.
 	output: OutputIdentifier,
 }
 


### PR DESCRIPTION
This _potentially_ solves the issue in #544 where rewinding on a fork can resurrect a once spent output back into the utxo set (resulting in incorrect output mmr pos).

* include `block_hash` in `output_identifier` (so ensure they are unique)
* use hash of `output_identifier` to build key for output_pos index
  * `features|commitment|block_hash`

Note - 
* this breaks the utxo endpoint as we need the block hash to retrieve a utxo by commitment
* also do we want to include block_hash in the entry hash in the MMR itself (or just as part of how we maintain the output_pos index)? Does it make a difference?

Putting this up for discussion.
This is quite likely the _wrong_ approach to solving this but keen on getting some feedback and thoughts on how we are relying on commitments right now.
@ignopeverell 

