### PR TITLE
dandelion config in grin.toml matches actual defaults

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -78,10 +78,10 @@ run_test_miner = false
 #relay_secs = 600
 
 #fluff and broadcast after embargo expires if tx not seen on network
-#embargo_secs = 300
+#embargo_secs = 180
 
 #run dandelion stem/fluff processing every n secs (stem tx aggregation in this window)
-#patience_secs = 30
+#patience_secs = 10
 
 #dandelion stem probability (stem 90% of the time, fluff 10% of the time)
 #stem_probability = 90


### PR DESCRIPTION
```
embargo: 180s
patience: 10s
```

