### PR TITLE
drop msgs received from a banned peer

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -442,4 +442,8 @@ impl NetAdapter for TrackingAdapter {
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
 		self.adapter.peer_difficulty(addr, diff, height)
 	}
+
+	fn is_banned(&self, addr: SocketAddr) -> bool {
+		self.adapter.is_banned(addr)
+	}
 }

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -638,4 +638,13 @@ impl NetAdapter for Peers {
 			}
 		}
 	}
+
+	fn is_banned(&self, addr: SocketAddr) -> bool {
+		if let Some(peer) = self.get_connected_peer(&addr) {
+			let mut peer = peer.write().unwrap();
+			peer.is_banned()
+		} else {
+			false
+		}
+	}
 }

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -41,6 +41,19 @@ impl MessageHandler for Protocol {
 	fn consume<'a>(&self, mut msg: Message<'a>) -> Result<Option<Response<'a>>, Error> {
 		let adapter = &self.adapter;
 
+		// If we received a msg from a banned peer then log and drop it.
+		// If we are getting a lot of these then maybe we are not cleaning
+		// banned peers up correctly?
+		if adapter.is_banned(self.addr.clone()) {
+			debug!(
+				LOGGER,
+				"handler: consume: peer {:?} banned, received: {:?}, dropping.",
+				self.addr,
+				msg.header.msg_type,
+			);
+			return Ok(None);
+		}
+
 		match msg.header.msg_type {
 			Type::Ping => {
 				let ping: Ping = msg.body()?;

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -244,4 +244,7 @@ impl NetAdapter for DummyAdapter {
 	}
 	fn peer_addrs_received(&self, _: Vec<SocketAddr>) {}
 	fn peer_difficulty(&self, _: SocketAddr, _: Difficulty, _: u64) {}
+	fn is_banned(&self, _: SocketAddr) -> bool {
+		false
+	}
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -223,4 +223,7 @@ pub trait NetAdapter: ChainAdapter {
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
 	fn peer_difficulty(&self, SocketAddr, Difficulty, u64);
+
+	/// Is this peer currently banned?
+	fn is_banned(&self, addr: SocketAddr) -> bool;
 }


### PR DESCRIPTION
If the peer is "banned" then just drop the msg during consume.
Just assume the responsibility of closing the connection and removing the peer is happening elsewhere (at the connection layer hopefully).

Resolves #885. Where we were seeing a block header msg from a banned peer and then failing to successfully request the block from the banned peer.

