### PR TITLE
ShortId implementation (and CompactBlock)

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -367,6 +367,30 @@ impl BlockPrintable {
 	}
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CompactBlockPrintable {
+	/// The block header
+	pub header: BlockHeaderPrintable,
+	/// Inputs (hex short_ids)
+	pub inputs: Vec<String>,
+	/// Outputs (hex short_ids)
+	pub outputs: Vec<String>,
+	/// Kernels (hex short_ids)
+	pub kernels: Vec<String>,
+}
+
+impl CompactBlockPrintable {
+	/// Convert a compact block into a printable representation suitable for api response
+	pub fn from_compact_block(cb: &core::CompactBlock) -> CompactBlockPrintable {
+		CompactBlockPrintable {
+			header: BlockHeaderPrintable::from_header(&cb.header),
+			inputs: cb.inputs.iter().map(|x| x.to_hex()).collect(),
+			outputs: cb.outputs.iter().map(|x| x.to_hex()).collect(),
+			kernels: cb.kernels.iter().map(|x| x.to_hex()).collect(),
+		}
+	}
+}
+
 // For wallet reconstruction, include the header info along with the
 // transactions in the block
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ num-bigint = "^0.1.35"
 rand = "^0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
+siphasher = "~0.1"
 time = "^0.1"
 lazy_static = "~0.2.8"
 grin_keychain = { path = "../keychain" }

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -1,0 +1,152 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! short ids for compact blocks
+
+use std::cmp::min;
+
+use byteorder::{LittleEndian, ByteOrder};
+use siphasher::sip::SipHasher24;
+
+use core::hash::{Hash, Hashed};
+use ser;
+use util;
+
+
+/// The size of a short id used to identify inputs|outputs|kernels (6 bytes)
+pub const SHORT_ID_SIZE: usize = 6;
+
+/// A trait for types that have a short_id (inputs/outputs/kernels)
+pub trait ShortIdentifiable {
+	/// The short_id of the instance.
+	fn short_id(&self, block_hash: &Hash) -> ShortId;
+}
+
+impl<H: Hashed> ShortIdentifiable for H {
+	/// Generate a short_id via the following -
+	///
+	///   * extract k0/k1 from block_hash (first two u64 values)
+	///   * initialize a siphasher24 with k0/k1
+	///   * self.hash() passing in the siphasher24 instance
+	///   * drop the 2 most significant bytes (to return a 6 byte short_id)
+	///
+	fn short_id(&self, block_hash: &Hash) -> ShortId {
+		// we "use" core::hash::Hash in the outer namespace
+		// so doing this here in the fn to minimize collateral damage/confusion
+		use std::hash::Hasher;
+
+		// extract k0/k1 from the block_hash
+		let k0 = LittleEndian::read_u64(&block_hash.0[0..8]);
+		let k1 = LittleEndian::read_u64(&block_hash.0[8..16]);
+
+		// initialize a siphasher24 with k0/k1
+		let mut sip_hasher = SipHasher24::new_with_keys(k0, k1);
+
+		// hash our id (self.hash()) using the siphasher24 instance
+		sip_hasher.write(&self.hash().to_vec()[..]);
+		let res = sip_hasher.finish();
+
+		// construct a short_id from the resulting bytes (dropping the 2 most significant bytes)
+		let mut buf = [0; 8];
+		LittleEndian::write_u64(&mut buf, res);
+		ShortId::from_bytes(&buf[0..6])
+	}
+}
+
+/// Short id for identifying inputs/outputs/kernels
+#[derive(PartialEq)]
+pub struct ShortId([u8; 6]);
+
+impl ::std::fmt::Debug for ShortId {
+	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+		try!(write!(f, "{}(", stringify!(ShortId)));
+		try!(write!(f, "{}", self.to_hex()));
+		write!(f, ")")
+	}
+}
+
+impl ShortId {
+	/// Build a new short_id from a byte slice
+	pub fn from_bytes(bytes: &[u8]) -> ShortId {
+		let mut hash = [0; SHORT_ID_SIZE];
+		for i in 0..min(SHORT_ID_SIZE, bytes.len()) {
+			hash[i] = bytes[i];
+		}
+		ShortId(hash)
+	}
+
+	/// Hex string representation of a short_id
+	pub fn to_hex(&self) -> String {
+		util::to_hex(self.0.to_vec())
+	}
+
+	/// Reconstructs a switch commit hash from a hex string.
+	pub fn from_hex(hex: &str) -> Result<ShortId, ser::Error> {
+		let bytes = util::from_hex(hex.to_string())
+			.map_err(|_| ser::Error::HexError(format!("short_id from_hex error")))?;
+		Ok(ShortId::from_bytes(&bytes))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use ser::{Writeable, Writer};
+
+
+	#[test]
+	fn test_short_id() {
+		// minimal struct for testing
+		// make it implement Writeable, therefore Hashable, therefore ShortIdentifiable
+		struct Foo(u64);
+		impl Writeable for Foo {
+			fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+				writer.write_u64(self.0)?;
+				Ok(())
+			}
+		}
+
+		let foo = Foo(0);
+		let expected_hash = Hash::from_hex(
+			"81e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c",
+		).unwrap();
+		assert_eq!(foo.hash(), expected_hash);
+
+		let other_hash = Hash::zero();
+		println!("{:?}", foo.short_id(&other_hash));
+		assert_eq!(foo.short_id(&other_hash), ShortId::from_hex("e973960ba690").unwrap());
+
+		let foo = Foo(5);
+		let expected_hash = Hash::from_hex(
+			"3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673",
+		).unwrap();
+		assert_eq!(foo.hash(), expected_hash);
+
+		let other_hash = Hash::zero();
+		println!("{:?}", foo.short_id(&other_hash));
+		assert_eq!(foo.short_id(&other_hash), ShortId::from_hex("f0c06e838e59").unwrap());
+
+		let foo = Foo(5);
+		let expected_hash = Hash::from_hex(
+			"3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673",
+		).unwrap();
+		assert_eq!(foo.hash(), expected_hash);
+
+		let other_hash = Hash::from_hex(
+			"81e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c",
+		).unwrap();
+		println!("{:?}", foo.short_id(&other_hash));
+		assert_eq!(foo.short_id(&other_hash), ShortId::from_hex("95bf0ca12d5b").unwrap());
+	}
+}

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -66,7 +66,7 @@ impl<H: Hashed> ShortIdentifiable for H {
 }
 
 /// Short id for identifying inputs/outputs/kernels
