### PR TITLE
shorter log msg for ping/pong

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -623,8 +623,7 @@ impl NetAdapter for Peers {
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
 		debug!(
 			LOGGER,
-			"peer total_diff @ height (ping/pong): {}: {} @ {} \
-			 vs us: {} @ {}",
+			"ping/pong: {}: {} @ {} vs us: {} @ {}",
 			addr,
 			diff,
 			height,


### PR DESCRIPTION
```
Mar 27 08:15:42.246 DEBG ping/pong: 159.203.22.5:13414: 8439 @ 45 vs us: 8439 @ 45
Mar 27 08:15:42.255 DEBG ping/pong: 51.15.219.12:13414: 8439 @ 45 vs us: 8439 @ 45
Mar 27 08:15:42.292 DEBG ping/pong: 109.74.202.16:13414: 8439 @ 45 vs us: 8439 @ 45
Mar 27 08:15:42.293 DEBG ping/pong: 167.99.87.54:13414: 8439 @ 45 vs us: 8439 @ 45
Mar 27 08:15:42.295 DEBG ping/pong: 104.236.150.29:13414: 8439 @ 45 vs us: 8439 @ 45
```

Related (does not fix) - #878.