### PR TITLE
archive_mode is optional in grin.toml

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -42,13 +42,15 @@ db_root = ".grin"
 #
 chain_type = "Testnet1"
 
+#run the node in "full archive" mode (default is fast-sync, pruned node)
+#archive_mode = false
+
 #7 = Bit flags for FULL_NODE, this structure needs to be changed
 #internally to make it more configurable
-
 capabilities = [7]
 
 #skip waiting for sync on startup, (optional param, mostly for testing)
-#skip_sync_wait = true
+#skip_sync_wait = false
 
 #The P2P server details (i.e. the server that communicates with other
 #grin server nodes

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -140,6 +140,15 @@ impl Server {
 				p2p_server.clone(), config.capabilities, seeder, stop.clone());
 		}
 
+		// Defaults to None (optional) in config file.
+		// This translates to false here.
+		let archive_mode = match config.archive_mode {
+			None => false,
+			Some(b) => b,
+		};
+
+		// Defaults to None (optional) in config file.
+		// This translates to false here so we do not skip by default.
 		let skip_sync_wait = match config.skip_sync_wait {
 			None => false,
 			Some(b) => b,
@@ -150,7 +159,7 @@ impl Server {
 			p2p_server.peers.clone(),
 			shared_chain.clone(),
 			skip_sync_wait,
-			!config.archive_mode,
+			!archive_mode,
 			stop.clone(),
 		);
 

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -117,7 +117,7 @@ pub struct ServerConfig {
 	pub chain_type: ChainTypes,
 
 	/// Whether this node is a full archival node or a fast-sync, pruned node
-	pub archive_mode: bool,
+	pub archive_mode: Option<bool>,
 
 	/// Method used to get the list of seed nodes for initial bootstrap.
 	#[serde(default)]
@@ -158,9 +158,9 @@ impl Default for ServerConfig {
 			p2p_config: p2p::P2PConfig::default(),
 			mining_config: Some(pow::types::MinerConfig::default()),
 			chain_type: ChainTypes::default(),
-			archive_mode: false,
+			archive_mode: None,
 			pool_config: pool::PoolConfig::default(),
-			skip_sync_wait: Some(true),
+			skip_sync_wait: None,
 		}
 	}
 }

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -269,7 +269,7 @@ fn simulate_fast_sync() {
 	thread::sleep(time::Duration::from_secs(8));
 
 	let mut conf = config(1001, "grin-fast");
-	conf.archive_mode = false;
+	conf.archive_mode = Some(false);
 	conf.seeds = Some(vec!["127.0.0.1:12000".to_string()]);
 	let s2 = grin::Server::new(conf).unwrap();
 	while s2.head().height != s2.header_head().height || s2.head().height < 20 {
@@ -294,7 +294,7 @@ fn simulate_fast_sync_double() {
 
 	{
 		let mut conf = config(1001, "grin-double-fast2");
-		conf.archive_mode = false;
+		conf.archive_mode = Some(false);
 		conf.seeds = Some(vec!["127.0.0.1:12000".to_string()]);
 		let s2 = grin::Server::new(conf).unwrap();
 		while s2.head().height != s2.header_head().height || s2.head().height < 20 {
@@ -308,7 +308,7 @@ fn simulate_fast_sync_double() {
 	thread::sleep(time::Duration::from_secs(20));
 
 	let mut conf = config(1001, "grin-double-fast2");
-	conf.archive_mode = false;
+	conf.archive_mode = Some(false);
 	conf.seeds = Some(vec!["127.0.0.1:12000".to_string()]);
 	let s2 = grin::Server::new(conf).unwrap();
 	while s2.head().height != s2.header_head().height || s2.head().height < 50 {
@@ -327,7 +327,7 @@ fn config(n: u16, test_name_dir: &str) -> grin::ServerConfig {
 		seeding_type: grin::Seeding::List,
 		seeds: Some(vec!["127.0.0.1:11000".to_string()]),
 		chain_type: core::global::ChainTypes::AutomatedTesting,
-		archive_mode: true,
+		archive_mode: Some(true),
 		skip_sync_wait: Some(true),
 		..Default::default()
 	}


### PR DESCRIPTION
Failing to start if this config was missing from grin.toml - 

```
thread 'main' panicked at 'Error parsing config file: Error parsing configuration file at 
/antiochp/grin/node1/grin.toml - missing field `archive_mode` for key `server`', 
/antiochp/grin/src/bin/grin.rs:83:2
```

* default to None in grin.toml (optional config, defaults to false when parsing config)
* add example config in grin.toml