-#[derive(PartialEq, Clone, PartialOrd, Ord, Eq)]
+#[derive(PartialEq, Clone, PartialOrd, Ord, Eq, Serialize, Deserialize)]
 pub struct ShortId([u8; 6]);
 
 impl ::std::fmt::Debug for ShortId {

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Grin Developers
+// Copyright 2018 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 pub mod block;
 pub mod build;
 pub mod hash;
+pub mod id;
 pub mod pmmr;
 pub mod target;
 pub mod transaction;

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -34,6 +34,7 @@ use util::secp::pedersen::*;
 
 pub use self::block::*;
 pub use self::transaction::*;
+pub use self::id::ShortId;
 use self::hash::Hashed;
 use ser::{Error, Readable, Reader, Writeable, Writer};
 use global;
@@ -397,7 +398,7 @@ mod test {
 			&key_id,
 			Difficulty::minimum(),
 		).unwrap();
-		b.compact().validate().unwrap();
+		b.cut_through().validate().unwrap();
 	}
 
 	#[test]
@@ -415,7 +416,7 @@ mod test {
 			&key_id,
 			Difficulty::minimum(),
 		).unwrap();
-		b.compact().validate().unwrap();
+		b.cut_through().validate().unwrap();
 	}
 
 	#[test]

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -14,6 +14,8 @@
 
 //! Transactions
 use blake2::blake2b::blake2b;
+use byteorder::{LittleEndian, ByteOrder};
+use siphasher::sip::SipHasher24;
 use util::secp::{self, Message, Signature};
 use util::{static_secp_instance, kernel_sig_msg};
 use util::secp::pedersen::{Commitment, RangeProof};
@@ -35,6 +37,9 @@ pub const SWITCH_COMMIT_HASH_SIZE: usize = 20;
 
 /// The size of the secret key used to generate the switch commitment hash (blake2)
 pub const SWITCH_COMMIT_KEY_SIZE: usize = 20;
+
+/// The size of a short id used to identify inputs|outputs|kernels (6 bytes)
+pub const SHORT_ID_SIZE: usize = 6;
 
 bitflags! {
 	/// Options for a kernel's structure or use
@@ -662,6 +667,49 @@ impl Output {
 			}
 			Err(_) => None,
 		}
+	}
+
+	/// Generate a short_id via the following -
+	///
+	///   * extract k0/k1 from block_hash (first two u64 values)
+	///   * initialize a siphasher24 with k0/k1
+	///   * self.hash() passing in the siphasher24 instance
+	///   * drop the 2 most significant bytes (to return a 6 byte short_id)
+	///
+	pub fn short_id(&self, block_hash: &Hash) -> ShortId {
+		// we "use" core::hash::Hash in the outer namespace
+		// so doing this here in the fn to minimize collateral damage/confusion
+		use std::hash::Hasher;
+
+		// extract k0/k1 from the block_hash
+		let k0 = LittleEndian::read_u64(&block_hash.0[0..8]);
+		let k1 = LittleEndian::read_u64(&block_hash.0[8..16]);
+
+		// initialize a siphasher24 with k0/k1
+		let mut sip_hasher = SipHasher24::new_with_keys(k0, k1);
+
+		// hash our id (self.hash()) using the siphasher24 instance
+		sip_hasher.write(&self.hash().to_vec()[..]);
+		let res = sip_hasher.finish();
+
+		// construct a short_id from the resulting bytes (dropping the 2 most significant bytes)
+		let mut buf = [0; 8];
+		LittleEndian::write_u64(&mut buf, res);
+		ShortId::from_bytes(&buf[0..6])
+	}
+}
+
+/// Short id for identifying inputs/outputs/kernels
+pub struct ShortId([u8; 6]);
+
+impl ShortId {
+	/// Build a new short_id from a byte slice
+	pub fn from_bytes(bytes: &[u8]) -> ShortId {
+		let mut hash = [0; SHORT_ID_SIZE];
+		for i in 0..min(SHORT_ID_SIZE, bytes.len()) {
+			hash[i] = bytes[i];
+		}
+		ShortId(hash)
 	}
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,7 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate siphasher;
 #[macro_use]
 extern crate slog;
 extern crate time;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -555,6 +555,11 @@ impl AsFixedBytes for [u8; 4] {
 		return 4;
 	}
 }
+impl AsFixedBytes for [u8; 6] {
+	fn len(&self) -> usize {
+		return 6;
+	}
+}
 impl AsFixedBytes for [u8; 8] {
 	fn len(&self) -> usize {
 		return 8;


### PR DESCRIPTION
TODO - 
- [x] make this more reusable (a trait?) so we can use it for inputs/outputs/kernels easily
- [x] add some test coverage (basically hashes in -> ids out)
- [x] serialize/deserialize short_ids as hex strings (also for debugging purposes)
- [x] impl minimal `CompactBlock` (lists of short_ids)
- [x] expose compact block via block api endpoint (optional `?compact` query param)

Resolves #632 
