### PR TITLE
introduce some minimal sync state

### DIFF
--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -796,8 +796,7 @@ impl<'a> Extension<'a> {
 					if proof_count % 500 == 0 {
 						debug!(
 							LOGGER,
-							"txhashset: verify_rangeproofs: verified {} rangeproofs",
-							proof_count,
+							"txhashset: verify_rangeproofs: verified {} rangeproofs", proof_count,
 						);
 					}
 				}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -792,6 +792,14 @@ impl<'a> Extension<'a> {
 						return Err(Error::OutputNotFound);
 					}
 					proof_count += 1;
+
+					if proof_count % 500 == 0 {
+						debug!(
+							LOGGER,
+							"txhashset: verify_rangeproofs: verified {} rangeproofs",
+							proof_count,
+						);
+					}
 				}
 			}
 		}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -199,7 +199,9 @@ impl Server {
 			Some(b) => b,
 		};
 
-		sync::run_sync(
+		let syncer = sync::Syncer::new();
+
+		syncer.run_sync(
 			currently_syncing.clone(),
 			awaiting_peers.clone(),
 			p2p_server.peers.clone(),

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -105,10 +105,10 @@ pub fn run_sync(
 					si.highest_height = most_work_height;
 				}
 
-				let fast_sync_enabled = !archive_mode && si.prev_fast_sync.is_none()
-					&& si.highest_height.saturating_sub(head.height) > horizon;
-
 				if syncing {
+					let fast_sync_enabled =
+						!archive_mode && si.highest_height.saturating_sub(head.height) > horizon;
+
 					// run the header sync every 10s
 					if si.header_sync_due(&header_head) {
 						header_sync(peers.clone(), chain.clone());

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -19,12 +19,44 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use time;
 
 use chain;
+use common::types::Error;
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use core::global;
+use grin::sync;
 use p2p::{self, Peer, Peers};
-use common::types::Error;
 use util::LOGGER;
+
+pub struct Syncer {
+}
+
+impl Syncer {
+	pub fn new() -> Syncer {
+		Syncer {}
+	}
+
+	pub fn run_sync(
+		&self,
+		currently_syncing: Arc<AtomicBool>,
+		awaiting_peers: Arc<AtomicBool>,
+		peers: Arc<p2p::Peers>,
+		chain: Arc<chain::Chain>,
+		skip_sync_wait: bool,
+		archive_mode: bool,
+		stop: Arc<AtomicBool>,
+	) {
+		sync::run_sync(
+			currently_syncing,
+			awaiting_peers,
+			peers,
+			chain,
+			skip_sync_wait,
+			archive_mode,
+			stop,
+		)
+	}
+}
+
 
 /// Starts the syncing loop, just spawns two threads that loop forever
 pub fn run_sync(
@@ -265,10 +297,6 @@ fn needs_syncing(
 	if is_syncing {
 		if let Some(peer) = peer {
 			if let Ok(peer) = peer.try_read() {
-				debug!(
-					LOGGER,
-					"needs_syncing {} {}", local_diff, peer.info.total_difficulty
-				);
 				most_work_height = peer.info.height;
 
 				if peer.info.total_difficulty <= local_diff {
@@ -360,7 +388,7 @@ fn get_locator_heights(height: u64) -> Vec<u64> {
 struct SyncInfo {
 	prev_body_sync: (time::Tm, u64),
 	prev_header_sync: (time::Tm, u64),
-	prev_fast_sync: time::Tm,
+	prev_fast_sync: Option<time::Tm>,
 	highest_height: u64,
 }
 
@@ -370,7 +398,7 @@ impl SyncInfo {
 		SyncInfo {
 			prev_body_sync: (now.clone(), 0),
 			prev_header_sync: (now.clone(), 0),
-			prev_fast_sync: now.clone() - time::Duration::seconds(5 * 60),
+			prev_fast_sync: None,
 			highest_height: 0,
 		}
 	}
@@ -399,13 +427,15 @@ impl SyncInfo {
 		false
 	}
 
+	// For now this is a one-time thing (it can be slow) at initial startup.
 	fn fast_sync_due(&mut self) -> bool {
-		let now = time::now_utc();
-		if now - self.prev_fast_sync > time::Duration::seconds(5 * 60) {
-			self.prev_fast_sync = now;
-			return true;
+		if let None = self.prev_fast_sync {
+			let now = time::now_utc();
+			self.prev_fast_sync = Some(now);
+			true
+		} else {
+			false
 		}
-		false
 	}
 }
 

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -27,8 +27,7 @@ use grin::sync;
 use p2p::{self, Peer, Peers};
 use util::LOGGER;
 
-pub struct Syncer {
-}
+pub struct Syncer {}
 
 impl Syncer {
 	pub fn new() -> Syncer {
@@ -56,7 +55,6 @@ impl Syncer {
 		)
 	}
 }
-
 
 /// Starts the syncing loop, just spawns two threads that loop forever
 pub fn run_sync(


### PR DESCRIPTION
* we now instantiate a `sync::Syncer` from `grin/server.rs`
* debug log for every 500 rangeproofs verified
* we now only run "fast sync" once on init
  * prevent multiple txhashset downloads overlapping
  * revisit this once we can track actual state of txhashset download and verification

Still slow but we can now reliably run a "fast sync" to completion, even if it takes longer than 5 mins (and it does).

