### PR TITLE
standardize naming and usage of PhantomData

### DIFF
--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -36,7 +36,7 @@
 //! either be a simple Vec or a database.
 
 use std::clone::Clone;
-use std::marker::PhantomData;
+use std::marker;
 use core::hash::Hash;
 use ser;
 use ser::{Readable, Reader, Writeable, Writer};
@@ -268,7 +268,7 @@ where
 	last_pos: u64,
 	backend: &'a mut B,
 	// only needed for parameterizing Backend
-	writeable: PhantomData<T>,
+	_marker: marker::PhantomData<T>,
 }
 
 impl<'a, T, B> PMMR<'a, T, B>
@@ -281,7 +281,7 @@ where
 		PMMR {
 			last_pos: 0,
 			backend: backend,
-			writeable: PhantomData,
+			_marker: marker::PhantomData,
 		}
 	}
 
@@ -292,7 +292,7 @@ where
 		PMMR {
 			last_pos: last_pos,
 			backend: backend,
-			writeable: PhantomData,
+			_marker: marker::PhantomData,
 		}
 	}
 

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -41,7 +41,7 @@ const SEP: u8 = ':' as u8;
 
 use std::fmt;
 use std::iter::Iterator;
-use std::marker::PhantomData;
+use std::marker;
 use std::sync::RwLock;
 
 use byteorder::{BigEndian, WriteBytesExt};
@@ -167,7 +167,7 @@ impl Store {
 		let db = self.rdb.read().unwrap();
 		SerIterator {
 			iter: db.iterator(IteratorMode::From(from, Direction::Forward)),
-			_marker: PhantomData,
+			_marker: marker::PhantomData,
 		}
 	}
 
@@ -225,7 +225,7 @@ where
 	T: ser::Readable,
 {
 	iter: DBIterator,
-	_marker: PhantomData<T>,
+	_marker: marker::PhantomData<T>,
 }
 
 impl<T> Iterator for SerIterator<T>

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -15,7 +15,7 @@
 
 use std::fs;
 use std::io;
-use std::marker::PhantomData;
+use std::marker;
 
 use core::core::pmmr::{self, family, Backend};
 use core::ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
@@ -92,7 +92,7 @@ where
 	data_file: AppendOnlyFile,
 	rm_log: RemoveLog,
 	pruned_nodes: pmmr::PruneList,
-	phantom: PhantomData<T>,
+	_marker: marker::PhantomData<T>,
 }
 
 impl<T> Backend<T> for PMMRBackend<T>
@@ -257,7 +257,7 @@ where
 			pruned_nodes: pmmr::PruneList {
 				pruned_nodes: prune_list,
 			},
-			phantom: PhantomData,
+			_marker: marker::PhantomData,
 		})
 	}
 


### PR DESCRIPTION
Still do not fully understand what PhantomData is *for* exactly...
Standardized naming and usage to match -
https://doc.rust-lang.org/beta/nomicon/phantom-data.html
So at least it looks similar to the official docs.