### PR TITLE
PMMR data compaction

### DIFF
--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -63,13 +63,17 @@ where
 	/// occurred (see remove).
 	fn rewind(&mut self, position: u64, index: u32) -> Result<(), String>;
 
-	/// Get a Hash/Element by insertion position. If include_data is true, will
+	/// Get a Hash by insertion position. If include_data is true, will
 	/// also return the associated data element
 	fn get(&self, position: u64, include_data: bool) -> Option<(Hash, Option<T>)>;
 
-	/// Get a Hash/Element by original insertion position (ignoring the remove
+	/// Get a Hash  by original insertion position (ignoring the remove
 	/// list).
 	fn get_from_file(&self, position: u64) -> Option<Hash>;
+
+	/// Get a Data Element by original insertion position (ignoring the remove
+	/// list).
+	fn get_data_from_file(&self, position: u64) -> Option<T>;
 
 	/// Remove HashSums by insertion position. An index is also provided so the
 	/// underlying backend can implement some rollback of positions up to a

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -1023,6 +1023,14 @@ mod test {
 			}
 		}
 
+		fn get_data_from_file(&self, position: u64) -> Option<T> {
+			if let Some(ref x) = self.elems[(position - 1) as usize] {
+				x.1.clone()
+			} else {
+				None
+			}
+		}
+
 		fn remove(&mut self, positions: Vec<u64>, _index: u32) -> Result<(), String> {
 			for n in positions {
 				self.remove_list.push(n)

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -342,8 +342,7 @@ where
 
 		// Paths for tmp hash and data files.
 		let tmp_prune_file_hash = format!("{}/{}.hashprune", self.data_dir, PMMR_HASH_FILE);
-		let tmp_prune_file_data = format!("{}/{}.dataprune", self.data_dir,
-			PMMR_DATA_FILE);
+		let tmp_prune_file_data = format!("{}/{}.dataprune", self.data_dir, PMMR_DATA_FILE);
 
 		// Pos we want to get rid of.
 		// Filtered by cutoff index.
@@ -376,7 +375,7 @@ where
 		// 2. Save compact copy of the data file, skipping removed leaves.
 		{
 			let record_len = T::len() as u64;
-		
+
 			let off_to_rm = leaf_pos_to_rm
 				.iter()
 				.map(|pos| {
@@ -385,10 +384,12 @@ where
 					//(pos - 1 - shift.unwrap()) * record_len
 				})
 				.collect::<Vec<_>>();
-		
-		println!("compacting the data file: pos {:?}, offs {:?}", leaf_pos_to_rm,
-		off_to_rm);
-		
+
+			println!(
+				"compacting the data file: pos {:?}, offs {:?}",
+				leaf_pos_to_rm, off_to_rm
+			);
+
 			self.data_file.save_prune(
 				tmp_prune_file_data.clone(),
 				off_to_rm,
@@ -421,8 +422,7 @@ where
 			tmp_prune_file_data.clone(),
 			format!("{}/{}", self.data_dir, PMMR_DATA_FILE),
 		)?;
-		self.data_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir,
-		PMMR_DATA_FILE), 0)?;
+		self.data_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir, PMMR_DATA_FILE), 0)?;
 
 		// 6. Truncate the rm log based on pos removed.
 		// Excluding roots which remain in rm log.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -137,18 +137,36 @@ where
 		}
 	}
 
+	fn get_data_from_file(&self, position: u64) -> Option<T> {
+		let shift = self.pruned_nodes.get_leaf_shift(position);
+		if let None = shift {
+			return None;
+		}
+
+		let pos = pmmr::n_leaves(position) - 1;
+
+		// Must be on disk, doing a read at the correct position
+		let record_len = T::len();
+		let file_offset = ((pos - shift.unwrap()) as usize) * record_len;
+		let data = self.data_file.read(file_offset, record_len);
+		match ser::deserialize(&mut &data[..]) {
+			Ok(h) => Some(h),
+			Err(e) => {
+				error!(
+					LOGGER,
+					"Corrupted storage, could not read an entry from data store: {:?}", e
+				);
+				return None;
+			}
+		}
+	}
+
 	/// Get a Hash by insertion position
 	fn get(&self, position: u64, include_data: bool) -> Option<(Hash, Option<T>)> {
 		// Check if this position has been pruned in the remove log...
 		if self.rm_log.includes(position) {
 			return None;
 		}
-
-		// ... or in the prune list
-		// let prune_shift = match self.pruned_nodes.get_leaf_shift(position) {
-		// 	Some(shift) => shift,
-		// 	None => return None,
-		// };
 
 		let hash_val = self.get_from_file(position);
 		if !include_data {
@@ -160,24 +178,7 @@ where
 			return hash_val.map(|hash| (hash, None));
 		}
 
-		// Optionally read flatfile storage to get data element
-		// let flatfile_pos = pmmr::n_leaves(position) - 1 - prune_shift;
-		let flatfile_pos = pmmr::n_leaves(position) - 1;
-
-		let record_len = T::len();
-		let file_offset = flatfile_pos as usize * T::len();
-		let data = self.data_file.read(file_offset, record_len);
-		let data = match ser::deserialize(&mut &data[..]) {
-			Ok(elem) => Some(elem),
-			Err(e) => {
-				error!(
-					LOGGER,
-					"Corrupted storage, could not read an entry from backend flatfile store: {:?}",
-					e
-				);
-				None
-			}
-		};
+		let data = self.get_data_from_file(position);
 
 		hash_val.map(|x| (x, data))
 	}
