### PR TITLE
Trying out random PoW by default

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -137,7 +137,7 @@ impl Default for BlockHeader {
 			kernel_root: ZERO_HASH,
 			total_kernel_offset: BlindingFactor::zero(),
 			nonce: 0,
-			pow: Proof::zero(proof_size),
+			pow: Proof::random(proof_size),
 		}
 	}
 }


### PR DESCRIPTION
Avoid unintentional collisions which could account for some occasional test failures.