### PR TITLE
Anti-aggregation mechanism for multi-kernel transaction

### DIFF
--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -383,7 +383,6 @@ mod test {
 		assert!(deaggregated_tx34.validate().is_ok());
 		assert_eq!(tx34, deaggregated_tx34);
 
-
 		let deaggregated_tx12 = deaggregate(tx1234.clone(), vec![tx34.clone()]).unwrap();
 
 		assert!(deaggregated_tx12.validate().is_ok());
@@ -447,10 +446,19 @@ mod test {
 		assert!(tx4.validate().is_ok());
 		assert!(tx5.validate().is_ok());
 
-		let tx12345 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx5.clone()]).unwrap();
+		let tx12345 = aggregate(vec![
+			tx1.clone(),
+			tx2.clone(),
+			tx3.clone(),
+			tx4.clone(),
+			tx5.clone(),
+		]).unwrap();
 		assert!(tx12345.validate().is_ok());
 
-		let deaggregated_tx5 = deaggregate(tx12345.clone(), vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]).unwrap();
+		let deaggregated_tx5 = deaggregate(
+			tx12345.clone(),
+			vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()],
+		).unwrap();
 		assert!(deaggregated_tx5.validate().is_ok());
 		assert_eq!(tx5, deaggregated_tx5);
 	}
@@ -469,13 +477,20 @@ mod test {
 		assert!(tx4.validate().is_ok());
 		assert!(tx5.validate().is_ok());
 
-		let tx12345 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx5.clone()]).unwrap();
+		let tx12345 = aggregate(vec![
+			tx1.clone(),
+			tx2.clone(),
+			tx3.clone(),
+			tx4.clone(),
+			tx5.clone(),
+		]).unwrap();
 		let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 		let tx34 = aggregate(vec![tx3.clone(), tx4.clone()]).unwrap();
 
 		assert!(tx12345.validate().is_ok());
 
