### PR TITLE
Improve bounding block timestamp

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -181,7 +181,7 @@ impl Readable for BlockHeader {
 		let total_kernel_offset = BlindingFactor::read(reader)?;
 		let pow = Proof::read(reader)?;
 
-		if timestamp > (1 << 60) {
+		if timestamp > (1 << 55) ||  timestamp < -(1 << 55) {
 			return Err(ser::Error::CorruptedData);
 		}
 


### PR DESCRIPTION
Fixes #783.
* 2^60 still fails on OSX, experimentally found safe max 2^55
* Handle negative values

I tried to use .abs(), unfortuantely fuzz test kills it with
`panicked at 'attempt to negate with overflow', /Users/travis/build/rust-lang/rust/src/libcore/num/mod.rs:1146:17`