### PR TITLE
we can now hydrate empty compact blocks and process them

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -854,7 +854,7 @@ mod test {
 	use core::hash::ZERO_HASH;
 	use core::Transaction;
 	use core::build::{self, input, output, with_fee};
-	use core::test::tx2i1o;
+	use core::test::{tx1i2o, tx2i1o};
 	use keychain::{Identifier, Keychain};
 	use consensus::{MAX_BLOCK_WEIGHT, BLOCK_OUTPUT_WEIGHT};
 	use std::time::Instant;
@@ -1089,6 +1089,100 @@ mod test {
 		assert_eq!(b.inputs, b2.inputs);
 		assert_eq!(b.outputs, b2.outputs);
 		assert_eq!(b.kernels, b2.kernels);
+	}
+
+	#[test]
+	fn empty_block_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let b = new_block(vec![], &keychain);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			5_676,
+		);
+	}
+
+	#[test]
+	fn block_single_tx_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let tx1 = tx1i2o();
+		let b = new_block(vec![&tx1], &keychain);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			16_224,
+		);
+	}
+
+	#[test]
+	fn empty_compact_block_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let b = new_block(vec![], &keychain);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			5_662,
+		);
+	}
+
+	#[test]
+	fn compact_block_single_tx_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let tx1 = tx1i2o();
+		let b = new_block(vec![&tx1], &keychain);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			5_668,
+		);
+	}
+
+	#[test]
+	fn block_10_tx_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+
+		let mut txs = vec![];
+		for _ in 0..10 {
+			let tx = tx1i2o();
+			txs.push(tx);
+		}
+
+		let b = new_block(
+			txs.iter().collect(),
+			&keychain,
+		);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			111_156,
+		);
+	}
+
+	#[test]
+	fn compact_block_10_tx_serialized_size() {
+		let keychain = Keychain::from_random_seed().unwrap();
+
+		let mut txs = vec![];
+		for _ in 0..10 {
+			let tx = tx1i2o();
+			txs.push(tx);
+		}
+
+		let b = new_block(
+			txs.iter().collect(),
+			&keychain,
+		);
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		assert_eq!(
+			vec.len(),
+			5_722,
+		);
 	}
 
 	#[test]

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -1188,14 +1188,14 @@ mod test {
 	#[test]
 	fn convert_block_to_compact_block() {
 		let keychain = Keychain::from_random_seed().unwrap();
-		let tx1 = tx2i1o();
+		let tx1 = tx1i2o();
 		let b = new_block(vec![&tx1], &keychain);
 
 		let cb = b.as_compact_block();
 
 		assert_eq!(cb.out_full.len(), 1);
 		assert_eq!(cb.kern_full.len(), 1);
-		assert_eq!(cb.kern_ids.len(), 1);
+		assert_eq!(cb.kern_ids.len(), 2);
 
 		assert_eq!(
 			cb.kern_ids[0],
@@ -1205,6 +1205,17 @@ mod test {
 				.unwrap()
 				.short_id(&b.hash())
 		);
+	}
+
+	#[test]
+	fn hydrate_empty_compact_block() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let b = new_block(vec![], &keychain);
+		let cb = b.as_compact_block();
+		let hb = Block::hydrate_from(cb, vec![], vec![], vec![]);
+		assert_eq!(hb.header, b.header);
+		assert_eq!(hb.outputs, b.outputs);
+		assert_eq!(hb.kernels, b.kernels);
 	}
 
 	#[test]

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -1195,7 +1195,7 @@ mod test {
 
 		assert_eq!(cb.out_full.len(), 1);
 		assert_eq!(cb.kern_full.len(), 1);
-		assert_eq!(cb.kern_ids.len(), 2);
+		assert_eq!(cb.kern_ids.len(), 1);
 
 		assert_eq!(
 			cb.kern_ids[0],

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -537,4 +537,24 @@ mod test {
 		).map(|(tx, _)| tx)
 			.unwrap()
 	}
+
+	// utility producing a transaction with a single input
+	// and two outputs (one change output)
+	pub fn tx1i2o() -> Transaction {
+		let keychain = keychain::Keychain::from_random_seed().unwrap();
+		let key_id1 = keychain.derive_key_id(1).unwrap();
+		let key_id2 = keychain.derive_key_id(2).unwrap();
+		let key_id3 = keychain.derive_key_id(3).unwrap();
+
+		build::transaction(
+			vec![
+				input(6, ZERO_HASH, key_id1),
+				output(3, key_id2),
+				output(1, key_id3),
+				with_fee(2),
+			],
+			&keychain,
+		).map(|(tx, _)| tx)
+			.unwrap()
+	}
 }


### PR DESCRIPTION
Compact blocks contain full coinbase kernels and outputs.
So if there are no txs in the block we can hydrate a compact block into a full block without any additional data required.
Skip the "request block" step on receiving an empty compact block, hydrate it and process it.

This is just a small incremental change getting us closer to being able to use the tx pool to hydrate non-empty compact blocks.

