### PR TITLE
Change wallet retry strategy (and address stratum panic)

### DIFF
--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -101,14 +101,14 @@ pub fn get_block(
 					LOGGER,
 					"Duplicate commit for potential coinbase detected. Trying next derivation."
 				);
-			},
+			}
 			self::Error::Wallet(_) => {
 				error!(
 					LOGGER,
 					"Stratum server: Can't connect to wallet listener at {:?}; will retry",
 					wallet_listener_url.as_ref().unwrap()
 				);
-			},
+			}
 			ae => {
 				warn!(LOGGER, "Error building new block: {:?}. Retrying.", ae);
 			}

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -101,7 +101,14 @@ pub fn get_block(
 					LOGGER,
 					"Duplicate commit for potential coinbase detected. Trying next derivation."
 				);
-			}
+			},
+			self::Error::Wallet(_) => {
+				error!(
+					LOGGER,
+					"Stratum server: Can't connect to wallet listener at {:?}; will retry",
+					wallet_listener_url.as_ref().unwrap()
+				);
+			},
 			ae => {
 				warn!(LOGGER, "Error building new block: {:?}. Retrying.", ae);
 			}
@@ -227,7 +234,6 @@ fn get_coinbase(
 			let url = format!("{}/v1/receive/coinbase", wallet_listener_url.as_str());
 
 			let res = wallet::client::create_coinbase(&url, &block_fees)?;
-
 			let out_bin = util::from_hex(res.output).unwrap();
 			let kern_bin = util::from_hex(res.kernel).unwrap();
 			let key_id_bin = util::from_hex(res.key_id).unwrap();

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -86,6 +86,7 @@ pub fn get_block(
 	max_tx: u32,
 	wallet_listener_url: Option<String>,
 ) -> (core::Block, BlockFees) {
+	let wallet_retry_interval = 5;
 	// get the latest chain state and build a block on top of it
 	let mut result = build_block(
 		chain,
@@ -108,6 +109,7 @@ pub fn get_block(
 					"Stratum server: Can't connect to wallet listener at {:?}; will retry",
 					wallet_listener_url.as_ref().unwrap()
 				);
+				thread::sleep(Duration::from_secs(wallet_retry_interval));
 			}
 			ae => {
 				warn!(LOGGER, "Error building new block: {:?}. Retrying.", ae);

--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{time, thread};
+use std::{thread, time};
 
 use futures::{Future, Stream};
 use failure::ResultExt;
@@ -31,7 +31,7 @@ use std::io;
 pub fn create_coinbase(url: &str, block_fees: &BlockFees) -> Result<CbData, Error> {
 	let retry_interval = 5;
 
-	match single_create_coinbase(&url, &block_fees){
+	match single_create_coinbase(&url, &block_fees) {
 		Err(e) => {
 			error!(
 				LOGGER,
@@ -39,10 +39,8 @@ pub fn create_coinbase(url: &str, block_fees: &BlockFees) -> Result<CbData, Erro
 			);
 			thread::sleep(time::Duration::from_secs(retry_interval));
 			Err(e)
-		},
-		Ok(res) => {
-			Ok(res)
 		}
+		Ok(res) => Ok(res),
 	}
 }
 

--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{thread, time};
-
 use futures::{Future, Stream};
 use failure::ResultExt;
 use hyper;
@@ -29,15 +27,12 @@ use std::io;
 /// Call the wallet API to create a coinbase output for the given block_fees.
 /// Will retry based on default "retry forever with backoff" behavior.
 pub fn create_coinbase(url: &str, block_fees: &BlockFees) -> Result<CbData, Error> {
-	let retry_interval = 5;
-
 	match single_create_coinbase(&url, &block_fees) {
 		Err(e) => {
 			error!(
 				LOGGER,
 				"Failed to get coinbase from {}. Run grin wallet listen", url
 			);
-			thread::sleep(time::Duration::from_secs(retry_interval));
 			Err(e)
 		}
 		Ok(res) => Ok(res),


### PR DESCRIPTION
Should resolve https://github.com/mimblewimble/grin/issues/1000.. basically remove the complex tokio-future wrapped retry from create_coinbase in the wallet and just let it return an error if there's an issue. Removes whatever complexity that was causing reactor to vomit and it seems to make more sense to let the caller decide what it wants to do if it can't get a wallet connection.