### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most .editorconfig file
+root = true
+
+# use hard tabs for rust source files
+[*.rs]
+indent_style = tab


### PR DESCRIPTION
See editorconfig.org for plugins and details.

The only setting of note is to use hard tabs in rust source files. This is pretty nice for contributors who use soft tabs by default.