### PR TITLE
Make peer connect attempts asynchronous

### DIFF
--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -213,18 +213,18 @@ fn listen_for_addrs(
 				.spawn(move || {
 					let connect_peer = p2p_c.connect(&addr);
 					match connect_peer {
-					Ok(p) => {
-						trace!(LOGGER, "connect_and_req: ok. attempting send_peer_request");
-						if let Ok(p) = p.try_read() {
-							let _ = p.send_peer_request(capab);
+						Ok(p) => {
+							trace!(LOGGER, "connect_and_req: ok. attempting send_peer_request");
+							if let Ok(p) = p.try_read() {
+								let _ = p.send_peer_request(capab);
+							}
+						}
+						Err(e) => {
+							debug!(LOGGER, "connect_and_req: {} is Defunct; {:?}", addr, e);
+							let _ = peers_c.update_state(addr, p2p::State::Defunct);
 						}
 					}
-					Err(e) => {
-						debug!(LOGGER, "connect_and_req: {} is Defunct; {:?}", addr, e);
-						let _ = peers_c.update_state(addr, p2p::State::Defunct);
-					}
-				}
-			});
+				});
 		}
 	}
 }

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -206,19 +206,25 @@ fn listen_for_addrs(
 	let pc = peers.peer_count();
 	for addr in rx.try_iter() {
 		if pc < PEER_MAX_COUNT {
-			let connect_peer = p2p.connect(&addr);
-			match connect_peer {
-				Ok(p) => {
-					trace!(LOGGER, "connect_and_req: ok. attempting send_peer_request");
-					if let Ok(p) = p.try_read() {
-						let _ = p.send_peer_request(capab);
+			let peers_c = peers.clone();
+			let p2p_c = p2p.clone();
+			let _ = thread::Builder::new()
+				.name("peer_connect".to_string())
+				.spawn(move || {
+					let connect_peer = p2p_c.connect(&addr);
+					match connect_peer {
+					Ok(p) => {
+						trace!(LOGGER, "connect_and_req: ok. attempting send_peer_request");
+						if let Ok(p) = p.try_read() {
+							let _ = p.send_peer_request(capab);
+						}
+					}
+					Err(e) => {
+						debug!(LOGGER, "connect_and_req: {} is Defunct; {:?}", addr, e);
+						let _ = peers_c.update_state(addr, p2p::State::Defunct);
 					}
 				}
-				Err(e) => {
-					debug!(LOGGER, "connect_and_req: {} is Defunct; {:?}", addr, e);
-					let _ = peers.update_state(addr, p2p::State::Defunct);
-				}
-			}
+			});
 		}
 	}
 }


### PR DESCRIPTION
As experienced on Testnet2 just now, grin didn't seem to be reconnecting to peers properly on startup (or doing so inconsistently)

The reason appears to be that the peer connection code is synchronous and goes one by one down the list, so if the first in the list takes a while to timeout for any reason, the sync wait ends, decides there are no peers and continues solo. Symptom was an inconsistent view on startup.

This puts each peer connection attempt onto its own thread, so all known peers up to max are connected to instantly on startup.