### PR TITLE
fix issue where we have no metadata for a block

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -157,15 +157,20 @@ impl Chain {
 
 		// check if we have a head in store, otherwise the genesis block is it
 		let head = store.head();
+
 		let txhashset_md = match head {
 			Ok(h) => {
 				// Add the height to the metadata for the use of the rewind log, as this isn't
 				// stored
-				let mut ts = store.get_block_pmmr_file_metadata(&h.last_block_h)?;
-				ts.output_file_md.block_height = h.height;
-				ts.rproof_file_md.block_height = h.height;
-				ts.kernel_file_md.block_height = h.height;
-				Some(ts)
+				if let Ok(mut ts) = store.get_block_pmmr_file_metadata(&h.last_block_h) {
+					ts.output_file_md.block_height = h.height;
+					ts.rproof_file_md.block_height = h.height;
+					ts.kernel_file_md.block_height = h.height;
+					Some(ts)
+				} else {
+					debug!(LOGGER, "metadata not found for {} @ {}", h.height, h.hash());
+					None
+				}
 			}
 			Err(NotFoundErr) => None,
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
@@ -175,6 +180,7 @@ impl Chain {
 			txhashset::TxHashSet::open(db_root.clone(), store.clone(), txhashset_md)?;
 
 		let head = store.head();
+
 		let head = match head {
 			Ok(h) => h,
 			Err(NotFoundErr) => {

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -103,7 +103,8 @@ impl Server {
 			global::ChainTypes::AutomatedTesting => genesis::genesis_dev(),
 			_ => pow::mine_genesis_block(config.mining_config.clone())?,
 		};
-		info!(LOGGER, "Starting server, genesis block: {}", genesis.hash(),);
+
+		info!(LOGGER, "Starting server, genesis block: {}", genesis.hash());
 
 		let shared_chain = Arc::new(chain::Chain::init(
 			config.db_root.clone(),

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -248,6 +248,14 @@ impl MessageHandler for Protocol {
 					tmp_zip,
 					self.addr,
 				);
+
+				debug!(
+					LOGGER,
+					"handle_payload: txhashset archive for {} at {}, DONE",
+					sm_arch.hash,
+					sm_arch.height
+				);
+
 				Ok(None)
 			}
 


### PR DESCRIPTION
We have no metadata when restarting node before initial sync completed.
Modify `chain::init()` to handle this case (metadata is optional).

