### PR TITLE
header sync does not touch txhashset so no need to take a write lock

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -152,11 +152,6 @@ pub fn sync_block_header(
 	validate_header(&bh, &mut sync_ctx)?;
 	add_block_header(bh, &mut sync_ctx)?;
 
-	// TODO - confirm this is needed during sync process (I don't see how it is)
-	// we do not touch the txhashset when syncing headers
-	// just taking the shared lock
-	let _ = header_ctx.txhashset.write().unwrap();
-
 	// now update the header_head (if new header with most work) and the sync_head
 	// (always)
 	update_header_head(bh, &mut header_ctx)?;


### PR DESCRIPTION
99% certain we don't need to lock on the txhashset here.