@@ -341,8 +342,8 @@ where
 
 		// Paths for tmp hash and data files.
 		let tmp_prune_file_hash = format!("{}/{}.hashprune", self.data_dir, PMMR_HASH_FILE);
-		// let tmp_prune_file_data = format!("{}/{}.dataprune", self.data_dir,
-		// PMMR_DATA_FILE);
+		let tmp_prune_file_data = format!("{}/{}.dataprune", self.data_dir,
+			PMMR_DATA_FILE);
 
 		// Pos we want to get rid of.
 		// Filtered by cutoff index.
@@ -350,7 +351,7 @@ where
 		// Filtered to exclude the subtree "roots".
 		let pos_to_rm = removed_excl_roots(rm_pre_cutoff.clone());
 		// Filtered for leaves only.
-		// let leaf_pos_to_rm = removed_leaves(pos_to_rm.clone());
+		let leaf_pos_to_rm = removed_leaves(pos_to_rm.clone());
 
 		// 1. Save compact copy of the hash file, skipping removed data.
 		{
@@ -373,27 +374,28 @@ where
 		}
 
 		// 2. Save compact copy of the data file, skipping removed leaves.
-		// {
-		// 	let record_len = T::len() as u64;
-		//
-		// 	let off_to_rm = leaf_pos_to_rm
-		// 		.iter()
-		// 		.map(|pos| {
-		// 			let shift = self.pruned_nodes.get_leaf_shift(*pos);
-		// 			(pos - 1 - shift.unwrap()) * record_len
-		// 		})
-		// 		.collect::<Vec<_>>();
-		//
-		// println!("compacting the data file: pos {:?}, offs {:?}", leaf_pos_to_rm,
-		// off_to_rm);
-		//
-		// 	self.data_file.save_prune(
-		// 		tmp_prune_file_data.clone(),
-		// 		off_to_rm,
-		// 		record_len,
-		// 		prune_cb,
-		// 	)?;
-		// }
+		{
+			let record_len = T::len() as u64;
+		
+			let off_to_rm = leaf_pos_to_rm
+				.iter()
+				.map(|pos| {
+					let shift = self.pruned_nodes.get_leaf_shift(*pos);
+					(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
+					//(pos - 1 - shift.unwrap()) * record_len
+				})
+				.collect::<Vec<_>>();
+		
+		println!("compacting the data file: pos {:?}, offs {:?}", leaf_pos_to_rm,
+		off_to_rm);
+		
+			self.data_file.save_prune(
+				tmp_prune_file_data.clone(),
+				off_to_rm,
+				record_len,
+				prune_cb,
+			)?;
+		}
 
 		// 3. Update the prune list and save it in place.
 		{
@@ -415,12 +417,12 @@ where
 		self.hash_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir, PMMR_HASH_FILE), 0)?;
 
 		// 5. Rename the compact copy of the data file and reopen it.
-		// fs::rename(
-		// 	tmp_prune_file_data.clone(),
-		// 	format!("{}/{}", self.data_dir, PMMR_DATA_FILE),
-		// )?;
-		// self.data_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir,
-		// PMMR_DATA_FILE), 0)?;
+		fs::rename(
+			tmp_prune_file_data.clone(),
+			format!("{}/{}", self.data_dir, PMMR_DATA_FILE),
+		)?;
+		self.data_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir,
+		PMMR_DATA_FILE), 0)?;
 
 		// 6. Truncate the rm log based on pos removed.
 		// Excluding roots which remain in rm log.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -384,11 +384,6 @@ where
 				})
 				.collect::<Vec<_>>();
 
