### PR TITLE
remove redundant verify_proof call

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -457,13 +457,7 @@ impl Transaction {
 			return Err(Error::TooManyInputs);
 		}
 		self.verify_sorted()?;
-
 		self.verify_inputs()?;
-
-		for out in &self.outputs {
-			out.verify_proof()?;
-		}
-
 		self.verify_kernels()?;
 
 		Ok(())

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -302,11 +302,11 @@ impl Readable for Transaction {
 		let (input_len, output_len, kernel_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 
-		if input_len > consensus::MAX_TX_INPUTS
-			|| output_len > consensus::MAX_TX_OUTPUTS
-			|| kernel_len > consensus::MAX_TX_KERNELS {
-				return Err(ser::Error::CorruptedData)
-			}
+		if input_len > consensus::MAX_TX_INPUTS || output_len > consensus::MAX_TX_OUTPUTS
+			|| kernel_len > consensus::MAX_TX_KERNELS
+		{
+			return Err(ser::Error::CorruptedData);
+		}
 
 		let inputs = read_and_verify_sorted(reader, input_len)?;
 		let outputs = read_and_verify_sorted(reader, output_len)?;


### PR DESCRIPTION
We verify all the rangeproofs in `sum_commitments()` which happens in `verify_kernels()`.