### PR TITLE
chain validation can now optionally skip rangeproof verification (faster)

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -405,6 +405,20 @@ impl Handler for ChainHandler {
 	}
 }
 
+/// Chain validation handler.
+/// GET /v1/chain/validate
+pub struct ChainValidationHandler {
+	pub chain: Weak<chain::Chain>,
+}
+
+impl Handler for ChainValidationHandler {
+	fn handle(&self, _req: &mut Request) -> IronResult<Response> {
+		// TODO - read skip_rproofs from query params
+		w(&self.chain).validate(true).unwrap();
+		Ok(Response::with((status::Ok, "{}")))
+	}
+}
+
 /// Chain compaction handler. Trigger a compaction of the chain state to regain
 /// storage space.
 /// GET /v1/chain/compact
@@ -636,6 +650,9 @@ pub fn start_rest_apis<T>(
 			let chain_compact_handler = ChainCompactHandler {
 				chain: chain.clone(),
 			};
+			let chain_validation_handler = ChainValidationHandler {
+				chain: chain.clone(),
+			};
 			let status_handler = StatusHandler {
 				chain: chain.clone(),
 				peers: peers.clone(),
@@ -667,6 +684,7 @@ pub fn start_rest_apis<T>(
 				"get blocks".to_string(),
 				"get chain".to_string(),
 				"get chain/compact".to_string(),
+				"get chain/validate".to_string(),
 				"get chain/outputs".to_string(),
 				"get status".to_string(),
 				"get txhashset/roots".to_string(),
@@ -688,6 +706,7 @@ pub fn start_rest_apis<T>(
 				blocks: get "/blocks/*" => block_handler,
 				chain_tip: get "/chain" => chain_tip_handler,
 				chain_compact: get "/chain/compact" => chain_compact_handler,
+				chain_validate: get "/chain/validate" => chain_validation_handler,
 				chain_outputs: get "/chain/outputs/*" => output_handler,
 				status: get "/status" => status_handler,
 				txhashset_roots: get "/txhashset/*" => txhashset_handler,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -412,7 +412,7 @@ impl Chain {
 	}
 
 	/// Validate the current chain state.
-	pub fn validate(&self) -> Result<(), Error> {
+	pub fn validate(&self, skip_rproofs: bool) -> Result<(), Error> {
 		let header = self.store.head_header()?;
 		let mut txhashset = self.txhashset.write().unwrap();
 
@@ -423,7 +423,7 @@ impl Chain {
 		// Force rollback first as this is a "read-only" extension.
 		txhashset::extending(&mut txhashset, |extension| {
 			extension.force_rollback();
-			extension.validate(&header)
+			extension.validate(&header, skip_rproofs)
 		})
 	}
 
@@ -532,7 +532,7 @@ impl Chain {
 		let mut txhashset =
 			txhashset::TxHashSet::open(self.db_root.clone(), self.store.clone(), None)?;
 		txhashset::extending(&mut txhashset, |extension| {
-			extension.validate(&header)?;
+			extension.validate(&header, false)?;
 			// TODO validate kernels and their sums with Outputs
 			extension.rebuild_index()?;
 			Ok(())
@@ -572,7 +572,7 @@ impl Chain {
 		// First check we can successfully validate the full chain state.
 		// If we cannot then do not attempt to compact.
 		// This should not be required long term - but doing this for debug purposes.
-		self.validate()?;
+		self.validate(true)?;
 
 		// Now compact the txhashset via the extension.
 		{
@@ -588,7 +588,7 @@ impl Chain {
 
 		// Now check we can still successfully validate the chain state after
 		// compacting.
-		self.validate()?;
+		self.validate(true)?;
 
 		// we need to be careful here in testing as 20 blocks is not that long
 		// in wall clock time

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -118,13 +118,13 @@ fn data_files() {
 				.expect("previous block pmmr file data doesn't exist");
 
 			println!("Cur_pmmr_md: {:?}", cur_pmmr_md);
-			chain.validate().unwrap();
+			chain.validate(false).unwrap();
 		}
 	}
 	// Now reload the chain, should have valid indices
 	{
 		let chain = reload_chain(chain_dir);
-		chain.validate().unwrap();
+		chain.validate(false).unwrap();
 	}
 }
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -112,7 +112,7 @@ fn mine_empty_chain() {
 		let header_by_height = chain.get_header_by_height(n).unwrap();
 		assert_eq!(header_by_height.hash(), bhash);
 
-		chain.validate().unwrap();
+		chain.validate(false).unwrap();
 	}
 }
 
@@ -295,7 +295,7 @@ fn spend_in_fork_and_compact() {
 	chain
 		.process_block(next.clone(), chain::Options::SKIP_POW)
 		.unwrap();
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 
 	println!("tx 1 processed, should have 6 outputs or 396 bytes in file, first skipped");
 
@@ -311,7 +311,7 @@ fn spend_in_fork_and_compact() {
 	let next = prepare_block_tx(&kc, &prev_main, &chain, 9, vec![&tx2]);
 	let prev_main = next.header.clone();
 	chain.process_block(next, chain::Options::SKIP_POW).unwrap();
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 
 	println!("tx 2 processed");
 	/* panic!("Stop"); */
@@ -326,7 +326,7 @@ fn spend_in_fork_and_compact() {
 	chain
 		.process_block(fork_next, chain::Options::SKIP_POW)
 		.unwrap();
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 
 	// check state
 	let head = chain.head_header().unwrap();
@@ -349,7 +349,7 @@ fn spend_in_fork_and_compact() {
 	chain
 		.process_block(fork_next, chain::Options::SKIP_POW)
 		.unwrap();
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 
 	// check state
 	let head = chain.head_header().unwrap();
@@ -374,9 +374,9 @@ fn spend_in_fork_and_compact() {
 		chain.process_block(next, chain::Options::SKIP_POW).unwrap();
 	}
 
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 	chain.compact().unwrap();
-	chain.validate().unwrap();
+	chain.validate(false).unwrap();
 }
 
 fn prepare_block(kc: &Keychain, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block {


### PR DESCRIPTION
* chain.validate() now takes `skip_rproof=true|false`
  * "fast" version for use in check_compact
  * "slow" version for use in fast sync
* api endpoint to run a full chain validation `GET /v1/chain/validate`
* reworked chain kernel validation to use kernel MMR for consistency with output validation

Resolves #831.
