### PR TITLE
Add DNS Seed and make DNSSeed default

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -25,7 +25,7 @@ api_http_addr = "127.0.0.1:13413"
 
 db_root = ".grin"
 
-#How to seed this server, can be None, List or WebStatic
+#How to seed this server, can be None, List, WebStatic or DNSSeed
 #
 #seeding_type = "None"
 

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -32,7 +32,7 @@ use p2p;
 use util::LOGGER;
 
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
-const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org", "seed.grin.lesceller.com"];
+const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org", "seed.grin.lesceller.com","grin-seed.owncrypto.de"];
 
 pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -34,9 +34,9 @@ use util::LOGGER;
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
 // DNS Seeds with contact email associated
 const DNS_SEEDS: &'static [&'static str] = &[
-	"seed.grin-tech.org", // igno.peverell@protonmail.com
+	"seed.grin-tech.org",      // igno.peverell@protonmail.com
 	"seed.grin.lesceller.com", // q.lesceller@gmail.com
-	"grin-seed.owncrypto.de", // roll@yourowncryp.to
+	"grin-seed.owncrypto.de",  // roll@yourowncryp.to
 ];
 
 pub fn connect_and_monitor(

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -32,10 +32,11 @@ use p2p;
 use util::LOGGER;
 
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
+// DNS Seeds with contact email associated
 const DNS_SEEDS: &'static [&'static str] = &[
-	"seed.grin-tech.org",
-	"seed.grin.lesceller.com",
-	"grin-seed.owncrypto.de",
+	"seed.grin-tech.org", // igno.peverell@protonmail.com
+	"seed.grin.lesceller.com", // q.lesceller@gmail.com
+	"grin-seed.owncrypto.de", // roll@yourowncryp.to
 ];
 
 pub fn connect_and_monitor(

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -32,7 +32,11 @@ use p2p;
 use util::LOGGER;
 
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
-const DNS_SEEDS: &'static [&'static str] = &["seed.grin-tech.org", "seed.grin.lesceller.com","grin-seed.owncrypto.de"];
+const DNS_SEEDS: &'static [&'static str] = &[
+	"seed.grin-tech.org",
+	"seed.grin.lesceller.com",
+	"grin-seed.owncrypto.de",
+];
 
 pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -119,7 +119,7 @@ pub enum Seeding {
 
 impl Default for Seeding {
 	fn default() -> Seeding {
-		Seeding::WebStatic
+		Seeding::DNSSeed
 	}
 }
 


### PR DESCRIPTION
Thanks to @hashmap, we now have three DNS seeds (grin-seed.owncrypto.de).
This PR also make DNS seeding the default seeding method.