### PR TITLE
Send panics and backtraces to log

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,6 +10,7 @@ slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_
 slog-term = "^2.2.0"
 slog-async = "^2.1.0"
 lazy_static = "~0.2.8"
+backtrace = "^0.3.5"
 byteorder = "^1.0"
 rand = "^0.3"
 serde = "~1.0.8"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -21,6 +21,7 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+extern crate backtrace;
 extern crate byteorder;
 extern crate rand;
 #[macro_use]


### PR DESCRIPTION
This adds a hook to all panics that sends full backtrace and error information to the logs as well as stderr. stderr will get the basic error message, while the log will get the message plus the full backtrace each and every time regardless of whether RUST_BACKTRACE is set.

Think this will be very useful... it does require make, objcopy, and ar to be present on the system (due to the new backtrace-rs dependency), but I think these are already installed as part of the cmake dependency anyhow.

With this, we'll get this kind of thing in the logs:
```
Mar 14 13:46:56.115 WARN No seeds were retrieved.
Mar 14 13:47:09.326 ERRO thread 'ui' panicked at 'index out of bounds: the len is 3 but the index is 7': /checkout/src/liballoc/vec.rs:1551stack backtrace:
   0:     0x55da6b389c14 - backtrace::backtrace::libunwind::trace::h52b9d0421dc07e00
                        at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.5/src/backtrace/libunwind.rs:53
                         - backtrace::backtrace::trace::he556d966c356bd5b
                        at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.5/src/backtrace/mod.rs:42
   1:     0x55da6b38077c - backtrace::capture::Backtrace::new_unresolved::h0fe6f394cd1ad6fe
                        at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.5/src/capture.rs:88
```