### PR TITLE
cannot use write_mode in rustfmt.toml in stable (get rid of the warnings)

### DIFF
--- a/api/rustfmt.toml
+++ b/api/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/chain/rustfmt.toml
+++ b/chain/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/core/rustfmt.toml
+++ b/core/rustfmt.toml
@@ -1,4 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-comment_width = 120 # we have some long urls in comments
-write_mode = "Overwrite"

--- a/grin/rustfmt.toml
+++ b/grin/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/keychain/rustfmt.toml
+++ b/keychain/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/p2p/rustfmt.toml
+++ b/p2p/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/pool/rustfmt.toml
+++ b/pool/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/store/rustfmt.toml
+++ b/store/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"

--- a/wallet/rustfmt.toml
+++ b/wallet/rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 wrap_comments = true
-write_mode = "Overwrite"


### PR DESCRIPTION
`write_mode` is not in stable (and we pass it explicitly via the git hook)
`comment_width` is also not in stable

Seems like we can opt-in via `unstable_features = true` if we _want_ to do this but getting rid of it for now. We can put it back if this causes issues.