### PR TITLE
Rustify core/src/core

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -568,7 +568,7 @@ impl BlockHandler {
 			))?;
 		}
 		let vec = util::from_hex(input).unwrap();
-		Ok(Hash::from_vec(vec))
+		Ok(Hash::from_vec(&vec))
 	}
 }
 

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -53,7 +53,7 @@ impl Tip {
 			height: tip.height,
 			last_block_pushed: util::to_hex(tip.last_block_h.to_vec()),
 			prev_block_to_last: util::to_hex(tip.prev_block_h.to_vec()),
-			total_difficulty: tip.total_difficulty.into_num(),
+			total_difficulty: tip.total_difficulty.to_num(),
 		}
 	}
 }
@@ -497,7 +497,7 @@ impl BlockHeaderPrintable {
 			range_proof_root: util::to_hex(h.range_proof_root.to_vec()),
 			kernel_root: util::to_hex(h.kernel_root.to_vec()),
 			nonce: h.nonce,
-			total_difficulty: h.total_difficulty.into_num(),
+			total_difficulty: h.total_difficulty.to_num(),
 			total_kernel_offset: h.total_kernel_offset.to_hex(),
 		}
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,8 +30,8 @@ use pipe;
 use store;
 use txhashset;
 use types::*;
-use util::secp::pedersen::{Commitment, RangeProof};
 use util::LOGGER;
+use util::secp::pedersen::{Commitment, RangeProof};
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
 pub const MAX_ORPHAN_SIZE: usize = 200;
