### PR TITLE
use deterministic genesis block for user testing

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -126,6 +126,7 @@ impl Server {
 			global::ChainTypes::Testnet1 => genesis::genesis_testnet1(),
 			global::ChainTypes::Testnet2 => genesis::genesis_testnet2(),
 			global::ChainTypes::AutomatedTesting => genesis::genesis_dev(),
+			global::ChainTypes::UserTesting => genesis::genesis_dev(),
 			_ => pow::mine_genesis_block(config.mining_config.clone())?,
 		};
 


### PR DESCRIPTION
We were generating different genesis blocks every time a user testing node started up.
And this prevented them from peering successfully.

