### PR TITLE
[WIP] Wallet Restore

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -22,7 +22,6 @@ use chain;
 use p2p;
 use util;
 use util::secp::pedersen;
-use util::secp::constants::MAX_PROOF_SIZE;
 use serde;
 use serde::ser::SerializeStruct;
 use serde::de::MapAccess;
@@ -233,7 +232,7 @@ pub struct OutputPrintable {
 	/// Whether the output has been spent
 	pub spent: bool,
 	/// Rangeproof (as hex string)
-	pub proof: Option<pedersen::RangeProof>,
+	pub proof: Option<String>,
 	/// Rangeproof hash (as hex string)
 	pub proof_hash: String,
 
@@ -260,7 +259,7 @@ impl OutputPrintable {
 		let spent = chain.is_unspent(&out_id).is_err();
 
 		let proof = if include_proof {
-			Some(output.proof)
+			Some(util::to_hex(output.proof.proof.to_vec()))
 		} else {
 			None
 		};
@@ -298,9 +297,19 @@ impl OutputPrintable {
 	}
 
 	pub fn range_proof(&self) -> Result<pedersen::RangeProof, ser::Error> {
-		self.proof
+		let proof_str = self.proof
 			.clone()
 			.ok_or_else(|| ser::Error::HexError(format!("output range_proof missing")))
+			.unwrap();
+		let p_vec = util::from_hex(proof_str).unwrap();
+		let mut p_bytes = [0; util::secp::constants::MAX_PROOF_SIZE];
+		for i in 0..p_bytes.len() {
+			p_bytes[i]=p_vec[i];
+		}
+		Ok(pedersen::RangeProof {
+			proof: p_bytes,
+			plen: p_bytes.len(),
+		})
 	}
 }
 
@@ -390,22 +399,8 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 						}
 						Field::Proof => {
 							no_dup!(proof);
-
-							let val: Option<String> = map.next_value()?;
-
-							if val.is_some() {
-								let vec = util::from_hex(val.unwrap().clone())
-									.map_err(serde::de::Error::custom)?;
-								let mut bytes = [0; MAX_PROOF_SIZE];
-								for i in 0..vec.len() {
-									bytes[i] = vec[i];
-								}
-
-								proof = Some(pedersen::RangeProof {
-									proof: bytes,
-									plen: vec.len(),
-								})
-							}
+							proof = map.next_value()?
+							
 						}
 						Field::ProofHash => {
 							no_dup!(proof_hash);

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -304,7 +304,7 @@ impl OutputPrintable {
 		let p_vec = util::from_hex(proof_str).unwrap();
 		let mut p_bytes = [0; util::secp::constants::MAX_PROOF_SIZE];
 		for i in 0..p_bytes.len() {
-			p_bytes[i]=p_vec[i];
+			p_bytes[i] = p_vec[i];
 		}
 		Ok(pedersen::RangeProof {
 			proof: p_bytes,
@@ -400,7 +400,6 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 						Field::Proof => {
 							no_dup!(proof);
 							proof = map.next_value()?
-							
 						}
 						Field::ProofHash => {
 							no_dup!(proof_hash);

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -84,48 +84,6 @@ fn start_server_tui(config: grin::ServerConfig) {
 }
 
 fn main() {
-	// First, load a global config object,
-	// then modify that object with any switches
-	// found so that the switches override the
-	// global config file
-
-	// This will return a global config object,
-	// which will either contain defaults for all // of the config structures or a
-	// configuration
-	// read from a config file
-
-	let mut global_config = GlobalConfig::new(None).unwrap_or_else(|e| {
-		panic!("Error parsing config file: {}", e);
-	});
-
-	if global_config.using_config_file {
-		// initialise the logger
-		let mut log_conf = global_config
-			.members
-			.as_mut()
-			.unwrap()
-			.logging
-			.clone()
-			.unwrap();
-		let run_tui = global_config.members.as_mut().unwrap().server.run_tui;
-		if run_tui.is_some() && run_tui.unwrap() {
-			log_conf.log_to_stdout = false;
-			log_conf.tui_running = Some(true);
-		}
-		init_logger(Some(log_conf));
-		global::set_mining_mode(
-			global_config
-				.members
-				.as_mut()
-				.unwrap()
-				.server
-				.clone()
-				.chain_type,
-		);
-	} else {
-		init_logger(Some(LoggingConfig::default()));
-	}
-
 	let args = App::new("Grin")
 		.version("0.1")
 		.author("The Grin Team")
@@ -300,6 +258,48 @@ fn main() {
 				NOTE: Backup wallet.* and run `wallet listen` before running restore.")))
 
 	.get_matches();
+
+	// load a global config object,
+	// then modify that object with any switches
+	// found so that the switches override the
+	// global config file
+
+	// This will return a global config object,
+	// which will either contain defaults for all // of the config structures or a
+	// configuration
+	// read from a config file
+
+	let mut global_config = GlobalConfig::new(None).unwrap_or_else(|e| {
+		panic!("Error parsing config file: {}", e);
+	});
+
+	if global_config.using_config_file {
+		// initialise the logger
+		let mut log_conf = global_config
+			.members
+			.as_mut()
+			.unwrap()
+			.logging
+			.clone()
+			.unwrap();
+		let run_tui = global_config.members.as_mut().unwrap().server.run_tui;
+		if run_tui.is_some() && run_tui.unwrap() && args.subcommand().0 != "wallet" {
+			log_conf.log_to_stdout = false;
+			log_conf.tui_running = Some(true);
+		}
+		init_logger(Some(log_conf));
+		global::set_mining_mode(
+			global_config
+				.members
+				.as_mut()
+				.unwrap()
+				.server
+				.clone()
+				.chain_type,
+		);
+	} else {
+		init_logger(Some(LoggingConfig::default()));
+	}
 
 	match args.subcommand() {
 		// server commands and options


### PR DESCRIPTION
This at least gets wallet restore working again (there were serialization issues with the rangeproof meaning it would fail earlier) but it's still much, much slower than it was on testnet1. However, the key derivation was far simpler in that iteration as the switch proof hash was just a function of b instead of b + another derived key.

The slowdown is all due to the iterating needed `derived_child_key`:

```
-   97.88%     0.02%  grin     grin                 [.] grin_keychain::keychain::Keychain::derived_child_key                                                                                                                                                                               ▒
   - 97.86% grin_keychain::keychain::Keychain::derived_child_key                                                                                                                                                                                                                           ▒
      - 97.01% grin_keychain::extkey::ExtendedKey::derive                                                                                                                                                                                                                                  ▒
         - 80.64% grin_keychain::extkey::Identifier::from_secret_key                                                                                                                                                                                                                       ▒
            - 74.92% secp256k1zkp::key::PublicKey::from_secret_key                                                                                                                                                                                                                         ▒
               - 74.88% secp256k1_ec_pubkey_create                                                                                                                                                                                                                                         ▒
                  + 62.80% secp256k1_ecmult_gen                                                                                                                                                                                                                                            ▒
                  + 11.76% secp256k1_ge_set_gej                                                                                                                                                                                                                                            ▒
            + 5.68% grin_keychain::extkey::Identifier::from_pubkey                                                                                                                                                                                                                         ▒
         + 14.86% blake2_rfc::blake2b::blake2b                                                                                                                                                                                                                                             ▒
      + 0.61% <std::collections::hash::map::HashMap<K, V, S>>::contains_key   
```

We could potentially make this work much, much faster by generating key in pairs, so if a child key for the blinding factor is derived from child_index n, then the key for the switch commit hash is generated from index n+1.