@@ -260,7 +260,7 @@ impl Chain {
 		debug!(
 			LOGGER,
 			"Chain init: {} @ {} [{}]",
-			head.total_difficulty.into_num(),
+			head.total_difficulty.to_num(),
 			head.height,
 			head.last_block_h,
 		);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -277,7 +277,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 
 		let target_difficulty = header.total_difficulty.clone() - prev.total_difficulty.clone();
 
-		if header.pow.clone().to_difficulty() < target_difficulty {
+		if header.pow.to_difficulty() < target_difficulty {
 			return Err(Error::DifficultyTooLow);
 		}
 
@@ -297,8 +297,8 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 			error!(
 				LOGGER,
 				"validate_header: BANNABLE OFFENCE: header cumulative difficulty {} != {}",
-				target_difficulty.into_num(),
-				prev.total_difficulty.into_num() + network_difficulty.into_num()
+				target_difficulty.to_num(),
+				prev.total_difficulty.to_num() + network_difficulty.to_num()
 			);
 			return Err(Error::WrongTotalDifficulty);
 		}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -930,7 +930,7 @@ impl<'a> Extension<'a> {
 			if pmmr::is_leaf(n) {
 				if let Some(out) = self.output_pmmr.get_data(n) {
 					if let Some(rp) = self.rproof_pmmr.get_data(n) {
-						out.to_output(rp).verify_proof()?;
+						out.into_output(rp).verify_proof()?;
 					} else {
 						// TODO - rangeproof not found
 						return Err(Error::OutputNotFound);

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -24,8 +24,8 @@ extern crate time;
 use std::fs;
 use std::sync::Arc;
 
-use chain::types::*;
 use chain::Chain;
+use chain::types::*;
 use core::consensus;
 use core::core::hash::Hashed;
 use core::core::target::Difficulty;
@@ -444,7 +444,7 @@ fn actual_diff_iter_output() {
 		println!(
 			"next_difficulty time: {}, diff: {}, duration: {} ",
 			elem.0,
-			elem.1.into_num(),
+			elem.1.to_num(),
 			last_time - elem.0
 		);
 		last_time = elem.0;

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -221,7 +221,7 @@ where
 	let diff_sum = diff_data
 		.iter()
 		.skip(MEDIAN_TIME_WINDOW as usize)
-		.fold(0, |sum, d| sum + d.clone().unwrap().1.into_num());
+		.fold(0, |sum, d| sum + d.clone().unwrap().1.to_num());
 
 	// Apply dampening except when difficulty is near 1
 	let ts_damp = if diff_sum < DAMP_FACTOR * DIFFICULTY_ADJUST_WINDOW {

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -38,8 +38,8 @@ pub trait ShortIdentifiable {
 impl<H: Hashed> ShortIdentifiable for H {
 	/// Generate a short_id via the following -
 	///
-	///   * extract k0/k1 from block_hash hashed with the nonce (first two u64 values)
-	///   * initialize a siphasher24 with k0/k1
+	/// * extract k0/k1 from block_hash hashed with the nonce (first two u64
+	/// values)   * initialize a siphasher24 with k0/k1
 	///   * self.hash() passing in the siphasher24 instance
 	///   * drop the 2 most significant bytes (to return a 6 byte short_id)
 	///
@@ -75,24 +75,23 @@ impl<H: Hashed> ShortIdentifiable for H {
 pub struct ShortId([u8; 6]);
 
 /// We want to sort short_ids in a canonical and consistent manner so we can
-/// verify sort order in the same way we do for full inputs|outputs|kernels themselves.
+/// verify sort order in the same way we do for full inputs|outputs|kernels
+/// themselves.
 hashable_ord!(ShortId);
 
 impl ::std::fmt::Debug for ShortId {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		try!(write!(f, "{}(", stringify!(ShortId)));
-		try!(write!(f, "{}", self.to_hex()));
+		write!(f, "{}(", stringify!(ShortId))?;
+		write!(f, "{}", self.to_hex())?;
 		write!(f, ")")
 	}
 }
 
 impl Readable for ShortId {
 	fn read(reader: &mut Reader) -> Result<ShortId, ser::Error> {
-		let v = try!(reader.read_fixed_bytes(SHORT_ID_SIZE));
+		let v = reader.read_fixed_bytes(SHORT_ID_SIZE)?;
 		let mut a = [0; SHORT_ID_SIZE];
-		for i in 0..a.len() {
-			a[i] = v[i];
-		}
+		a.copy_from_slice(&v[..]);
 		Ok(ShortId(a))
 	}
 }
@@ -107,9 +106,8 @@ impl ShortId {
 	/// Build a new short_id from a byte slice
 	pub fn from_bytes(bytes: &[u8]) -> ShortId {
 		let mut hash = [0; SHORT_ID_SIZE];
-		for i in 0..min(SHORT_ID_SIZE, bytes.len()) {
-			hash[i] = bytes[i];
-		}
+		let copy_size = min(SHORT_ID_SIZE, bytes.len());
+		hash[..copy_size].copy_from_slice(&bytes[..copy_size]);
 		ShortId(hash)
 	}
 
@@ -121,7 +119,7 @@ impl ShortId {
 	/// Reconstructs a switch commit hash from a hex string.
 	pub fn from_hex(hex: &str) -> Result<ShortId, ser::Error> {
 		let bytes = util::from_hex(hex.to_string())
-			.map_err(|_| ser::Error::HexError(format!("short_id from_hex error")))?;
+			.map_err(|_| ser::Error::HexError("short_id from_hex error".to_string()))?;
 		Ok(ShortId::from_bytes(&bytes))
 	}
 

--- a/core/src/core/target.rs
+++ b/core/src/core/target.rs
@@ -29,7 +29,7 @@ use core::hash::Hash;
 use ser::{self, Readable, Reader, Writeable, Writer};
 
 /// The difficulty is defined as the maximum target divided by the block hash.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Difficulty {
 	num: u64,
 }
@@ -63,7 +63,7 @@ impl Difficulty {
 	}
 
 	/// Converts the difficulty into a u64
-	pub fn into_num(&self) -> u64 {
+	pub fn to_num(&self) -> u64 {
 		self.num
 	}
 }
@@ -118,7 +118,7 @@ impl Writeable for Difficulty {
 
 impl Readable for Difficulty {
 	fn read(reader: &mut Reader) -> Result<Difficulty, ser::Error> {
-		let data = try!(reader.read_u64());
+		let data = reader.read_u64()?;
 		Ok(Difficulty { num: data })
 	}
 }
@@ -155,7 +155,7 @@ impl<'de> de::Visitor<'de> for DiffVisitor {
 		E: de::Error,
 	{
 		let num_in = s.parse::<u64>();
-		if let Err(_) = num_in {
+		if num_in.is_err() {
 			return Err(de::Error::invalid_value(
 				de::Unexpected::Str(s),
 				&"a value number",

--- a/core/src/pow/cuckoo.rs
+++ b/core/src/pow/cuckoo.rs
@@ -17,8 +17,8 @@
 //! simple miner is included, mostly for testing purposes. John Tromp's Tomato
 //! miner will be much faster in almost every environment.
 
-use std::collections::HashSet;
 use std::cmp;
+use std::collections::HashSet;
 
 use blake2;
 
@@ -93,9 +93,9 @@ impl Cuckoo {
 	pub fn verify(&self, proof: Proof, ease: u64) -> bool {
 		let easiness = ease * (self.size as u64) / 100;
 		let nonces = proof.to_u64s();
-		let mut us = vec![0; proof.proof_size];
-		let mut vs = vec![0; proof.proof_size];
-		for n in 0..proof.proof_size {
+		let mut us = vec![0; proof.proof_size()];
+		let mut vs = vec![0; proof.proof_size()];
+		for n in 0..proof.proof_size() {
 			if nonces[n] >= easiness || (n != 0 && nonces[n] <= nonces[n - 1]) {
 				return false;
 			}
@@ -103,10 +103,10 @@ impl Cuckoo {
 			vs[n] = self.new_node(nonces[n], 1);
 		}
 		let mut i = 0;
-		let mut count = proof.proof_size;
+		let mut count = proof.proof_size();
 		loop {
 			let mut j = i;
-			for k in 0..proof.proof_size {
+			for k in 0..proof.proof_size() {
 				// find unique other j with same vs[j]
 				if k != i && vs[k] == vs[i] {
 					if j != i {
@@ -119,7 +119,7 @@ impl Cuckoo {
 				return false;
 			}
 			i = j;
-			for k in 0..proof.proof_size {
+			for k in 0..proof.proof_size() {
 				// find unique other i with same us[i]
 				if k != j && us[k] == us[j] {
 					if i != j {
@@ -361,8 +361,8 @@ mod test {
 		assert!(Cuckoo::new(&[51], 20).verify(Proof::new(V3.to_vec().clone()), 70));
 	}
 
-	/// Just going to disable this for now, as it's painful to try and get a valid
-	/// cuckoo28 vector (TBD: 30 is more relevant now anyhow)
+	/// Just going to disable this for now, as it's painful to try and get a
+	/// valid cuckoo28 vector (TBD: 30 is more relevant now anyhow)
 	#[test]
 	#[ignore]
 	fn validate28_vectors() {

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -35,14 +35,14 @@ extern crate time;
 
 extern crate grin_util as util;
 
-mod siphash;
 pub mod cuckoo;
+mod siphash;
 
 use consensus;
-use core::{Block, BlockHeader};
 use core::target::Difficulty;
-use global;
+use core::{Block, BlockHeader};
 use genesis;
+use global;
 use pow::cuckoo::{Cuckoo, Error};
 
 /// Validates the proof of work of a given header, and that the proof of work
@@ -97,7 +97,7 @@ pub fn pow_size(
 		if let Ok(proof) =
 			cuckoo::Miner::new(&pow_hash[..], consensus::EASINESS, proof_size, sz).mine()
 		{
-			if proof.clone().to_difficulty() >= diff {
+			if proof.to_difficulty() >= diff {
 				bh.pow = proof.clone();
 				return Ok(());
 			}
@@ -117,9 +117,9 @@ pub fn pow_size(
 #[cfg(test)]
 mod test {
 	use super::*;
-	use global;
 	use core::target::Difficulty;
 	use genesis;
+	use global;
 
 	/// We'll be generating genesis blocks differently
 	#[ignore]
@@ -134,7 +134,7 @@ mod test {
 			global::sizeshift(),
 		).unwrap();
 		assert!(b.header.nonce != 310);
-		assert!(b.header.pow.clone().to_difficulty() >= Difficulty::one());
+		assert!(b.header.pow.to_difficulty() >= Difficulty::one());
 		assert!(verify_size(&b.header, global::sizeshift()));
 	}
 }

--- a/core/src/pow/siphash.rs
+++ b/core/src/pow/siphash.rs
@@ -24,30 +24,30 @@ pub fn siphash24(v: [u64; 4], nonce: u64) -> u64 {
 
 	// macro for left rotation
 	macro_rules! rotl {
-    ($num:ident, $shift:expr) => {
-      $num = ($num << $shift) | ($num >> (64 - $shift));
-    }
-  }
+		($num:ident, $shift:expr) => {
+			$num = ($num << $shift) | ($num >> (64 - $shift));
+		};
+	}
 
 	// macro for a single siphash round
 	macro_rules! round {
-    () => {
-      v0 = v0.wrapping_add(v1);
-      v2 = v2.wrapping_add(v3);
-      rotl!(v1, 13);
-      rotl!(v3, 16);
-      v1 ^= v0;
-      v3 ^= v2;
-      rotl!(v0, 32);
-      v2 = v2.wrapping_add(v1);
-      v0 = v0.wrapping_add(v3);
-      rotl!(v1, 17);
-      rotl!(v3, 21);
-      v1 ^= v2;
-      v3 ^= v0;
-      rotl!(v2, 32);
-    }
-  }
+		() => {
+			v0 = v0.wrapping_add(v1);
+			v2 = v2.wrapping_add(v3);
+			rotl!(v1, 13);
+			rotl!(v3, 16);
+			v1 ^= v0;
+			v3 ^= v2;
+			rotl!(v0, 32);
+			v2 = v2.wrapping_add(v1);
+			v0 = v0.wrapping_add(v3);
+			rotl!(v1, 17);
+			rotl!(v3, 21);
+			v1 ^= v2;
+			v3 ^= v0;
+			rotl!(v2, 32);
+		};
+	}
 
 	// 2 rounds
 	round!();

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, RwLock};
 use rand::Rng;
 use rand::os::OsRng;
 
-use core::core::target::Difficulty;
 use core::core::hash::Hash;
+use core::core::target::Difficulty;
 use msg::*;
 use peer::Peer;
 use types::*;
@@ -35,7 +35,8 @@ pub struct Handshake {
 	/// a node id.
 	nonces: Arc<RwLock<VecDeque<u64>>>,
 	/// The genesis block header of the chain seen by this node.
-	/// We only want to connect to other nodes seeing the same chain (forks are ok).
+	/// We only want to connect to other nodes seeing the same chain (forks are
+	/// ok).
 	genesis: Hash,
 	config: P2PConfig,
 }
@@ -111,7 +112,7 @@ impl Handshake {
 		debug!(
 			LOGGER,
 			"Connected! Cumulative {} offered from {:?} {:?} {:?}",
-			peer_info.total_difficulty.into_num(),
+			peer_info.total_difficulty.to_num(),
 			peer_info.addr,
 			peer_info.user_agent,
 			peer_info.capabilities

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -686,7 +686,7 @@ impl NetAdapter for Peers {
 			);
 		}
 
-		if diff.into_num() > 0 {
+		if diff.to_num() > 0 {
 			if let Some(peer) = self.get_connected_peer(&addr) {
 				let mut peer = peer.write().unwrap();
 				peer.info.total_difficulty = diff;

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -61,7 +61,7 @@ fn peer_handshake() {
 			p2p_config.clone(),
 			dandelion_config.clone(),
 			net_adapter.clone(),
-			Hash::from_vec(vec![]),
+			Hash::from_vec(&vec![]),
 			Arc::new(AtomicBool::new(false)),
 			false,
 			None,
@@ -82,7 +82,7 @@ fn peer_handshake() {
 		p2p::Capabilities::UNKNOWN,
 		Difficulty::one(),
 		my_addr,
-		&p2p::handshake::Handshake::new(Hash::from_vec(vec![]), p2p_config.clone()),
+		&p2p::handshake::Handshake::new(Hash::from_vec(&vec![]), p2p_config.clone()),
 		net_adapter,
 	).unwrap();
 

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -15,8 +15,8 @@
 //! Server stat collection types, to be used by tests, logging or GUI/TUI
 //! to collect information about server status
 
-use std::sync::{Arc, RwLock};
 use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
 use chain;
@@ -165,7 +165,7 @@ impl PeerStats {
 			state: state.to_string(),
 			addr: addr,
 			version: peer.info.version,
-			total_difficulty: peer.info.total_difficulty.into_num(),
+			total_difficulty: peer.info.total_difficulty.to_num(),
 			height: peer.info.height,
 			direction: direction.to_string(),
 		}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -376,7 +376,7 @@ impl Server {
 					last_time = time;
 					DiffBlock {
 						block_number: height,
-						difficulty: diff.into_num(),
+						difficulty: diff.to_num(),
 						time: time,
 						duration: dur,
 					}

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{thread, cmp};
-use std::time::Duration;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use std::{cmp, thread};
 use time;
 
 use chain;
@@ -296,7 +296,7 @@ fn needs_syncing(
 					info!(
 						LOGGER,
 						"synchronised at {} @ {} [{}]",
-						local_diff.into_num(),
+						local_diff.to_num(),
 						ch.height,
 						ch.last_block_h
 					);
@@ -338,8 +338,8 @@ fn needs_syncing(
 }
 
 /// We build a locator based on sync_head.
-/// Even if sync_head is significantly out of date we will "reset" it once we start getting
-/// headers back from a peer.
+/// Even if sync_head is significantly out of date we will "reset" it once we
+/// start getting headers back from a peer.
 ///
 /// TODO - this gets *expensive* with a large header chain to iterate over
 /// as we need to get each block header from the db

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -181,15 +181,14 @@ fn build_block(
 	b.header.nonce = rng.gen();
 	b.header.timestamp = time::at_utc(time::Timespec::new(now_sec, 0));
 
-	let b_difficulty =
-		(b.header.total_difficulty.clone() - head.total_difficulty.clone()).into_num();
+	let b_difficulty = (b.header.total_difficulty.clone() - head.total_difficulty.clone()).to_num();
 	debug!(
 		LOGGER,
 		"Built new block with {} inputs and {} outputs, network difficulty: {}, cumulative difficulty {}",
 		b.inputs.len(),
 		b.outputs.len(),
 		b_difficulty,
-		b.header.clone().total_difficulty.clone().into_num(),
+		b.header.clone().total_difficulty.to_num(),
 	);
 
 	let roots_result = chain.set_txhashset_roots(&mut b, false);

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -446,7 +446,6 @@ impl StratumServer {
 			// Reconstruct the block header with this nonce and pow added
 			b = self.current_block.clone();
 			b.header.nonce = submit_params.nonce;
-			b.header.pow.proof_size = submit_params.pow.len();
 			b.header.pow.nonces = submit_params.pow;
 			let res = self.chain.process_block(b.clone(), chain::Options::MINE);
 			if let Err(e) = res {
@@ -644,7 +643,7 @@ impl StratumServer {
 				self.current_block = new_block;
 				self.current_difficulty = (self.current_block.header.total_difficulty.clone()
 					- head.total_difficulty.clone())
-					.into_num();
+					.to_num();
 				self.current_key_id = block_fees.key_id();
 				current_hash = latest_hash;
 				// set a new deadline for rebuilding with fresh transactions

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -17,23 +17,23 @@
 //! header with its proof-of-work.  Any valid mined blocks are submitted to the
 //! network.
 
-use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 use time;
 
 use common::adapters::PoolToChainAdapter;
+use common::types::StratumServerConfig;
 use core::consensus;
 use core::core::Proof;
-use core::core::{Block, BlockHeader};
 use core::core::hash::{Hash, Hashed};
+use core::core::{Block, BlockHeader};
 use core::pow::cuckoo;
-use common::types::StratumServerConfig;
 use util::LOGGER;
 
 use chain;
-use pool;
-use mining::mine_block;
 use core::global;
+use mining::mine_block;
+use pool;
 
 // Max number of transactions this miner will assemble in a block
 const MAX_TX: u32 = 5000;
@@ -108,7 +108,7 @@ impl Miner {
 				global::sizeshift(),
 			).mine()
 			{
-				let proof_diff = proof.clone().to_difficulty();
+				let proof_diff = proof.to_difficulty();
 				if proof_diff >= (b.header.total_difficulty.clone() - head.total_difficulty.clone())
 				{
 					sol = Some(proof);

--- a/wallet/src/libwallet/restore.rs
+++ b/wallet/src/libwallet/restore.rs
@@ -137,7 +137,7 @@ fn find_outputs_with_key<T: WalletBackend>(
 			None,
 			output.range_proof().unwrap(),
 		).unwrap();
-		let message = ProofMessageElements::from_proof_message(info.message).unwrap();
+		let message = ProofMessageElements::from_proof_message(&info.message).unwrap();
 		let value = message.value();
 		if value.is_err() {
 			continue;
@@ -175,7 +175,7 @@ fn find_outputs_with_key<T: WalletBackend>(
 				None,
 				output.range_proof().unwrap(),
 			).unwrap();
-			let message = ProofMessageElements::from_proof_message(info.message).unwrap();
+			let message = ProofMessageElements::from_proof_message(&info.message).unwrap();
 			let value = message.value();
 			if value.is_err() || !message.zeroes_correct() {
 				continue;


### PR DESCRIPTION
Small refactoring of one folder, if it makes sense I could extend the scope.
* Remove some cloning (real and just verbosity in the code)
* Naming conventions like to/into*
* copy_from_slice instead of manual copy
* Some Clippy's suggestions
* Some refactoring

I found that we don't use field init shorthand syntax, so I didn't touch this part, was it discussed before?