### PR TITLE
Add versioning and build information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 exclude = ["**/*.grin", "**/*.grin2"]
 publish = false
+build = "src/build/build.rs"
 
 [workspace]
 members = ["api", "chain", "config", "core", "grin", "keychain", "p2p", "store", "util", "pool", "wallet"]
@@ -41,3 +42,6 @@ tag="grin_integration_1"
 # TODO - once "patch" is available we should be able to clean up the workspace dependencies
 # [patch.crate-io]
 # secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
+
+[build-dependencies]
+built = "^0.2.3"

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -51,6 +51,37 @@ use core::core::amount_to_hr_string;
 use util::{init_logger, LoggingConfig, LOGGER};
 use tui::ui;
 
+// include build information
+pub mod built_info {
+	include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+pub fn info_strings() -> (String, String, String) {
+	(
+		format!(
+			"This is Grin version {}{}, built for {} by {}.",
+			built_info::PKG_VERSION,
+			built_info::GIT_VERSION.map_or_else(|| "".to_owned(), |v| format!(" (git {})", v)),
+			built_info::TARGET,
+			built_info::RUSTC_VERSION
+		).to_string(),
+		format!(
+			"Built with profile \"{}\", features \"{}\" on {}.",
+			built_info::PROFILE,
+			built_info::FEATURES_STR,
+			built_info::BUILT_TIME_UTC
+		).to_string(),
+		format!("Dependencies:\n {}", built_info::DEPENDENCIES_STR).to_string(),
+	)
+}
+
+fn log_build_info() {
+	let (basic_info, detailed_info, deps) = info_strings();
+	info!(LOGGER, "{}", basic_info);
+	debug!(LOGGER, "{}", detailed_info);
+	debug!(LOGGER, "{}", deps);
+}
+
 /// wrap below to allow UI to clean up on stop
 fn start_server(config: grin::ServerConfig) {
 	start_server_tui(config);
@@ -296,6 +327,8 @@ fn main() {
 	} else {
 		init_logger(Some(LoggingConfig::default()));
 	}
+
+	log_build_info();
 
 	match args.subcommand() {
 		// server commands and options

--- a/src/bin/tui/constants.rs
+++ b/src/bin/tui/constants.rs
@@ -28,6 +28,9 @@ pub const SUBMENU_MINING_BUTTON: &str = "mining_submenu_button";
 pub const TABLE_MINING_STATUS: &str = "mining_status_table";
 pub const TABLE_MINING_DIFF_STATUS: &str = "mining_diff_status_table";
 
+// Mining View
+pub const VIEW_VERSION: &str = "version_view";
+
 // Menu and root elements
 pub const MAIN_MENU: &str = "main_menu";
 pub const ROOT_STACK: &str = "root_stack";

--- a/src/bin/tui/menu.rs
+++ b/src/bin/tui/menu.rs
@@ -33,6 +33,7 @@ pub fn create() -> Box<View> {
 		.get_mut()
 		.add_item("Peers and Sync", VIEW_PEER_SYNC);
 	main_menu.get_mut().add_item("Mining", VIEW_MINING);
+	main_menu.get_mut().add_item("Version Info", VIEW_VERSION);
 	let change_view = |s: &mut Cursive, v: &&str| {
 		if *v == "" {
 			return;

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -29,11 +29,12 @@ use cursive::direction::Orientation;
 use cursive::traits::*;
 
 use grin::Server;
-//use util::LOGGER;
 
-use tui::{menu, mining, peers, status};
+use tui::{menu, mining, peers, status, version};
 use tui::types::*;
 use tui::constants::*;
+
+use built_info;
 
 pub struct UI {
 	cursive: Cursive,
@@ -69,10 +70,12 @@ impl UI {
 		let status_view = status::TUIStatusView::create();
 		let mining_view = mining::TUIMiningView::create();
 		let peer_view = peers::TUIPeerView::create();
+		let version_view = version::TUIVersionView::create();
 
 		let main_menu = menu::create();
 
 		let root_stack = StackView::new()
+			.layer(version_view)
 			.layer(mining_view)
 			.layer(peer_view)
 			.layer(status_view)
@@ -80,7 +83,7 @@ impl UI {
 
 		let mut title_string = StyledString::new();
 		title_string.append(StyledString::styled(
-			"Grin Version 0.0.1",
+			format!("Grin Version {}", built_info::PKG_VERSION),
 			Color::Dark(BaseColor::Green),
 		));
 
@@ -123,6 +126,7 @@ impl UI {
 					status::TUIStatusView::update(&mut self.cursive, &update);
 					mining::TUIMiningView::update(&mut self.cursive, &update);
 					peers::TUIPeerView::update(&mut self.cursive, &update);
+					version::TUIVersionView::update(&mut self.cursive, &update);
 				}
 			}
 		}

--- a/src/bin/tui/version.rs
+++ b/src/bin/tui/version.rs
@@ -1,0 +1,46 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Version and build info
+
+use cursive::Cursive;
+use cursive::view::View;
+use cursive::views::{BoxView, LinearLayout, TextView};
+use cursive::direction::Orientation;
+use cursive::traits::*;
+
+use tui::constants::*;
+use tui::types::*;
+
+use grin::ServerStats;
+use info_strings;
+
+pub struct TUIVersionView;
+
+impl TUIStatusListener for TUIVersionView {
+	/// Create basic status view
+	fn create() -> Box<View> {
+		let (basic_info, detailed_info, _) = info_strings();
+		let basic_status_view = BoxView::with_full_screen(
+			LinearLayout::new(Orientation::Vertical)
+				.child(TextView::new(basic_info))
+				.child(TextView::new(" "))
+				.child(TextView::new(detailed_info)),
+		);
+		Box::new(basic_status_view.with_id(VIEW_VERSION))
+	}
+
+	/// update
+	fn update(_c: &mut Cursive, _stats: &ServerStats) {}
+}

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -24,7 +24,6 @@ fn main() {
 	built::write_built_file_with_opts(
 		&opts,
 		env!("CARGO_MANIFEST_DIR"),
-		format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs"))
-		.expect("Failed to acquire build-time information");
+		format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs"),
+	).expect("Failed to acquire build-time information");
 }
-

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Grin TUI
-extern crate chrono;
-extern crate grin_pow as pow;
+//! Build hooks to spit out version+build time info
 
-pub mod ui;
-pub mod table;
-mod peers;
-mod constants;
-mod menu;
-mod status;
-mod mining;
-mod version;
-mod types;
+extern crate built;
+
+use std::env;
+
+fn main() {
+	let mut opts = built::Options::default();
+	opts.set_dependencies(true);
+	built::write_built_file_with_opts(
+		&opts,
+		env!("CARGO_MANIFEST_DIR"),
+		format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs"))
+		.expect("Failed to acquire build-time information");
+}
+


### PR DESCRIPTION
Turns out there's a handy crate https://docs.rs/built/0.2.3/built/index.html that only needs to be added as a build time dependency, then spits out a file full of constants with useful build info that the rest of the code can pick up and compile in. This adds this crate, spits out the info to the debug log and displays the rust crate version+other info in the TUI

![screenshot from 2018-03-23 10-18-14](https://user-images.githubusercontent.com/7074070/37824198-c47457c4-2e83-11e8-81b4-69ddc707af01.png)
