### PR TITLE
print default --key_derivations only once

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -201,7 +201,7 @@ fn main() {
 		.arg(Arg::with_name("key_derivations")
 				.help("The number of keys possiblities to search for each output. \
 				Ideally, set this to a number greater than the number of outputs \
-				you believe should belong to this seed/password. (Default 1000)")
+				you believe should belong to this seed/password.")
 				.short("k")
 				.long("key_derivations")
 				.default_value("1000")


### PR DESCRIPTION
Since the default value is also embedded in the help string it appears twice in the output from `grin wallet help`.  This PR just removes the default from the help string.