### PR TITLE
rustfmt install instruction gotcha

### DIFF
--- a/doc/style.md
+++ b/doc/style.md
@@ -35,8 +35,18 @@ ln -s -f ../../.hooks/pre-commit
 
 To run rustfmt against a single file, this __new__ command works with latest rust and after having done `rustup component add rustfmt-preview` and by setting --write-mode it doesn't overwrite files.
 
+First maybe try a dry-run to see what changes would be made:
 `rustfmt --write-mode diff -- client.rs`
 
-The old method, which always overwrote almost every file in the grin repo, was written like this:
+Then if you don't want to do any other cleanups manually, make rustfmt make the changes 
+
+`rustfmt -- client.rs`
+
+and add that as a separate commit at the end of your Pull Request.
+
+
+The old method would typically change formatting in _nearly every file_ in the grin repo. If you feel adventurous, try this:
 
 `cargo +nightly fmt -- ./core/src/lib.rs`
+
+(and please take care, since the ending `-- file/names.rs` actually doesn't have any effect)

--- a/doc/style.md
+++ b/doc/style.md
@@ -33,8 +33,10 @@ ln -s -f ../../.hooks/pre-commit
 
 ## Running rustfmt
 
-To run rustfmt against a single file in grin -
+To run rustfmt against a single file, this __new__ command works with latest rust and after having done `rustup component add rustfmt-preview` and by setting --write-mode it doesn't overwrite files.
 
-```
-cargo +nightly fmt -- ./core/src/lib.rs
-```
+`rustfmt --write-mode diff -- client.rs`
+
+The old method, which always overwrote almost every file in the grin repo, was written like this:
+
+`cargo +nightly fmt -- ./core/src/lib.rs`

--- a/doc/style.md
+++ b/doc/style.md
@@ -15,6 +15,8 @@ rustup install nightly
 rustup run nightly cargo install rustfmt-nightly
 ```
 
+If you still get problems with running `cargo +nightly fmt`, you might need to also do `rustup component add rustfmt-preview` (see [more info](https://github.com/rust-lang-nursery/rustfmt/issues/2304))
+
 ## Install git pre-commit hook
 
 There is a basic git [pre-commit](../.hooks/pre-commit) hook in the repo.


### PR DESCRIPTION
rustfmt stopped working for me. It turns out people started having trouble with this last year already https://github.com/rust-lang-nursery/rustfmt/issues/2304