### PR TITLE
adds gitlab CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+# Official rust image https://hub.docker.com/r/library/rust/tags/
+image: "rust:latest"
+
+before_script:
+ - apt-get update --yes -qq # yqq = yes, very quitely
+ - apt-get install -yqq --no-install-recommends cmake llvm-dev libclang-dev clang
+
+test:cargo:
+  script:
+  - rustc --version && cargo --version
+  - cargo test --all --verbose # matrix-style is a possibility too


### PR DESCRIPTION
Basic impl. for #849 using test --all

See an example of `cargo test --all` passing:
https://gitlab.com/mimblewimble/grin-ci/-/jobs/58984836

Gitlab syncs from github master branch automatically, so this would allow us to optimistically merge into master if Travis is acting up, and get a second opinion from Gitlab.