### PR TITLE
Fix inconsistent key_derivations default in help string

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -201,7 +201,7 @@ fn main() {
 		.arg(Arg::with_name("key_derivations")
 				.help("The number of keys possiblities to search for each output. \
 				Ideally, set this to a number greater than the number of outputs \
-				you believe should belong to this seed/password. (Default 500)")
+				you believe should belong to this seed/password. (Default 1000)")
 				.short("k")
 				.long("key_derivations")
 				.default_value("1000")


### PR DESCRIPTION
I noticed that the doc and the default disagreed. This patch changes the doc to agree with the default.