### PR TITLE
Wallet restore fixes

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,7 +30,7 @@ use pipe;
 use store;
 use txhashset;
 use types::*;
-use util::secp::pedersen::RangeProof;
+use util::secp::pedersen::{Commitment, RangeProof};
 use util::LOGGER;
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
@@ -505,6 +505,13 @@ impl Chain {
 		})?;
 
 		Ok(merkle_proof)
+	}
+
+	/// Return a merkle proof valid for the current output pmmr state at the
+	/// given pos
+	pub fn get_merkle_proof_for_pos(&self, commit: Commitment) -> Result<MerkleProof, String> {
+		let mut txhashset = self.txhashset.write().unwrap();
+		txhashset.merkle_proof(commit)
 	}
 
 	/// Returns current txhashset roots

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -205,6 +205,14 @@ impl TxHashSet {
 		(output_pmmr.root(), rproof_pmmr.root(), kernel_pmmr.root())
 	}
 
+	/// build a new merkle proof for the given position
+	pub fn merkle_proof(&mut self, commit: Commitment) -> Result<MerkleProof, String> {
+		let pos = self.commit_index.get_output_pos(&commit).unwrap();
+		let output_pmmr: PMMR<OutputIdentifier, _> =
+			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
+		output_pmmr.merkle_proof(pos)
+	}
+
 	/// Compact the MMR data files and flush the rm logs
 	pub fn compact(&mut self) -> Result<(), Error> {
 		let commit_index = self.commit_index.clone();


### PR DESCRIPTION
This *should* let wallet restore work (regardless of whether it was fast synched), with the limitation that coinbase transactions are re-locked for 1000 blocks after the restore. This is because the merkle proof is gone when identifying outputs from the UTXO set and needs to be regenerated. The simplest thing to do is generate one for the current PMMR state and re-lock.

We should be able to optimise this later, and even restore differently if we're restoring against a full archival node, but in the meantime this should at least get basic wallet restore working.