### PR TITLE
Make `pre-commit` more portable

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Grin Developers
 #


### PR DESCRIPTION
Right now it's failing on NixOS, and this is fixing it.