### PR TITLE
remove difficulty field from block_header (derive from total_difficulty)

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -511,8 +511,6 @@ pub struct BlockHeaderPrintable {
 	pub kernel_root: String,
 	/// Nonce increment used to mine this block.
 	pub nonce: u64,
-	/// Difficulty used to mine the block.
-	pub difficulty: u64,
 	/// Total accumulated difficulty since genesis block
 	pub total_difficulty: u64,
 }
@@ -529,7 +527,6 @@ impl BlockHeaderPrintable {
 			range_proof_root: util::to_hex(h.range_proof_root.to_vec()),
 			kernel_root: util::to_hex(h.kernel_root.to_vec()),
 			nonce: h.nonce,
-			difficulty: h.difficulty.into_num(),
 			total_difficulty: h.total_difficulty.into_num(),
 		}
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -122,7 +122,7 @@ pub struct Chain {
 	txhashset: Arc<RwLock<txhashset::TxHashSet>>,
 
 	// POW verification function
-	pow_verifier: fn(&BlockHeader, u32) -> bool,
+	pow_verifier: fn(&BlockHeader, Option<BlockHeader>, u32) -> bool,
 }
 
 unsafe impl Sync for Chain {}
@@ -148,7 +148,7 @@ impl Chain {
 		db_root: String,
 		adapter: Arc<ChainAdapter>,
 		genesis: Block,
-		pow_verifier: fn(&BlockHeader, u32) -> bool,
+		pow_verifier: fn(&BlockHeader, Option<BlockHeader>, u32) -> bool,
 	) -> Result<Chain, Error> {
 		let chain_store = store::ChainKVStore::new(db_root.clone())?;
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -122,7 +122,7 @@ pub struct Chain {
 	txhashset: Arc<RwLock<txhashset::TxHashSet>>,
 
 	// POW verification function
-	pow_verifier: fn(&BlockHeader, Option<BlockHeader>, u32) -> bool,
+	pow_verifier: fn(&BlockHeader, u32) -> bool,
 }
 
 unsafe impl Sync for Chain {}
@@ -148,7 +148,7 @@ impl Chain {
 		db_root: String,
 		adapter: Arc<ChainAdapter>,
 		genesis: Block,
-		pow_verifier: fn(&BlockHeader, Option<BlockHeader>, u32) -> bool,
+		pow_verifier: fn(&BlockHeader, u32) -> bool,
 	) -> Result<Chain, Error> {
 		let chain_store = store::ChainKVStore::new(db_root.clone())?;
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -272,7 +272,8 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		)),
 	}?;
 
