### PR TITLE
[DNM] prune a PMMR and we cannot construct a Merkle proof (minimal example)

### DIFF
--- a/store/tests/sumtree.rs
+++ b/store/tests/sumtree.rs
@@ -23,6 +23,53 @@ use core::ser::*;
 use core::core::pmmr::{Backend, HashSum, Summable, PMMR};
 use core::core::hash::Hashed;
 
+
+#[test]
+fn sumtree_merkle_proof_problems() {
+	let (data_dir, elems) = setup("merkle_proof_problems");
+	let mut backend = store::sumtree::PMMRBackend::new(data_dir.to_string()).unwrap();
+
+	load(0, &elems[0..1], &mut backend);
+
+	println!("");
+	println!("MMR with a single leaf node");
+	{
+		let pmmr = PMMR::at(&mut backend, 1);
+		println!("pos 1 - {:?}", pmmr.get(1));
+		println!("root - {:?}", pmmr.root());
+	}
+
+	load(1, &elems[1..2], &mut backend);
+
+	println!("");
+	println!("MMR with 2 leaf nodes (root built from single peak)");
+	{
+		let pmmr = PMMR::at(&mut backend, 3);
+		println!("pos 1 - {:?}", pmmr.get(1));
+		println!("pos 2 - {:?}", pmmr.get(2));
+		println!("pos 3 - {:?} (peak)", pmmr.get(3));
+		println!("root - {:?}", pmmr.root());
+	}
+
+	{
+		let mut pmmr = PMMR::at(&mut backend, 3);
+		pmmr.prune(1, 1).unwrap();
+	}
+
+	println!("");
+	println!("After pruning pos 1");
+	{
+		let pmmr = PMMR::at(&mut backend, 3);
+		println!("pos 1 - {:?}", pmmr.get(1));
+		println!("pos 2 - {:?}", pmmr.get(2));
+		println!("pos 3 - {:?} (peak)", pmmr.get(3));
+		println!("root - {:?}", pmmr.root());
+	}
+
+	println!("");
+	assert!(false);
+}
+
 #[test]
 fn sumtree_append() {
 	let (data_dir, elems) = setup("append");


### PR DESCRIPTION
I _think_ this shows the problem I am seeing when trying to generate Merkle proofs for some outputs.

This is a very simple example.
* initialize empty PMMR backend
* add a single element to the PMMR
  * show the hash matches the root hash (single node)
* add a 2nd element to the PMMR
  * show these hash together to give the peak at pos 3
  * show the root matches this single peak
* prune the element at pos 1
  * the peak and the root are unaffected by this pruning operation
  * but we do not have enough information to build the Merkle proof for pos 2, given just pos 2 and pos 3

The problem is how do we show inclusion of the element at pos 2 under the peak at pos 3?
There is no "sibling hash" that we can use as part of the branch to show inclusion of pos 2 under pos 3.

```
---- sumtree_merkle_proof_problems stdout ----

MMR with a single leaf node
pos 1 - Some(HashSum { hash: 213d8607, sum: 1 })
root - HashSum { hash: 213d8607, sum: 1 }

MMR with 2 leaf nodes (root built from single peak)
pos 1 - Some(HashSum { hash: 213d8607, sum: 1 })
pos 2 - Some(HashSum { hash: 3e02a5b8, sum: 2 })
pos 3 - Some(HashSum { hash: 8b4382e2, sum: 3 }) (peak)
root - HashSum { hash: 8b4382e2, sum: 3 }

After pruning pos 1
pos 1 - None
pos 2 - Some(HashSum { hash: 3e02a5b8, sum: 2 })
pos 3 - Some(HashSum { hash: 8b4382e2, sum: 3 }) (peak)
root - HashSum { hash: 8b4382e2, sum: 3 }
```
