### PR TITLE
Build index header by height after fast sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -561,6 +561,7 @@ impl Chain {
 			*head = Tip::from_block(&header);
 			let _ = self.store.save_body_head(&head);
 			self.store.save_header_height(&header)?;
+			self.store.build_by_height_index(&header, true)?;
 		}
 
 		self.check_orphans(header.hash());

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -265,7 +265,6 @@ fn simulate_fast_sync() {
 	while s2.head().height != s2.header_head().height || s2.head().height < 20 {
 		thread::sleep(time::Duration::from_millis(1000));
 	}
-	s2.chain.rebuild_header_by_height();
 	let h2 = s2.chain.get_header_by_height(1).unwrap();
 
 	s1.stop();


### PR DESCRIPTION
Make sure that all headers are indexed