### PR TITLE
Call init_head and not reset_head on startup

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -216,9 +216,8 @@ impl Chain {
 			Err(e) => return Err(Error::StoreErr(e, "chain init load head".to_owned())),
 		};
 
-		// Reset sync_head and header_head to head of current chain.
-		// Make sure sync_head is available for later use when needed.
-		store.reset_head()?;
+		// Initialize header_head and sync_head as necessary for chain init.
+		store.init_head()?;
 
 		debug!(
 			LOGGER,

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -88,6 +88,15 @@ impl ChainStore for ChainKVStore {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
+	fn init_head(&self) -> Result<(), Error> {
+		if self.get_header_head().is_err() {
+			let tip = self.head()?;
+			self.save_header_head(&tip)?;
+		}
+		let header_tip = self.get_header_head()?;
+		self.save_sync_head(&header_tip)
+	}
+
 	// Reset both header_head and sync_head to the current head of the body chain
 	fn reset_head(&self) -> Result<(), Error> {
 		let tip = self.head()?;

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -288,6 +288,9 @@ pub trait ChainStore: Send + Sync {
 	/// Save the provided tip as the current head of the sync header chain
 	fn save_sync_head(&self, t: &Tip) -> Result<(), store::Error>;
 
+	/// Initialize header_head if necessary and set sync_head to header_head.
+	fn init_head(&self) -> Result<(), store::Error>;
+
 	/// Reset header_head and sync_head to head of current body chain
 	fn reset_head(&self) -> Result<(), store::Error>;
 


### PR DESCRIPTION
This does not reset the sync_head to chain head if we restart during a sync
and allows the header sync to pick up where it left off before the restart.



