### PR TITLE
Remove unused error type switch commitment

### DIFF
--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -75,8 +75,6 @@ pub enum Error {
 	InvalidBlockHeight,
 	/// One of the root hashes in the block is invalid
 	InvalidRoot,
-	/// Something does not look right with the switch commitment
-	InvalidSwitchCommit,
 	/// Error from underlying keychain impl
 	Keychain(keychain::Error),
 	/// Error from underlying secp lib

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -17,8 +17,8 @@
 use std::{error, fmt, io};
 
 use util::secp;
-use util::secp_static;
 use util::secp::pedersen::Commitment;
+use util::secp_static;
 
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;

--- a/doc/coinbase_maturity.md
+++ b/doc/coinbase_maturity.md
@@ -12,7 +12,6 @@ The maturity rule _only_ applies to coinbase outputs, regular transaction output
 An output consists of -
   * features (currently coinbase vs. non-coinbase)
   * commitment `rG+vH`
-  * switch commitment hash `blake2(rJ)`
   * rangeproof
 
 To spend a regular transaction output two conditions must be met. We need to show the output has not been previously spent and we need to prove ownership of the output.


### PR DESCRIPTION
Remove the ```InvalidSwitchCommit```which is currently unused. 
Bonus remove it from the output doc.
For the record, switch commitment might be reintroduced later.