### PR TITLE
[DNM] add failing test to cover case where we compact a previously compacted MMR 

### DIFF
--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -338,6 +338,11 @@ where
 				let shift = self.pruned_nodes.get_leaf_shift(*pos);
 				(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
 			});
+			println!("about to save pruned data file");
+			println!("rm_log: {:?}", self.rm_log.removed);
+			println!("leaf_pos_to_rm: {:?}", leaf_pos_to_rm);
+			println!("prunelist: {:?}", self.pruned_nodes.pruned_nodes);
+			println!("off_to_rm: {:?}", off_to_rm);
 
 			self.data_file.save_prune(
 				tmp_prune_file_data.clone(),

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -222,6 +222,10 @@ impl AppendOnlyFile {
 				let mut buf_start = 0;
 				while prune_offs[prune_pos] >= read && prune_offs[prune_pos] < read + len {
 					let prune_at = (prune_offs[prune_pos] - read) as usize;
+					println!(
+						"save_prune: {}, {}, {}, {}, {}",
+						read, len, prune_at, buf_start, prune_pos
+					);
 					if prune_at != buf_start {
 						writer.write_all(&buf[buf_start..prune_at])?;
 					} else {


### PR DESCRIPTION
Test case that reliably reproduces the error during compaction.
This happens when we compact the output MMR, spend some subsequent outputs and then compact the (previously compacted) MMR a second time.

Related #1127.

Staring at the code for a while and don't see what's happening yet - but at least we can reproduce this now on a small test MMR.

cc/ @ignopeverell 

