### PR TITLE
Factor out wallet communications

### DIFF
--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -239,13 +239,7 @@ fn get_coinbase(
 			return burn_reward(block_fees);
 		}
 		Some(wallet_listener_url) => {
-			// Get the wallet coinbase
-			let url = format!(
-				"{}/v1/wallet/foreign/build_coinbase",
-				wallet_listener_url.as_str()
-			);
-
-			let res = wallet::libwallet::client::create_coinbase(&url, &block_fees)?;
+			let res = wallet::create_coinbase(&wallet_listener_url, &block_fees)?;
 			let out_bin = util::from_hex(res.output).unwrap();
 			let kern_bin = util::from_hex(res.kernel).unwrap();
 			let key_id_bin = util::from_hex(res.key_id).unwrap();
@@ -258,7 +252,6 @@ fn get_coinbase(
 			};
 
 			debug!(LOGGER, "get_coinbase: {:?}", block_fees);
-
 			return Ok((output, kernel, block_fees));
 		}
 	}

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -326,7 +326,7 @@ impl LocalServerContainer {
 			.expect("Failed to derive keychain from seed file and passphrase.");
 		let max_outputs = 500;
 
-		let mut wallet = FileWallet::new(config.clone(), "grin_test")
+		let mut wallet = FileWallet::new(config.clone(), "")
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let _ =

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -329,28 +329,29 @@ impl LocalServerContainer {
 		let mut wallet = FileWallet::new(config.clone(), "grin_test")
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
-		let _ = wallet::controller::owner_single_use(&mut wallet, |api| {
-			let result = api.issue_send_tx(
-				amount,
-				minimum_confirmations,
-				dest,
-				max_outputs,
-				selection_strategy == "all",
-				fluff,
-			);
-			match result {
-				Ok(_) => println!(
-					"Tx sent: {} grin to {} (strategy '{}')",
-					core::core::amount_to_hr_string(amount),
+		let _ =
+			wallet::controller::owner_single_use(&mut wallet, |api| {
+				let result = api.issue_send_tx(
+					amount,
+					minimum_confirmations,
 					dest,
-					selection_strategy,
-				),
-				Err(e) => {
-					println!("Tx not sent to {}: {:?}", dest, e);
-				}
-			};
-			Ok(())
-		}).unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
+					max_outputs,
+					selection_strategy == "all",
+					fluff,
+				);
+				match result {
+					Ok(_) => println!(
+						"Tx sent: {} grin to {} (strategy '{}')",
+						core::core::amount_to_hr_string(amount),
+						dest,
+						selection_strategy,
+					),
+					Err(e) => {
+						println!("Tx not sent to {}: {:?}", dest, e);
+					}
+				};
+				Ok(())
+			}).unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 	}
 
 	/// Stops the running wallet server

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -329,26 +329,28 @@ impl LocalServerContainer {
 		let mut wallet = FileWallet::new(config.clone(), "grin_test")
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
-		let result = wallet::libwallet::internal::tx::issue_send_tx(
-			&mut wallet,
-			amount,
-			minimum_confirmations,
-			dest,
-			max_outputs,
-			selection_strategy == "all",
-			fluff,
-		);
-		match result {
-			Ok(_) => println!(
-				"Tx sent: {} grin to {} (strategy '{}')",
-				core::core::amount_to_hr_string(amount),
+		let _ = wallet::controller::owner_single_use(&mut wallet, |api| {
+			let result = api.issue_send_tx(
+				amount,
+				minimum_confirmations,
 				dest,
-				selection_strategy,
-			),
-			Err(e) => {
-				println!("Tx not sent to {}: {:?}", dest, e);
-			}
-		};
+				max_outputs,
+				selection_strategy == "all",
+				fluff,
+			);
+			match result {
+				Ok(_) => println!(
+					"Tx sent: {} grin to {} (strategy '{}')",
+					core::core::amount_to_hr_string(amount),
+					dest,
+					selection_strategy,
+				),
+				Err(e) => {
+					println!("Tx not sent to {}: {:?}", dest, e);
+				}
+			};
+			Ok(())
+		}).unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 	}
 
 	/// Stops the running wallet server

--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -33,10 +33,7 @@ use util::LOGGER;
 /// Call the wallet API to create a coinbase output for the given block_fees.
 /// Will retry based on default "retry forever with backoff" behavior.
 pub fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Error> {
-	let url = format!(
-		"{}/v1/wallet/foreign/build_coinbase",
-		dest
-	);
+	let url = format!("{}/v1/wallet/foreign/build_coinbase", dest);
 	match single_create_coinbase(&url, &block_fees) {
 		Err(e) => {
 			error!(
@@ -54,11 +51,9 @@ pub fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Err
 /// Send the slate to a listening wallet instance
 pub fn send_tx_slate(dest: &str, slate: &Slate) -> Result<Slate, Error> {
 	if &dest[..4] != "http" {
-		
 		error!(
 			LOGGER,
-			"dest formatted as {} but send -d expected stdout or http://IP:port",
-			dest
+			"dest formatted as {} but send -d expected stdout or http://IP:port", dest
 		);
 		Err(ErrorKind::Node)?
 	}
@@ -133,9 +128,6 @@ pub fn post_tx(dest: &str, tx: &TxWrapper, fluff: bool) -> Result<(), Error> {
 /// Return the chain tip from a given node
 pub fn get_chain_height(addr: &str) -> Result<u64, Error> {
 	let url = format!("{}/v1/chain", addr);
-	let res = api::client::get::<api::Tip>(url.as_str())
-		.context(ErrorKind::Node)?;
+	let res = api::client::get::<api::Tip>(url.as_str()).context(ErrorKind::Node)?;
 	Ok(res.height)
 }
-
-

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -208,11 +208,6 @@ impl WalletBackend for FileWallet {
 		self.keychain.as_mut().unwrap()
 	}
 
-	/// Return URL for check node
-	fn node_url(&self) -> &str {
-		&self.config.check_node_api_http_addr
-	}
-
 	/// Return the outputs directly
 	fn outputs(&mut self) -> &mut HashMap<String, OutputData> {
 		&mut self.outputs
@@ -403,7 +398,12 @@ impl WalletBackend for FileWallet {
 }
 
 impl WalletClient for FileWallet {
-	/// Call the wallet API to create a coinbase transaction
+		/// Return URL for check node
+	fn node_url(&self) -> &str {
+		&self.config.check_node_api_http_addr
+	}
+
+/// Call the wallet API to create a coinbase transaction
 	fn create_coinbase(
 		&self,
 		dest: &str,

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -31,6 +31,7 @@ use failure::ResultExt;
 use keychain::{self, Keychain};
 use util;
 use util::LOGGER;
+use util::secp::pedersen;
 
 use error::{Error, ErrorKind};
 
@@ -434,8 +435,28 @@ impl WalletClient for FileWallet {
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node(&self) -> Result<(), libwallet::Error> {
-		Err(libwallet::ErrorKind::GenericError("Not Implemented"))?
+	fn get_outputs_from_node(&self, addr: &str, wallet_outputs:Vec<pedersen::Commitment>)
+		-> Result<HashMap<pedersen::Commitment, String>, libwallet::Error> {
+		let res = client::get_outputs_from_node(addr, wallet_outputs).context(libwallet::ErrorKind::Node)?;
+		Ok(res)
+	}
+
+	/// Get any missing block hashes from node
+	fn get_missing_block_hashes_from_node(
+		&self,
+		addr: &str,
+		height: u64,
+		wallet_outputs: Vec<pedersen::Commitment>,
+	) -> Result<
+	(
+		HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
+		HashMap<pedersen::Commitment, MerkleProofWrapper>,
+	),
+	libwallet::Error,
+	> {
+		let res = client::get_missing_block_hashes_from_node(addr, height, wallet_outputs)
+			.context(libwallet::ErrorKind::Node)?;
+		Ok(res)
 	}
 
 	/// retrieve merkle proof for a commit from a node

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -398,12 +398,12 @@ impl WalletBackend for FileWallet {
 }
 
 impl WalletClient for FileWallet {
-		/// Return URL for check node
+	/// Return URL for check node
 	fn node_url(&self) -> &str {
 		&self.config.check_node_api_http_addr
 	}
 
-/// Call the wallet API to create a coinbase transaction
+	/// Call the wallet API to create a coinbase transaction
 	fn create_coinbase(
 		&self,
 		dest: &str,

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -34,10 +34,10 @@ use util::LOGGER;
 
 use error::{Error, ErrorKind};
 
-use libwallet;
-use libtx::slate::Slate;
-use libwallet::types::*;
 use client;
+use libtx::slate::Slate;
+use libwallet;
+use libwallet::types::*;
 
 const DAT_FILE: &'static str = "wallet.dat";
 const BCK_FILE: &'static str = "wallet.bck";
@@ -403,15 +403,19 @@ impl WalletBackend for FileWallet {
 }
 
 impl WalletClient for FileWallet {
-
 	/// Call the wallet API to create a coinbase transaction
-	fn create_coinbase(&self, dest: &str, block_fees: &BlockFees) -> Result<CbData, libwallet::Error>{
-	 let res = client::create_coinbase(dest, block_fees).context(libwallet::ErrorKind::WalletComms)?;
-	 Ok(res)
+	fn create_coinbase(
+		&self,
+		dest: &str,
+		block_fees: &BlockFees,
+	) -> Result<CbData, libwallet::Error> {
+		let res =
+			client::create_coinbase(dest, block_fees).context(libwallet::ErrorKind::WalletComms)?;
+		Ok(res)
 	}
 
 	/// Send a transaction slate to another listening wallet and return result
-	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, libwallet::Error>{
+	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, libwallet::Error> {
 		let res = client::send_tx_slate(dest, slate).context(libwallet::ErrorKind::WalletComms)?;
 		Ok(res)
 	}
@@ -430,15 +434,18 @@ impl WalletClient for FileWallet {
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node(&self, ) -> Result<(), libwallet::Error> {
+	fn get_outputs_from_node(&self) -> Result<(), libwallet::Error> {
 		Err(libwallet::ErrorKind::GenericError("Not Implemented"))?
 	}
 
 	/// retrieve merkle proof for a commit from a node
-	fn get_merkle_proof_for_commit(&self, addr: &str, commit: &str) -> Result<MerkleProofWrapper, libwallet::Error>{
+	fn get_merkle_proof_for_commit(
+		&self,
+		addr: &str,
+		commit: &str,
+	) -> Result<MerkleProofWrapper, libwallet::Error> {
 		Err(libwallet::ErrorKind::GenericError("Not Implemented"))?
 	}
-
 }
 
 impl FileWallet {

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -435,9 +435,13 @@ impl WalletClient for FileWallet {
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node(&self, addr: &str, wallet_outputs:Vec<pedersen::Commitment>)
-		-> Result<HashMap<pedersen::Commitment, String>, libwallet::Error> {
-		let res = client::get_outputs_from_node(addr, wallet_outputs).context(libwallet::ErrorKind::Node)?;
+	fn get_outputs_from_node(
+		&self,
+		addr: &str,
+		wallet_outputs: Vec<pedersen::Commitment>,
+	) -> Result<HashMap<pedersen::Commitment, String>, libwallet::Error> {
+		let res = client::get_outputs_from_node(addr, wallet_outputs)
+			.context(libwallet::ErrorKind::Node)?;
 		Ok(res)
 	}
 
@@ -448,11 +452,11 @@ impl WalletClient for FileWallet {
 		height: u64,
 		wallet_outputs: Vec<pedersen::Commitment>,
 	) -> Result<
-	(
-		HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
-		HashMap<pedersen::Commitment, MerkleProofWrapper>,
-	),
-	libwallet::Error,
+		(
+			HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
+			HashMap<pedersen::Commitment, MerkleProofWrapper>,
+		),
+		libwallet::Error,
 	> {
 		let res = client::get_missing_block_hashes_from_node(addr, height, wallet_outputs)
 			.context(libwallet::ErrorKind::Node)?;

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -33,8 +33,11 @@ use util;
 use util::LOGGER;
 
 use error::{Error, ErrorKind};
+
 use libwallet;
+use libtx::slate::Slate;
 use libwallet::types::*;
+use client;
 
 const DAT_FILE: &'static str = "wallet.dat";
 const BCK_FILE: &'static str = "wallet.bck";
@@ -397,6 +400,45 @@ impl WalletBackend for FileWallet {
 		libwallet::internal::restore::restore(self).context(libwallet::ErrorKind::Restore)?;
 		Ok(())
 	}
+}
+
+impl WalletClient for FileWallet {
+
+	/// Call the wallet API to create a coinbase transaction
+	fn create_coinbase(&self, dest: &str, block_fees: &BlockFees) -> Result<CbData, libwallet::Error>{
+	 let res = client::create_coinbase(dest, block_fees).context(libwallet::ErrorKind::WalletComms)?;
+	 Ok(res)
+	}
+
+	/// Send a transaction slate to another listening wallet and return result
+	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, libwallet::Error>{
+		let res = client::send_tx_slate(dest, slate).context(libwallet::ErrorKind::WalletComms)?;
+		Ok(res)
+	}
+
+	/// Posts a tranaction to a grin node
+	fn post_tx(&self, dest: &str, tx: &TxWrapper, fluff: bool) -> Result<(), libwallet::Error> {
+		let res = client::post_tx(dest, tx, fluff).context(libwallet::ErrorKind::Node)?;
+		Ok(res)
+	}
+
+	/// retrieves the current tip from the specified grin node
+	fn get_chain_height(&self, addr: &str) -> Result<u64, libwallet::Error> {
+		let res = client::get_chain_height(addr).context(libwallet::ErrorKind::Node)?;
+		Ok(res)
+	}
+
+	/// retrieve a list of outputs from the specified grin node
+	/// need "by_height" and "by_id" variants
+	fn get_outputs_from_node(&self, ) -> Result<(), libwallet::Error> {
+		Err(libwallet::ErrorKind::GenericError("Not Implemented"))?
+	}
+
+	/// retrieve merkle proof for a commit from a node
+	fn get_merkle_proof_for_commit(&self, addr: &str, commit: &str) -> Result<MerkleProofWrapper, libwallet::Error>{
+		Err(libwallet::ErrorKind::GenericError("Not Implemented"))?
+	}
+
 }
 
 impl FileWallet {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -48,6 +48,7 @@ extern crate grin_util as util;
 
 pub mod display;
 mod error;
+mod client;
 pub mod file_wallet;
 pub mod libtx;
 pub mod libwallet;
@@ -56,3 +57,4 @@ pub use error::{Error, ErrorKind};
 pub use file_wallet::{FileWallet, WalletConfig, WalletSeed};
 pub use libwallet::controller;
 pub use libwallet::types::{BlockFees, CbData, WalletInfo};
+pub use client::create_coinbase;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -46,15 +46,15 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 
+mod client;
 pub mod display;
 mod error;
-mod client;
 pub mod file_wallet;
 pub mod libtx;
 pub mod libwallet;
 
+pub use client::create_coinbase;
 pub use error::{Error, ErrorKind};
 pub use file_wallet::{FileWallet, WalletConfig, WalletSeed};
 pub use libwallet::controller;
 pub use libwallet::types::{BlockFees, CbData, WalletInfo};
-pub use client::create_coinbase;

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -18,9 +18,10 @@
 //! Still experimental, not sure this is the best way to do this
 
 use libtx::slate::Slate;
-use libwallet::internal::{tx, updater};
-use libwallet::types::{BlockFees, CbData, OutputData, TxWrapper, WalletBackend, WalletClient, WalletInfo};
 use libwallet::Error;
+use libwallet::internal::{tx, updater};
+use libwallet::types::{BlockFees, CbData, OutputData, TxWrapper, WalletBackend, WalletClient,
+                       WalletInfo};
 
 use core::ser;
 use util::{self, LOGGER};
@@ -74,7 +75,6 @@ where
 		selection_strategy_is_use_all: bool,
 		fluff: bool,
 	) -> Result<(), Error> {
-
 		let (slate, context, lock_fn) = tx::create_send_tx(
 			self.wallet,
 			amount,
@@ -98,7 +98,8 @@ where
 
 		// All good here, so let's post it
 		let tx_hex = util::to_hex(ser::ser_vec(&slate.tx).unwrap());
-		self.wallet.post_tx(self.wallet.node_url(), &TxWrapper {tx_hex: tx_hex}, fluff)?;
+		self.wallet
+			.post_tx(self.wallet.node_url(), &TxWrapper { tx_hex: tx_hex }, fluff)?;
 
 		// All good here, lock our inputs
 		lock_fn(self.wallet)?;
@@ -114,7 +115,8 @@ where
 	) -> Result<(), Error> {
 		let tx_burn = tx::issue_burn_tx(self.wallet, amount, minimum_confirmations, max_outputs)?;
 		let tx_hex = util::to_hex(ser::ser_vec(&tx_burn).unwrap());
-		self.wallet.post_tx(self.wallet.node_url(), &TxWrapper {tx_hex: tx_hex}, false)?;
+		self.wallet
+			.post_tx(self.wallet.node_url(), &TxWrapper { tx_hex: tx_hex }, false)?;
 		Ok(())
 	}
 

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -17,11 +17,11 @@
 //! vs. functions to interact with someone else)
 //! Still experimental, not sure this is the best way to do this
 
-use libwallet::client;
 use libtx::slate::Slate;
-use libwallet::{Error, ErrorKind};
+use libwallet::client;
 use libwallet::internal::{tx, updater};
 use libwallet::types::{BlockFees, CbData, OutputData, TxWrapper, WalletBackend, WalletInfo};
+use libwallet::{Error, ErrorKind};
 
 use failure::ResultExt;
 
@@ -121,7 +121,6 @@ where
 		// All good so, lock our inputs
 		lock_fn(self.wallet)?;
 		Ok(())
-
 	}
 
 	/// Issue a burn TX
@@ -134,8 +133,8 @@ where
 		let tx_burn = tx::issue_burn_tx(self.wallet, amount, minimum_confirmations, max_outputs)?;
 		let tx_hex = util::to_hex(ser::ser_vec(&tx_burn).unwrap());
 		let url = format!("{}/v1/pool/push", self.wallet.node_url());
-		let _: () =
-			api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex }).context(ErrorKind::Node)?;
+		let _: () = api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex })
+			.context(ErrorKind::Node)?;
 		Ok(())
 	}
 

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -93,6 +93,10 @@ pub enum ErrorKind {
 	#[fail(display = "Node API error")]
 	Node,
 
+	/// Error contacting wallet API
+	#[fail(display = "Wallet communication error")]
+	WalletComms,
+
 	/// Error originating from hyper.
 	#[fail(display = "Hyper error")]
 	Hyper,

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -71,7 +71,7 @@ fn coinbase_status(output: &api::OutputPrintable) -> bool {
 
 fn outputs_batch<T>(wallet: &T, start_height: u64, max: u64) -> Result<api::OutputListing, Error>
 where
-	T: WalletBackend,
+	T: WalletBackend + WalletClient,
 {
 	let query_param = format!("start_index={}&max={}", start_height, max);
 
@@ -93,7 +93,7 @@ where
 }
 
 // TODO - wrap the many return values in a struct
-fn find_outputs_with_key<T: WalletBackend>(
+fn find_outputs_with_key<T: WalletBackend + WalletClient>(
 	wallet: &mut T,
 	outputs: Vec<api::OutputPrintable>,
 	found_key_index: &mut Vec<u32>,
@@ -243,7 +243,7 @@ fn find_outputs_with_key<T: WalletBackend>(
 }
 
 /// Restore a wallet
-pub fn restore<T: WalletBackend>(wallet: &mut T) -> Result<(), Error> {
+pub fn restore<T: WalletBackend + WalletClient>(wallet: &mut T) -> Result<(), Error> {
 	// Don't proceed if wallet.dat has anything in it
 	let is_empty = wallet
 		.read_wallet(|wallet_data| Ok(wallet_data.outputs().len() == 0))

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 //! Functions to restore a wallet's outputs from just the master seed
 
+/// TODO: Remove api
 use api;
 use byteorder::{BigEndian, ByteOrder};
 use core::core::transaction::ProofMessageElements;

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -27,24 +27,6 @@ use util;
 use util::LOGGER;
 use util::secp::pedersen;
 
-fn get_chain_height(node_addr: &str) -> Result<u64, Error> {
-	let url = format!("{}/v1/chain", node_addr);
-
-	match api::client::get::<api::Tip>(url.as_str()) {
-		Ok(tip) => Ok(tip.height),
-		Err(e) => {
-			// if we got anything other than 200 back from server, bye
-			error!(
-				LOGGER,
-				"get_chain_height: Restore failed... unable to contact API {}. Error: {}",
-				node_addr,
-				e
-			);
-			Err(e.context(ErrorKind::Node).into())
-		}
-	}
-}
-
 fn get_merkle_proof_for_commit(node_addr: &str, commit: &str) -> Result<MerkleProofWrapper, Error> {
 	let url = format!("{}/v1/txhashset/merkleproof?id={}", node_addr, commit);
 
@@ -121,7 +103,7 @@ fn find_outputs_with_key<T: WalletBackend + WalletClient>(
 	let max_derivations = 1_000_000;
 
 	info!(LOGGER, "Scanning {} outputs", outputs.len(),);
-	let current_chain_height = get_chain_height(wallet.node_url()).unwrap();
+	let current_chain_height = wallet.get_chain_height(wallet.node_url()).unwrap();
 
 	// skey doesn't matter in this case
 	let skey = wallet.keychain().derive_key_id(1).unwrap();

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -14,17 +14,13 @@
 
 //! Transaction buinding functions
 
-use api;
-use core::ser;
-use failure::ResultExt;
+use core::core::Transaction;
 use keychain::{Identifier, Keychain};
 use libtx::slate::Slate;
 use libtx::{build, tx_fee};
-use libwallet::client;
-use libwallet::internal::{selection, updater};
-use libwallet::types::{TxWrapper, WalletBackend};
+use libwallet::internal::{selection, updater, sigcontext};
+use libwallet::types::WalletBackend;
 use libwallet::{Error, ErrorKind};
-use util;
 use util::LOGGER;
 
 /// Receive a tranaction, modifying the slate accordingly (which can then be
@@ -53,29 +49,17 @@ pub fn receive_tx<T: WalletBackend>(wallet: &mut T, slate: &mut Slate) -> Result
 
 /// Issue a new transaction to the provided sender by spending some of our
 /// wallet
-/// Outputs. The destination can be "stdout" (for command line) (currently
-/// disabled) or a URL to the recipients wallet receiver (to be implemented).
-/// TBD: this just does a straight http request to recipient.. split this out
-/// somehow
-pub fn issue_send_tx<T: WalletBackend>(
+pub fn create_send_tx<T: WalletBackend>(
 	wallet: &mut T,
 	amount: u64,
 	minimum_confirmations: u64,
-	dest: &str,
 	max_outputs: usize,
 	selection_strategy_is_use_all: bool,
-	fluff: bool,
-) -> Result<(), Error> {
-	// TODO: Stdout option, probably in a separate implementation
-	if &dest[..4] != "http" {
-		panic!(
-			"dest formatted as {} but send -d expected stdout or http://IP:port",
-			dest
-		);
-	}
-
-	updater::refresh_outputs(wallet)?;
-
+) -> Result<(
+		Slate,
+		sigcontext::Context,
+		impl FnOnce(&mut T) -> Result<(), Error>,
+), Error> {
 	// Get lock height
 	let chain_tip = updater::get_tip_from_node(wallet.node_url())?;
 	let current_height = chain_tip.height;
@@ -112,36 +96,21 @@ pub fn issue_send_tx<T: WalletBackend>(
 		0,
 	)?;
 
-	let url = format!("{}/v1/wallet/foreign/receive_tx", dest);
-	debug!(LOGGER, "Posting partial transaction to {}", url);
-	let mut slate = match client::send_slate(&url, &slate, fluff).context(ErrorKind::Node) {
-		Ok(s) => s,
-		Err(e) => {
-			error!(
-				LOGGER,
-				"Communication with receiver failed on SenderInitiation send. Aborting transaction"
-			);
-			return Err(e)?;
-		}
-	};
+	Ok((slate, context, sender_lock_fn))
+}
 
+/// Complete a transaction as the sender
+pub fn complete_tx<T: WalletBackend>(
+	wallet: &mut T,
+	slate: &mut Slate,
+	context: &sigcontext::Context,
+) -> Result<(), Error> {
 	let _ = slate.fill_round_2(wallet.keychain(), &context.sec_key, &context.sec_nonce, 0)?;
-
 	// Final transaction can be built by anyone at this stage
-	slate.finalize(wallet.keychain())?;
-
-	// So let's post it
-	let tx_hex = util::to_hex(ser::ser_vec(&slate.tx).unwrap());
-	let url;
-	if fluff {
-		url = format!("{}/v1/pool/push?fluff", wallet.node_url(),);
-	} else {
-		url = format!("{}/v1/pool/push", wallet.node_url());
+	let res = slate.finalize(wallet.keychain());
+	if let Err(e) = res {
+		Err(ErrorKind::LibTX(e.kind()))?
 	}
-	api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex }).context(ErrorKind::Node)?;
-
-	// All good so, lock our inputs
-	sender_lock_fn(wallet)?;
 	Ok(())
 }
 
@@ -151,7 +120,7 @@ pub fn issue_burn_tx<T: WalletBackend>(
 	amount: u64,
 	minimum_confirmations: u64,
 	max_outputs: usize,
-) -> Result<(), Error> {
+) -> Result<Transaction, Error> {
 	let keychain = &Keychain::burn_enabled(wallet.keychain(), &Identifier::zero());
 
 	let chain_tip = updater::get_tip_from_node(wallet.node_url())?;
@@ -184,12 +153,7 @@ pub fn issue_burn_tx<T: WalletBackend>(
 	// finalize the burn transaction and send
 	let tx_burn = build::transaction(parts, &keychain)?;
 	tx_burn.validate()?;
-
-	let tx_hex = util::to_hex(ser::ser_vec(&tx_burn).unwrap());
-	let url = format!("{}/v1/pool/push", wallet.node_url());
-	let _: () =
-		api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex }).context(ErrorKind::Node)?;
-	Ok(())
+	Ok(tx_burn)
 }
 
 #[cfg(test)]

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -18,7 +18,7 @@ use core::core::Transaction;
 use keychain::{Identifier, Keychain};
 use libtx::slate::Slate;
 use libtx::{build, tx_fee};
-use libwallet::internal::{selection, updater, sigcontext};
+use libwallet::internal::{selection, sigcontext, updater};
 use libwallet::types::WalletBackend;
 use libwallet::{Error, ErrorKind};
 use util::LOGGER;
@@ -55,11 +55,14 @@ pub fn create_send_tx<T: WalletBackend>(
 	minimum_confirmations: u64,
 	max_outputs: usize,
 	selection_strategy_is_use_all: bool,
-) -> Result<(
+) -> Result<
+	(
 		Slate,
 		sigcontext::Context,
 		impl FnOnce(&mut T) -> Result<(), Error>,
-), Error> {
+	),
+	Error,
+> {
 	// Get lock height
 	let chain_tip = updater::get_tip_from_node(wallet.node_url())?;
 	let current_height = chain_tip.height;

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -81,7 +81,7 @@ where
 // refreshed
 fn refresh_missing_block_hashes<T>(wallet: &mut T, height: u64) -> Result<(), Error>
 where
-	T: WalletBackend,
+	T: WalletBackend + WalletClient,
 {
 	// build a local map of wallet outputs keyed by commit
 	// and a list of outputs we want to query the node for
@@ -231,7 +231,7 @@ where
 /// So we can refresh the local wallet outputs.
 fn refresh_output_state<T>(wallet: &mut T, height: u64) -> Result<(), Error>
 where
-	T: WalletBackend,
+	T: WalletBackend + WalletClient,
 {
 	debug!(LOGGER, "Refreshing wallet outputs");
 

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -86,10 +86,7 @@ where
 	// and a list of outputs we want to query the node for
 	let wallet_outputs = map_wallet_outputs_missing_block(wallet)?;
 
-	let wallet_output_keys = wallet_outputs
-		.keys()
-		.map(|commit| commit.clone())
-		.collect();
+	let wallet_output_keys = wallet_outputs.keys().map(|commit| commit.clone()).collect();
 
 	// nothing to do so return (otherwise we hit the api with a monster query...)
 	if wallet_outputs.is_empty() {
@@ -102,11 +99,8 @@ where
 		wallet_outputs.len(),
 	);
 
-	let (api_blocks, api_merkle_proofs) = wallet.get_missing_block_hashes_from_node(
-		wallet.node_url(),
-		height,
-		wallet_output_keys,
-	)?;
+	let (api_blocks, api_merkle_proofs) =
+		wallet.get_missing_block_hashes_from_node(wallet.node_url(), height, wallet_output_keys)?;
 
 	// now for each commit, find the output in the wallet and
 	// the corresponding api output (if it exists)
@@ -214,10 +208,7 @@ where
 	// and a list of outputs we want to query the node for
 	let wallet_outputs = map_wallet_outputs(wallet)?;
 
-	let wallet_output_keys = wallet_outputs
-		.keys()
-		.map(|commit| commit.clone())
-		.collect();
+	let wallet_output_keys = wallet_outputs.keys().map(|commit| commit.clone()).collect();
 
 	let api_outputs = wallet.get_outputs_from_node(wallet.node_url(), wallet_output_keys)?;
 	apply_api_outputs(wallet, &wallet_outputs, &api_outputs)?;

--- a/wallet/src/libwallet/mod.rs
+++ b/wallet/src/libwallet/mod.rs
@@ -23,7 +23,6 @@
 #![warn(missing_docs)]
 
 pub mod api;
-pub mod client;
 pub mod controller;
 mod error;
 pub mod internal;

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -14,6 +14,7 @@
 
 //! Types and traits that should be provided by a wallet
 //! implementation
+
 use std::collections::HashMap;
 use std::fmt;
 
@@ -28,6 +29,8 @@ use keychain::{Identifier, Keychain};
 
 use libtx::slate::Slate;
 use libwallet::error::{Error, ErrorKind};
+
+use util::secp::pedersen;
 
 /// TODO:
 /// Wallets should implement this backend for their storage. All functions
@@ -109,7 +112,22 @@ pub trait WalletClient {
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node(&self) -> Result<(), Error>;
+	fn get_outputs_from_node(&self, addr: &str, wallet_outputs:Vec<pedersen::Commitment>)
+		-> Result<HashMap<pedersen::Commitment, String>, Error>;
+
+	/// Get any missing block hashes from node
+	fn get_missing_block_hashes_from_node(
+		&self,
+		addr: &str,
+		height: u64,
+		wallet_outputs: Vec<pedersen::Commitment>,
+	) -> Result<
+	(
+		HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
+		HashMap<pedersen::Commitment, MerkleProofWrapper>,
+	),
+	Error,
+	>;
 
 	/// retrieve merkle proof for a commit from a node
 	fn get_merkle_proof_for_commit(

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -21,7 +21,6 @@ use serde;
 
 use failure::ResultExt;
 
-use api;
 use core::core::hash::Hash;
 use core::core::pmmr::MerkleProof;
 
@@ -96,20 +95,24 @@ pub trait WalletBackend {
 /// should care about communication details
 pub trait WalletClient {
 	/// Call the wallet API to create a coinbase transaction
-	fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Error>;
+	fn create_coinbase(&self, dest: &str, block_fees: &BlockFees) -> Result<CbData, Error>;
 
 	/// Send a transaction slate to another listening wallet and return result
-	fn send_tx_slate(dest: &str, slate: &Slate, fluff: bool) -> Result<Slate, Error>;
+	/// TODO: Probably need a slate wrapper type
+	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, Error>;
+
+	/// Posts a tranaction to a grin node
+	fn post_tx(&self, dest: &str, tx: &TxWrapper, fluff: bool) -> Result<(), Error>;
 
 	/// retrieves the current tip from the specified grin node
-	fn get_tip_from_node(addr: &str) -> Result<api::Tip, Error>;
+	fn get_chain_height(&self, addr: &str) -> Result<u64, Error>;
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node() -> Result<(), Error>;
+	fn get_outputs_from_node(&self) -> Result<(), Error>;
 
 	/// retrieve merkle proof for a commit from a node
-	fn get_merkle_proof_for_commit(addr: &str, commit: &str) -> Result<MerkleProofWrapper, Error>;
+	fn get_merkle_proof_for_commit(&self, addr: &str, commit: &str) -> Result<MerkleProofWrapper, Error>;
 }
 
 /// Information about an output that's being tracked by the wallet. Must be

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -43,9 +43,6 @@ pub trait WalletBackend {
 	/// Return the keychain being used
 	fn keychain(&mut self) -> &mut Keychain;
 
-	/// Return the URL of the check node
-	fn node_url(&self) -> &str;
-
 	/// Return the outputs directly
 	fn outputs(&mut self) -> &mut HashMap<String, OutputData>;
 
@@ -94,6 +91,9 @@ pub trait WalletBackend {
 /// Encapsulate all communication functions. No functions within libwallet
 /// should care about communication details
 pub trait WalletClient {
+	/// Return the URL of the check node
+	fn node_url(&self) -> &str;
+
 	/// Call the wallet API to create a coinbase transaction
 	fn create_coinbase(&self, dest: &str, block_fees: &BlockFees) -> Result<CbData, Error>;
 

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -23,10 +23,12 @@ use failure::ResultExt;
 
 use core::core::hash::Hash;
 use core::core::pmmr::MerkleProof;
+use api;
 
 use keychain::{Identifier, Keychain};
 
 use libwallet::error::{Error, ErrorKind};
+use libtx::slate::Slate;
 
 /// TODO:
 /// Wallets should implement this backend for their storage. All functions
@@ -89,6 +91,28 @@ pub trait WalletBackend {
 	/// Attempt to restore the contents of a wallet from seed
 	fn restore(&mut self) -> Result<(), Error>;
 }
+
+/// Encapsulate all communication functions. No functions within libwallet
+/// should care about communication details
+pub trait WalletClient {
+	/// Call the wallet API to create a coinbase transaction
+	fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Error>;
+
+	/// Send a transaction slate to another listening wallet and return result
+	fn send_tx_slate(dest: &str, slate: &Slate, fluff: bool) -> Result<Slate, Error>;
+
+	/// retrieves the current tip from the specified grin node
+	fn get_tip_from_node(addr: &str) -> Result<api::Tip, Error>;
+
+	/// retrieve a list of outputs from the specified grin node
+	/// need "by_height" and "by_id" variants
+	fn get_outputs_from_node() -> Result<(), Error>;
+
+	/// retrieve merkle proof for a commit from a node
+	fn get_merkle_proof_for_commit(addr: &str, commit: &str) 
+		-> Result<MerkleProofWrapper, Error>;
+}
+
 
 /// Information about an output that's being tracked by the wallet. Must be
 /// enough to reconstruct the commitment associated with the ouput when the

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -112,8 +112,11 @@ pub trait WalletClient {
 
 	/// retrieve a list of outputs from the specified grin node
 	/// need "by_height" and "by_id" variants
-	fn get_outputs_from_node(&self, addr: &str, wallet_outputs:Vec<pedersen::Commitment>)
-		-> Result<HashMap<pedersen::Commitment, String>, Error>;
+	fn get_outputs_from_node(
+		&self,
+		addr: &str,
+		wallet_outputs: Vec<pedersen::Commitment>,
+	) -> Result<HashMap<pedersen::Commitment, String>, Error>;
 
 	/// Get any missing block hashes from node
 	fn get_missing_block_hashes_from_node(
@@ -122,11 +125,11 @@ pub trait WalletClient {
 		height: u64,
 		wallet_outputs: Vec<pedersen::Commitment>,
 	) -> Result<
-	(
-		HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
-		HashMap<pedersen::Commitment, MerkleProofWrapper>,
-	),
-	Error,
+		(
+			HashMap<pedersen::Commitment, (u64, BlockIdentifier)>,
+			HashMap<pedersen::Commitment, MerkleProofWrapper>,
+		),
+		Error,
 	>;
 
 	/// retrieve merkle proof for a commit from a node

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -21,14 +21,14 @@ use serde;
 
 use failure::ResultExt;
 
+use api;
 use core::core::hash::Hash;
 use core::core::pmmr::MerkleProof;
-use api;
 
 use keychain::{Identifier, Keychain};
 
-use libwallet::error::{Error, ErrorKind};
 use libtx::slate::Slate;
+use libwallet::error::{Error, ErrorKind};
 
 /// TODO:
 /// Wallets should implement this backend for their storage. All functions
@@ -109,10 +109,8 @@ pub trait WalletClient {
 	fn get_outputs_from_node() -> Result<(), Error>;
 
 	/// retrieve merkle proof for a commit from a node
-	fn get_merkle_proof_for_commit(addr: &str, commit: &str) 
-		-> Result<MerkleProofWrapper, Error>;
+	fn get_merkle_proof_for_commit(addr: &str, commit: &str) -> Result<MerkleProofWrapper, Error>;
 }
-
 
 /// Information about an output that's being tracked by the wallet. Must be
 /// enough to reconstruct the commitment associated with the ouput when the

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -112,7 +112,11 @@ pub trait WalletClient {
 	fn get_outputs_from_node(&self) -> Result<(), Error>;
 
 	/// retrieve merkle proof for a commit from a node
-	fn get_merkle_proof_for_commit(&self, addr: &str, commit: &str) -> Result<MerkleProofWrapper, Error>;
+	fn get_merkle_proof_for_commit(
+		&self,
+		addr: &str,
+		commit: &str,
+	) -> Result<MerkleProofWrapper, Error>;
 }
 
 /// Information about an output that's being tracked by the wallet. Must be

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -33,6 +33,7 @@ use wallet::libwallet::types::*;
 use wallet::libwallet::{Error, ErrorKind};
 
 use util::secp::pedersen;
+use util;
 
 /// Mostly for testing, refreshes output state against a local chain instance
 /// instead of via an http API call
@@ -48,11 +49,11 @@ pub fn refresh_output_state_local<T: WalletBackend>(
 			Ok(k) => Some(k),
 		})
 		.collect();
-	let mut api_outputs: HashMap<pedersen::Commitment, api::Output> = HashMap::new();
+	let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
 	for out in chain_outputs {
 		match out {
 			Some(o) => {
-				api_outputs.insert(o.commit.commit(), o);
+				api_outputs.insert(o.commit.commit(), util::to_hex(o.commit.to_vec()));
 			}
 			None => {}
 		}

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -32,8 +32,8 @@ use wallet::libwallet::internal::updater;
 use wallet::libwallet::types::*;
 use wallet::libwallet::{Error, ErrorKind};
 
-use util::secp::pedersen;
 use util;
+use util::secp::pedersen;
 
 /// Mostly for testing, refreshes output state against a local chain instance
 /// instead of via an http API call


### PR DESCRIPTION
Hopefully the last explicit wallet refactoring PR for the time being, the aim of this one being to factor out all inter-wallet and wallet-node communication into a single trait which can be used within libwallet whenever there needs to be communication. A new WalletClient trait will be used within libwallet, while the communication implementation details can be moved out into implementation-specific code.