### PR TITLE
Testnet1 keychain macro use

### DIFF
--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -169,7 +169,7 @@ impl LocalServerContainer {
 	pub fn new(config: LocalServerContainerConfig) -> Result<LocalServerContainer, Error> {
 		let working_dir = format!("target/test_servers/{}", config.name);
 		Ok(
-			(LocalServerContainer {
+			LocalServerContainer {
 				config: config,
 				p2p_server_stats: None,
 				api_server: None,
@@ -178,7 +178,7 @@ impl LocalServerContainer {
 				wallet_is_running: false,
 				working_dir: working_dir,
 				peer_list: Vec::new(),
-			}),
+			},
 		)
 	}
 
@@ -305,7 +305,7 @@ impl LocalServerContainer {
 	/// Stops the running wallet server
 
 	pub fn stop_wallet(&mut self) {
-		let mut api_server = self.api_server.as_mut().unwrap();
+		let api_server = self.api_server.as_mut().unwrap();
 		api_server.stop();
 	}
 
@@ -435,7 +435,7 @@ impl LocalServerContainerPool {
 		// self.server_containers.push(server_arc);
 
 		// Create a future that runs the server for however many seconds
-  // collect them all and run them in the run_all_servers
+		// collect them all and run them in the run_all_servers
 		let _run_time = self.config.run_length_in_seconds;
 
 		self.server_containers.push(server_container);
@@ -469,15 +469,15 @@ impl LocalServerContainerPool {
 			let handle = thread::spawn(move || {
 				if is_seeding && !s.config.is_seeding {
 					// there's a seed and we're not it, so hang around longer and give the seed
-	 // a chance to start
+	 				// a chance to start
 					thread::sleep(time::Duration::from_millis(2000));
 				}
 				let server_ref = s.run_server(run_length);
 				return_container_ref.lock().unwrap().push(server_ref);
 			});
 			// Not a big fan of sleeping hack here, but there appears to be a
-   // concurrency issue when creating files in rocksdb that causes
-   // failure if we don't pause a bit before starting the next server
+			// concurrency issue when creating files in rocksdb that causes
+			// failure if we don't pause a bit before starting the next server
 			thread::sleep(time::Duration::from_millis(500));
 			handles.push(handle);
 		}
@@ -497,6 +497,7 @@ impl LocalServerContainerPool {
 	}
 
 	pub fn connect_all_peers(&mut self) {
+
 		/// just pull out all currently active servers, build a list,
 		/// and feed into all servers
 		let mut server_addresses: Vec<String> = Vec::new();

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -37,14 +37,15 @@ use std::default::Default;
 use futures::{Async, Future, Poll};
 use futures::task::current;
 use tokio_core::reactor;
-use tokio_timer::Timer;
+// use tokio_timer::Timer;
 
-use core::consensus;
+// use core::consensus;
 use core::global;
 use core::global::ChainTypes;
-use wallet::WalletConfig;
+// use wallet::WalletConfig;
 
-use framework::{LocalServerContainer, LocalServerContainerConfig, LocalServerContainerPool,
+// use framework::LocalServerContainer;
+use framework::{LocalServerContainerConfig, LocalServerContainerPool,
                 LocalServerContainerPoolConfig};
 
 /// Testing the frameworks by starting a fresh server, creating a genesis

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -19,8 +19,8 @@ extern crate byteorder;
 extern crate grin_util as util;
 extern crate rand;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
+// #[macro_use]
+// extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate slog;

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -19,8 +19,10 @@ extern crate byteorder;
 extern crate grin_util as util;
 extern crate rand;
 extern crate serde;
-// #[macro_use]
-// extern crate serde_derive;
+// #[allow(unused_imports)]
+#[cfg(test)]
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate slog;

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -107,7 +107,7 @@ pub fn write_msg<T>(
 where
 	T: Writeable + 'static,
 {
-	let write_msg = ok((conn)).and_then(move |conn| {
+	let write_msg = ok(conn).and_then(move |conn| {
 		// prepare the body first so we know its serialized length
 		let mut body_buf = vec![];
 		ser::serialize(&mut body_buf, &msg).unwrap();

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -431,7 +431,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 					match e {
 						wallet::Error::FeeExceedsAmount {sender_amount, recipient_fee} => {
 							error!(
-								LOGGER, 
+								LOGGER,
 								"Cannot process because transaction fee ({}) exceeded received amount ({}).",
 								amount_to_hr_string(recipient_fee),
 								amount_to_hr_string(sender_amount)
@@ -474,7 +474,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 				minimum_confirmations,
 				dest.to_string(),
 				max_outputs,
-				(selection_strategy == "all"),
+				selection_strategy == "all",
 			);
 			match result {
 				Ok(_) => {
@@ -495,7 +495,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 				}
 				Err(wallet::Error::FeeExceedsAmount {sender_amount, recipient_fee}) => {
 					error!(
-						LOGGER, 
+						LOGGER,
 						"Recipient rejected the transfer because transaction fee ({}) exceeded amount ({}).",
 						amount_to_hr_string(recipient_fee),
 						amount_to_hr_string(sender_amount)


### PR DESCRIPTION
[Testnet1] cleanup compiler errors and fix tests concurrency issue for `cargo test -p grin_store sumtree`
- tried but failed to fix `cargo build` complaint about unused #[macro use]. See also 7a803a8
- fix other compiler complaints
- give sumtree tests method-tagged folder names so they don't overwrite each others' files

Fixes #658