### PR TITLE
do not save header during header first sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -339,11 +339,7 @@ impl Chain {
 	}
 
 	/// Process a block header received during "header first" propagation.
-	pub fn process_block_header(
-		&self,
-		bh: &BlockHeader,
-		opts: Options,
-	) -> Result<Option<Tip>, Error> {
+	pub fn process_block_header(&self, bh: &BlockHeader, opts: Options) -> Result<(), Error> {
 		let header_head = self.get_header_head()?;
 		let ctx = self.ctx_from_head(header_head, opts);
 		pipe::process_block_header(bh, ctx)

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -164,7 +164,9 @@ pub fn sync_block_header(
 }
 
 /// Process block header as part of "header first" block propagation.
-pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
+/// We validate the header but we do not store it or update header head based on this.
+/// We will update these once we get the block back after requesting it.
+pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<(), Error> {
 	debug!(
 		LOGGER,
 		"pipe: process_block_header: {} at {}",
@@ -173,19 +175,7 @@ pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<O
 	);
 
 	check_header_known(bh.hash(), &mut ctx)?;
-	validate_header(&bh, &mut ctx)?;
-
-	debug!(
-		LOGGER,
-		"pipe: process_block_header: {} at {} is valid, saving.",
-		bh.hash(),
-		bh.height,
-	);
-
-	add_block_header(bh, &mut ctx)?;
-
-	// now update the header_head (if new header with most work)
-	update_header_head(bh, &mut ctx)
+	validate_header(&bh, &mut ctx)
 }
 
 /// Quick in-memory check to fast-reject any block header we've already handled

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -544,6 +544,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 		// If block contains txs then broadcast the compact block.
 		// If we received the block from another node then broadcast "header first"
 		// to minimize network traffic.
+
 		if opts.contains(Options::MINE) {
 			// propagate compact block out if we mined the block
 			// but broadcast full block if we have no txs
@@ -552,7 +553,6 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 				// in the interest of testing all code paths
 				// randomly decide how we send an empty block out
 				// TODO - lock this down once we are comfortable it works...
-
 				let mut rng = rand::thread_rng();
 				if rng.gen() {
 					wo(&self.peers).broadcast_block(&b);
@@ -564,7 +564,16 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			}
 		} else {
 			// "header first" propagation if we are not the originator of this block
-			wo(&self.peers).broadcast_header(&b.header);
+			// again randomly chose between "header first" or "compact block" propagation
+			// to ensure we test a wide variety of code paths
+
+			let mut rng = rand::thread_rng();
+			if rng.gen() {
+				wo(&self.peers).broadcast_header(&b.header);
+			} else {
+				let cb = b.as_compact_block();
+				wo(&self.peers).broadcast_compact_block(&cb);
+			}
 		}
 	}
 }


### PR DESCRIPTION
just use the header as a hint to go request the block

If this fails then at least we have other peers sending us the header that we can act on.

Also randomly propagate compact block vs header first. We don't actually know which is better for the network as a whole.

