### PR TITLE
Add support for DNS Seed

### DIFF
--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -240,7 +240,14 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 		for dns_seed in DNS_SEEDS {
 			debug!(LOGGER, "Retrieving seed nodes from dns {}", dns_seed);
 			match (dns_seed.to_owned(), 0).to_socket_addrs() {
-				Ok(addrs) => addresses.append(&mut (addrs.map(|mut addr| {addr.set_port(13414); addr}).collect())),
+				Ok(addrs) => addresses.append(
+					&mut (addrs
+						.map(|mut addr| {
+							addr.set_port(13414);
+							addr
+						})
+						.collect()),
+				),
 				Err(e) => debug!(
 					LOGGER,
 					"Failed to resolve seed {:?} got error {:?}", dns_seed, e

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -239,9 +239,12 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 		let mut addresses: Vec<SocketAddr> = vec![];
 		for dns_seed in DNS_SEEDS {
 			debug!(LOGGER, "Retrieving seed nodes from dns {}", dns_seed);
-			match (dns_seed.to_owned(),0).to_socket_addrs() {
+			match (dns_seed.to_owned(), 0).to_socket_addrs() {
 				Ok(addrs) => addresses.append(&mut (addrs.into_iter().collect())),
-				Err(e) => debug!(LOGGER, "Failed to resolve seed {:?} got error {:?}", dns_seed, e),
+				Err(e) => debug!(
+					LOGGER,
+					"Failed to resolve seed {:?} got error {:?}", dns_seed, e
+				),
 			}
 		}
 		addresses

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -240,7 +240,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 		for dns_seed in DNS_SEEDS {
 			debug!(LOGGER, "Retrieving seed nodes from dns {}", dns_seed);
 			match (dns_seed.to_owned(), 0).to_socket_addrs() {
-				Ok(addrs) => addresses.append(&mut (addrs.into_iter().collect())),
+				Ok(addrs) => addresses.append(&mut (addrs.map(|mut addr| {addr.set_port(13414); addr}).collect())),
 				Err(e) => debug!(
 					LOGGER,
 					"Failed to resolve seed {:?} got error {:?}", dns_seed, e

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -32,7 +32,7 @@ use p2p;
 use util::LOGGER;
 
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
-const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org","seed.grin.lesceller.com"];
+const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org", "seed.grin.lesceller.com"];
 
 pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -32,8 +32,7 @@ use p2p;
 use util::LOGGER;
 
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
-// TODO Add more DNS Seeds
-const DNS_SEEDS: &'static [&'static str] = &["seed.grin.lesceller.com"];
+const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org","seed.grin.lesceller.com"];
 
 pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -237,6 +237,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 	Box::new(|| {
 		let mut addresses: Vec<SocketAddr> = vec![];
 		for dns_seed in DNS_SEEDS {
+			let temp_addresses = addresses.clone();
 			debug!(LOGGER, "Retrieving seed nodes from dns {}", dns_seed);
 			match (dns_seed.to_owned(), 0).to_socket_addrs() {
 				Ok(addrs) => addresses.append(
@@ -245,6 +246,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 							addr.set_port(13414);
 							addr
 						})
+						.filter(|addr| !temp_addresses.contains(addr))
 						.collect()),
 				),
 				Err(e) => debug!(

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -167,6 +167,7 @@ impl Server {
 					seed::predefined_seeds(vec![])
 				}
 				Seeding::List => seed::predefined_seeds(config.seeds.as_mut().unwrap().clone()),
+				Seeding::DNSSeed => seed::dns_seeds(),
 				Seeding::WebStatic => seed::web_seeds(),
 				_ => unreachable!(),
 			};

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -111,6 +111,8 @@ pub enum Seeding {
 	List,
 	/// Automatically download a text file with a list of server addresses
 	WebStatic,
+	/// Automatically get a list of seeds from mutliple DNS
+	DNSSeed,
 	/// Mostly for tests, where connections are initiated programmatically
 	Programmatic,
 }


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/218.
This PR add support for DNS Seed in Grin.
Currently only one DNS which resolve to the current list of seeds at http://grin-tech.org/seeds.txt.
It will need more DNS to be the default connection method.