### PR TITLE
Idiomatic cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ name = "grin"
 path = "src/bin/grin.rs"
 
 [dependencies]
-blake2-rfc = "~0.2.17"
-clap = "^2.23.3"
-daemonize = "^0.2.3"
+blake2-rfc = "0.2"
+chrono = "0.4"
+clap = "2.23"
+daemonize = "0.2"
 serde = "1"
 serde_json = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
-term = "~0.4.6"
-time = "^0.1"
-chrono = "^0.4.0"
+term = "0.4"
+time = "0.1"
 
 grin_api = { path = "./api" }
 grin_config = { path = "./config" }
@@ -44,4 +44,4 @@ tag = "grin_integration_1"
 # secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 
 [build-dependencies]
-built = "^0.2.3"
+built = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ grin_wallet = { path = "./wallet" }
 #This is temporary until cursive author does a new release
 [dependencies.cursive]
 git = "https://github.com/yeastplume/Cursive"
-tag="grin_integration_1"
+tag = "grin_integration_1"
 
 # TODO - once "patch" is available we should be able to clean up the workspace dependencies
 # [patch.crate-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/bin/grin.rs"
 blake2-rfc = "~0.2.17"
 clap = "^2.23.3"
 daemonize = "^0.2.3"
-serde = "~1.0.8"
-serde_json = "~1.0.7"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+serde = "1"
+serde_json = "1"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 term = "~0.4.6"
 time = "^0.1"
 chrono = "^0.4.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,10 +13,10 @@ iron = "~0.5.1"
 router = "~0.5.1"
 regex = "^0.2"
 mount = "~0.3.0"
