### PR TITLE
log # kernels so we can see tx aggregation (if any)

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -125,11 +125,10 @@ where
 	) -> Result<(), PoolError> {
 		debug!(
 			LOGGER,
-			"pool [{}]: add_to_pool: {}, {:?}, {}",
+			"pool [{}]: add_to_pool: {}, {:?}",
 			self.name,
 			entry.tx.hash(),
 			entry.src,
-			extra_txs.len(),
 		);
 
 		// Combine all the txs from the pool with any extra txs provided.

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -20,10 +20,12 @@
 use std::sync::Arc;
 use time;
 
+use core::core::hash::Hashed;
 use core::core::transaction;
 use core::core::{Block, CompactBlock, Transaction};
 use pool::Pool;
 use types::*;
+use util::LOGGER;
 
 /// Transaction pool implementation.
 pub struct TransactionPool<T> {
@@ -95,6 +97,14 @@ where
 		tx: Transaction,
 		stem: bool,
 	) -> Result<(), PoolError> {
+		debug!(
+			LOGGER,
+			"pool: add_to_pool: {:?}, kernels - {}, stem? {}",
+			tx.hash(),
+			tx.kernels.len(),
+			stem,
+		);
+
 		// Do we have the capacity to accept this transaction?
 		self.is_acceptable(&tx)?;
 


### PR DESCRIPTION
Log # kernels when adding a tx to the pool.

```
May 31 11:22:43.407 DEBG pool: add_to_pool: ae1d3478, kernels - 1, stem? false
```