### PR TITLE
Add doc and persistent storage for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ ENV LANG en_US.UTF-8
 COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 COPY --from=builder /usr/src/grin/grin.toml /usr/src/grin/grin.toml
 
-# Contains the blockchain and wallet
-VOLUME /usr/src/grin
-
 WORKDIR /usr/src/grin
 
 EXPOSE 13413

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ENV LANG en_US.UTF-8
 COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 COPY --from=builder /usr/src/grin/grin.toml /usr/src/grin/grin.toml
 
+# Contains the blockchain and wallet
+VOLUME /usr/src/grin
+
 WORKDIR /usr/src/grin
 
 EXPOSE 13413

--- a/doc/build.md
+++ b/doc/build.md
@@ -20,16 +20,13 @@ you can start mining by building and runing grin-miner against your running Grin
         # Build using all available cores
         docker build -t grin .
 
-        # or build using a specific number of cores (reduce RAM requirement)
-        docker build --build-arg NPROC=1 -t grin .
-
-        # either run in foreground
+        # run in foreground
         docker run -it -v grin:/usr/src/grin grin
 
         # or in background
         docker run -it -d -v grin:/usr/src/grin grin
 
-If you decide to use a persistent storage you'll need the grin.toml file in it.
+If you decide to use a persistent storage (e.g. ```-v grin:/usr/src/grin```) you will need grin.toml configuration file in it.
 
 ## Requirements
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -15,6 +15,22 @@ Please note that all mining functions for Grin have moved into a separate, stand
 [grin_miner](https://github.com/mimblewimble/grin-miner). Once your Grin code node is up and running,
 you can start mining by building and runing grin-miner against your running Grin node.
 
+## Docker
+
+        # Build using all available cores
+        docker build -t grin .
+
+        # or build using a specific number of cores (reduce RAM requirement)
+        docker build --build-arg NPROC=1 -t grin .
+
+        # either run in foreground
+        docker run -it -v grin:/usr/src/grin grin
+
+        # or in background
+        docker run -it -d -v grin:/usr/src/grin grin
+
+If you decide to use a persistent storage you'll need the grin.toml file in it.
+
 ## Requirements
 
 - rust 1.24+ (use [rustup]((https://www.rustup.rs/))- i.e. `curl https://sh.rustup.rs -sSf | sh; source $HOME/.cargo/env`)
@@ -53,7 +69,7 @@ See [Troubleshooting](https://github.com/mimblewimble/docs/wiki/Troubleshooting)
 A successful build gets you:
 
  - `target/debug/grin` - the main grin binary
- 
+
 Grin is still sensitive to the directory from which it's run. Make sure you
 always run it within a directory that contains a `grin.toml` configuration and
 stay consistent as to where it's run from.
@@ -88,7 +104,7 @@ The `grin.toml` file can placed in one of several locations, using the first one
 
 While it's recommended that you perform all grin server configuration via
 `grin.toml`, it's also possible to supply command line switches to grin that
-override any settings in the `grin.toml` file. 
+override any settings in the `grin.toml` file.
 
 For help on grin commands and their switches, try:
 
@@ -103,4 +119,3 @@ grin client help
 The wiki page [How to use grin](https://github.com/mimblewimble/docs/wiki/How-to-use-grin)
 and linked pages have more information on what features we have,
 troubleshooting, etc.
-


### PR DESCRIPTION
- Add documentation for the Dockerfile.
- Add the possibility to use a persistent storage. (Please note that in that case you'll need to copy paste the grin.toml in it)