### PR TITLE
Do not request a full block for invalid compact block during syncing

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -157,12 +157,20 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 					debug!(LOGGER, "adapter: successfully hydrated block from tx pool!");
 					self.process_block(block, addr)
 				} else {
-					debug!(
-						LOGGER,
-						"adapter: block invalid after hydration, requesting full block"
-					);
-					self.request_block(&cb.header, &addr);
-					true
+					if self.sync_state.status() == SyncStatus::NoSync {
+						debug!(
+							LOGGER,
+							"adapter: block invalid after hydration, requesting full block"
+						);
+						self.request_block(&cb.header, &addr);
+						true
+					} else {
+						debug!(
+							LOGGER,
+							"adapter: block invalid after hydration, ignoring it, cause still syncing"
+						);
+						true
+					}
 				}
 			} else {
 				debug!(


### PR DESCRIPTION
During sync, if we fail to hydrate a compact block, we should ignore if it's invalid.   
Currently, we try to get a full block, if a compact one is invalid.

Should solve https://github.com/mimblewimble/grin/issues/973