### PR TITLE
Add a minimal dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN cargo build --release
 # runtime stage
 FROM debian:9.4
 
-RUN set -ex && \
-    apt-get update && \
-    apt-get --no-install-recommends --yes install locales && \
-    apt-get clean && \
-    rm -rf /var/lib/apt && \
-    sed -i '157 s/^##*//' /etc/locale.gen && \
-    locale-gen
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
 
 COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 COPY --from=builder /usr/src/grin/grin.toml /usr/src/grin/grin.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,24 @@ RUN set -ex && \
         cmake \
         git
 
-WORKDIR /usr/src/
+WORKDIR /usr/src/grin
+
+# Copying Grin
+COPY . .
 
 # Building Grin
-RUN set -ex \
-    && git clone https://github.com/mimblewimble/grin.git\
-    && cd grin \
-    && cargo build --release
+RUN cargo build --release
 
 # runtime stage
 FROM debian:9.4
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get --no-install-recommends --yes install locales && \
+    apt-get clean && \
+    rm -rf /var/lib/apt && \
+    sed -i '157 s/^##*//' /etc/locale.gen && \
+    locale-gen
 
 COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 COPY --from=builder /usr/src/grin/grin.toml /usr/src/grin/grin.toml
@@ -33,5 +41,6 @@ WORKDIR /usr/src/grin
 EXPOSE 13413
 EXPOSE 13414
 EXPOSE 13415
+EXPOSE 13416
 
-ENTRYPOINT ["grin", "server", "start"]
+ENTRYPOINT ["grin", "server", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Multistage docker build, requires docker 17.05
+
+# builder stage
+FROM rust:1.26 as builder
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get --no-install-recommends --yes install \
+        clang \
+        libclang-dev \
+        llvm-dev \
+        libncurses5 \
+        libncursesw5 \
+        cmake \
+        git
+
+WORKDIR /usr/src/
+
+# Building Grin
+RUN set -ex \
+    && git clone https://github.com/mimblewimble/grin.git\
+    && cd grin \
+    && cargo build --release
+
+# runtime stage
+FROM debian:9.4
+
+COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
+COPY --from=builder /usr/src/grin/grin.toml /usr/src/grin/grin.toml
+
+WORKDIR /usr/src/grin
+
+EXPOSE 13413
+EXPOSE 13414
+EXPOSE 13415
+
+ENTRYPOINT ["grin", "server", "start"]


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/919 by adding a minimal dockerfile.

Build instructions:
```
$ docker build -t grin .
$ docker run -it --rm --name grin_node grin
```

Still have weird character with the TUI despite having UTF-8 locales.