### PR TITLE
use hashable_ord on short_ids

### DIFF
--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -36,7 +36,7 @@ use util::secp::pedersen::*;
 pub use self::block::*;
 pub use self::transaction::*;
 pub use self::id::ShortId;
-use self::hash::Hashed;
+use core::hash::Hashed;
 use ser::{Error, Readable, Reader, Writeable, Writer};
 use global;
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -45,29 +45,6 @@ bitflags! {
 	}
 }
 
-// don't seem to be able to define an Ord implementation for Hash due to
-// Ord being defined on all pointers, resorting to a macro instead
-macro_rules! hashable_ord {
-	($hashable: ident) => {
-		impl Ord for $hashable {
-			fn cmp(&self, other: &$hashable) -> Ordering {
-				self.hash().cmp(&other.hash())
-			}
-		}
-		impl PartialOrd for $hashable {
-			fn partial_cmp(&self, other: &$hashable) -> Option<Ordering> {
-				Some(self.hash().cmp(&other.hash()))
-			}
-		}
-		impl PartialEq for $hashable {
-			fn eq(&self, other: &$hashable) -> bool {
-				self.hash() == other.hash()
-			}
-		}
-		impl Eq for $hashable {}
-	}
-}
-
 /// Errors thrown by Block validation
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -92,3 +92,26 @@ macro_rules! ser_multiwrite {
     $( try!($wrtr.$write_call($val)) );*
   }
 }
+
+// don't seem to be able to define an Ord implementation for Hash due to
+// Ord being defined on all pointers, resorting to a macro instead
+macro_rules! hashable_ord {
+	($hashable: ident) => {
+		impl Ord for $hashable {
+			fn cmp(&self, other: &$hashable) -> Ordering {
+				self.hash().cmp(&other.hash())
+			}
+		}
+		impl PartialOrd for $hashable {
+			fn partial_cmp(&self, other: &$hashable) -> Option<Ordering> {
+				Some(self.cmp(other))
+			}
+		}
+		impl PartialEq for $hashable {
+			fn eq(&self, other: &$hashable) -> bool {
+				self.hash() == other.hash()
+			}
+		}
+		impl Eq for $hashable {}
+	}
+}


### PR DESCRIPTION
Use hashable_ord on short_ids so we sort them consistently.
Sort short_ids by hash, same as inputs|outputs|kernels.
Move hashable_ord to macros.rs for reuse.
Add test for sort order of short_ids.

Resolves #908.