### PR TITLE
standardize and cleanup SerializationMode

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -145,12 +145,11 @@ impl Default for BlockHeader {
 /// Serialization of a block header
 impl Writeable for BlockHeader {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		if writer.serialization_mode() == ser::SerializationMode::Hash {
-			try!(self.pow.write(writer));
-		} else {
+		if writer.serialization_mode() != ser::SerializationMode::Hash {
 			self.write_pre_pow(writer)?;
-			self.pow.write(writer)?;
 		}
+
+		self.pow.write(writer)?;
 		Ok(())
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -706,7 +706,7 @@ impl Writeable for Output {
 		self.commit.write(writer)?;
 		// The hash of an output doesn't include the range proof, which
 		// is commit to separately
-		if writer.serialization_mode() == ser::SerializationMode::Full {
+		if writer.serialization_mode() != ser::SerializationMode::Hash {
 			writer.write_bytes(&self.proof)?
 		}
 		Ok(())

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -112,11 +112,6 @@ pub enum SerializationMode {
 	Full,
 	/// Serialize the data that defines the object
 	Hash,
-	/// Serialize everything that a signer of the object should know
-	SigHash,
-	/// Serialize for local storage, for instance in the case where
-	/// an output doesn't wish to store its range proof
-	Storage,
 }
 
 /// Implementations defined how different numbers and binary structures are


### PR DESCRIPTION
We only use `Hash` vs. `Full` so get rid of the other unused modes.

Normalize our "hash mode" checks for consistency - 
```
    if writer.serialization_mode() != ser::SerializationMode::Hash {
```

