### PR TITLE
Randomize Dandelion timer

### DIFF
--- a/grin/src/dandelion_monitor.rs
+++ b/grin/src/dandelion_monitor.rs
@@ -51,7 +51,6 @@ pub fn monitor_transactions<T>(
 					let time_transaction = time_stem_transactions.get(tx_hash).unwrap();
 					let interval = now_utc().to_timespec().sec - time_transaction;
 
-					// TODO Randomize between 30 and 60 seconds
 					if interval >= config.dandelion_embargo {
 						let source = TxSource {
 							debug_name: "dandelion-monitor".to_string(),

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -255,7 +255,7 @@ where
 		// Track the case where a parent of a transaction is in stempool
 		let mut parent_in_stempool = false;
 		// The timer attached to this transaction
-		let mut timer: i64 = <i64>::max_value();
+		let mut timer: i64 = 0;
 
 		// The next issue is to identify all unspent outputs that
 		// this transaction will consume and make sure they exist in the set.
@@ -279,7 +279,7 @@ where
 					debug!(LOGGER, "Parent is in stempool, going in stempool");
 					pool_refs.push(base.with_source(Some(x)));
 					let temp_timer = self.time_stem_transactions.get(&x).unwrap().clone();
-					if temp_timer < timer {
+					if temp_timer > timer {
 						timer = temp_timer;
 					}
 				}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -274,17 +274,14 @@ where
 			match self.search_for_best_output(&output) {
 				Parent::PoolTransaction { tx_ref: x } => pool_refs.push(base.with_source(Some(x))),
 				Parent::StemPoolTransaction { tx_ref: x } => {
-						will_stem = true;
-						parent_in_stempool = true;
-						debug!(
-							LOGGER,
-							"Parent is in stempool, going in stempool"
-						);
-						pool_refs.push(base.with_source(Some(x)));
-						let temp_timer = self.time_stem_transactions.get(&x).unwrap().clone();
-						if  temp_timer < timer {
-							timer = temp_timer;
-						}
+					will_stem = true;
+					parent_in_stempool = true;
+					debug!(LOGGER, "Parent is in stempool, going in stempool");
+					pool_refs.push(base.with_source(Some(x)));
+					let temp_timer = self.time_stem_transactions.get(&x).unwrap().clone();
+					if temp_timer < timer {
+						timer = temp_timer;
+					}
 				}
 				Parent::BlockTransaction => {
 					let height = head_header.height + 1;
@@ -353,8 +350,7 @@ where
 				self.adapter.stem_tx_accepted(&tx);
 				self.stem_transactions.insert(tx_hash, Box::new(tx));
 				// Track this transaction
-				self.time_stem_transactions
-					.insert(tx_hash, timer);
+				self.time_stem_transactions.insert(tx_hash, timer);
 			} else {
 				// Fluff phase: transaction is added to memory pool and broadcasted normally
 				self.pool.add_pool_transaction(

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -252,6 +252,11 @@ where
 		let stem_propagation = random <= self.config.dandelion_probability;
 		let mut will_stem = stem && stem_propagation;
 
+		// Track the case where a parent of a transaction is in stempool
+		let mut parent_in_stempool = false;
+		// The timer attached to this transaction
+		let mut timer: i64 = <i64>::max_value();
+
 		// The next issue is to identify all unspent outputs that
 		// this transaction will consume and make sure they exist in the set.
 		let mut pool_refs: Vec<graph::Edge> = Vec::new();
@@ -269,18 +274,17 @@ where
 			match self.search_for_best_output(&output) {
 				Parent::PoolTransaction { tx_ref: x } => pool_refs.push(base.with_source(Some(x))),
 				Parent::StemPoolTransaction { tx_ref: x } => {
-					if will_stem {
-						// Going to stem this transaction if parent is in stempool it's ok.
-						debug!(LOGGER, "Going in stempool");
-						pool_refs.push(base.with_source(Some(x)));
-					} else {
 						will_stem = true;
+						parent_in_stempool = true;
 						debug!(
 							LOGGER,
-							"Parent is in stempool, force transaction to go in stempool"
+							"Parent is in stempool, going in stempool"
 						);
 						pool_refs.push(base.with_source(Some(x)));
-					}
+						let temp_timer = self.time_stem_transactions.get(&x).unwrap().clone();
+						if  temp_timer < timer {
+							timer = temp_timer;
+						}
 				}
 				Parent::BlockTransaction => {
 					let height = head_header.height + 1;
@@ -298,6 +302,11 @@ where
 		}
 
 		let is_orphan = orphan_refs.len() > 0;
+
+		// In the case the parent is not in stempool we randomize the timer
+		if !parent_in_stempool {
+			timer = time::now_utc().to_timespec().sec + rand::thread_rng().gen_range(0, 31);
+		}
 
 		// Next we examine the outputs this transaction creates and ensure
 		// that they do not already exist.
@@ -345,7 +354,7 @@ where
 				self.stem_transactions.insert(tx_hash, Box::new(tx));
 				// Track this transaction
 				self.time_stem_transactions
-					.insert(tx_hash, time::now_utc().to_timespec().sec);
+					.insert(tx_hash, timer);
 			} else {
 				// Fluff phase: transaction is added to memory pool and broadcasted normally
 				self.pool.add_pool_transaction(


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/894.

Now the Dandelion timer is randomized between 30 (or DANDELION_EMBARGO_DELAY) and 60 seconds just like the Dandelion BIP.
If parents are found in the stempool, the timer will go to the highest parent timer.