### PR TITLE
Revert "move siphash out of pow and into util"

### DIFF
--- a/pow/src/cuckoo.rs
+++ b/pow/src/cuckoo.rs
@@ -23,7 +23,7 @@ use std::cmp;
 use blake2;
 
 use core::core::Proof;
-use util::siphash::siphash24;
+use siphash::siphash24;
 use MiningWorker;
 
 const MAXPATHLEN: usize = 8192;

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -44,6 +44,7 @@ extern crate grin_util as util;
 
 extern crate cuckoo_miner;
 
+mod siphash;
 pub mod plugin;
 pub mod cuckoo;
 pub mod types;

--- a/pow/src/siphash.rs
+++ b/pow/src/siphash.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Grin Developers
+// Copyright 2016 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,30 +24,30 @@ pub fn siphash24(v: [u64; 4], nonce: u64) -> u64 {
 
 	// macro for left rotation
 	macro_rules! rotl {
-		($num:ident, $shift:expr) => {
-			$num = ($num << $shift) | ($num >> (64 - $shift));
-		}
-	}
+    ($num:ident, $shift:expr) => {
+      $num = ($num << $shift) | ($num >> (64 - $shift));
+    }
+  }
 
 	// macro for a single siphash round
 	macro_rules! round {
-		() => {
-			v0 = v0.wrapping_add(v1);
-			v2 = v2.wrapping_add(v3);
-			rotl!(v1, 13);
-			rotl!(v3, 16);
-			v1 ^= v0;
-			v3 ^= v2;
-			rotl!(v0, 32);
-			v2 = v2.wrapping_add(v1);
-			v0 = v0.wrapping_add(v3);
-			rotl!(v1, 17);
-			rotl!(v3, 21);
-			v1 ^= v2;
-			v3 ^= v0;
-			rotl!(v2, 32);
-		}
-	}
+    () => {
+      v0 = v0.wrapping_add(v1);
+      v2 = v2.wrapping_add(v3);
+      rotl!(v1, 13);
+      rotl!(v3, 16);
+      v1 ^= v0;
+      v3 ^= v2;
+      rotl!(v0, 32);
+      v2 = v2.wrapping_add(v1);
+      v0 = v0.wrapping_add(v3);
+      rotl!(v1, 17);
+      rotl!(v3, 21);
+      v1 ^= v2;
+      v3 ^= v0;
+      rotl!(v2, 32);
+    }
+  }
 
 	// 2 rounds
 	round!();

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -50,8 +50,6 @@ pub use secp_static::static_secp_instance;
 pub mod types;
 pub use types::{LoggingConfig, LogLevel};
 
-pub mod siphash;
-
 // other utils
 use std::cell::{Ref, RefCell};
 #[allow(unused_imports)]


### PR DESCRIPTION
Reverts mimblewimble/grin#633 (this siphash impl is specific to cuckoo/pow).
We are going to use a more general purpose impl for short ids.