### PR TITLE
Rename Hash::zero() to Hash::default()

### DIFF
--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -67,11 +67,6 @@ impl Hash {
 		self.0.to_vec()
 	}
 
-	/// The "zero" hash. No known preimage.
-	pub fn zero() -> Hash {
-		ZERO_HASH
-	}
-
 	/// Convert a hash to hex string format.
 	pub fn to_hex(&self) -> String {
 		util::to_hex(self.to_vec())
@@ -151,6 +146,12 @@ impl Add for Hash {
 	type Output = Hash;
 	fn add(self, other: Hash) -> Hash {
 		self.hash_with(other)
+	}
+}
+
+impl Default for Hash {
+	fn default() -> Hash {
+		ZERO_HASH
 	}
 }
 

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -150,7 +150,7 @@ mod test {
 		).unwrap();
 		assert_eq!(foo.hash(), expected_hash);
 
-		let other_hash = Hash::zero();
+		let other_hash = Hash::default();
 		assert_eq!(
 			foo.short_id(&other_hash, foo.0),
 			ShortId::from_hex("4cc808b62476").unwrap()
@@ -162,7 +162,7 @@ mod test {
 		).unwrap();
 		assert_eq!(foo.hash(), expected_hash);
 
-		let other_hash = Hash::zero();
+		let other_hash = Hash::default();
 		assert_eq!(
 			foo.short_id(&other_hash, foo.0),
 			ShortId::from_hex("02955a094534").unwrap()

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -176,8 +176,8 @@ impl MerkleProof {
 	/// Basically some reasonable defaults. Will not verify successfully.
 	pub fn empty() -> MerkleProof {
 		MerkleProof {
-			root: Hash::zero(),
-			node: Hash::zero(),
+			root: Hash::default(),
+			node: Hash::default(),
 			peaks: vec![],
 			path: vec![],
 		}
@@ -335,7 +335,7 @@ where
 
 		let path = family_branch
 			.iter()
-			.map(|x| (self.get_from_file(x.1).unwrap_or(Hash::zero()), x.1))
+			.map(|x| (self.get_from_file(x.1).unwrap_or(Hash::default()), x.1))
 			.collect::<Vec<_>>();
 
 		let peaks = peaks(self.last_pos)

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -583,10 +583,10 @@ impl Input {
 	}
 
 	/// Convenience functon to return the (optional) block_hash for this input.
-	/// Will return the "zero" hash if we do not have one.
+	/// Will return the default hash if we do not have one.
 	pub fn block_hash(&self) -> Hash {
 		let block_hash = self.block_hash.clone();
-		block_hash.unwrap_or(Hash::zero())
+		block_hash.unwrap_or(Hash::default())
 	}
 
 	/// Convenience function to return the (optional) merkle_proof for this input.

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -107,7 +107,7 @@ impl DummyChainImpl {
 impl BlockChain for DummyChainImpl {
 	fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<hash::Hash, PoolError> {
 		match self.output.read().unwrap().get_output(&output_ref.commit) {
-			Some(_) => Ok(hash::Hash::zero()),
+			Some(_) => Ok(hash::Hash::default()),
 			None => Err(PoolError::GenericPoolError),
 		}
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -1654,9 +1654,9 @@ mod tests {
 		let mut tx_elements = Vec::new();
 
 		let merkle_proof = MerkleProof {
-			node: Hash::zero(),
-			root: Hash::zero(),
-			peaks: vec![Hash::zero()],
+			node: Hash::default(),
+			root: Hash::default(),
+			peaks: vec![Hash::default()],
 			..MerkleProof::default()
 		};
 


### PR DESCRIPTION
It is more idiomatic, also `zero` is misleading in context of `+`
operator.