### PR TITLE
we may receive a block (header) with no previous header

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -147,9 +147,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 					true
 				}
 			} else {
-				error!(
+				debug!(
 					LOGGER,
-					"adapter: failed to retrieve previous block header (consider ban here?)"
+					"adapter: failed to retrieve previous block header (still syncing?)"
 				);
 				true
 			}


### PR DESCRIPTION
as we have not yet sync'd to that point
this is valid and not an error

For example - 
```
Apr 17 20:33:14.092 DEBG handle_payload: CompactBlock: 589ada06
Apr 17 20:33:14.092 DEBG Received compact_block 589ada06 at 35116 from 139.59.105.169:13414, going to process.
Apr 17 20:33:14.092 DEBG pool: retrieve_transactions: kern_ids - [ShortId(16f21d3ee3d7), ShortId(665da81910c8), ShortId(19956430cd9e), ShortId(09b354334071), ShortId(626ad5345ed1), ShortId(cbadd777188d), ShortId(c5e0aa870c35), ShortId(47ef485a5b94)], txs - 0, []
Apr 17 20:33:14.092 DEBG pool: retrieve_transactions: matching txs from pool - 0
Apr 17 20:33:14.093 DEBG adapter: txs from tx pool - 0
Apr 17 20:33:14.093 ERRO adapter: failed to retrieve previous block header (consider ban here?)
```

The final ERRO log line there is not an error - this state is valid and we should not log an error.
This can occur if we receive a block (or compact block, or block header) for a "future" block while still sync'ing.


