### PR TITLE
make kernel offsets commitments

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -498,7 +498,7 @@ impl BlockHeaderPrintable {
 			kernel_root: util::to_hex(h.kernel_root.to_vec()),
 			nonce: h.nonce,
 			total_difficulty: h.total_difficulty.into_num(),
-			total_kernel_offset: h.total_kernel_offset.to_hex(),
+			total_kernel_offset: util::to_hex(h.total_kernel_offset.0.to_vec()),
 		}
 	}
 }

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -36,7 +36,7 @@ use grin_store;
 use grin_store::pmmr::PMMRBackend;
 use grin_store::types::prune_noop;
 use types::{BlockMarker, ChainStore, Error, TxHashSetRoots};
-use util::{zip, LOGGER};
+use util::{secp_static, zip, LOGGER};
 
 const TXHASHSET_SUBDIR: &'static str = "txhashset";
 const OUTPUT_SUBDIR: &'static str = "output";
@@ -712,9 +712,7 @@ impl<'a> Extension<'a> {
 	// So "summing" is just a case of taking the total kernel offset
 	// directly from the current block header.
 	fn sum_kernel_offsets(&self, header: &BlockHeader) -> Result<Option<Commitment>, Error> {
-		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
-		let zero_commit = secp.commit_value(0)?;
+		let zero_commit = secp_static::commit_to_zero_value();
 
 		let offset = {
 			if header.total_kernel_offset == zero_commit {

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -279,7 +279,7 @@ mod test {
 		let tx = tx2i1o();
 		let mut vec = Vec::new();
 		ser::serialize(&mut vec, &tx).expect("serialization failed");
-		let target_len = 954;
+		let target_len = 955;
 		assert_eq!(vec.len(), target_len,);
 	}
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -30,7 +30,7 @@ use core::BlockHeader;
 use core::hash::{Hash, Hashed, ZERO_HASH};
 use core::pmmr::MerkleProof;
 use keychain;
-use keychain::{BlindingFactor, Keychain};
+use keychain::Keychain;
 use ser::{self, read_and_verify_sorted, ser_vec, PMMRable, Readable, Reader, Writeable,
           WriteableSorted, Writer};
 use util;
@@ -229,9 +229,11 @@ pub struct Transaction {
 	pub outputs: Vec<Output>,
 	/// List of kernels that make up this transaction (usually a single kernel).
 	pub kernels: Vec<TxKernel>,
+
 	/// The kernel "offset" k2
 	/// excess is k1G after splitting the key k = k1 + k2
-	pub offset: BlindingFactor,
+	/// stored as a Commitment to value 0 here
+	pub offset: Commitment,
 }
 
 /// PartialEq
@@ -272,7 +274,7 @@ impl Writeable for Transaction {
 /// transaction from a binary stream.
 impl Readable for Transaction {
 	fn read(reader: &mut Reader) -> Result<Transaction, ser::Error> {
-		let offset = BlindingFactor::read(reader)?;
+		let offset = Commitment::read(reader)?;
 
 		let (input_len, output_len, kernel_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
@@ -318,8 +320,14 @@ impl Default for Transaction {
 impl Transaction {
 	/// Creates a new empty transaction (no inputs or outputs, zero fee).
 	pub fn empty() -> Transaction {
+		let zero_offset = {
+			let secp = static_secp_instance();
+			let secp = secp.lock().unwrap();
+			secp.commit_value(0).unwrap()
+		};
+
 		Transaction {
-			offset: BlindingFactor::zero(),
+			offset: zero_offset,
 			inputs: vec![],
 			outputs: vec![],
 			kernels: vec![],
@@ -329,8 +337,14 @@ impl Transaction {
 	/// Creates a new transaction initialized with
 	/// the provided inputs, outputs, kernels
 	pub fn new(inputs: Vec<Input>, outputs: Vec<Output>, kernels: Vec<TxKernel>) -> Transaction {
+		let zero_offset = {
+			let secp = static_secp_instance();
+			let secp = secp.lock().unwrap();
+			secp.commit_value(0).unwrap()
+		};
+
 		Transaction {
-			offset: BlindingFactor::zero(),
+			offset: zero_offset,
 			inputs: inputs,
 			outputs: outputs,
 			kernels: kernels,
@@ -339,7 +353,7 @@ impl Transaction {
 
 	/// Creates a new transaction using this transaction as a template
 	/// and with the specified offset.
-	pub fn with_offset(self, offset: BlindingFactor) -> Transaction {
+	pub fn with_offset(self, offset: Commitment) -> Transaction {
 		Transaction {
 			offset: offset,
 			..self
@@ -396,15 +410,16 @@ impl Transaction {
 
 			let secp = static_secp_instance();
 			let secp = secp.lock().unwrap();
+			let zero_commit = secp.commit_value(0)?;
 
-			// add the offset in as necessary (unless offset is zero)
-			if self.offset != BlindingFactor::zero() {
-				let skey = self.offset.secret_key(&secp)?;
-				let offset_commit = secp.commit(0, skey)?;
-				kernel_commits.push(offset_commit);
+			kernel_commits.push(self.offset);
+			kernel_commits.retain(|x| *x != zero_commit);
+
+			if kernel_commits.is_empty() {
+				zero_commit
+			} else {
+				secp.commit_sum(kernel_commits, vec![])?
 			}
-
-			secp.commit_sum(kernel_commits, vec![])?
 		};
 
 		// sum of kernel commitments (including the offset) must match
@@ -515,18 +530,13 @@ pub fn aggregate_with_cut_through(transactions: Vec<Transaction>) -> Result<Tran
 	let total_kernel_offset = {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
-		let mut keys = kernel_offsets
-			.iter()
-			.cloned()
-			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
-			.collect::<Vec<_>>();
+		let zero_commit = secp.commit_value(0)?;
 
-		if keys.is_empty() {
-			BlindingFactor::zero()
+		kernel_offsets.retain(|x| *x != zero_commit);
+		if kernel_offsets.is_empty() {
+			zero_commit
 		} else {
-			let sum = secp.blind_sum(keys, vec![])?;
-			BlindingFactor::from_secret_key(sum)
+			secp.commit_sum(kernel_offsets, vec![])?
 		}
 	};
 
@@ -589,18 +599,13 @@ pub fn aggregate(transactions: Vec<Transaction>) -> Result<Transaction, Error> {
 	let total_kernel_offset = {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
-		let mut keys = kernel_offsets
-			.iter()
-			.cloned()
-			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
-			.collect::<Vec<_>>();
+		let zero_commit = secp.commit_value(0)?;
 
-		if keys.is_empty() {
-			BlindingFactor::zero()
+		kernel_offsets.retain(|x| *x != zero_commit);
+		if kernel_offsets.is_empty() {
+			zero_commit
 		} else {
-			let sum = secp.blind_sum(keys, vec![])?;
-			BlindingFactor::from_secret_key(sum)
+			secp.commit_sum(kernel_offsets, vec![])?
 		}
 	};
 
@@ -649,25 +654,9 @@ pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transact
 	let total_kernel_offset = {
 		let secp = static_secp_instance();
 		let secp = secp.lock().unwrap();
-		let mut positive_key = vec![mk_tx.offset]
-			.iter()
-			.cloned()
-			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
-			.collect::<Vec<_>>();
-		let mut negative_keys = kernel_offsets
-			.iter()
-			.cloned()
-			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
-			.collect::<Vec<_>>();
 
-		if positive_key.is_empty() && negative_keys.is_empty() {
-			BlindingFactor::zero()
-		} else {
-			let sum = secp.blind_sum(positive_key, negative_keys)?;
-			BlindingFactor::from_secret_key(sum)
-		}
+		// TODO - handle "zero commits" here?
+		secp.commit_sum(vec![mk_tx.offset], kernel_offsets)?
 	};
 
 	// Sorting them lexicographically

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -22,15 +22,14 @@
 use std::{cmp, error, fmt, mem};
 use std::io::{self, Read, Write};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
+use keychain::{Identifier, IDENTIFIER_SIZE};
 use consensus;
 use consensus::VerifySortOrder;
 use core::hash::{Hash, Hashed};
 use util::secp::pedersen::Commitment;
 use util::secp::pedersen::RangeProof;
 use util::secp::Signature;
-use util::secp::constants::{AGG_SIGNATURE_SIZE, MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE,
-                            SECRET_KEY_SIZE};
+use util::secp::constants::{AGG_SIGNATURE_SIZE, MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE};
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Debug)]
@@ -326,19 +325,6 @@ impl Readable for Commitment {
 impl Writeable for Commitment {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_fixed_bytes(self)
-	}
-}
-
-impl Writeable for BlindingFactor {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		writer.write_fixed_bytes(self)
-	}
-}
-
-impl Readable for BlindingFactor {
-	fn read(reader: &mut Reader) -> Result<BlindingFactor, Error> {
-		let bytes = reader.read_fixed_bytes(SECRET_KEY_SIZE)?;
-		Ok(BlindingFactor::from_slice(&bytes))
 	}
 }
 
@@ -645,11 +631,6 @@ impl AsFixedBytes for ::util::secp::Signature {
 impl AsFixedBytes for ::util::secp::pedersen::Commitment {
 	fn len(&self) -> usize {
 		return PEDERSEN_COMMITMENT_SIZE;
-	}
-}
-impl AsFixedBytes for BlindingFactor {
-	fn len(&self) -> usize {
-		return SECRET_KEY_SIZE;
 	}
 }
 impl AsFixedBytes for ::keychain::Identifier {

--- a/util/src/secp_static.rs
+++ b/util/src/secp_static.rs
@@ -26,9 +26,17 @@ lazy_static! {
 }
 
 /// Returns the static instance, but calls randomize on it as well
-/// (Recommended to avoid side channel attacks
+/// (Recommended to avoid side channel attacks)
 pub fn static_secp_instance() -> Arc<Mutex<secp::Secp256k1>> {
 	let mut secp_inst = SECP256K1.lock().unwrap();
 	secp_inst.randomize(&mut thread_rng());
 	SECP256K1.clone()
+}
+
+// TODO - Can we generate this once and memoize it for subsequent use?
+// Even if we clone it each time it will likely be faster than this.
+pub fn commit_to_zero_value() -> secp::pedersen::Commitment {
+	let secp = static_secp_instance();
+	let secp = secp.lock().unwrap();
+	secp.commit_value(0).unwrap()
 }

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -28,10 +28,11 @@ use core::consensus::reward;
 use core::core::{amount_to_hr_string, build, Block, Committed, Output, Transaction, TxKernel};
 use core::{global, ser};
 use failure::{Fail, ResultExt};
-use keychain::{BlindingFactor, Identifier, Keychain};
+use keychain::{Identifier, Keychain};
 use types::*;
 use urlencoded::UrlEncodedQuery;
 use util::{secp, to_hex, LOGGER};
+use util::secp::pedersen::Commitment;
 
 /// Dummy wrapper for the hex-encoded serialized transaction.
 #[derive(Serialize, Deserialize)]
@@ -404,7 +405,7 @@ fn build_final_transaction(
 	config: &WalletConfig,
 	keychain: &Keychain,
 	amount: u64,
-	kernel_offset: BlindingFactor,
+	kernel_offset: Commitment,
 	excess_sig: &secp::Signature,
 	tx: Transaction,
 ) -> Result<Transaction, Error> {
@@ -482,13 +483,9 @@ fn build_final_transaction(
 		let tx_excess = final_tx.sum_commitments().context(ErrorKind::Transaction)?;
 
 		// subtract the kernel_excess (built from kernel_offset)
-		let offset_excess = keychain
-			.secp()
-			.commit(0, kernel_offset.secret_key(&keychain.secp()).unwrap())
-			.unwrap();
 		keychain
 			.secp()
-			.commit_sum(vec![tx_excess], vec![offset_excess])
+			.commit_sum(vec![tx_excess], vec![kernel_offset])
 			.context(ErrorKind::Transaction)?
 	};
 

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -91,7 +91,9 @@ pub fn issue_send_tx(
 		.aggsig_create_context(&tx_id, skey)
 		.context(ErrorKind::Keychain)?;
 
-	let kernel_offset = keychain.secp().commit(0, skey)
+	let kernel_offset = keychain
+		.secp()
+		.commit(0, skey)
 		.context(ErrorKind::Keychain)?;
 
 	let partial_tx = build_partial_tx(&tx_id, keychain, amount_with_fee, kernel_offset, None, tx);


### PR DESCRIPTION
We track "kernel offsets" of transactions and blocks.

We have been storing these as `blinding_factors` but I think the code is probably cleaner if we store these as `commitments`.

It never felt clean to be serializing/deserializing a `blinding_factor` on a tx (or a block).

This adds a single byte to each transaction and each block (a commitment is 33 bytes, a blinding_factor 32 bytes).
But the tradeoff is less code (and less time) converting between blinding_factors, secret_keys and commitments.

TODO
- [x] refactor common code related to `zero_commit` default values
- [x] cleanup wallet code (to use commitments)
- [x] clean up serialization code (no need to ser/deser blinding_factors?)

NOTE: this is consensus breaking - changes the serialization format of both transactions and blocks...


