### PR TITLE
fix bug - p2p store was ignoring port numbers

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -314,6 +314,7 @@ impl Readable for GetPeerAddrs {
 
 /// Peer addresses we know of that are fresh enough, in response to
 /// GetPeerAddrs.
+#[derive(Debug)]
 pub struct PeerAddrs {
 	pub peers: Vec<SockAddr>,
 }
@@ -375,6 +376,7 @@ impl Readable for PeerError {
 /// Only necessary so we can implement Readable and Writeable. Rust disallows
 /// implementing traits when both types are outside of this crate (which is the
 /// case for SocketAddr and Readable/Writeable).
+#[derive(Debug)]
 pub struct SockAddr(pub SocketAddr);
 
 impl Writeable for SockAddr {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -130,7 +130,7 @@ impl PeerStore {
 	}
 
 	/// List all known peers
-	/// Used for /v1/peers, for seed / sync (debug & if too few peers connected)
+	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Vec<PeerData> {
 		self.db
 			.iter::<PeerData>(&to_key(PEER_PREFIX, &mut "".to_string().into_bytes()))
@@ -155,5 +155,5 @@ impl PeerStore {
 }
 
 fn peer_key(peer_addr: SocketAddr) -> Vec<u8> {
-	to_key(PEER_PREFIX, &mut format!("{}", peer_addr.ip()).into_bytes())
+	to_key(PEER_PREFIX, &mut format!("{}:{}", peer_addr.ip(), peer_addr.port()).into_bytes())
 }


### PR DESCRIPTION
The p2p store was only taking the ip into consideration when generating keys for the db.
It was ignoring port numbers.

So the following were actually overwriting each other in the store ("all peers") - 
* `127.0.0.1:13413`
* `127.0.0.1:13414`

