### PR TITLE
change to bulletproof interface to separate nonce from blind in unwind

### DIFF
--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -285,7 +285,7 @@ impl Keychain {
 	) -> Result<ProofInfo, Error> {
 		let nonce = self.derived_key(key_id)?;
 		let proof_message = self.secp
-			.unwind_bullet_proof(commit, nonce, extra_data, proof);
+			.unwind_bullet_proof(commit, nonce, nonce, extra_data, proof);
 		let proof_info = match proof_message {
 			Ok(p) => ProofInfo {
 				success: true,

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -19,6 +19,6 @@ zip = "^0.2.6"
 
 [dependencies.secp256k1zkp]
 git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
-tag="grin_integration_14"
+tag="grin_integration_15"
 #path = "../../rust-secp256k1-zkp"
 features=["bullet-proof-sizing"]


### PR DESCRIPTION
Keeping the code in sync with changes from: https://github.com/mimblewimble/rust-secp256k1-zkp/issues/13