-		let deaggregated_tx5 = deaggregate(tx12345.clone(), vec![tx12.clone(), tx34.clone()]).unwrap();
+		let deaggregated_tx5 =
+			deaggregate(tx12345.clone(), vec![tx12.clone(), tx34.clone()]).unwrap();
 		assert!(deaggregated_tx5.validate().is_ok());
 		assert_eq!(tx5, deaggregated_tx5);
 	}

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -234,7 +234,7 @@ mod test {
 	use core::block::Error::KernelLockHeight;
 	use ser;
 	use keychain;
-	use keychain::{BlindingFactor, Keychain};
+	use keychain::Keychain;
 
 	#[test]
 	pub fn test_amount_to_hr() {
@@ -353,9 +353,156 @@ mod test {
 		assert!(tx2.validate().is_ok());
 
 		// now build a "cut_through" tx from tx1 and tx2
-		let tx3 = aggregate(vec![tx1, tx2]).unwrap();
+		let tx3 = aggregate_with_cut_through(vec![tx1, tx2]).unwrap();
 
 		assert!(tx3.validate().is_ok());
+	}
+
+	// Attempt to deaggregate a multi-kernel transaction in a different way
+	#[test]
+	fn multi_kernel_transaction_deaggregation() {
+		let tx1 = tx1i1o();
+		let tx2 = tx1i1o();
+		let tx3 = tx1i1o();
+		let tx4 = tx1i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+		assert!(tx3.validate().is_ok());
+		assert!(tx4.validate().is_ok());
+
+		let tx1234 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]).unwrap();
+		let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
+		let tx34 = aggregate(vec![tx3.clone(), tx4.clone()]).unwrap();
+
+		assert!(tx1234.validate().is_ok());
+		assert!(tx12.validate().is_ok());
+		assert!(tx34.validate().is_ok());
+
+		let deaggregated_tx34 = deaggregate(tx1234.clone(), vec![tx12.clone()]).unwrap();
+		assert!(deaggregated_tx34.validate().is_ok());
+		assert_eq!(tx34, deaggregated_tx34);
+
+
+		let deaggregated_tx12 = deaggregate(tx1234.clone(), vec![tx34.clone()]).unwrap();
+
+		assert!(deaggregated_tx12.validate().is_ok());
+		assert_eq!(tx12, deaggregated_tx12);
+	}
+
+	#[test]
+	fn multi_kernel_transaction_deaggregation_2() {
+		let tx1 = tx1i1o();
+		let tx2 = tx1i1o();
+		let tx3 = tx1i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+		assert!(tx3.validate().is_ok());
+
+		let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
+		let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
+
+		assert!(tx123.validate().is_ok());
+		assert!(tx12.validate().is_ok());
+
+		let deaggregated_tx3 = deaggregate(tx123.clone(), vec![tx12.clone()]).unwrap();
+		assert!(deaggregated_tx3.validate().is_ok());
+		assert_eq!(tx3, deaggregated_tx3);
+	}
+
+	#[test]
+	fn multi_kernel_transaction_deaggregation_3() {
+		let tx1 = tx1i1o();
+		let tx2 = tx1i1o();
+		let tx3 = tx1i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+		assert!(tx3.validate().is_ok());
+
+		let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
+		let tx13 = aggregate(vec![tx1.clone(), tx3.clone()]).unwrap();
+		let tx2 = aggregate(vec![tx2.clone()]).unwrap();
+
+		assert!(tx123.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+
+		let deaggregated_tx13 = deaggregate(tx123.clone(), vec![tx2.clone()]).unwrap();
+		assert!(deaggregated_tx13.validate().is_ok());
+		assert_eq!(tx13, deaggregated_tx13);
+	}
+
+	#[test]
+	fn multi_kernel_transaction_deaggregation_4() {
+		let tx1 = tx1i1o();
+		let tx2 = tx1i1o();
+		let tx3 = tx1i1o();
+		let tx4 = tx1i1o();
+		let tx5 = tx1i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+		assert!(tx3.validate().is_ok());
+		assert!(tx4.validate().is_ok());
+		assert!(tx5.validate().is_ok());
+
+		let tx12345 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx5.clone()]).unwrap();
+		assert!(tx12345.validate().is_ok());
+
+		let deaggregated_tx5 = deaggregate(tx12345.clone(), vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]).unwrap();
+		assert!(deaggregated_tx5.validate().is_ok());
+		assert_eq!(tx5, deaggregated_tx5);
+	}
+
+	#[test]
+	fn multi_kernel_transaction_deaggregation_5() {
+		let tx1 = tx1i1o();
+		let tx2 = tx1i1o();
+		let tx3 = tx1i1o();
+		let tx4 = tx1i1o();
+		let tx5 = tx1i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+		assert!(tx3.validate().is_ok());
+		assert!(tx4.validate().is_ok());
+		assert!(tx5.validate().is_ok());
+
+		let tx12345 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone(), tx5.clone()]).unwrap();
+		let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
+		let tx34 = aggregate(vec![tx3.clone(), tx4.clone()]).unwrap();
+
+		assert!(tx12345.validate().is_ok());
+
+		let deaggregated_tx5 = deaggregate(tx12345.clone(), vec![tx12.clone(), tx34.clone()]).unwrap();
+		assert!(deaggregated_tx5.validate().is_ok());
+		assert_eq!(tx5, deaggregated_tx5);
+	}
+
+	// Attempt to deaggregate a multi-kernel transaction
+	#[test]
+	fn basic_transaction_deaggregation() {
+		let tx1 = tx1i2o();
+		let tx2 = tx2i1o();
+
+		assert!(tx1.validate().is_ok());
+		assert!(tx2.validate().is_ok());
+
+		// now build a "cut_through" tx from tx1 and tx2
+		let tx3 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
+
+		assert!(tx3.validate().is_ok());
+
+		let deaggregated_tx1 = deaggregate(tx3.clone(), vec![tx2.clone()]).unwrap();
+
+		assert!(deaggregated_tx1.validate().is_ok());
+		assert_eq!(tx1, deaggregated_tx1);
+
+		let deaggregated_tx2 = deaggregate(tx3.clone(), vec![tx1.clone()]).unwrap();
+
+		assert!(deaggregated_tx2.validate().is_ok());
+		assert_eq!(tx2, deaggregated_tx2);
 	}
 
 	#[test]

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -234,6 +234,17 @@ pub struct Transaction {
 	pub offset: BlindingFactor,
 }
 
+/// PartialEq
+impl PartialEq for Transaction {
+    fn eq(&self, tx: &Transaction) -> bool {
+        if self.inputs == tx.inputs && self.outputs == tx.outputs && self.kernels == tx.kernels && self.offset == tx.offset {
+			true
+		} else {
+			false
+		}
+    }
+}
+
 /// Implementation of Writeable for a fully blinded transaction, defines how to
 /// write the transaction as binary.
 impl Writeable for Transaction {
@@ -482,8 +493,8 @@ impl Transaction {
 	}
 }
 
