### PR TITLE
Fix 2nd compact

### DIFF
--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -338,6 +338,11 @@ where
 				let shift = self.pruned_nodes.get_leaf_shift(*pos);
 				(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
 			});
+			println!("about to save pruned data file");
+			println!("rm_log: {:?}", self.rm_log.removed);
+			println!("leaf_pos_to_rm: {:?}", leaf_pos_to_rm);
+			println!("prunelist: {:?}", self.pruned_nodes.pruned_nodes);
+			println!("off_to_rm: {:?}", off_to_rm);
 
 			self.data_file.save_prune(
 				tmp_prune_file_data.clone(),

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -335,14 +335,10 @@ where
 			let record_len = T::len() as u64;
 
 			let off_to_rm = map_vec!(leaf_pos_to_rm, |pos| {
-				let shift = self.pruned_nodes.get_leaf_shift(*pos);
-				(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
+				let flat_pos = pmmr::n_leaves(*pos);
+				let shift = self.pruned_nodes.get_leaf_shift(*pos).unwrap();
+				(flat_pos - 1 - shift) * record_len
 			});
-			println!("about to save pruned data file");
-			println!("rm_log: {:?}", self.rm_log.removed);
-			println!("leaf_pos_to_rm: {:?}", leaf_pos_to_rm);
-			println!("prunelist: {:?}", self.pruned_nodes.pruned_nodes);
-			println!("off_to_rm: {:?}", off_to_rm);
 
 			self.data_file.save_prune(
 				tmp_prune_file_data.clone(),
@@ -357,6 +353,8 @@ where
 			for &pos in &rm_pre_cutoff {
 				self.pruned_nodes.add(pos);
 			}
+			// TODO - we can get rid of leaves in the prunelist here (and things still work)
+			// self.pruned_nodes.pruned_nodes.retain(|&x| !pmmr::is_leaf(x));
 
 			write_vec(
 				format!("{}/{}", self.data_dir, PMMR_PRUNED_FILE),

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -222,6 +222,10 @@ impl AppendOnlyFile {
 				let mut buf_start = 0;
 				while prune_offs[prune_pos] >= read && prune_offs[prune_pos] < read + len {
 					let prune_at = (prune_offs[prune_pos] - read) as usize;
+					println!(
+						"save_prune: {}, {}, {}, {}, {}",
+						read, len, prune_at, buf_start, prune_pos
+					);
 					if prune_at != buf_start {
 						writer.write_all(&buf[buf_start..prune_at])?;
 					} else {

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -222,10 +222,6 @@ impl AppendOnlyFile {
 				let mut buf_start = 0;
 				while prune_offs[prune_pos] >= read && prune_offs[prune_pos] < read + len {
 					let prune_at = (prune_offs[prune_pos] - read) as usize;
-					println!(
-						"save_prune: {}, {}, {}, {}, {}",
-						read, len, prune_at, buf_start, prune_pos
-					);
 					if prune_at != buf_start {
 						writer.write_all(&buf[buf_start..prune_at])?;
 					} else {


### PR DESCRIPTION
Resolves #1127.
Related #1141.

This fixes the broken logic that we were using when pruning/compacting the data file (flat, leaves only).

We were doing the following to get the offsets in the file to remove - 
```
# find the "leaf shift" based on current prunelist
let shift = self.pruned_nodes.get_leaf_shift(*pos);

# do "something" with with the pos and the shift and the flat file translation (via n_leaves)
(pmmr::n_leaves(pos - shift.unwrap()) - 1) * record_len
```

But having spent some time staring at this, I _believe_ we want to be doing this instead - 
```
# translate the MMR pos to the flat data file pos
let flat_pos = pmmr::n_leaves(*pos);

# find the "leaf shift" based on current prunelist
let shift = self.pruned_nodes.get_leaf_shift(*pos).unwrap();

# find the offset by shifting the flat file pos (and use 0 index)
(flat_pos - 1 - shift) * record_len
```

If somebody could check my thinking here that would be awesome.
But the "compact twice" test case from #1141 passes now. 
And I cannot reproduce the error locally now after multiple compaction steps.

