### PR TITLE
split out verify_rangeproofs from sum_outputs

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -415,6 +415,7 @@ impl Chain {
 	pub fn validate(&self) -> Result<(), Error> {
 		let header = self.store.head_header()?;
 		let mut txhashset = self.txhashset.write().unwrap();
+		txhashset.force_rollback();
 		txhashset::extending(&mut txhashset, |extension| extension.validate(&header))
 	}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -415,7 +415,6 @@ impl Chain {
 	pub fn validate(&self) -> Result<(), Error> {
 		let header = self.store.head_header()?;
 		let mut txhashset = self.txhashset.write().unwrap();
-		txhashset.force_rollback();
 		txhashset::extending(&mut txhashset, |extension| extension.validate(&header))
 	}
 


### PR DESCRIPTION
* split out verify_rangeproofs from sum_outputs
* added some timing to the debug msgs - 

```
Mar 20 14:00:25.036 DEBG Validated, summed (and offset) 4120 kernels, pmmr size 8237, took 4s
Mar 20 14:00:25.688 DEBG Summed 4117 Outputs, pmmr size 8245, took 0s
Mar 20 14:01:37.413 DEBG Verified 4117 Rangeproofs, pmmr size 8245, took 71s
```

Summing and offsetting the kernels is reasonably fast (4s for ~4,000 kernels).
Summing the outputs is fast.
Verifying the rangeproofs for each of these outputs is _slow_ (71s for ~4,000 rangeproofs).

