### PR TITLE
add dump_stats so we can see pmmr sizes after compaction

### DIFF
--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -622,6 +622,8 @@ impl<'a> Extension<'a> {
 	pub fn dump_output_pmmr(&self) {
 		debug!(LOGGER, "-- outputs --");
 		self.output_pmmr.dump_from_file(false);
+		debug!(LOGGER, "--");
+		self.output_pmmr.dump_stats();
 		debug!(LOGGER, "-- end of outputs --");
 	}
 

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -1042,6 +1042,8 @@ mod test {
 		fn get_data_file_path(&self) -> String {
 			"".to_string()
 		}
+
+		fn dump_stats(&self) {}
 	}
 
 	impl<T> VecBackend<T>

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -81,6 +81,9 @@ where
 	/// sit well with the design, but TxKernels have to be summed and the
 	/// fastest way to to be able to allow direct access to the file
 	fn get_data_file_path(&self) -> String;
+
+	/// For debugging purposes so we can see how compaction is doing.
+	fn dump_stats(&self);
 }
 
 /// A Merkle proof.
@@ -564,6 +567,15 @@ where
 			trace!(LOGGER, "{}", idx);
 			trace!(LOGGER, "{}", hashes);
 		}
+	}
+
+	pub fn dump_stats(&self) {
+		debug!(
+			LOGGER,
+			"pmmr: unpruned - {}",
+			self.unpruned_size()
+		);
+		self.backend.dump_stats();
 	}
 
 	/// Debugging utility to print information about the MMRs. Short version

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -570,11 +570,7 @@ where
 	}
 
 	pub fn dump_stats(&self) {
-		debug!(
-			LOGGER,
-			"pmmr: unpruned - {}",
-			self.unpruned_size()
-		);
+		debug!(LOGGER, "pmmr: unpruned - {}", self.unpruned_size());
 		self.backend.dump_stats();
 	}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -97,7 +97,7 @@ where
 
 impl<T> Backend<T> for PMMRBackend<T>
 where
-	T: PMMRable,
+	T: PMMRable + ::std::fmt::Debug,
 {
 	/// Append the provided Hashes to the backend storage.
 	#[allow(unused_variables)]
@@ -209,6 +209,16 @@ where
 	/// Return data file path
 	fn get_data_file_path(&self) -> String {
 		self.data_file.path()
+	}
+
+	fn dump_stats(&self) {
+		debug!(
+			LOGGER,
+			"pmmr backend: unpruned - {}, hashes - {}, data - {}",
+			self.unpruned_size().unwrap_or(0),
+			self.hash_size().unwrap_or(0),
+			self.data_size().unwrap_or(0)
+		);
 	}
 }
 


### PR DESCRIPTION
Add `dump_stats()` so we can see what's going on after compaction.

```
Mar 15 09:39:16.803 DEBG pmmr: unpruned - 89
Mar 15 09:39:16.803 DEBG pmmr backend: unpruned - 89, hashes - 69, data - 47
``` 
