### PR TITLE
[WIP] Core PMMR and API updates to support wallet restore

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -127,7 +127,12 @@ impl OutputHandler {
 				.iter()
 				.filter(|output| commitments.is_empty() || commitments.contains(&output.commit))
 				.map(|output| {
-					OutputPrintable::from_output(output, w(&self.chain), Some(&header), include_proof)
+					OutputPrintable::from_output(
+						output,
+						w(&self.chain),
+						Some(&header),
+						include_proof,
+					)
 				})
 				.collect();
 
@@ -260,14 +265,16 @@ impl TxHashSetHandler {
 		if max > 1000 {
 			max = 1000;
 		}
-		let outputs = w(&self.chain).unspent_outputs_by_insertion_index(start_index, max).unwrap();
+		let outputs = w(&self.chain)
+			.unspent_outputs_by_insertion_index(start_index, max)
+			.unwrap();
 		OutputListing {
 			last_retrieved_index: outputs.0,
 			highest_index: outputs.1,
-			outputs: outputs.2.iter()
-				.map(|x|{
-					OutputPrintable::from_output(x, w(&self.chain), None, true)
-				})
+			outputs: outputs
+				.2
+				.iter()
+				.map(|x| OutputPrintable::from_output(x, w(&self.chain), None, true))
 				.collect(),
 		}
 	}

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -127,7 +127,7 @@ impl OutputHandler {
 				.iter()
 				.filter(|output| commitments.is_empty() || commitments.contains(&output.commit))
 				.map(|output| {
-					OutputPrintable::from_output(output, w(&self.chain), &header, include_proof)
+					OutputPrintable::from_output(output, w(&self.chain), Some(&header), include_proof)
 				})
 				.collect();
 
@@ -226,6 +226,9 @@ impl Handler for OutputHandler {
 // GET /v1/txhashset/lastoutputs?n=5
 // GET /v1/txhashset/lastrangeproofs
 // GET /v1/txhashset/lastkernels
+
+// UTXO traversal::
+// GET /v1/txhashset/outputs?start_index=1&max=100
 struct TxHashSetHandler {
 	chain: Weak<chain::Chain>,
 }
@@ -250,12 +253,32 @@ impl TxHashSetHandler {
 	fn get_last_n_kernel(&self, distance: u64) -> Vec<TxHashSetNode> {
 		TxHashSetNode::get_last_n_kernel(w(&self.chain), distance)
 	}
+
+	// allows traversal of utxo set
+	fn outputs(&self, start_index: u64, mut max: u64) -> OutputListing {
+		//set a limit here
+		if max > 1000 {
+			max = 1000;
+		}
+		let outputs = w(&self.chain).unspent_outputs_by_insertion_index(start_index, max).unwrap();
+		OutputListing {
+			last_retrieved_index: outputs.0,
+			highest_index: outputs.1,
+			outputs: outputs.2.iter()
+				.map(|x|{
+					OutputPrintable::from_output(x, w(&self.chain), None, true)
+				})
+				.collect(),
+		}
+	}
 }
 
 impl Handler for TxHashSetHandler {
 	fn handle(&self, req: &mut Request) -> IronResult<Response> {
 		let url = req.url.clone();
 		let mut path_elems = url.path();
+		let mut start_index = 1;
+		let mut max = 100;
 		if *path_elems.last().unwrap() == "" {
 			path_elems.pop();
 		}
@@ -269,12 +292,27 @@ impl Handler for TxHashSetHandler {
 					}
 				}
 			}
+			if let Some(start_indexes) = params.get("start_index") {
+				for si in start_indexes {
+					if let Ok(s) = str::parse(si) {
+						start_index = s;
+					}
+				}
+			}
+			if let Some(maxes) = params.get("max") {
+				for ma in maxes {
+					if let Ok(m) = str::parse(ma) {
+						max = m;
+					}
+				}
+			}
 		}
 		match *path_elems.last().unwrap() {
 			"roots" => json_response_pretty(&self.get_roots()),
 			"lastoutputs" => json_response_pretty(&self.get_last_n_output(last_n)),
 			"lastrangeproofs" => json_response_pretty(&self.get_last_n_rangeproof(last_n)),
 			"lastkernels" => json_response_pretty(&self.get_last_n_kernel(last_n)),
+			"outputs" => json_response_pretty(&self.outputs(start_index, max)),
 			_ => Ok(Response::with((status::BadRequest, ""))),
 		}
 	}
@@ -710,6 +748,7 @@ pub fn start_rest_apis<T>(
 				"get txhashset/lastoutputs?n=10".to_string(),
 				"get txhashset/lastrangeproofs".to_string(),
 				"get txhashset/lastkernels".to_string(),
+				"get txhashset/outputs?start_index=1&max=100".to_string(),
 				"get pool".to_string(),
 				"post pool/push".to_string(),
 				"post peers/a.b.c.d:p/ban".to_string(),

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -528,7 +528,12 @@ impl BlockPrintable {
 			.outputs
 			.iter()
 			.map(|output| {
-				OutputPrintable::from_output(output, chain.clone(), Some(&block.header), include_proof)
+				OutputPrintable::from_output(
+					output,
+					chain.clone(),
+					Some(&block.header),
+					include_proof,
+				)
 			})
 			.collect();
 		let kernels = block

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -240,7 +240,7 @@ impl OutputPrintable {
 	pub fn from_output(
 		output: &core::Output,
 		chain: Arc<chain::Chain>,
-		block_header: &core::BlockHeader,
+		block_header: Option<&core::BlockHeader>,
 		include_proof: bool,
 	) -> OutputPrintable {
 		let output_type = if output
@@ -269,8 +269,9 @@ impl OutputPrintable {
 		if output
 			.features
 			.contains(core::transaction::OutputFeatures::COINBASE_OUTPUT) && !spent
+			&& block_header.is_some()
 		{
-			merkle_proof = chain.get_merkle_proof(&out_id, &block_header).ok()
+			merkle_proof = chain.get_merkle_proof(&out_id, &block_header.unwrap()).ok()
 		};
 
 		OutputPrintable {
@@ -527,7 +528,7 @@ impl BlockPrintable {
 			.outputs
 			.iter()
 			.map(|output| {
-				OutputPrintable::from_output(output, chain.clone(), &block.header, include_proof)
+				OutputPrintable::from_output(output, chain.clone(), Some(&block.header), include_proof)
 			})
 			.collect();
 		let kernels = block
@@ -566,7 +567,7 @@ impl CompactBlockPrintable {
 		let block = chain.get_block(&cb.hash()).unwrap();
 		let out_full = cb.out_full
 			.iter()
-			.map(|x| OutputPrintable::from_output(x, chain.clone(), &block.header, false))
+			.map(|x| OutputPrintable::from_output(x, chain.clone(), Some(&block.header), false))
 			.collect();
 		let kern_full = cb.kern_full
 			.iter()
@@ -587,6 +588,18 @@ impl CompactBlockPrintable {
 pub struct BlockOutputs {
 	/// The block header
 	pub header: BlockHeaderInfo,
+	/// A printable version of the outputs
+	pub outputs: Vec<OutputPrintable>,
+}
+
+// For traversing all outputs in the UTXO set
+// transactions in the block
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OutputListing {
+	/// The last available output index
+	pub highest_index: u64,
+	/// The last insertion index retrieved
+	pub last_retrieved_index: u64,
 	/// A printable version of the outputs
 	pub outputs: Vec<OutputPrintable>,
 }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,7 +20,7 @@ use std::fs::File;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use core::core::{Block, BlockHeader, Input, OutputFeatures, OutputIdentifier, TxKernel};
+use core::core::{Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel};
 use core::core::hash::{Hash, Hashed};
 use core::core::pmmr::MerkleProof;
 use core::core::target::Difficulty;
@@ -660,6 +660,27 @@ impl Chain {
 	pub fn get_last_n_kernel(&self, distance: u64) -> Vec<(Hash, TxKernel)> {
 		let mut txhashset = self.txhashset.write().unwrap();
 		txhashset.last_n_kernel(distance)
+	}
+
+	/// outputs by insertion index
+	pub fn unspent_outputs_by_insertion_index(&self, start_index: u64, max: u64) 
+		-> Result<(u64, u64, Vec<Output>), Error> {
+		let mut txhashset = self.txhashset.write().unwrap();
+		let max_index = txhashset.highest_output_insertion_index();
+		let outputs = txhashset.outputs_by_insertion_index(start_index, max);
+		let rangeproofs = txhashset.rangeproofs_by_insertion_index(start_index, max);
+		if outputs.0 != rangeproofs.0 || outputs.1.len() != rangeproofs.1.len() {
+			return Err(Error::TxHashSetErr(String::from("Output and rangeproof sets don't match")));
+		}
+		let mut output_vec:Vec<Output> = vec![];
+		for (ref x, &y) in outputs.1.iter().zip(rangeproofs.1.iter()) {
+			output_vec.push(Output {
+				commit: x.commit,
+				features: x.features,
+				proof: y,
+			});
+		}
+		Ok((outputs.0, max_index, output_vec))
 	}
 
 	/// Total difficulty at the head of the chain

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -663,16 +663,21 @@ impl Chain {
 	}
 
 	/// outputs by insertion index
-	pub fn unspent_outputs_by_insertion_index(&self, start_index: u64, max: u64) 
-		-> Result<(u64, u64, Vec<Output>), Error> {
+	pub fn unspent_outputs_by_insertion_index(
+		&self,
+		start_index: u64,
+		max: u64,
+	) -> Result<(u64, u64, Vec<Output>), Error> {
 		let mut txhashset = self.txhashset.write().unwrap();
 		let max_index = txhashset.highest_output_insertion_index();
 		let outputs = txhashset.outputs_by_insertion_index(start_index, max);
 		let rangeproofs = txhashset.rangeproofs_by_insertion_index(start_index, max);
 		if outputs.0 != rangeproofs.0 || outputs.1.len() != rangeproofs.1.len() {
-			return Err(Error::TxHashSetErr(String::from("Output and rangeproof sets don't match")));
+			return Err(Error::TxHashSetErr(String::from(
+				"Output and rangeproof sets don't match",
+			)));
 		}
-		let mut output_vec:Vec<Output> = vec![];
+		let mut output_vec: Vec<Output> = vec![];
 		for (ref x, &y) in outputs.1.iter().zip(rangeproofs.1.iter()) {
 			output_vec.push(Output {
 				commit: x.commit,

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -183,6 +183,28 @@ impl TxHashSet {
 		kernel_pmmr.get_last_n_insertions(distance)
 	}
 
+	/// returns outputs from the given insertion (leaf) index up to the specified
+	/// limit. Also returns the last index actually populated
+	pub fn outputs_by_insertion_index(&mut self, start_index: u64, max_count: u64) 
+		-> (u64, Vec<OutputIdentifier>) {
+		let output_pmmr: PMMR<OutputIdentifier, _> =
+			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
+		output_pmmr.elements_from_insertion_index(start_index, max_count)
+	}
+
+	/// highest output insertion index availalbe
+	pub fn highest_output_insertion_index(&mut self) -> u64 {
+		pmmr::n_leaves(self.output_pmmr_h.last_pos)
+	}
+
+	/// As above, for rangeproofs
+	pub fn rangeproofs_by_insertion_index(&mut self, start_index: u64, max_count: u64) 
+		-> (u64, Vec<RangeProof>) {
+		let rproof_pmmr: PMMR<RangeProof, _> =
+			PMMR::at(&mut self.rproof_pmmr_h.backend, self.rproof_pmmr_h.last_pos);
+		rproof_pmmr.elements_from_insertion_index(start_index, max_count)
+	}
+
 	/// Output and kernel MMR indexes at the end of the provided block
 	pub fn indexes_at(&self, bh: &Hash) -> Result<(u64, u64), Error> {
 		self.commit_index.get_block_marker(bh).map_err(&From::from)

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -185,8 +185,11 @@ impl TxHashSet {
 
 	/// returns outputs from the given insertion (leaf) index up to the specified
 	/// limit. Also returns the last index actually populated
-	pub fn outputs_by_insertion_index(&mut self, start_index: u64, max_count: u64) 
-		-> (u64, Vec<OutputIdentifier>) {
+	pub fn outputs_by_insertion_index(
+		&mut self,
+		start_index: u64,
+		max_count: u64,
+	) -> (u64, Vec<OutputIdentifier>) {
 		let output_pmmr: PMMR<OutputIdentifier, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		output_pmmr.elements_from_insertion_index(start_index, max_count)
@@ -198,8 +201,11 @@ impl TxHashSet {
 	}
 
 	/// As above, for rangeproofs
-	pub fn rangeproofs_by_insertion_index(&mut self, start_index: u64, max_count: u64) 
-		-> (u64, Vec<RangeProof>) {
+	pub fn rangeproofs_by_insertion_index(
+		&mut self,
+		start_index: u64,
+		max_count: u64,
+	) -> (u64, Vec<RangeProof>) {
 		let rproof_pmmr: PMMR<RangeProof, _> =
 			PMMR::at(&mut self.rproof_pmmr_h.backend, self.rproof_pmmr_h.last_pos);
 		rproof_pmmr.elements_from_insertion_index(start_index, max_count)

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -37,7 +37,7 @@
 
 use std::clone::Clone;
 use std::marker::PhantomData;
-use core::hash::{Hash};
+use core::hash::Hash;
 use ser;
 use ser::{Readable, Reader, Writeable, Writer};
 use ser::{PMMRIndexHashable, PMMRable};
@@ -222,8 +222,8 @@ impl MerkleProof {
 			let mut bagged = None;
 			for peak in self.peaks.iter().rev() {
 				bagged = match bagged {
-					None      => Some(*peak),
-					Some(rhs) => Some((*peak,rhs).hash_with_index(self.mmr_size)),
+					None => Some(*peak),
+					Some(rhs) => Some((*peak, rhs).hash_with_index(self.mmr_size)),
 				}
 			}
 			return bagged == Some(self.root);
@@ -236,9 +236,9 @@ impl MerkleProof {
 		// hash our node and sibling together (noting left/right position of the
 		// sibling)
 		let parent = if is_left_sibling(sibling_pos) {
-			(sibling, self.node).hash_with_index(parent_pos-1)
+			(sibling, self.node).hash_with_index(parent_pos - 1)
 		} else {
-			(self.node, sibling).hash_with_index(parent_pos-1)
+			(self.node, sibling).hash_with_index(parent_pos - 1)
 		};
 
 		let proof = MerkleProof {
@@ -315,8 +315,8 @@ where
 		let mut res = None;
 		for peak in self.peaks().iter().rev() {
 			res = match res {
-				None        => Some(*peak),
-				Some(rhash) => Some((*peak,rhash).hash_with_index(self.unpruned_size())),
+				None => Some(*peak),
+				Some(rhash) => Some((*peak, rhash).hash_with_index(self.unpruned_size())),
 			}
 		}
 		res.expect("no root, invalid tree")
@@ -370,7 +370,7 @@ where
 	/// the same time if applicable.
 	pub fn push(&mut self, elmt: T) -> Result<u64, String> {
 		let elmt_pos = self.last_pos + 1;
-		let mut current_hash = elmt.hash_with_index(elmt_pos-1);
+		let mut current_hash = elmt.hash_with_index(elmt_pos - 1);
 
 		let mut to_append = vec![(current_hash, Some(elmt))];
 		let mut height = 0;
@@ -390,7 +390,7 @@ where
 			height += 1;
 			pos += 1;
 
-			current_hash = (left_hash, current_hash).hash_with_index(pos-1);
+			current_hash = (left_hash, current_hash).hash_with_index(pos - 1);
 
 			to_append.push((current_hash.clone(), None));
 		}
@@ -561,7 +561,9 @@ where
 						if let Some(right_child_hs) = self.get_from_file(right_pos) {
 							// hash the two child nodes together with parent_pos and compare
 							let (parent_pos, _) = family(left_pos);
-							if (left_child_hs, right_child_hs).hash_with_index(parent_pos-1) != hash {
+							if (left_child_hs, right_child_hs).hash_with_index(parent_pos - 1)
+								!= hash
+							{
 								return Err(format!(
 									"Invalid MMR, hash of parent at {} does \
 									 not match children.",
@@ -846,10 +848,10 @@ pub fn n_leaves(mut sz: u64) -> u64 {
 }
 
 /// Returns the pmmr index of the nth inserted element
-pub fn insertion_to_pmmr_index(mut sz: u64) -> u64{
+pub fn insertion_to_pmmr_index(mut sz: u64) -> u64 {
 	//1 based pmmrs
-	sz = sz-1;
-	2*sz - sz.count_ones() as u64 + 1
+	sz = sz - 1;
+	2 * sz - sz.count_ones() as u64 + 1
 }
 
 /// The height of a node in a full binary tree from its postorder traversal
@@ -1500,7 +1502,10 @@ mod test {
 		pmmr.push(elems[6]).unwrap();
 		let pos_10 = elems[6].hash_with_index(10);
 		assert_eq!(pmmr.peaks(), vec![pos_6, pos_9, pos_10]);
-		assert_eq!(pmmr.root(), (pos_6, (pos_9, pos_10).hash_with_index(11)).hash_with_index(11));
+		assert_eq!(
+			pmmr.root(),
+			(pos_6, (pos_9, pos_10).hash_with_index(11)).hash_with_index(11)
+		);
 		assert_eq!(pmmr.unpruned_size(), 11);
 
 		// 001001200100123
@@ -1929,11 +1934,10 @@ mod test {
 		assert_eq!(n_leaves(10), 6);
 	}
 
-
 	#[test]
 	fn check_all_ones() {
 		for i in 0..1000000 {
-			assert_eq!(old_all_ones(i),all_ones(i));
+			assert_eq!(old_all_ones(i), all_ones(i));
 		}
 	}
 
@@ -1955,7 +1959,7 @@ mod test {
 	#[test]
 	fn check_most_significant_pos() {
 		for i in 0u64..1000000 {
-			assert_eq!(old_most_significant_pos(i),most_significant_pos(i));
+			assert_eq!(old_most_significant_pos(i), most_significant_pos(i));
 		}
 	}
 
@@ -1972,14 +1976,14 @@ mod test {
 
 	#[test]
 	fn check_insertion_to_pmmr_index() {
-		assert_eq!(insertion_to_pmmr_index(1),1);
-		assert_eq!(insertion_to_pmmr_index(2),2);
-		assert_eq!(insertion_to_pmmr_index(3),4);
-		assert_eq!(insertion_to_pmmr_index(4),5);
-		assert_eq!(insertion_to_pmmr_index(5),8);
-		assert_eq!(insertion_to_pmmr_index(6),9);
-		assert_eq!(insertion_to_pmmr_index(7),11);
-		assert_eq!(insertion_to_pmmr_index(8),12);
+		assert_eq!(insertion_to_pmmr_index(1), 1);
+		assert_eq!(insertion_to_pmmr_index(2), 2);
+		assert_eq!(insertion_to_pmmr_index(3), 4);
+		assert_eq!(insertion_to_pmmr_index(4), 5);
+		assert_eq!(insertion_to_pmmr_index(5), 8);
+		assert_eq!(insertion_to_pmmr_index(6), 9);
+		assert_eq!(insertion_to_pmmr_index(7), 11);
+		assert_eq!(insertion_to_pmmr_index(8), 12);
 	}
 
 	#[test]
@@ -2021,6 +2025,5 @@ mod test {
 		assert_eq!(res.1.len(), 345);
 		assert_eq!(res.1[0].0[3], 652);
 		assert_eq!(res.1[344].0[3], 999);
-
 	}
 }

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -208,14 +208,6 @@ fn main() {
 			.long("api_server_address")
 			.help("Api address of running node on which to check inputs and post transactions")
 			.takes_value(true))
-		.arg(Arg::with_name("key_derivations")
-				.help("The number of keys possiblities to search for each output. \
-				Ideally, set this to a number greater than the number of outputs \
-				you believe should belong to this seed/password.")
-				.short("k")
-				.long("key_derivations")
-				.default_value("1000")
-				.takes_value(true))
 
 		.subcommand(SubCommand::with_name("listen")
 			.about("Runs the wallet in listening mode waiting for transactions.")
@@ -528,12 +520,6 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 		wallet_config.check_node_api_http_addr = sa.to_string().clone();
 	}
 
-	let key_derivations: u32 = wallet_args
-		.value_of("key_derivations")
-		.unwrap()
-		.parse()
-		.unwrap();
-
 	let mut show_spent = false;
 	if wallet_args.is_present("show_spent") {
 		show_spent = true;
@@ -656,7 +642,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			wallet::show_outputs(&wallet_config, &keychain, show_spent);
 		}
 		("restore", Some(_)) => {
-			let _ = wallet::restore(&wallet_config, &keychain, key_derivations);
+			let _ = wallet::restore(&wallet_config, &keychain);
 		}
 		_ => panic!("Unknown wallet command, use 'grin help wallet' for details"),
 	}


### PR DESCRIPTION
Given we can't rely on full blocks being present on all nodes, for functions such as wallet restore we need to way to return the contents of the UTXO set to a requesting caller in reasonably-sized chunks. The most logical way seems to be via returning UTXOs by their PMMR insertion index, so if there are N utxos, the caller can say 'get me utxos 0..99' .. scan them.. then say 'now get 100..199' etc...

However, because of pruning, it will be more practical to say 'get me the first 100 unpruned outputs starting at position 0, and then have the caller return the actual index of the last returned output for the next query, which the caller can repeat until it's up to the most recent output.

Going to add this in a few parts, with this PR adding the appropriate functions to PMMRs and the API, then do the wallet work separately.