### PR TITLE
Handle locked funds

### DIFF
--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -282,7 +282,7 @@ fn build_send_tx(
 	if total == 0 {
 		return Err(ErrorKind::NotEnoughFunds(total as u64))?;
 	}
-	
+
 	// Check if we need to use a change address
 	if total > amount_with_fee {
 		fee = tx_fee(coins.len(), 2, coins_proof_count(&coins), None);

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -279,6 +279,10 @@ fn build_send_tx(
 	let mut total: u64 = coins.iter().map(|c| c.value).sum();
 	let mut amount_with_fee = amount + fee;
 
+	if total == 0 {
+		return Err(ErrorKind::NotEnoughFunds(total as u64))?;
+	}
+	
 	// Check if we need to use a change address
 	if total > amount_with_fee {
 		fee = tx_fee(coins.len(), 2, coins_proof_count(&coins), None);


### PR DESCRIPTION
Instead of crashing with overflow, return ```NotEnoughFunds``` when no outputs are available.