### PR TITLE
[WIP] read/write prune list with associated hashes (for fast sync)

### DIFF
--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -322,6 +322,29 @@ where
 		}
 	}
 
+	pub fn experimental_write_for_fast_sync(&self) -> io::Result<()> {
+		let tmp_prune_file = format!("{}/{}.tmp", self.data_dir, "fast_sync_prune");
+
+		let mut pruned_pos_hash = vec![];
+
+		// collect the hashes for all the pos in the prune list
+		for pos in &self.pruned_nodes.pruned_nodes {
+			let hash = self.get_from_file(*pos).expect("missing hash");
+			pruned_pos_hash.push((pos, hash));
+		}
+
+		// then write all the (pos, hash) to the tmp file
+		write_vec(tmp_prune_file, &pruned_pos_hash)?;
+
+		Ok(())
+	}
+
+	pub fn experimental_read_for_fast_sync(&self) -> io::Result<Vec<(u64, Hash)>> {
+		let tmp_prune_file = format!("{}/{}.tmp", self.data_dir, "fast_sync_prune");
+		let pruned_pos_hash = read_ordered_vec(tmp_prune_file, (8 + 32))?;
+		Ok(pruned_pos_hash)
+	}
+
 	/// Checks the length of the remove log to see if it should get compacted.
 	/// If so, the remove log is flushed into the pruned list, which itself gets
 	/// saved, and the hash and data files are rewritten, cutting the removed

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -25,6 +25,46 @@ use core::core::hash::Hash;
 use store::types::prune_noop;
 
 #[test]
+fn fast_sync_files() {
+	let (data_dir, elems) = setup("fast_sync");
+	let mut backend = store::pmmr::PMMRBackend::new(data_dir.to_string(), None).unwrap();
+
+	let mmr_size = load(0, &elems[..], &mut backend);
+	backend.sync().unwrap();
+
+	let pos_7_hash = backend.get_from_file(7).unwrap();
+
+	// prune some leaves
+	// will prune up to and including pos 7
+	{
+		let mut pmmr: PMMR<TestElem, _> = PMMR::at(&mut backend, mmr_size);
+		pmmr.prune(1, 1).unwrap();
+		pmmr.prune(2, 1).unwrap();
+		pmmr.prune(4, 1).unwrap();
+		pmmr.prune(5, 1).unwrap();
+	}
+	backend.sync().unwrap();
+
+	// check we can still get the hash for pos_7 from the file
+	assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+
+	// aggressively compact the PMMR files
+	backend.check_compact(1, 2, &prune_noop).unwrap();
+
+	// check we can still get the hash for pos_7 from the file
+	assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+
+	// now write the "fast sync" prune list out to disk
+	backend.experimental_write_for_fast_sync().unwrap();
+
+	// read "fast sync" prune list back in
+	let res = backend.experimental_read_for_fast_sync().unwrap();
+
+	// and check it looks like we expect it to
+	assert_eq!(res, vec![(7, pos_7_hash)]);
+}
+
+#[test]
 fn pmmr_append() {
 	let (data_dir, elems) = setup("append");
 	let mut backend = store::pmmr::PMMRBackend::new(data_dir.to_string(), None).unwrap();


### PR DESCRIPTION
See #804 for context/discussion.

This is part of the "more compact" txhashset representation that we will send over the wire as part of the fast sync.

We need the following to fully reconstruct a txhashset on the receiving end -
1. prune list (with corresponding hashes for each pos)
1. data file (with corresponding pos for each element, maybe better way to do this?)
1. rm_log

We do not need -
1. full hash file (we can rebuild this from data file and "pruned" hashes)

This PR covers (1) and is relatively straight forward implementation wise.

From the vec of `(pos, hash)` we _should_ be able to -
* build the actual prune list (just the vec of pos)
* insert the hashes at the necessary pos back into the hash file during rebuild 