-urlencoded = "~0.5.0"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+urlencoded = "0.5" # 0.6+ lacks trait `plugin::Plugin<iron::Request<'_, '_>>`
 
 grin_core = { path = "../core" }
 grin_chain = { path = "../chain" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 hyper = "~0.10.6"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 lazy_static = "~0.2.8"
 iron = "~0.5.1"
 router = "~0.5.1"
@@ -16,11 +15,12 @@ mount = "~0.3.0"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 urlencoded = "0.5" # 0.6+ lacks trait `plugin::Plugin<iron::Request<'_, '_>>`
 
 grin_core = { path = "../core" }
 grin_chain = { path = "../chain" }
+grin_p2p = { path = "../p2p" }
 grin_pool = { path = "../pool" }
 grin_store = { path = "../store" }
 grin_util = { path = "../util" }
-grin_p2p = { path = "../p2p" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,12 +6,12 @@ workspace = ".."
 publish = false
 
 [dependencies]
-hyper = "~0.10.6"
-lazy_static = "~0.2.8"
-iron = "~0.5.1"
-router = "~0.5.1"
-regex = "^0.2"
-mount = "~0.3.0"
+hyper = "0.10"
+iron = "0.5"
+lazy_static = "0.2"
+mount = "0.3"
+regex = "0.2"
+router = "0.5"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,16 +7,16 @@ publish = false
 
 [dependencies]
 hyper = "~0.10.6"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 lazy_static = "~0.2.8"
 iron = "~0.5.1"
 router = "~0.5.1"
 regex = "^0.2"
 mount = "~0.3.0"
 urlencoded = "~0.5.0"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-serde_json = "~1.0.9"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 
 grin_core = { path = "../core" }
 grin_chain = { path = "../chain" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 bitflags = "^1.0"
 byteorder = "^0.5"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+serde = "1"
+serde_derive = "1"
 time = "^0.1"
 
 grin_core = { path = "../core" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,10 +15,11 @@ time = "^0.1"
 
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }
-grin_util = { path = "../util" }
 grin_store = { path = "../store" }
+grin_util = { path = "../util" }
 
 [dev-dependencies]
 env_logger = "^0.3.5"
 rand = "^0.3"
+
 grin_pow = { path = "../pow" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -6,12 +6,12 @@ workspace = ".."
 publish = false
 
 [dependencies]
-bitflags = "^1.0"
-byteorder = "^0.5"
+bitflags = "1"
+byteorder = "0.5"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"
-time = "^0.1"
+time = "0.1"
 
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }
@@ -19,7 +19,7 @@ grin_store = { path = "../store" }
 grin_util = { path = "../util" }
 
 [dev-dependencies]
-env_logger = "^0.3.5"
-rand = "^0.3"
+env_logger = "0.3"
+rand = "0.3"
 
 grin_pow = { path = "../pow" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -11,7 +11,7 @@ serde_derive = "1"
 toml = "0.4"
 
 grin_grin = { path = "../grin" }
+grin_p2p = { path = "../p2p" }
 grin_pow = { path = "../pow"}
 grin_util = { path = "../util" }
-grin_p2p = { path = "../p2p" }
 grin_wallet = { path = "../wallet"}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -6,8 +6,8 @@ workspace = ".."
 publish = false
 
 [dependencies]
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+serde = "1"
+serde_derive = "1"
 toml = "0.4"
 
 grin_grin = { path = "../grin" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,17 +6,17 @@ workspace = ".."
 publish = false
 
 [dependencies]
-bitflags = "^1.0"
-blake2-rfc = "~0.2.17"
-byteorder = "^1.0"
-num-bigint = "^0.1.35"
-rand = "^0.3"
+bitflags = "1"
+blake2-rfc = "0.2"
+byteorder = "1"
+lazy_static = "0.2"
+num-bigint = "0.1"
+rand = "0.3"
 serde = "1"
 serde_derive = "1"
-siphasher = "~0.1"
-time = "^0.1"
-lazy_static = "~0.2.8"
+siphasher = "0.1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+time = "0.1"
 
 grin_keychain = { path = "../keychain" }
 grin_util = { path = "../util" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 bitflags = "^1.0"
 blake2-rfc = "~0.2.17"
 byteorder = "^1.0"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 num-bigint = "^0.1.35"
 rand = "^0.3"
 serde = "1"
@@ -17,6 +16,7 @@ serde_derive = "1"
 siphasher = "~0.1"
 time = "^0.1"
 lazy_static = "~0.2.8"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 
 grin_keychain = { path = "../keychain" }
 grin_util = { path = "../util" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 bitflags = "^1.0"
 blake2-rfc = "~0.2.17"
 byteorder = "^1.0"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 num-bigint = "^0.1.35"
 rand = "^0.3"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+serde = "1"
+serde_derive = "1"
 siphasher = "~0.1"
 time = "^0.1"
 lazy_static = "~0.2.8"

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -1,8 +1,7 @@
-
 [package]
 name = "grin_core-fuzz"
 version = "0.0.1"
-authors = ["Automatically generated"]
+authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 publish = false
 
 [package.metadata]

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -19,13 +19,13 @@ itertools = "~0.6.0"
 grin_api = { path = "../api" }
 grin_chain = { path = "../chain" }
 grin_core = { path = "../core" }
-grin_store = { path = "../store" }
+grin_keychain = { path = "../keychain" }
 grin_p2p = { path = "../p2p" }
 grin_pool = { path = "../pool" }
-grin_util = { path = "../util" }
-grin_keychain = { path = "../keychain" }
-grin_wallet = { path = "../wallet" }
 grin_pow = { path = "../pow" }
+grin_store = { path = "../store" }
+grin_util = { path = "../util" }
+grin_wallet = { path = "../wallet" }
 
 [dev-dependencies]
 blake2-rfc = "~0.2.17"

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 
 [dependencies]
 hyper = "~0.10.6"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 time = "^0.1"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-serde_json = "~1.0.8"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 rand = "^0.3"
 router = "~0.5.1"
 itertools = "~0.6.0"

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -6,15 +6,15 @@ workspace = ".."
 publish = false
 
 [dependencies]
-hyper = "~0.10.6"
+hyper = "0.10"
+itertools = "0.6"
+rand = "0.3"
+router = "0.5"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
-time = "^0.1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-rand = "^0.3"
-router = "~0.5.1"
-itertools = "~0.6.0"
+time = "0.1"
 
 grin_api = { path = "../api" }
 grin_chain = { path = "../chain" }
@@ -28,5 +28,5 @@ grin_util = { path = "../util" }
 grin_wallet = { path = "../wallet" }
 
 [dev-dependencies]
-blake2-rfc = "~0.2.17"
+blake2-rfc = "0.2"
 grin_config = { path = "../config" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -10,9 +10,9 @@ byteorder = "^1.0"
 blake2-rfc = "~0.2.17"
 uuid = { version = "~0.5.1", features = ["serde", "v4"] }
 rand = "^0.3"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-serde_json = "~1.0.8"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 
 grin_util = { path = "../util" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -6,13 +6,13 @@ workspace = '..'
 publish = false
 
 [dependencies]
-byteorder = "^1.0"
-blake2-rfc = "~0.2.17"
-uuid = { version = "~0.5.1", features = ["serde", "v4"] }
-rand = "^0.3"
+byteorder = "1"
+blake2-rfc = "0.2"
+rand = "0.3"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+uuid = { version = "0.5", features = ["serde", "v4"] }
 
 grin_util = { path = "../util" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -6,16 +6,16 @@ workspace = ".."
 publish = false
 
 [dependencies]
-bitflags = "^1.0"
-net2 = "0.2.0"
-rand = "^0.3"
+bitflags = "1"
+bytes = "0.4"
+enum_primitive = "0.1"
+net2 = "0.2"
+num = "0.1"
+rand = "0.3"
 serde = "1"
 serde_derive = "1"
-bytes = "0.4.3"
-time = "^0.1"
-enum_primitive = "^0.1.0"
-num = "^0.1.36"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+time = "0.1"
 
 grin_core = { path = "../core" }
 grin_store = { path = "../store" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 
 [dependencies]
 bitflags = "^1.0"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 net2 = "0.2.0"
 rand = "^0.3"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+serde = "1"
+serde_derive = "1"
 bytes = "0.4.3"
 time = "^0.1"
 enum_primitive = "^0.1.0"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 bitflags = "^1.0"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 net2 = "0.2.0"
 rand = "^0.3"
 serde = "1"
@@ -16,6 +15,7 @@ bytes = "0.4.3"
 time = "^0.1"
 enum_primitive = "^0.1.0"
 num = "^0.1.36"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 
 grin_core = { path = "../core" }
 grin_store = { path = "../store" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -6,12 +6,12 @@ workspace = '..'
 publish = false
 
 [dependencies]
-blake2-rfc = "~0.2.17"
+blake2-rfc = "0.2"
+rand = "0.3"
 serde = "1"
 serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
-time = "^0.1"
-rand = "^0.3"
+time = "0.1"
 
 grin_core = { path = "../core" }
 grin_keychain = { path = "../keychain" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 blake2-rfc = "~0.2.17"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+serde = "1"
+serde_derive = "1"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 time = "^0.1"
 rand = "^0.3"
 

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -6,13 +6,13 @@ workspace = ".."
 publish = false
 
 [dependencies]
-blake2-rfc = "~0.2.17"
-rand = "^0.3"
-time = "^0.1"
-lazy_static = "~0.2.8"
+blake2-rfc = "0.2"
+lazy_static = "0.2"
+rand = "0.3"
 serde = "1"
 serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+time = "0.1"
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 blake2-rfc = "~0.2.17"
 rand = "^0.3"
 time = "^0.1"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 lazy_static = "~0.2.8"
 serde = "1"
 serde_derive = "1"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 blake2-rfc = "~0.2.17"
 rand = "^0.3"
 time = "^0.1"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 lazy_static = "~0.2.8"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+serde = "1"
+serde_derive = "1"
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -12,7 +12,7 @@ serde = "1"
 serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 libc = "^0.2"
-memmap = { git = "https://github.com/danburkert/memmap-rs", tag="0.6.0" }
+memmap = { git = "https://github.com/danburkert/memmap-rs", tag = "0.6.0" }
 rocksdb = "^0.8.0"
 
 grin_core = { path = "../core" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -6,17 +6,17 @@ workspace = ".."
 publish = false
 
 [dependencies]
-byteorder = "^1.0"
-env_logger = "^0.3.5"
+byteorder = "1"
+env_logger = "0.3"
+libc = "0.2"
+memmap = { git = "https://github.com/danburkert/memmap-rs", tag = "0.6.0" }
+rocksdb = "0.8"
 serde = "1"
 serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
-libc = "^0.2"
-memmap = { git = "https://github.com/danburkert/memmap-rs", tag = "0.6.0" }
-rocksdb = "^0.8.0"
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }
 
 [dev-dependencies]
-time = "^0.1"
+time = "0.1"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 byteorder = "^1.0"
 env_logger = "^0.3.5"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+serde = "1"
+serde_derive = "1"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 libc = "^0.2"
 memmap = { git = "https://github.com/danburkert/memmap-rs", tag="0.6.0" }
 rocksdb = "^0.8.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,6 +6,8 @@ workspace = ".."
 publish = false
 
 [dependencies]
+serde = "1"
+serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "2"
 slog-async = "2"
@@ -13,8 +15,6 @@ lazy_static = "~0.2.8"
 backtrace = "^0.3.5"
 byteorder = "^1.0"
 rand = "^0.3"
-serde = "1"
-serde_derive = "1"
 walkdir = "^2.0.1"
 zip = "^0.2.6"
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,17 +6,17 @@ workspace = ".."
 publish = false
 
 [dependencies]
+backtrace = "0.3"
+byteorder = "1"
+lazy_static = "0.2"
+rand = "0.3"
 serde = "1"
 serde_derive = "1"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "2"
 slog-async = "2"
-lazy_static = "~0.2.8"
-backtrace = "^0.3.5"
-byteorder = "^1.0"
-rand = "^0.3"
-walkdir = "^2.0.1"
-zip = "^0.2.6"
+walkdir = "2"
+zip = "0.2"
 
 [dependencies.secp256k1zkp]
 git = "https://github.com/mimblewimble/rust-secp256k1-zkp"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,15 +6,15 @@ workspace = ".."
 publish = false
 
 [dependencies]
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
-slog-term = "^2.2.0"
-slog-async = "^2.1.0"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+slog-term = "2"
+slog-async = "2"
 lazy_static = "~0.2.8"
 backtrace = "^0.3.5"
 byteorder = "^1.0"
 rand = "^0.3"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
+serde = "1"
+serde_derive = "1"
 walkdir = "^2.0.1"
 zip = "^0.2.6"
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 byteorder = "^1.0"
-slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 rand = "^0.3"
 blake2-rfc = "~0.2.17"
-serde = "~1.0.8"
-serde_derive = "~1.0.8"
-serde_json = "~1.0.8"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 bodyparser = "~0.7.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 byteorder = "^1.0"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 rand = "^0.3"
 blake2-rfc = "~0.2.17"
 serde = "1"
@@ -26,6 +25,7 @@ prettytable-rs = "^0.6"
 term = "~0.4.6"
 uuid = { version = "~0.5.1", features = ["serde", "v4"] }
 urlencoded = "~0.5.0"
+slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 
 grin_api = { path = "../api" }
 grin_core = { path = "../core" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,26 +6,26 @@ workspace = '..'
 publish = false
 
 [dependencies]
-byteorder = "^1.0"
-rand = "^0.3"
-blake2-rfc = "~0.2.17"
+blake2-rfc = "0.2"
+bodyparser = "0.7"
+byteorder = "1"
+failure = "0.1"
+failure_derive = "0.1"
+futures = "0.1"
+hyper = "0.11"
+iron = "0.5"
+prettytable-rs = "0.6"
+rand = "0.3"
+router = "0.5"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-bodyparser = "~0.7.0"
-failure = "0.1.1"
-failure_derive = "0.1.1"
-futures = "^0.1.15"
-iron = "~0.5.1"
-hyper = "~0.11.4"
-tokio-core = "~0.1.1"
-tokio-retry = "~0.1.0"
-router = "~0.5.1"
-prettytable-rs = "^0.6"
-term = "~0.4.6"
-uuid = { version = "~0.5.1", features = ["serde", "v4"] }
-urlencoded = "~0.5.0"
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
+term = "0.4"
+tokio-core = "0.1"
+tokio-retry = "0.1"
+uuid = { version = "0.5", features = ["serde", "v4"] }
+urlencoded = "0.5"
 
 grin_api = { path = "../api" }
 grin_core = { path = "../core" }


### PR DESCRIPTION
Specify versions SemVer-style

According to docs, straight semvers like "1" or rust-adjusted version strings
like "0.3" without any extra funny characters Just Works.

If we ever need a dependency with major.minor.patch and we know that only
updates on the patch level are allowed, that's when the ~ comes into play.

A dependency version can be written with or without ^ and this means exactly
the same to cargo. I looked at lots of github public projects with a Cargo.toml
to find useful things (platform-specificity is possible with cfg!)
and also concluded that the idiomatic way is to not use ^.

Checked and verified
 - [x] `cargo update` -> Cargo.lock is identical before and after
 - [x] `cargo build` -> identical grin binary built before and after
 - [x] Long live SemVer!