### PR TITLE
fix grin.toml parsing error for missing values

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -75,16 +75,16 @@ run_test_miner = false
 
 [server.dandelion_config]
 #dandelion relay time (choose new relay peer every n secs)
-#relay_secs = 600
+relay_secs = 600
 
 #fluff and broadcast after embargo expires if tx not seen on network
-#embargo_secs = 180
+embargo_secs = 180
 
 #run dandelion stem/fluff processing every n secs (stem tx aggregation in this window)
-#patience_secs = 10
+patience_secs = 10
 
 #dandelion stem probability (stem 90% of the time, fluff 10% of the time)
-#stem_probability = 90
+stem_probability = 90
 
 #The P2P server details (i.e. the server that communicates with other
 #grin server nodes


### PR DESCRIPTION
short term fix - just uncomment all the "required" fields...

Need to revisit this in #1115 to clean this up and do it properly.

