### PR TITLE
fix for previous

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.23"
 daemonize = "0.2"
 serde = "1"
 serde_json = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 term = "0.4"
 time = "0.1"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,7 +15,7 @@ router = "0.5"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 urlencoded = "0.5" # 0.6+ lacks trait `plugin::Plugin<iron::Request<'_, '_>>`
 
 grin_core = { path = "../core" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bitflags = "1"
 byteorder = "0.5"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"
 time = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.3"
 serde = "1"
 serde_derive = "1"
 siphasher = "0.1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 time = "0.1"
 
 grin_keychain = { path = "../keychain" }

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -10,7 +10,7 @@ hyper = "0.10"
 itertools = "0.6"
 rand = "0.3"
 router = "0.5"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 byteorder = "1"
 blake2-rfc = "0.2"
 rand = "0.3"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -14,7 +14,7 @@ num = "0.1"
 rand = "0.3"
 serde = "1"
 serde_derive = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 time = "0.1"
 
 grin_core = { path = "../core" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -10,7 +10,7 @@ blake2-rfc = "0.2"
 rand = "0.3"
 serde = "1"
 serde_derive = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 time = "0.1"
 
 grin_core = { path = "../core" }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "0.2"
 rand = "0.3"
 serde = "1"
 serde_derive = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 time = "0.1"
 
 grin_core = { path = "../core" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -13,7 +13,7 @@ memmap = { git = "https://github.com/danburkert/memmap-rs", tag = "0.6.0" }
 rocksdb = "0.8"
 serde = "1"
 serde_derive = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 
 grin_core = { path = "../core" }
 grin_util = { path = "../util" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,7 +12,7 @@ lazy_static = "0.2"
 rand = "0.3"
 serde = "1"
 serde_derive = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "2.1"
 slog-async = "2.1"
 walkdir = "2"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -20,7 +20,7 @@ router = "0.5"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
 term = "0.4"
 tokio-core = "0.1"
 tokio-retry = "0.1"


### PR DESCRIPTION
cargo update takes "2.1" and updates to 2.x
Here's a case where we need ~, so only the patch level version (third number) is allowed to be changed by cargo update.