### PR TITLE
pass in next height when applying raw txs

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,8 +30,8 @@ use pipe;
 use store;
 use txhashset;
 use types::*;
-use util::LOGGER;
 use util::secp::pedersen::{Commitment, RangeProof};
+use util::LOGGER;
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
 pub const MAX_ORPHAN_SIZE: usize = 200;
@@ -460,23 +460,23 @@ impl Chain {
 		txhashset.is_unspent(output_ref)
 	}
 
+	fn next_block_height(&self) -> Result<u64, Error> {
+		let bh = self.head_header()?;
+		Ok(bh.height + 1)
+	}
+
 	/// Validate a vector of "raw" transactions against the current chain state.
 	pub fn validate_raw_txs(
 		&self,
 		txs: Vec<Transaction>,
 		pre_tx: Option<Transaction>,
 	) -> Result<Vec<Transaction>, Error> {
-		let bh = self.head_header()?;
+		let height = self.next_block_height()?;
 		let mut txhashset = self.txhashset.write().unwrap();
 		txhashset::extending_readonly(&mut txhashset, |extension| {
-			let valid_txs = extension.validate_raw_txs(txs, pre_tx, bh.height)?;
+			let valid_txs = extension.validate_raw_txs(txs, pre_tx, height)?;
 			Ok(valid_txs)
 		})
-	}
-
-	fn next_block_height(&self) -> Result<u64, Error> {
-		let bh = self.head_header()?;
-		Ok(bh.height + 1)
 	}
 
 	/// Verify we are not attempting to spend a coinbase output


### PR DESCRIPTION
* pass in next height when applying raw txs
* rewind correctly to the previous height as necessary

Looking again the recent changes were actually incorrect, specifically this part -
https://github.com/mimblewimble/grin/blob/d6b689bada7c103fbe549209b8c34fa7e077ee91/chain/src/txhashset.rs#L434-L439

We should be using "next" height to apply the input, but the previous height if we encounter an error and need to rewind (to back the tx out).

Resolves - #1124.

