### PR TITLE
[WIP] exploring how we might generate Merkle Proofs for PMMR

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -128,7 +128,7 @@ impl UtxoHandler {
 				commitments.is_empty() || commitments.contains(&output.commit)
 			})
 			.map(|output| {
-				OutputPrintable::from_output(output, w(&self.chain), include_proof)
+				OutputPrintable::from_output(output, w(&self.chain), &block, include_proof)
 			})
 			.collect();
 		BlockOutputs {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -24,7 +24,7 @@ use util::secp::pedersen::RangeProof;
 
 use core::core::{Input, OutputIdentifier, SumCommit};
 use core::core::hash::Hashed;
-use core::core::pmmr::{HashSum, NoSum};
+use core::core::pmmr::{HashSum, NoSum, MerkleProof};
 use core::global;
 
 use core::core::{Block, BlockHeader, TxKernel};
@@ -390,7 +390,7 @@ impl Chain {
 	/// Return an error if the output does not exist or has been spent.
 	/// This querying is done in a way that is consistent with the current chain state,
 	/// specifically the current winning (valid, most work) fork.
-	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<(), Error> {
+	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<Hash, Error> {
 		let mut sumtrees = self.sumtrees.write().unwrap();
 		sumtrees.is_unspent(output_ref)
 	}
@@ -432,6 +432,19 @@ impl Chain {
 		b.header.range_proof_root = roots.1.hash;
 		b.header.kernel_root = roots.2.hash;
 		Ok(())
+	}
+
+	pub fn get_merkle_proof(
+		&self,
+		output: &OutputIdentifier,
+		block: &Block,
+	) -> Result<MerkleProof, Error> {
+		debug!(LOGGER, "******** chain: get_merkle_proof");
+		let mut sumtrees = self.sumtrees.write().unwrap();
+		sumtree::extending(&mut sumtrees, |extension| {
+			extension.force_rollback();
+			extension.merkle_proof(output, block)
+		})
 	}
 
 	/// Returns current sumtree roots

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -71,6 +71,7 @@ pub enum Error {
 	DuplicateKernel(Commitment),
 	/// coinbase can only be spent after it has matured (n blocks)
 	ImmatureCoinbase,
+	MerkleProof,
 	/// output not found
 	OutputNotFound,
 	/// output spent

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -278,7 +278,7 @@ fn spend_in_fork() {
 
 	let tx2 = build::transaction(
 		vec![
-			build::input(consensus::REWARD - 20000, next.hash(), kc.derive_key_id(30).unwrap()),
+			build::input(consensus::REWARD - 20000, kc.derive_key_id(30).unwrap()),
 			build::output(consensus::REWARD - 40000, kc.derive_key_id(31).unwrap()),
 			build::with_fee(20000),
 		],

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -783,42 +783,6 @@ impl Block {
 		Ok(())
 	}
 
-	// /// NOTE: this happens during apply_block (not the earlier validate_block)
-	// ///
-	// /// Calculate lock_height as block_height + 1,000
-	// /// Confirm height <= lock_height
-	// pub fn verify_coinbase_maturity(
-	// 	&self,
-	// 	input: &Input,
-	// 	height: u64,
-	// ) -> Result<(), Error> {
-	// 	let output = OutputIdentifier::from_input(&input);
-	//
-	// 	// We should only be calling verify_coinbase_maturity
-	// 	// if the sender claims we are spending a coinbase output
-	// 	// _and_ that we trust this claim.
-	// 	// We should have already confirmed the entry from the MMR exists
-	// 	// and has the expected hash.
-	// 	assert!(output.features.contains(OutputFeatures::COINBASE_OUTPUT));
-	//
-	// 	if let Some(_) = self.outputs
-	// 		.iter()
-	// 		.find(|x| OutputIdentifier::from_output(&x) == output)
-	// 	{
-	// 		let lock_height = self.header.height + global::coinbase_maturity();
-	// 		if lock_height > height {
-	// 			Err(Error::ImmatureCoinbase{
-	// 				height: height,
-	// 				lock_height: lock_height,
-	// 			})
-	// 		} else {
-	// 			Ok(())
-	// 		}
-	// 	} else {
-	// 		Err(Error::Other(format!("output not found in block")))
-	// 	}
-	// }
-
 	/// Builds the blinded output and related signature proof for the block reward.
 	pub fn reward_output(
 		keychain: &keychain::Keychain,

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -29,6 +29,7 @@ use util::{secp, kernel_sig_msg};
 
 use core::{Transaction, TxKernel, Input, Output, OutputFeatures, SwitchCommitHash};
 use core::hash::Hash;
+use core::pmmr::MerkleProof;
 use keychain;
 use keychain::{Keychain, BlindSum, BlindingFactor, Identifier};
 use util::LOGGER;
@@ -47,7 +48,8 @@ pub type Append = for<'a> Fn(&'a mut Context, (Transaction, TxKernel, BlindSum))
 fn build_input(
 	value: u64,
 	features: OutputFeatures,
-	out_block: Option<Hash>,
+	block_hash: Option<Hash>,
+	merkle_proof: Option<MerkleProof>,
 	key_id: Identifier,
 ) -> Box<Append> {
 	Box::new(move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
@@ -55,7 +57,8 @@ fn build_input(
 		let input = Input::new(
 			features,
 			commit,
-			out_block,
+			block_hash.clone(),
+			merkle_proof.clone(),
 		);
 		(tx.with_input(input), kern, sum.sub_key_id(key_id.clone()))
 	})
@@ -65,22 +68,22 @@ fn build_input(
 /// being built.
 pub fn input(
 	value: u64,
-	out_block: Hash,
 	key_id: Identifier,
 ) -> Box<Append> {
 	debug!(LOGGER, "Building input (spending regular output): {}, {}", value, key_id);
-	build_input(value, OutputFeatures::DEFAULT_OUTPUT, Some(out_block), key_id)
+	build_input(value, OutputFeatures::DEFAULT_OUTPUT, None, None, key_id)
 }
 
 /// Adds a coinbase input spending a coinbase output.
 /// We will use the block hash to verify coinbase maturity.
 pub fn coinbase_input(
 	value: u64,
-	out_block: Hash,
+	block_hash: Hash,
+	merkle_proof: MerkleProof,
 	key_id: Identifier,
 ) -> Box<Append> {
 	debug!(LOGGER, "Building input (spending coinbase): {}, {}", value, key_id);
-	build_input(value, OutputFeatures::COINBASE_OUTPUT, Some(out_block), key_id)
+	build_input(value, OutputFeatures::COINBASE_OUTPUT, Some(block_hash), Some(merkle_proof), key_id)
 }
 
 /// Adds an output with the provided value and key identifier from the
@@ -268,8 +271,8 @@ mod test {
 
 		let tx = transaction(
 			vec![
-				input(10, ZERO_HASH, key_id1),
-				input(12, ZERO_HASH, key_id2),
+				input(10, key_id1),
+				input(12, key_id2),
 				output(20, key_id3),
 				with_fee(2),
 			],
@@ -288,8 +291,8 @@ mod test {
 
 		let tx = transaction_with_offset(
 			vec![
-				input(10, ZERO_HASH, key_id1),
-				input(12, ZERO_HASH, key_id2),
+				input(10, key_id1),
+				input(12, key_id2),
 				output(20, key_id3),
 				with_fee(2),
 			],
@@ -306,7 +309,7 @@ mod test {
 		let key_id2 = keychain.derive_key_id(2).unwrap();
 
 		let tx = transaction(
-			vec![input(6, ZERO_HASH, key_id1), output(2, key_id2), with_fee(4)],
+			vec![input(6, key_id1), output(2, key_id2), with_fee(4)],
 			&keychain,
 		).unwrap();
 

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -250,7 +250,7 @@ mod test {
 		// blinding should fail as signing with a zero r*G shouldn't work
 		build::transaction(
 			vec![
-				input(10, ZERO_HASH, key_id1.clone()),
+				input(10, key_id1.clone()),
 				output(9, key_id1.clone()),
 				with_fee(1),
 			],
@@ -312,7 +312,7 @@ mod test {
 		// first build a valid tx with corresponding blinding factor
 		let tx = build::transaction(
 			vec![
-				input(10, ZERO_HASH, key_id1),
+				input(10, key_id1),
 				output(5, key_id2),
 				output(3, key_id3),
 				with_fee(2),
@@ -376,7 +376,7 @@ mod test {
 
 		let tx = build::transaction(
 			vec![
-				input(75, ZERO_HASH, key_id1),
+				input(75, key_id1),
 				output(42, key_id2),
 				output(32, key_id3),
 				with_fee(1),
@@ -485,7 +485,7 @@ mod test {
 		let (tx_alice, blind_sum) = {
 			// Alice gets 2 of her pre-existing outputs to send 5 coins to Bob, they
 			// become inputs in the new transaction
-			let (in1, in2) = (input(4, ZERO_HASH, key_id1), input(3, ZERO_HASH, key_id2));
+			let (in1, in2) = (input(4, key_id1), input(3, key_id2));
 
 			// Alice builds her transaction, with change, which also produces the sum
 			// of blinding factors before they're obscured.
@@ -576,7 +576,7 @@ mod test {
 		// and that the resulting block is valid
 		let tx1 = build::transaction(
 			vec![
-				input(5, ZERO_HASH, key_id1.clone()),
+				input(5, key_id1.clone()),
 				output(3, key_id2.clone()),
 				with_fee(2),
 				with_lock_height(1),
@@ -596,7 +596,7 @@ mod test {
 		// now try adding a timelocked tx where lock height is greater than current block height
 		let tx1 = build::transaction(
 			vec![
-				input(5, ZERO_HASH, key_id1.clone()),
+				input(5, key_id1.clone()),
 				output(3, key_id2.clone()),
 				with_fee(2),
 				with_lock_height(2),
@@ -640,8 +640,8 @@ mod test {
 
 		build::transaction_with_offset(
 			vec![
-				input(10, ZERO_HASH, key_id1),
-				input(11, ZERO_HASH, key_id2),
+				input(10, key_id1),
+				input(11, key_id2),
 				output(19, key_id3),
 				with_fee(2),
 			],
@@ -656,7 +656,7 @@ mod test {
 		let key_id2 = keychain.derive_key_id(2).unwrap();
 
 		build::transaction_with_offset(
-			vec![input(5, ZERO_HASH, key_id1), output(3, key_id2), with_fee(2)],
+			vec![input(5, key_id1), output(3, key_id2), with_fee(2)],
 			&keychain,
 		).unwrap()
 	}
@@ -672,7 +672,7 @@ mod test {
 
 		build::transaction_with_offset(
 			vec![
-				input(6, ZERO_HASH, key_id1),
+				input(6, key_id1),
 				output(3, key_id2),
 				output(1, key_id3),
 				with_fee(2),

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -41,6 +41,7 @@ use std::ops::{self, Deref};
 
 use core::hash::{Hash, Hashed};
 use ser::{self, Readable, Reader, Writeable, Writer};
+use util;
 use util::LOGGER;
 
 /// Trait for an element of the tree that has a well-defined sum and hash that
@@ -286,6 +287,19 @@ impl MerkleProof {
 			path: vec![],
 			left_right: vec![],
 		}
+	}
+
+	pub fn to_hex(&self) -> String {
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, &self).expect("serialization failed");
+		util::to_hex(vec)
+	}
+
+	pub fn from_hex(hex: &str) -> Result<MerkleProof, String> {
+		let bytes = util::from_hex(hex.to_string()).unwrap();
+		let res = ser::deserialize(&mut &bytes[..])
+			.map_err(|_| format!("failed to deserialize a Merkle Proof"))?;
+		Ok(res)
 	}
 
 	pub fn verify(&self) -> bool {

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -984,6 +984,33 @@ mod test {
 		assert_eq!(peaks(32), [31, 32]);
 		assert_eq!(peaks(35), [31, 34, 35]);
 		assert_eq!(peaks(42), [31, 38, 41, 42]);
+
+		// large realistic example with almost 1.5 million nodes
+		// note the distance between peaks decreases toward the right (trees get smaller)
+		assert_eq!(
+			peaks(1048555),
+			[
+				524287,
+				786430,
+				917501,
+				983036,
+				1015803,
+				1032186,
+				1040377,
+				1044472,
+				1046519,
+				1047542,
+				1048053,
+				1048308,
+				1048435,
+				1048498,
+				1048529,
+				1048544,
+				1048551,
+				1048554,
+				1048555,
+			],
+		);
 	}
 
 	#[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -1202,6 +1202,12 @@ mod test {
 	}
 
 	#[test]
+	fn empty_merkle_proof() {
+		let proof = MerkleProof::empty();
+		assert_eq!(proof.verify(), false);
+	}
+
+	#[test]
 	fn pmmr_merkle_proof() {
 		// 0 0 1 0 0 1 2 0 0 1 0 0 1 2 3
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -552,7 +552,7 @@ impl PoolToChainAdapter {
 }
 
 impl pool::BlockChain for PoolToChainAdapter {
-	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<(), pool::PoolError> {
+	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<Hash, pool::PoolError> {
 		wo(&self.chain)
 			.is_unspent(output_ref)
 			.map_err(|e| match e {

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -106,9 +106,9 @@ impl DummyChainImpl {
 }
 
 impl BlockChain for DummyChainImpl {
-	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<(), PoolError> {
+	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<hash::Hash, PoolError> {
 		match self.utxo.read().unwrap().get_output(&output_ref.commit) {
-			Some(_) => Ok(()),
+			Some(_) => Ok(hash::Hash::zero()),
 			None => Err(PoolError::GenericPoolError),
 		}
 	}
@@ -117,7 +117,7 @@ impl BlockChain for DummyChainImpl {
 		if !input.features.contains(OutputFeatures::COINBASE_OUTPUT) {
 			return Ok(());
 		}
-		let block_hash = input.out_block.expect("requires a block hash");
+		let block_hash = input.block_hash.expect("requires a block hash");
 		let headers = self.block_headers.read().unwrap();
 		if let Some(h) = headers
 			.iter()

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -1276,7 +1276,7 @@ mod tests {
 
 		for input_value in input_values {
 			let key_id = keychain.derive_key_id(input_value as u32).unwrap();
-			tx_elements.push(build::input(input_value, ZERO_HASH, key_id));
+			tx_elements.push(build::input(input_value, key_id));
 		}
 
 		for output_value in output_values {
@@ -1334,7 +1334,7 @@ mod tests {
 
 		for input_value in input_values {
 			let key_id = keychain.derive_key_id(input_value as u32).unwrap();
-			tx_elements.push(build::input(input_value, ZERO_HASH, key_id));
+			tx_elements.push(build::input(input_value, key_id));
 		}
 
 		for output_value in output_values {

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -155,7 +155,7 @@ pub trait BlockChain {
 	/// orphans, etc.
 	/// We do not maintain outputs themselves. The only information we have is the
 	/// hash from the output MMR.
-	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<(), PoolError>;
+	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<hash::Hash, PoolError>;
 
 	/// Check if an output being spent by the input has sufficiently matured.
 	/// This is only applicable for coinbase outputs (1,000 blocks).

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -112,14 +112,15 @@ fn refresh_missing_block_hashes(config: &WalletConfig, keychain: &Keychain) -> R
 	debug!(LOGGER, "{:?}", url);
 
 	let mut api_blocks: HashMap<pedersen::Commitment, api::BlockHeaderInfo> = HashMap::new();
-	let mut api_merkle_proofs: HashMap<pedersen::Commitment, MerkleProof> = HashMap::new();
+	let mut api_merkle_proofs: HashMap<pedersen::Commitment, MerkleProofWrapper> = HashMap::new();
 	match api::client::get::<Vec<api::BlockOutputs>>(url.as_str()) {
 		Ok(blocks) => {
 			for block in blocks {
 				for out in block.outputs {
 					api_blocks.insert(out.commit, block.header.clone());
 					if let Some(merkle_proof) = out.merkle_proof {
-						api_merkle_proofs.insert(out.commit, merkle_proof);
+						let wrapper = MerkleProofWrapper(merkle_proof);
+						api_merkle_proofs.insert(out.commit, wrapper);
 					}
 				}
 			}
@@ -141,7 +142,7 @@ fn refresh_missing_block_hashes(config: &WalletConfig, keychain: &Keychain) -> R
 			if let Entry::Occupied(mut output) = wallet_data.outputs.entry(id.to_hex()) {
 				if let Some(b) = api_blocks.get(&commit) {
 					let output = output.get_mut();
-					output.block = Some(BlockIdentifier::from_str(&b.hash).unwrap());
+					output.block = Some(BlockIdentifier::from_hex(&b.hash).unwrap());
 					output.height = b.height;
 					if let Some(merkle_proof) = api_merkle_proofs.get(&commit) {
 						output.merkle_proof = Some(merkle_proof.clone());

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -97,7 +97,8 @@ fn handle_sender_initiation(
 			height: 0,
 			lock_height: 0,
 			is_coinbase: false,
-			block: BlockIdentifier::zero(),
+			block: None,
+			merkle_proof: None,
 		});
 
 		key_id
@@ -321,7 +322,8 @@ pub fn receive_coinbase(
 			height: height,
 			lock_height: lock_height,
 			is_coinbase: true,
-			block: BlockIdentifier::zero(),
+			block: None,
+			merkle_proof: None,
 		});
 
 		(key_id, derivation)
@@ -403,7 +405,8 @@ fn build_final_transaction(
 			height: 0,
 			lock_height: 0,
 			is_coinbase: false,
-			block: BlockIdentifier::zero(),
+			block: None,
+			merkle_proof: None,
 		});
 
 		(key_id, derivation)

--- a/wallet/src/restore.rs
+++ b/wallet/src/restore.rs
@@ -315,7 +315,8 @@ pub fn restore(
 							height: output.4,
 							lock_height: output.5,
 							is_coinbase: output.6,
-							block: BlockIdentifier::zero(),
+							block: None,
+							merkle_proof: None,
 						});
 					};
 				}

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -333,11 +333,13 @@ fn inputs_and_change(
 		if coin.is_coinbase {
 			let block = coin.block.clone();
 			let merkle_proof = coin.merkle_proof.clone();
+			let merkle_proof = merkle_proof.unwrap().merkle_proof();
+
 			// TODO - we need a Merkle Proof here to spend a coinbase output
 			parts.push(build::coinbase_input(
 				coin.value,
 				block.unwrap().hash(),
-				merkle_proof.unwrap(),
+				merkle_proof,
 				key_id,
 			));
 		} else {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -234,6 +234,52 @@ impl fmt::Display for OutputStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub struct MerkleProofWrapper(pub MerkleProof);
+
+impl MerkleProofWrapper {
+	pub fn merkle_proof(&self) -> MerkleProof {
+		self.0.clone()
+	}
+}
+
+impl serde::ser::Serialize for MerkleProofWrapper {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::ser::Serializer,
+	{
+		serializer.serialize_str(&self.0.to_hex())
+	}
+}
+
+impl<'de> serde::de::Deserialize<'de> for MerkleProofWrapper {
+	fn deserialize<D>(deserializer: D) -> Result<MerkleProofWrapper, D::Error>
+	where
+		D: serde::de::Deserializer<'de>,
+	{
+		deserializer.deserialize_str(MerkleProofWrapperVisitor)
+	}
+}
+
+struct MerkleProofWrapperVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MerkleProofWrapperVisitor {
+	type Value = MerkleProofWrapper;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str("a merkle proof")
+	}
+
+	fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+	where
+		E: serde::de::Error,
+	{
+		let merkle_proof = MerkleProof::from_hex(s).unwrap();
+		Ok(MerkleProofWrapper(merkle_proof))
+	}
+}
+
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct BlockIdentifier(Hash);
 
 impl BlockIdentifier {
@@ -241,7 +287,7 @@ impl BlockIdentifier {
 		self.0
 	}
 
-	pub fn from_str(hex: &str) -> Result<BlockIdentifier, Error> {
+	pub fn from_hex(hex: &str) -> Result<BlockIdentifier, Error> {
 		let hash = Hash::from_hex(hex)?;
 		Ok(BlockIdentifier(hash))
 	}
@@ -310,7 +356,7 @@ pub struct OutputData {
 	pub is_coinbase: bool,
 	/// Hash of the block this output originated from.
 	pub block: Option<BlockIdentifier>,
-	pub merkle_proof: Option<MerkleProof>,
+	pub merkle_proof: Option<MerkleProofWrapper>,
 }
 
 impl OutputData {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -36,6 +36,7 @@ use api;
 use core::consensus;
 use core::core::{transaction, Transaction};
 use core::core::hash::Hash;
+use core::core::pmmr::MerkleProof;
 use core::ser;
 use keychain;
 use keychain::BlindingFactor;
@@ -308,7 +309,8 @@ pub struct OutputData {
 	/// Is this a coinbase output? Is it subject to coinbase locktime?
 	pub is_coinbase: bool,
 	/// Hash of the block this output originated from.
-	pub block: BlockIdentifier,
+	pub block: Option<BlockIdentifier>,
+	pub merkle_proof: Option<MerkleProof>,
 }
 
 impl OutputData {


### PR DESCRIPTION
Merkle Proofs will let us spend timelocked Coinbase outputs without having access to the full block in the store.

Add `family_branch()` to PMMR to recursively call `family()` up the branch.
This gives us `pos` of each sibling.

TODO (coinbase maturity)
- [x] ser/deser merkle proof as hex (in api and wallet.dat)
- [ ] kernel file rewind appears to not be working as expected?
- [ ] cleanup code - block coinbase maturity still commented out

TODO (low level merkle proof creation)
- [x] we hit a peak traversing the branch, then we need to get to the root somehow (via `peaks()`?)
- [x] actually get the hashes to build the proof
- [x] actually build the proof
- [x] more robust code
- [x] better test coverage
- [x] serialization/deserialization of Merkle Proofs

-----------------

So a Merkle Proof for a MMR looks something like the following - 
* list of hashes that make up the "peaks" (when aggregated matches the root itself)
* hash of each sibling traversing the branch from the node in question up to its associated peak
  * some indicator of left/right for each sibling (order matters)

i.e. we prove the node is under a given peak and that the peak itself is part of the full tree under the root.