-			println!(
-				"compacting the data file: pos {:?}, offs {:?}",
-				leaf_pos_to_rm, off_to_rm
-			);
-
 			self.data_file.save_prune(
 				tmp_prune_file_data.clone(),
 				off_to_rm,

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -381,7 +381,6 @@ where
 				.map(|pos| {
 					let shift = self.pruned_nodes.get_leaf_shift(*pos);
 					(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
-					//(pos - 1 - shift.unwrap()) * record_len
 				})
 				.collect::<Vec<_>>();
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -395,7 +395,7 @@ fn pmmr_compact_entire_peak() {
 	assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
 	// now check we still have subsequent hash and data where we expect
-	assert_eq!(backend.get(8, true).unwrap().1, pos_8.1);
+	assert_eq!(backend.get(8, true), Some(pos_8));
 	assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
 
 	teardown(data_dir);
@@ -495,7 +495,7 @@ fn pmmr_compact_horizon() {
 		assert_eq!(backend.get(7, true), None);
 		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
-		assert_eq!(backend.get(8, true).unwrap().1, pos_8.1);
+		assert_eq!(backend.get(8, true), Some(pos_8));
 		assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
 	}
 
@@ -529,7 +529,7 @@ fn pmmr_compact_horizon() {
 		assert_eq!(backend.get(7, true), None);
 		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
-		assert_eq!(backend.get(11, true).unwrap().1, pos_11.1);
+		assert_eq!(backend.get(11, true), Some(pos_11));
 		assert_eq!(backend.get_from_file(11), Some(pos_11_hash));
 	}
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -122,6 +122,8 @@ fn pmmr_compact_leaf_sibling() {
 	// Check we can still retrieve the "removed" hash at pos 1 from the hash file.
 	// It should still be available even after pruning and compacting.
 	assert_eq!(backend.get_from_file(1).unwrap(), pos_1_hash);
+
+	teardown(data_dir);
 }
 
 #[test]
@@ -393,7 +395,7 @@ fn pmmr_compact_entire_peak() {
 	assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
 	// now check we still have subsequent hash and data where we expect
-	assert_eq!(backend.get(8, true), Some(pos_8));
+	assert_eq!(backend.get(8, true).unwrap().1, pos_8.1);
 	assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
 
 	teardown(data_dir);
@@ -408,8 +410,6 @@ fn pmmr_compact_horizon() {
 
 	// 0010012001001230
 	// 9 leaves
-	// data file compaction commented out for now
-	// assert_eq!(backend.data_size().unwrap(), 9);
 	assert_eq!(backend.data_size().unwrap(), 19);
 	assert_eq!(backend.hash_size().unwrap(), 35);
 
@@ -488,14 +488,14 @@ fn pmmr_compact_horizon() {
 		let backend =
 			store::pmmr::PMMRBackend::<TestElem>::new(data_dir.to_string(), None).unwrap();
 
-		assert_eq!(backend.data_size().unwrap(), 19);
+		assert_eq!(backend.data_size().unwrap(), 17);
 		assert_eq!(backend.hash_size().unwrap(), 33);
 
 		// check we can read a hash by pos correctly from recreated backend
 		assert_eq!(backend.get(7, true), None);
 		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
-		assert_eq!(backend.get(8, true), Some(pos_8));
+		assert_eq!(backend.get(8, true).unwrap().1, pos_8.1);
 		assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
 	}
 
@@ -522,14 +522,14 @@ fn pmmr_compact_horizon() {
 
 		// 0010012001001230
 
-		assert_eq!(backend.data_size().unwrap(), 19);
+		assert_eq!(backend.data_size().unwrap(), 15);
 		assert_eq!(backend.hash_size().unwrap(), 29);
 
 		// check we can read a hash by pos correctly from recreated backend
 		assert_eq!(backend.get(7, true), None);
 		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
-		assert_eq!(backend.get(11, true), Some(pos_11));
+		assert_eq!(backend.get(11, true).unwrap().1, pos_11.1);
 		assert_eq!(backend.get_from_file(11), Some(pos_11_hash));
 	}
 


### PR DESCRIPTION
Hopefully this fixes https://github.com/mimblewimble/grin/issues/770 and compacts data files properly again. The tests pass now, data is where it's expected to be and the files are the right length. The main thing was really just to use n_leaves for getting the data as opposed to just leaf shift, so that leaf indices are mapped to flat-file positions.

@antiochp do you see any hidden issues with this as a result of all your recent investigations?