### PR TITLE
rustfmt now runs and reformats files (need to opt out explicitly)

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 The Grin Developers
+# Copyright 2018 The Grin Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cargo +nightly fmt -- --version &>/dev/null
+rustfmt --version &>/dev/null
 if [ $? != 0 ]; then
-	printf "[pre_commit] \033[0;31merror\033[0m: \"cargo +nightly fmt\" not available?\n"
+	printf "[pre_commit] \033[0;31merror\033[0m: \"rustfmt\" not available. \n"
+	printf "[pre_commit] \033[0;31merror\033[0m: rustfmt can be installed via - \n"
+	printf "[pre_commit] $ rustup component add rustfmt-preview \n"
 	exit 1
 fi
 
@@ -24,9 +26,11 @@ result=0
 problem_files=()
 
 printf "[pre_commit] rustfmt "
+
 for file in $(git diff --name-only --cached); do
 	if [ ${file: -3} == ".rs" ]; then
-		cargo +nightly fmt -- --skip-children --write-mode=diff $file &>/dev/null
+		# first collect all the files that need reformatting
+		rustfmt --skip-children --write-mode=diff $file &>/dev/null
 		if [ $? != 0 ]; then
 			problem_files+=($file)
 			result=1
@@ -34,15 +38,20 @@ for file in $(git diff --name-only --cached); do
 	fi
 done
 
+# now reformat all the files that need reformatting
+for file in ${problem_files[@]}; do
+	rustfmt --skip-children --write-mode=overwrite $file
+done
+
+# and let the user know what just happened (and which files were affected)
+printf "\033[0;32mok\033[0m \n"
 if [ $result != 0 ]; then
-	printf "\033[0;31mfail\033[0m \n"
-	printf "[pre_commit] the following files need formatting: \n"
+	# printf "\033[0;31mrustfmt\033[0m \n"
+	printf "[pre_commit] the following files were rustfmt'd (not yet committed): \n"
 
 	for file in ${problem_files[@]}; do
-		printf "    cargo +nightly fmt -- $file\n"
+		printf "\033[0;31m    $file\033[0m \n"
 	done
-else
-	printf "\033[0;32mok\033[0m \n"
 fi
 
 exit 0


### PR DESCRIPTION
*** DO NOT MERGE UNTIL THE WEEKEND *** RUN RUSTFMT GLOBALLY FIRST ***

rustfmt is now available as preview (not just nightly) - https://blog.rust-lang.org/2018/02/15/Rust-1.24.html

This PR is to open up our semi-regular (and no doubt contentious) discussion around "do we want to make this opt-out rather than opt-in which we have currently".

Technically this is still opt-in as you need to enable the pre_commit hook.

But once enabled - the hook will do the following - 

* check any files being committed
* for any files that need reformatting - 
    * actually reformat them
    * notify the user of the list of affected files
    * (does not commit them, leaves them unstaged)
* the user will then need to make a conscious decision - 
    * `git add` and `git commit` to clean this up (easiest choice to make)
    * or revert any local changes to avoid reformatting (potentially appropriate in some circumstances)

Rustfmt docs are here - 
https://github.com/rust-lang-nursery/rustfmt


To (re)install rustfmt (via rustup component add) - 
* remove any existing rustfmt install
* `rustup component add rustfmt-preview`



---------------
Example output when file(s) are reformatted - 

<img width="486" alt="screen shot 2018-03-02 at 12 57 54 pm" src="https://user-images.githubusercontent.com/30642645/36913928-77769b96-1e19-11e8-83a9-63060a162091.png">
