### PR TITLE
Typo block/transaction in logs

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -309,7 +309,7 @@ impl Peers {
 			let p = p.read().unwrap();
 			if p.is_connected() {
 				if let Err(e) = p.send_transaction(tx) {
-					debug!(LOGGER, "Error sending block to peer: {:?}", e);
+					debug!(LOGGER, "Error sending transaction to peer: {:?}", e);
 				}
 			}
 		}


### PR DESCRIPTION
Just a small typo mixing up block/transaction in logs.