### PR TITLE
fix off by one in setup_height

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -236,7 +236,7 @@ impl ChainStore for ChainKVStore {
 	fn setup_height(&self, header: &BlockHeader, old_tip: &Tip) -> Result<(), Error> {
 		// remove headers ahead if we backtracked
 		for n in header.height..old_tip.height {
-			self.delete_header_by_height(n)?;
+			self.delete_header_by_height(n + 1)?;
 		}
 		self.build_by_height_index(header, false)
 	}


### PR DESCRIPTION
If we are backtracking we want to delete the header_by_height entries for everything _after_ the header height, up to and including the previous chain head.