-	// make sure this header has a height exactly one higher than the previous header
+	// make sure this header has a height exactly one higher than the previous
+	// header
 	if header.height != prev.height + 1 {
 		return Err(Error::InvalidBlockHeight);
 	}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -282,7 +282,7 @@ impl Iterator for DifficultyIter {
 	fn next(&mut self) -> Option<Self::Item> {
 		// Get both header and previous_header if this is the initial iteration.
 		// Otherwise move prev_header to header and get the next prev_header.
-		let self.header = if self.header.is_none() {
+		self.header = if self.header.is_none() {
 			self.store.get_block_header(&self.start).ok()
 		} else {
 			self.prev_header.clone()

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -293,12 +293,14 @@ impl Iterator for DifficultyIter {
 		if let Some(header) = self.header.clone() {
 			self.prev_header = self.store.get_block_header(&header.previous).ok();
 
-			let prev_difficulty = self.prev_header.clone().map_or(Difficulty::zero(), |x| x.total_difficulty);
+			let prev_difficulty = self.prev_header
+				.clone()
+				.map_or(Difficulty::zero(), |x| x.total_difficulty);
 			let difficulty = header.total_difficulty - prev_difficulty;
 
 			Some(Ok((header.timestamp.to_timespec().sec as u64, difficulty)))
 		} else {
-			return None
+			return None;
 		}
 	}
 }

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -278,7 +278,8 @@ impl Iterator for DifficultyIter {
 				self.next = bh.previous;
 
 				// TODO - error handling, base case for the loop, maybe look at height?
-				let difficulty = if let Ok(prev_header) = self.store.get_block_header(&bh.previous) {
+				let difficulty = if let Ok(prev_header) = self.store.get_block_header(&bh.previous)
+				{
 					bh.total_difficulty - prev_header.total_difficulty
 				} else {
 					bh.total_difficulty

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -276,7 +276,15 @@ impl Iterator for DifficultyIter {
 			Err(_) => None,
 			Ok(bh) => {
 				self.next = bh.previous;
-				Some(Ok((bh.timestamp.to_timespec().sec as u64, bh.difficulty)))
+
+				// TODO - error handling, base case for the loop, maybe look at height?
+				let difficulty = if let Ok(prev_header) = self.store.get_block_header(&bh.previous) {
+					bh.total_difficulty - prev_header.total_difficulty
+				} else {
+					bh.total_difficulty
+				};
+
+				Some(Ok((bh.timestamp.to_timespec().sec as u64, difficulty)))
 			}
 		}
 	}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -252,8 +252,15 @@ impl ChainStore for ChainKVStore {
 /// previous difficulties). Mostly used by the consensus next difficulty
 /// calculation.
 pub struct DifficultyIter {
-	next: Hash,
+	start: Hash,
 	store: Arc<ChainStore>,
+
+	// maintain state for both the "next" header in this iteration
+	// and its previous header in the chain ("next next" in the iteration)
+	// so we effectively read-ahead as we iterate through the chain back
+	// toward the genesis block (while maintaining current state)
+	header: Option<BlockHeader>,
+	prev_header: Option<BlockHeader>,
 }
 
 impl DifficultyIter {
@@ -261,8 +268,10 @@ impl DifficultyIter {
 	/// the provided block hash.
 	pub fn from(start: Hash, store: Arc<ChainStore>) -> DifficultyIter {
 		DifficultyIter {
-			next: start,
+			start: start,
 			store: store,
+			header: None,
+			prev_header: None,
 		}
 	}
 }
@@ -271,22 +280,25 @@ impl Iterator for DifficultyIter {
 	type Item = Result<(u64, Difficulty), TargetError>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let bhe = self.store.get_block_header(&self.next);
-		match bhe {
-			Err(_) => None,
-			Ok(bh) => {
-				self.next = bh.previous;
+		// Get both header and previous_header if this is the initial iteration.
+		// Otherwise move prev_header to header and get the next prev_header.
+		let self.header = if self.header.is_none() {
+			self.store.get_block_header(&self.start).ok()
+		} else {
+			self.prev_header.clone()
+		};
 
-				// TODO - error handling, base case for the loop, maybe look at height?
-				let difficulty = if let Ok(prev_header) = self.store.get_block_header(&bh.previous)
-				{
-					bh.total_difficulty - prev_header.total_difficulty
-				} else {
-					bh.total_difficulty
-				};
+		// If we have a header we can do this iteration.
+		// Otherwise we are done.
+		if let Some(header) = self.header.clone() {
+			self.prev_header = self.store.get_block_header(&header.previous).ok();
 
-				Some(Ok((bh.timestamp.to_timespec().sec as u64, difficulty)))
-			}
+			let prev_difficulty = self.prev_header.clone().map_or(Difficulty::zero(), |x| x.total_difficulty);
+			let difficulty = header.total_difficulty - prev_difficulty;
+
+			Some(Ok((header.timestamp.to_timespec().sec as u64, difficulty)))
+		} else {
+			return None
 		}
 	}
 }

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -92,7 +92,8 @@ fn data_files() {
 				core::core::Block::new(&prev, vec![], &keychain, &pk, difficulty.clone()).unwrap();
 			b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
-			b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
+			// TODO - if we only have total_difficulty do we need something here?
+			// b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
 			chain.set_txhashset_roots(&mut b, false).unwrap();
 
 			pow::pow_size(

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -92,8 +92,6 @@ fn data_files() {
 				core::core::Block::new(&prev, vec![], &keychain, &pk, difficulty.clone()).unwrap();
 			b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
-			// TODO - if we only have total_difficulty do we need something here?
-			// b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
 			chain.set_txhashset_roots(&mut b, false).unwrap();
 
 			pow::pow_size(

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -80,7 +80,8 @@ fn mine_empty_chain() {
 			core::core::Block::new(&prev, vec![], &keychain, &pk, difficulty.clone()).unwrap();
 		b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
-		b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
+		// TODO - if we only have total_difficulty do we need to do something here?
+		// b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
 		chain.set_txhashset_roots(&mut b, false).unwrap();
 
 		pow::pow_size(

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -430,6 +430,6 @@ fn prepare_block_nosum(
 		Ok(b) => b,
 	};
 	b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
-	b.header.total_difficulty = Difficulty::from_num(diff);
+	b.header.total_difficulty = prev.total_difficulty.clone() + Difficulty::from_num(diff);
 	b
 }

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -80,8 +80,6 @@ fn mine_empty_chain() {
 			core::core::Block::new(&prev, vec![], &keychain, &pk, difficulty.clone()).unwrap();
 		b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
-		// TODO - if we only have total_difficulty do we need to do something here?
-		// b.header.difficulty = difficulty.clone(); // TODO: overwrite here? really?
 		chain.set_txhashset_roots(&mut b, false).unwrap();
 
 		pow::pow_size(

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -199,7 +199,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	
+
 	chain.set_txhashset_roots(&mut block, false).unwrap();
 
 	pow::pow_size(

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -81,8 +81,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	// TODO - we only have total_difficulty?
-	// block.header.difficulty = difficulty.clone();
+
 	chain.set_txhashset_roots(&mut block, false).unwrap();
 
 	pow::pow_size(
@@ -139,8 +138,6 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	// TODO - we only have total_difficulty
-	// block.header.difficulty = difficulty.clone();
 
 	match chain.set_txhashset_roots(&mut block, false) {
 		Err(Error::Transaction(transaction::Error::ImmatureCoinbase)) => (),
@@ -167,8 +164,7 @@ fn test_coinbase_maturity() {
 		block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 		let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-		// TODO - only have total_difficulty
-		// block.header.difficulty = difficulty.clone();
+
 		chain.set_txhashset_roots(&mut block, false).unwrap();
 
 		pow::pow_size(
@@ -203,8 +199,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	// TODO - we only have total_difficulty
-	// block.header.difficulty = difficulty.clone();
+	
 	chain.set_txhashset_roots(&mut block, false).unwrap();
 
 	pow::pow_size(

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -81,7 +81,8 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	block.header.difficulty = difficulty.clone();
+	// TODO - we only have total_difficulty?
+	// block.header.difficulty = difficulty.clone();
 	chain.set_txhashset_roots(&mut block, false).unwrap();
 
 	pow::pow_size(
@@ -138,7 +139,8 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	block.header.difficulty = difficulty.clone();
+	// TODO - we only have total_difficulty
+	// block.header.difficulty = difficulty.clone();
 
 	match chain.set_txhashset_roots(&mut block, false) {
 		Err(Error::Transaction(transaction::Error::ImmatureCoinbase)) => (),
@@ -165,7 +167,8 @@ fn test_coinbase_maturity() {
 		block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 		let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-		block.header.difficulty = difficulty.clone();
+		// TODO - only have total_difficulty
+		// block.header.difficulty = difficulty.clone();
 		chain.set_txhashset_roots(&mut block, false).unwrap();
 
 		pow::pow_size(
@@ -200,7 +203,8 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
-	block.header.difficulty = difficulty.clone();
+	// TODO - we only have total_difficulty
+	// block.header.difficulty = difficulty.clone();
 	chain.set_txhashset_roots(&mut block, false).unwrap();
 
 	pow::pow_size(

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -115,8 +115,6 @@ pub struct BlockHeader {
 	pub nonce: u64,
 	/// Proof of work data.
 	pub pow: Proof,
-	/// Difficulty used to mine the block.
-	pub difficulty: Difficulty,
 	/// Total accumulated difficulty since genesis block
 	pub total_difficulty: Difficulty,
 	/// Total accumulated sum of kernel offsets since genesis block.
@@ -133,7 +131,6 @@ impl Default for BlockHeader {
 			height: 0,
 			previous: ZERO_HASH,
 			timestamp: time::at_utc(time::Timespec { sec: 0, nsec: 0 }),
-			difficulty: Difficulty::one(),
 			total_difficulty: Difficulty::one(),
 			output_root: ZERO_HASH,
 			range_proof_root: ZERO_HASH,
@@ -160,7 +157,6 @@ impl Writeable for BlockHeader {
 		);
 
 		try!(writer.write_u64(self.nonce));
-		try!(self.difficulty.write(writer));
 		try!(self.total_difficulty.write(writer));
 		try!(self.total_kernel_offset.write(writer));
 
@@ -181,7 +177,6 @@ impl Readable for BlockHeader {
 		let rproof_root = Hash::read(reader)?;
 		let kernel_root = Hash::read(reader)?;
 		let nonce = reader.read_u64()?;
-		let difficulty = Difficulty::read(reader)?;
 		let total_difficulty = Difficulty::read(reader)?;
 		let total_kernel_offset = BlindingFactor::read(reader)?;
 		let pow = Proof::read(reader)?;
@@ -199,7 +194,6 @@ impl Readable for BlockHeader {
 			kernel_root: kernel_root,
 			pow: pow,
 			nonce: nonce,
-			difficulty: difficulty,
 			total_difficulty: total_difficulty,
 			total_kernel_offset: total_kernel_offset,
 		})
@@ -616,7 +610,6 @@ impl Block {
 		Block {
 			header: BlockHeader {
 				pow: self.header.pow.clone(),
-				difficulty: self.header.difficulty.clone(),
 				total_difficulty: self.header.total_difficulty.clone(),
 				..self.header
 			},
@@ -1044,7 +1037,7 @@ mod test {
 		let b = new_block(vec![], &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
-		let target_len = 1_256;
+		let target_len = 1_248;
 		assert_eq!(vec.len(), target_len,);
 	}
 
@@ -1056,7 +1049,7 @@ mod test {
 		let b = new_block(vec![&tx1], &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
-		let target_len = 2_900;
+		let target_len = 2_892;
 		assert_eq!(vec.len(), target_len,);
 	}
 
@@ -1067,7 +1060,7 @@ mod test {
 		let b = new_block(vec![], &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
-		let target_len = 1_264;
+		let target_len = 1_256;
 		assert_eq!(vec.len(), target_len,);
 	}
 
@@ -1079,7 +1072,7 @@ mod test {
 		let b = new_block(vec![&tx1], &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
-		let target_len = 1_270;
+		let target_len = 1_262;
 		assert_eq!(vec.len(), target_len,);
 	}
 
@@ -1096,7 +1089,7 @@ mod test {
 		let b = new_block(txs.iter().collect(), &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b).expect("serialization failed");
-		let target_len = 17_696;
+		let target_len = 17_688;
 		assert_eq!(vec.len(), target_len,);
 	}
 
@@ -1113,7 +1106,7 @@ mod test {
 		let b = new_block(txs.iter().collect(), &keychain, &prev);
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &b.as_compact_block()).expect("serialization failed");
-		let target_len = 1_324;
+		let target_len = 1_316;
 		assert_eq!(vec.len(), target_len,);
 	}
 

--- a/core/src/core/target.rs
+++ b/core/src/core/target.rs
@@ -42,9 +42,8 @@ impl Difficulty {
 		Difficulty { num: 0 }
 	}
 
-	/// Difficulty of one, which is the minumum difficulty (when the hash
-	/// equals the max target)
-	/// TODO - is this the minimum dificulty or is consensus::MINIMUM_DIFFICULTY the minimum?
+	/// Difficulty of one, which is the minumum difficulty
+	/// (when the hash equals the max target)
 	pub fn one() -> Difficulty {
 		Difficulty { num: 1 }
 	}

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -90,7 +90,6 @@ pub fn genesis_testnet2() -> core::Block {
 				..time::empty_tm()
 			},
 			//TODO: Check this is over-estimated at T2 launch
-			difficulty: Difficulty::from_num(global::initial_block_difficulty()),
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),
 			nonce: 70081,
 			pow: core::Proof::new(vec![
@@ -122,7 +121,6 @@ pub fn genesis_main() -> core::Block {
 				tm_mday: 14,
 				..time::empty_tm()
 			},
-			difficulty: Difficulty::from_num(global::initial_block_difficulty()),
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),
 			nonce: global::get_genesis_nonce(),
 			pow: core::Proof::zero(consensus::PROOFSIZE),

--- a/doc/pow/pow.md
+++ b/doc/pow/pow.md
@@ -149,8 +149,6 @@ the median timestamps at the beginning and the end of the window. If the timespa
 range, (adjusted with a dampening factor to allow for normal variation,) then the difficulty is raised or lowered
 to a value aiming for the target block solve time.
 
-The minimum difficuly is 10, as defined in the consensus MINIMUM_DIFFICULTY value.
-
 ### The Mining Loop
 
 All of these systems are put together in the mining loop, which attempts to create

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -209,8 +209,7 @@ impl Miner {
 					proof_diff.into_num(),
 					difficulty.into_num()
 				);
-				if proof_diff >=
-					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				if proof_diff > (b.header.total_difficulty.clone() - head.total_difficulty.clone())
 				{
 					sol = Some(proof);
 					b.header.nonce = s.get_nonce_as_u64();
@@ -331,8 +330,7 @@ impl Miner {
 					proof_diff.into_num(),
 					b.header.total_difficulty.into_num()
 				);
-				if proof_diff >=
-					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				if proof_diff > (b.header.total_difficulty.clone() - head.total_difficulty.clone())
 				{
 					sol = Some(proof);
 					break;
@@ -442,8 +440,7 @@ impl Miner {
 			let pow_hash = b.hash();
 			if let Ok(proof) = miner.mine(&pow_hash[..]) {
 				let proof_diff = proof.clone().to_difficulty();
-				if proof_diff >=
-					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				if proof_diff > (b.header.total_difficulty.clone() - head.total_difficulty.clone())
 				{
 					sol = Some(proof);
 					break;

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -672,7 +672,6 @@ impl Miner {
 
 		let mut rng = rand::OsRng::new().unwrap();
 		b.header.nonce = rng.gen();
-		// b.header.difficulty = difficulty;
 		b.header.timestamp = time::at_utc(time::Timespec::new(now_sec, 0));
 
 		let roots_result = self.chain.set_txhashset_roots(&mut b, false);

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -167,7 +167,7 @@ impl Miner {
 			cuckoo_size,
 			attempt_time_per_block,
 			b.header.height,
-			b.header.difficulty
+			b.header.total_difficulty
 		);
 
 		// look for a pow for at most attempt_time_per_block sec on the
@@ -209,7 +209,9 @@ impl Miner {
 					proof_diff.into_num(),
 					difficulty.into_num()
 				);
-				if proof_diff >= b.header.difficulty {
+				if proof_diff >=
+					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				{
 					sol = Some(proof);
 					b.header.nonce = s.get_nonce_as_u64();
 					break;
@@ -304,7 +306,7 @@ impl Miner {
 			cuckoo_size,
 			attempt_time_per_block,
 			latest_hash,
-			b.header.difficulty
+			b.header.total_difficulty
 		);
 		let mut iter_count = 0;
 
@@ -327,9 +329,11 @@ impl Miner {
 					"Found cuckoo solution for nonce {} of difficulty {} (difficulty target {})",
 					b.header.nonce,
 					proof_diff.into_num(),
-					b.header.difficulty.into_num()
+					b.header.total_difficulty.into_num()
 				);
-				if proof_diff >= b.header.difficulty {
+				if proof_diff >=
+					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				{
 					sol = Some(proof);
 					break;
 				}
@@ -420,7 +424,7 @@ impl Miner {
 			cuckoo_size,
 			attempt_time_per_block,
 			latest_hash,
-			b.header.difficulty
+			b.header.total_difficulty
 		);
 		let mut iter_count = 0;
 
@@ -438,7 +442,9 @@ impl Miner {
 			let pow_hash = b.hash();
 			if let Ok(proof) = miner.mine(&pow_hash[..]) {
 				let proof_diff = proof.clone().to_difficulty();
-				if proof_diff >= b.header.difficulty {
+				if proof_diff >=
+					(b.header.total_difficulty.clone() - head.total_difficulty.clone())
+				{
 					sol = Some(proof);
 					break;
 				}
@@ -537,7 +543,8 @@ impl Miner {
 			{
 				let mut mining_stats = mining_stats.write().unwrap();
 				mining_stats.block_height = b.header.height;
-				mining_stats.network_difficulty = b.header.difficulty.into_num();
+				mining_stats.network_difficulty =
+					(b.header.total_difficulty.clone() - head.total_difficulty.clone()).into_num();
 			}
 
 			let mut sol = None;
@@ -551,7 +558,7 @@ impl Miner {
 				if use_async {
 					sol = self.inner_loop_async(
 						&mut p,
-						b.header.difficulty.clone(),
+						(b.header.total_difficulty.clone() - head.total_difficulty.clone()),
 						&mut b,
 						cuckoo_size,
 						&head,
@@ -668,7 +675,7 @@ impl Miner {
 
 		let mut rng = rand::OsRng::new().unwrap();
 		b.header.nonce = rng.gen();
-		b.header.difficulty = difficulty;
+		// b.header.difficulty = difficulty;
 		b.header.timestamp = time::at_utc(time::Timespec::new(now_sec, 0));
 
 		let roots_result = self.chain.set_txhashset_roots(&mut b, false);

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -76,21 +76,7 @@ pub trait MiningWorker {
 
 /// Validates the proof of work of a given header, and that the proof of work
 /// satisfies the requirements of the header.
-pub fn verify_size(bh: &BlockHeader, prev_bh: Option<BlockHeader>, cuckoo_sz: u32) -> bool {
-	// make sure the pow hash shows a difficulty at least as large
-	// as the target difficulty
-	let difficulty = if let Some(prev_bh) = prev_bh {
-		bh.total_difficulty.clone() - prev_bh.total_difficulty.clone()
-	} else {
-		// genesis block header total_difficulty is just the initial difficulty
-		bh.total_difficulty.clone()
-	};
-	
-	if difficulty > bh.pow.clone().to_difficulty()
-	{
-		return false;
-	}
-
+pub fn verify_size(bh: &BlockHeader, cuckoo_sz: u32) -> bool {
 	Cuckoo::new(&bh.hash()[..], cuckoo_sz).verify(bh.pow.clone(), consensus::EASINESS as u64)
 }
 


### PR DESCRIPTION
Trying this out to see how disruptive removing `difficulty` from `block_header` might be.

TODO - 
- [x] grin_pow tests are not building
- [x] cleanup TODOs in the code
- [x] rework difficulty iterator so we hit the db less
- [x] rework the difficulty validation process in `pipe::validate_header()`
    -  [x] Check this header's difficulty is strictly greater than previous first.


Resolves #771.
Related #769 (kernel_offset vs. total_kernel_offset on block_header).
