### PR TITLE
refactor on master, pass in offset as blinding_factor

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -722,16 +722,9 @@ impl Block {
 		let overage = (REWARD as i64).checked_neg().unwrap_or(0);
 		let io_sum = self.sum_commitments(overage, Some(prev_output_sum))?;
 
-		let offset = {
-			let secp = static_secp_instance();
-			let secp = secp.lock().unwrap();
-			let key = self.header.total_kernel_offset.secret_key(&secp)?;
-			secp.commit(0, key)?
-		};
-
 		// Sum the kernel excesses accounting for the kernel offset.
 		let (kernel_sum, kernel_sum_plus_offset) =
-			self.sum_kernel_excesses(&offset, Some(prev_kernel_sum))?;
+			self.sum_kernel_excesses(&self.header.total_kernel_offset, Some(prev_kernel_sum))?;
 
 		if io_sum != kernel_sum_plus_offset {
 			return Err(Error::KernelSumMismatch);

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -418,15 +418,8 @@ impl Transaction {
 		let overage = self.fee() as i64;
 		let io_sum = self.sum_commitments(overage, None)?;
 
-		let offset = {
-			let secp = static_secp_instance();
-			let secp = secp.lock().unwrap();
-			let key = self.offset.secret_key(&secp)?;
-			secp.commit(0, key)?
-		};
-
 		// Sum the kernel excesses accounting for the kernel offset.
-		let (_, kernel_sum) = self.sum_kernel_excesses(&offset, None)?;
+		let (_, kernel_sum) = self.sum_kernel_excesses(&self.offset, None)?;
 
 		// sum of kernel commitments (including the offset) must match
 		// the sum of input/output commitments (minus fee)


### PR DESCRIPTION
Refactor - make `sum_kernel_excesses` take a `blinding_factor`.
So we generate the kernel_offset commitment in one central place.

Related - #1062.

