### PR TITLE
Bulletproofs

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -1062,9 +1062,13 @@ mod test {
 		let b = new_block(vec![], &keychain);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 1_256,
+			false => 5_708,
+		};
 		assert_eq!(
 			vec.len(),
-			5_708,
+			target_len,
 		);
 	}
 
@@ -1075,9 +1079,13 @@ mod test {
 		let b = new_block(vec![&tx1], &keychain);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 2_900,
+			false => 16_256,
+		};
 		assert_eq!(
 			vec.len(),
-			16_256,
+			target_len,
 		);
 	}
 
@@ -1087,9 +1095,13 @@ mod test {
 		let b = new_block(vec![], &keychain);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 1_264,
+			false => 5_716,
+		};
 		assert_eq!(
 			vec.len(),
-			5_716,
+			target_len,
 		);
 	}
 
@@ -1100,9 +1112,13 @@ mod test {
 		let b = new_block(vec![&tx1], &keychain);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 1_270,
+			false => 5_722,
+		};
 		assert_eq!(
 			vec.len(),
-			5_722,
+			target_len,
 		);
 	}
 
@@ -1122,9 +1138,13 @@ mod test {
 		);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 17696,
+			false => 111188,
+		};
 		assert_eq!(
 			vec.len(),
-			111_188,
+			target_len,
 		);
 	}
 
@@ -1144,9 +1164,13 @@ mod test {
 		);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 1_324,
+			false => 5_776,
+		};
 		assert_eq!(
 			vec.len(),
-			5_776,
+			target_len,
 		);
 	}
 

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -263,9 +263,13 @@ mod test {
 		let tx = tx2i1o();
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &tx).expect("serialization failed");
+		let target_len = match Keychain::is_using_bullet_proofs() {
+			true => 986,
+			false => 5_438,
+		};
 		assert_eq!(
 			vec.len(),
-			5_438,
+			target_len,
 		);
 	}
 
@@ -389,6 +393,12 @@ mod test {
 	fn blind_tx() {
 		let btx = tx2i1o();
 		assert!(btx.validate().is_ok());
+
+	// Ignored for bullet proofs, info doesn't exist yet and calling range_proof_info
+	// with a bullet proof causes painful errors
+	if Keychain::is_using_bullet_proofs() {
+		return;
+	}
 
 		// checks that the range proof on our blind output is sufficiently hiding
 		let Output { proof, .. } = btx.outputs[0];

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -92,6 +92,8 @@ pub enum Error {
 	LockHeight(u64),
 	/// Error originating from an invalid switch commitment (coinbase lock_height related)
 	SwitchCommitment,
+	/// Range proof validation error
+	RangeProof,
 }
 
 impl From<secp::Error> for Error {
@@ -731,8 +733,11 @@ impl Output {
 	pub fn verify_proof(&self) -> Result<(), secp::Error> {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
-		secp.verify_range_proof(self.commit, self.proof).map(|_| ())
-	}
+		match Keychain::verify_range_proof(&secp, self.commit, self.proof){
+			Ok(_) => Ok(()),
+			Err(e) => Err(e),
+		}
+}
 
 	/// Given the original blinding factor we can recover the
 	/// value from the range proof and the commitment
@@ -1071,8 +1076,14 @@ mod test {
 		};
 
 		// check we can successfully recover the value with the original blinding factor
-		let recovered_value = output.recover_value(&keychain, &key_id).unwrap();
-		assert_eq!(recovered_value, 1003);
+		let result = output.recover_value(&keychain, &key_id);
+		// TODO: Remove this check once value recovery is supported within bullet proofs
+		if let Some(v) = result {
+			assert_eq!(v, 1003);
+		} else {
+			return;
+		}
+		
 
 		// check we cannot recover the value without the original blinding factor
 		let key_id2 = keychain.derive_key_id(2).unwrap();

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -3,6 +3,12 @@ name = "grin_keychain"
 version = "0.1.0"
 authors = ["Antioch Peverell"]
 
+[features]
+#remove this feature to use older-style rangeproofs
+#(this flag will disappear in future releases)
+default = ["use-bullet-proofs"]
+use-bullet-proofs = []
+
 [dependencies]
 byteorder = "^1.0"
 blake2-rfc = "~0.2.17"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "^1.0"
 rand = "^0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
-secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_7" }
+secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp", tag="grin_integration_8" }
 #secp256k1zkp = { path = "../../rust-secp256k1-zkp" }
 walkdir = "^2.0.1"
 zip = "^0.2.6"


### PR DESCRIPTION
This integrates bulletproofs into Grin via an update to our libsecp256k fork. A couple of notes:

* Refactored a direct secp call or two into Keychain to ensure changes are localised.
* No real need to rename anything or create any new rangeproof structures... a Bulletproof is simply an instance of a Rangeproof, so whether bulletproofs or 'classic' are being used is an implementation detail
* I've inserted a build flag into keychain/Cargo.toml to compile with either bullet proofs or traditional range proofs. I've done it this way so as to still allow development on the wallet if needed (and in case of early disasters,) but bulletproofs are enabled by default.
* Bulletproof unwinding and hence wallet recovery won't work if bulletproofs are enabled... will open a separate issue for this.

That aside, revel in how much smaller everything should become!