### PR TITLE
Travis cleaner caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 cache: cargo
+before_cache:
+  - rm -rf target/tmp
 dist: trusty
 sudo: false
 rust:
@@ -17,7 +19,7 @@ addons:
       - libdw-dev
       - cmake
       - gcc
-      - binutils-dev 
+      - binutils-dev
 env:
   global:
     - RUST_BACKTRACE="1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-cache: cargo
+cache:
+  cargo: true
+  timeout:
+    240 # =4 min (default 120). ~6 GB cache up/down from S3 needs time.
 before_cache:
   - rm -rf target/tmp
 dist: trusty

--- a/grin/tests/framework/mod.rs
+++ b/grin/tests/framework/mod.rs
@@ -34,7 +34,7 @@ use wallet::WalletConfig;
 
 /// Just removes all results from previous runs
 pub fn clean_all_output(test_name_dir: &str) {
-	let target_dir = format!("target/{}", test_name_dir);
+	let target_dir = format!("target/tmp/{}", test_name_dir);
 	let result = fs::remove_dir_all(target_dir);
 	if let Err(e) = result {
 		println!("{}", e);
@@ -156,10 +156,10 @@ pub struct LocalServerContainer {
 impl LocalServerContainer {
 	/// Create a new local server container with defaults, with the given name
 	/// all related files will be created in the directory
-	/// target/test_servers/{name}
+	/// target/tmp/test_servers/{name}
 
 	pub fn new(config: LocalServerContainerConfig) -> Result<LocalServerContainer, Error> {
-		let working_dir = format!("target/test_servers/{}", config.name);
+		let working_dir = format!("target/tmp/test_servers/{}", config.name);
 		let mut wallet_config = WalletConfig::default();
 
 		wallet_config.api_listen_port = format!("{}", config.wallet_port);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -190,7 +190,7 @@ fn a_simulate_block_propagation() {
 	for n in 0..5 {
 		let s = grin::Server::new(grin::ServerConfig {
 			api_http_addr: format!("127.0.0.1:{}", 19000 + n),
-			db_root: format!("target/{}/grin-prop-{}", test_name_dir, n),
+			db_root: format!("target/tmp/{}/grin-prop-{}", test_name_dir, n),
 			p2p_config: p2p::P2PConfig {
 				port: 18000 + n,
 				..p2p::P2PConfig::default()
@@ -299,8 +299,8 @@ fn simulate_fast_sync_double() {
 		s2.stop();
 	}
 	// locks files don't seem to be cleaned properly until process exit
-	std::fs::remove_file("target/grin-double-fast2/grin-sync-1001/chain/LOCK");
-	std::fs::remove_file("target/grin-double-fast2/grin-sync-1001/peers/LOCK");
+	std::fs::remove_file("target/tmp/grin-double-fast2/grin-sync-1001/chain/LOCK");
+	std::fs::remove_file("target/tmp/grin-double-fast2/grin-sync-1001/peers/LOCK");
 	thread::sleep(time::Duration::from_secs(20));
 
 	let mut conf = config(1001, "grin-double-fast2");
@@ -315,7 +315,7 @@ fn simulate_fast_sync_double() {
 fn config(n: u16, test_name_dir: &str) -> grin::ServerConfig {
 	grin::ServerConfig {
 		api_http_addr: format!("127.0.0.1:{}", 19000 + n),
-		db_root: format!("target/{}/grin-sync-{}", test_name_dir, n),
+		db_root: format!("target/tmp/{}/grin-sync-{}", test_name_dir, n),
 		p2p_config: p2p::P2PConfig {
 			port: 11000 + n,
 			..p2p::P2PConfig::default()

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -555,7 +555,7 @@ fn pmmr_compact_horizon() {
 fn setup(tag: &str) -> (String, Vec<TestElem>) {
 	let _ = env_logger::init();
 	let t = time::get_time();
-	let data_dir = format!("./target/{}.{}-{}", t.sec, t.nsec, tag);
+	let data_dir = format!("./target/tmp/{}.{}-{}", t.sec, t.nsec, tag);
 	fs::create_dir_all(data_dir.clone()).unwrap();
 
 	let mut elems = vec![];

--- a/util/tests/zip.rs
+++ b/util/tests/zip.rs
@@ -21,8 +21,8 @@ use util::zip;
 
 #[test]
 fn zip_unzip() {
-	let root = Path::new("./target");
-	let zip_name = "./target/zipped.zip";
+	let root = Path::new("./target/tmp");
+	let zip_name = "./target/tmp/zipped.zip";
 
 	fs::create_dir_all(root.join("./to_zip/sub")).unwrap();
 	write_files(&root).unwrap();


### PR DESCRIPTION
Keep all test data under target/tmp/ and erase before caching (minor effect)
Increase cache timeout (should fix a couple of cache timeouts).

After outstanding PRs are done (or merged with this) [purge Travis cache here once](https://travis-ci.org/mimblewimble/grin/caches).