### PR TITLE
forgot to use the split key correctly

### DIFF
--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -91,9 +91,12 @@ pub fn issue_send_tx(
 		.aggsig_create_context(&tx_id, skey)
 		.context(ErrorKind::Keychain)?;
 
+	let kernel_key = kernel_blind
+		.secret_key(keychain.secp())
+		.context(ErrorKind::Keychain)?;
 	let kernel_offset = keychain
 		.secp()
-		.commit(0, skey)
+		.commit(0, kernel_key)
 		.context(ErrorKind::Keychain)?;
 
 	let partial_tx = build_partial_tx(&tx_id, keychain, amount_with_fee, kernel_offset, None, tx);


### PR DESCRIPTION
We introduced this in #1020.
Incorrectly using `skey` when we need to extract the secret key from `kernel_blind`.