### PR TITLE
Clean awaiting confirmation when send fails (Fix #900)

### DIFF
--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -119,6 +119,10 @@ pub fn issue_send_tx(
 	} else */
 
 	if &dest[..4] != "http" {
+		WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
+			info!(LOGGER, "cleaning up unused change output from wallet");
+			wallet_data.delete_output(&change_key);
+		});
 		panic!(
 			"dest formatted as {} but send -d expected stdout or http://IP:port",
 			dest


### PR DESCRIPTION
Fix #900.
Now cleans the wallet ```awaiting confirmation``` when destination is incorrect.
