### PR TITLE
fix the broken compact block hashing behavior

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -20,6 +20,7 @@ use core::core::SwitchCommitHash;
 use chain;
 use p2p;
 use util;
+use util::LOGGER;
 use util::secp::pedersen;
 use util::secp::constants::MAX_PROOF_SIZE;
 use serde;

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -717,7 +717,7 @@ impl Writeable for Output {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		writer.write_u8(self.features.bits())?;
 		writer.write_fixed_bytes(&self.commit)?;
-		// Hash of an output doesn't cover the switch commit, it should 
+		// Hash of an output doesn't cover the switch commit, it should
 		// be wound into the range proof separately
 		if writer.serialization_mode() != ser::SerializationMode::Hash {
 			writer.write_fixed_bytes(&self.switch_commit_hash)?;
@@ -921,13 +921,13 @@ impl Readable for OutputStoreable {
 			features: features,
 		})
 	}
-} 
+}
 
 /// A structure which contains fields that are to be commited to within
-/// an Output's range (bullet) proof. 
+/// an Output's range (bullet) proof.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProofMessageElements {
-	/// The amount, stored to allow for wallet reconstruction as 
+	/// The amount, stored to allow for wallet reconstruction as
 	/// rewinding isn't supported in bulletproofs just yet
 	pub value: u64,
 }
@@ -1120,8 +1120,10 @@ fn input_short_id() {
 		"3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673",
 	).unwrap();
 
-	let short_id = input.short_id(&block_hash);
-	assert_eq!(short_id, ShortId::from_hex("3e1262905b7a").unwrap());
+	let nonce = 0;
+
+	let short_id = input.short_id(&block_hash, nonce);
+	assert_eq!(short_id, ShortId::from_hex("28fea5a693af").unwrap());
 
 	// now generate the short_id for a *very* similar output (single feature flag different)
 	// and check it generates a different short_id
@@ -1135,7 +1137,7 @@ fn input_short_id() {
 		"3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673",
 	).unwrap();
 
-	let short_id = input.short_id(&block_hash);
-	assert_eq!(short_id, ShortId::from_hex("90653c1c870a").unwrap());
+	let short_id = input.short_id(&block_hash, nonce);
+	assert_eq!(short_id, ShortId::from_hex("c8af83b54e46").unwrap());
 }
 }

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -84,7 +84,7 @@ where
 		for tx in self.transactions.values() {
 			for kernel in &tx.kernels {
 				// rehash each kernel to calculate the block specific short_id
-				let short_id = kernel.short_id(&cb.hash());
+				let short_id = kernel.short_id(&cb.hash(), cb.nonce);
 
 				// if any kernel matches then keep the tx for later
 				if cb.kern_ids.contains(&short_id) {


### PR DESCRIPTION
We were including the nonce (needed for the short_id) in the hash of the compact block.
But this was breaking block hashes as it needs to be based on the block header only.

We now pass the nonce in explicitly when generating short_ids to make this clearer.

This was causing a non-obvious error in grin_grin tests where a block appeared to not be found when asking for it in compact format via the api.