-/// Aggregate a vec of transactions into a multi-kernel transaction
-pub fn aggregate(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
+/// Aggregate a vec of transactions into a multi-kernel transaction with cut_through
+pub fn aggregate_with_cut_through(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
 	let mut inputs: Vec<Input> = vec![];
 	let mut outputs: Vec<Output> = vec![];
 	let mut kernels: Vec<TxKernel> = vec![];
@@ -552,6 +563,120 @@ pub fn aggregate(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
 	kernels.sort();
 
 	let tx = Transaction::new(new_inputs, new_outputs, kernels);
+
+	Ok(tx.with_offset(total_kernel_offset))
+}
+
+/// Aggregate a vec of transactions into a multi-kernel transaction
+pub fn aggregate(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
+	let mut inputs: Vec<Input> = vec![];
+	let mut outputs: Vec<Output> = vec![];
+	let mut kernels: Vec<TxKernel> = vec![];
+
+	// we will sum these together at the end to give us the overall offset for the
+	// transaction
+	let mut kernel_offsets = vec![];
+
+	for mut transaction in transactions {
+		// we will summ these later to give a single aggregate offset
+		kernel_offsets.push(transaction.offset);
+
+		inputs.append(&mut transaction.inputs);
+		outputs.append(&mut transaction.outputs);
+		kernels.append(&mut transaction.kernels);
+	}
+
+	// now sum the kernel_offsets up to give us an aggregate offset for the
+	// transaction
+	let total_kernel_offset = {
+		let secp = static_secp_instance();
+		let secp = secp.lock().unwrap();
+		let mut keys = kernel_offsets
+			.iter()
+			.cloned()
+			.filter(|x| *x != BlindingFactor::zero())
+			.filter_map(|x| x.secret_key(&secp).ok())
+			.collect::<Vec<_>>();
+
+		if keys.is_empty() {
+			BlindingFactor::zero()
+		} else {
+			let sum = secp.blind_sum(keys, vec![])?;
+			BlindingFactor::from_secret_key(sum)
+		}
+	};
+
+	// sort them lexicographically
+	inputs.sort();
+	outputs.sort();
+	kernels.sort();
+
+	let tx = Transaction::new(inputs, outputs, kernels);
+
+	Ok(tx.with_offset(total_kernel_offset))
+}
+
+/// Attempt to deaggregate a multi-kernel transaction based on multiple transactions
+pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transaction, Error> {
+	let mut inputs: Vec<Input> = vec![];
+	let mut outputs: Vec<Output> = vec![];
+	let mut kernels: Vec<TxKernel> = vec![];
+
+	// we will subtract these at the end to give us the overall offset for the transaction
+	let mut kernel_offsets = vec![];
+
+	let tx = aggregate(txs).unwrap();
+
+	for mk_input in mk_tx.clone().inputs {
+		if !tx.inputs.contains(&mk_input) && !inputs.contains(&mk_input) {
+			inputs.push(mk_input);
+		}
+	}
+	for mk_output in mk_tx.clone().outputs {
+		if !tx.outputs.contains(&mk_output) && !outputs.contains(&mk_output) {
+			outputs.push(mk_output);
+		}
+	}
+	for mk_kernel in mk_tx.clone().kernels {
+		if !tx.kernels.contains(&mk_kernel) && !kernels.contains(&mk_kernel) {
+			kernels.push(mk_kernel);
+		}
+	}
+
+	kernel_offsets.push(tx.offset);
+
+
+	// now compute the total kernel offset
+	let total_kernel_offset = {
+		let secp = static_secp_instance();
+		let secp = secp.lock().unwrap();
+		let mut positive_key = vec![mk_tx.offset]
+			.iter()
+			.cloned()
+			.filter(|x| *x != BlindingFactor::zero())
+			.filter_map(|x| x.secret_key(&secp).ok())
+			.collect::<Vec<_>>();
+		let mut negative_keys = kernel_offsets
+			.iter()
+			.cloned()
+			.filter(|x| *x != BlindingFactor::zero())
+			.filter_map(|x| x.secret_key(&secp).ok())
+			.collect::<Vec<_>>();
+
+		if positive_key.is_empty() && negative_keys.is_empty() {
+			BlindingFactor::zero()
+		} else {
+			let sum = secp.blind_sum(positive_key, negative_keys)?;
+			BlindingFactor::from_secret_key(sum)
+		}
+	};
+
+	// Sorting them lexicographically
+	inputs.sort();
+	outputs.sort();
+	kernels.sort();
+
+	let tx = Transaction::new(inputs, outputs, kernels);
 
 	Ok(tx.with_offset(total_kernel_offset))
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -236,13 +236,15 @@ pub struct Transaction {
 
 /// PartialEq
 impl PartialEq for Transaction {
-    fn eq(&self, tx: &Transaction) -> bool {
-        if self.inputs == tx.inputs && self.outputs == tx.outputs && self.kernels == tx.kernels && self.offset == tx.offset {
+	fn eq(&self, tx: &Transaction) -> bool {
+		if self.inputs == tx.inputs && self.outputs == tx.outputs && self.kernels == tx.kernels
+			&& self.offset == tx.offset
+		{
 			true
 		} else {
 			false
 		}
-    }
+	}
 }
 
 /// Implementation of Writeable for a fully blinded transaction, defines how to
@@ -493,7 +495,8 @@ impl Transaction {
 	}
 }
 
-/// Aggregate a vec of transactions into a multi-kernel transaction with cut_through
+/// Aggregate a vec of transactions into a multi-kernel transaction with
+/// cut_through
 pub fn aggregate_with_cut_through(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
 	let mut inputs: Vec<Input> = vec![];
 	let mut outputs: Vec<Output> = vec![];
@@ -616,13 +619,15 @@ pub fn aggregate(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
 	Ok(tx.with_offset(total_kernel_offset))
 }
 
-/// Attempt to deaggregate a multi-kernel transaction based on multiple transactions
+/// Attempt to deaggregate a multi-kernel transaction based on multiple
+/// transactions
 pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transaction, Error> {
 	let mut inputs: Vec<Input> = vec![];
 	let mut outputs: Vec<Output> = vec![];
 	let mut kernels: Vec<TxKernel> = vec![];
 
-	// we will subtract these at the end to give us the overall offset for the transaction
+	// we will subtract these at the end to give us the overall offset for the
+	// transaction
 	let mut kernel_offsets = vec![];
 
 	let tx = aggregate(txs).unwrap();
@@ -644,7 +649,6 @@ pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transact
 	}
 
 	kernel_offsets.push(tx.offset);
-
 
 	// now compute the total kernel offset
 	let total_kernel_offset = {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -237,13 +237,8 @@ pub struct Transaction {
 /// PartialEq
 impl PartialEq for Transaction {
 	fn eq(&self, tx: &Transaction) -> bool {
-		if self.inputs == tx.inputs && self.outputs == tx.outputs && self.kernels == tx.kernels
+		self.inputs == tx.inputs && self.outputs == tx.outputs && self.kernels == tx.kernels
 			&& self.offset == tx.offset
-		{
-			true
-		} else {
-			false
-		}
 	}
 }
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -470,8 +470,8 @@ where
 			let kernels_set_intersection: HashSet<&TxKernel> =
 				kernels_set.intersection(&candidates_kernels_set).collect();
 
-			// Consider the transaction only if all the kernels match
-			if kernels_set_intersection.len() == tx.kernels.len() {
+			// Consider the transaction only if all the kernels match and if it is indeed a subset
+			if kernels_set_intersection.len() == tx.kernels.len() && candidates_kernels_set.is_subset(&kernels_set){
 				debug!(LOGGER, "Found a transaction with the same kernel");
 				found_txs.push(*tx.clone());
 			}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -409,6 +409,22 @@ where
 		}
 	}
 
+	/// Attempt to deaggregate a transaction and add it to the mempool
+	pub fn deaggregate_and_add_to_memory_pool(
+		&mut self,
+		tx_source: TxSource,
+		tx: transaction::Transaction,
+		stem: bool,
+	) -> Result<(), PoolError> {
+		match self.deaggregate_transaction(tx.clone()) {
+			Ok(deaggragated_tx) => self.add_to_memory_pool(tx_source, deaggragated_tx, stem),
+			Err(e) => {
+				debug!(LOGGER,"Could not deaggregate multi-kernel transaction: {:?}", e);
+				self.add_to_memory_pool(tx_source, tx, stem)
+			},
+		}
+	}
+
 	/// Attempt to deaggregate multi-kernel transaction as much as possible based on the content
 	///of the mempool
 	pub fn deaggregate_transaction(

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -464,10 +464,11 @@ where
 
 		// Check each transaction in the pool
 		for (_, tx) in &self.transactions {
+			let candidates_kernels_set: HashSet<TxKernel> =
+				tx.kernels.iter().cloned().collect::<HashSet<_>>();
 
-			let candidates_kernels_set: HashSet<TxKernel> = tx.kernels.iter().cloned().collect::<HashSet<_>>();
-
-			let kernels_set_intersection: HashSet<&TxKernel> = kernels_set.intersection(&candidates_kernels_set).collect();
+			let kernels_set_intersection: HashSet<&TxKernel> =
+				kernels_set.intersection(&candidates_kernels_set).collect();
 
 			// Consider the transaction only if all the kernels match
 			if kernels_set_intersection.len() == tx.kernels.len() {

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -470,8 +470,11 @@ where
 			let kernels_set_intersection: HashSet<&TxKernel> =
 				kernels_set.intersection(&candidates_kernels_set).collect();
 
-			// Consider the transaction only if all the kernels match and if it is indeed a subset
-			if kernels_set_intersection.len() == tx.kernels.len() && candidates_kernels_set.is_subset(&kernels_set){
+			// Consider the transaction only if all the kernels match and if it is indeed a
+			// subset
+			if kernels_set_intersection.len() == tx.kernels.len()
+				&& candidates_kernels_set.is_subset(&kernels_set)
+			{
 				debug!(LOGGER, "Found a transaction with the same kernel");
 				found_txs.push(*tx.clone());
 			}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -419,9 +419,12 @@ where
 		match self.deaggregate_transaction(tx.clone()) {
 			Ok(deaggragated_tx) => self.add_to_memory_pool(tx_source, deaggragated_tx, stem),
 			Err(e) => {
-				debug!(LOGGER,"Could not deaggregate multi-kernel transaction: {:?}", e);
+				debug!(
+					LOGGER,
+					"Could not deaggregate multi-kernel transaction: {:?}", e
+				);
 				self.add_to_memory_pool(tx_source, tx, stem)
-			},
+			}
 		}
 	}
 

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -141,6 +141,8 @@ pub enum PoolError {
 		/// The spent output
 		spent_output: Commitment,
 	},
+	/// A failed deaggregation error
+	FailedDeaggregation,
 	/// Attempt to add a transaction to the pool with lock_height
 	/// greater than height of current block
 	ImmatureTransaction {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -80,7 +80,10 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		let h = tx.hash();
 
 		if !stem && tx.kernels.len() != 1 {
-			debug!(LOGGER, "Received regular multi-kernel transaction will attempt to deaggregate");
+			debug!(
+				LOGGER,
+				"Received regular multi-kernel transaction will attempt to deaggregate"
+			);
 			if let Err(e) = self.tx_pool
 				.write()
 				.unwrap()
@@ -97,7 +100,6 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				debug!(LOGGER, "Transaction {} rejected: {:?}", h, e);
 			}
 		}
-
 	}
 
 	fn block_received(&self, b: core::Block, addr: SocketAddr) -> bool {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -78,13 +78,26 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		);
 
 		let h = tx.hash();
-		if let Err(e) = self.tx_pool
-			.write()
-			.unwrap()
-			.add_to_memory_pool(source, tx, stem)
-		{
-			debug!(LOGGER, "Transaction {} rejected: {:?}", h, e);
+
+		if !stem && tx.kernels.len() != 1 {
+			debug!(LOGGER, "Received regular multi-kernel transaction will attempt to deaggregate");
+			if let Err(e) = self.tx_pool
+				.write()
+				.unwrap()
+				.deaggregate_and_add_to_memory_pool(source, tx, stem)
+			{
+				debug!(LOGGER, "Transaction {} rejected: {:?}", h, e);
+			}
+		} else {
+			if let Err(e) = self.tx_pool
+				.write()
+				.unwrap()
+				.add_to_memory_pool(source, tx, stem)
+			{
+				debug!(LOGGER, "Transaction {} rejected: {:?}", h, e);
+			}
 		}
+
 	}
 
 	fn block_received(&self, b: core::Block, addr: SocketAddr) -> bool {


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/799.

This PR adds an anti-aggregation mechanism in Grin.
The following function where implemented:
- ```aggregate_with_cut_through``` aggregate multiple tx in one big tx with cut_through
- ```aggregate``` which aggregates without cut-through (used internally for deaggragation)
- ```PartialEq``` for transaction for faster testing
- ```deaggregate``` based on a set of transaction, this function is capable to deaggregate a multi kernel transaction as much as possible.
-  ```deaggragate_and_add_to_memorypool```.

Whenever we receive a multi kernel transaction, we first try to deaggregate it.
  - If we are able to deaggregate it, we add the subset in our memory pool.
  - If we are not able to deaggregate it, we add the transaction as is in our memory pool.

One step closer to stempool aggregation :).