### PR TITLE
Fix the way shares are validated

### DIFF
--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -107,7 +107,7 @@ pub fn get_block(
 			self::Error::Wallet(_) => {
 				error!(
 					LOGGER,
-					"Stratum server: Can't connect to wallet listener at {:?}; will retry",
+					"Error building new block: Can't connect to wallet listener at {:?}; will retry",
 					wallet_listener_url.as_ref().unwrap()
 				);
 				thread::sleep(Duration::from_secs(wallet_retry_interval));

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -489,8 +489,9 @@ impl StratumServer {
 				}
 			// Success case falls through to be logged
 			} else {
+				// This is a low-difficulty share, not a full solution
 				// Do some validation but dont submit
-				if self.current_block.header.pre_pow_hash() != b.header.pre_pow_hash() {
+				if !core::pow::verify_size(&b.header, consensus::DEFAULT_SIZESHIFT) {
 					// Return error status
 					error!(
 						LOGGER,

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -31,7 +31,9 @@ use chain;
 use common::adapters::PoolToChainAdapter;
 use common::stats::{StratumStats, WorkerStats};
 use common::types::StratumServerConfig;
+use core::consensus;
 use core::core::{Block, BlockHeader};
+use core::pow;
 use keychain;
 use mining::mine_block;
 use pool;
@@ -491,7 +493,7 @@ impl StratumServer {
 			} else {
 				// This is a low-difficulty share, not a full solution
 				// Do some validation but dont submit
-				if !core::pow::verify_size(&b.header, consensus::DEFAULT_SIZESHIFT) {
+				if !pow::verify_size(&b.header, consensus::DEFAULT_SIZESHIFT) {
 					// Return error status
 					error!(
 						LOGGER,

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -468,7 +468,7 @@ impl StratumServer {
 					self.minimum_share_difficulty,
 				);
 				worker_stats.num_rejected += 1;
-				let e = r#"{"code": -1, "message": "Share rejected due to low difficulty"}"#;
+				let e = r#"{"code": -32501, "message": "Share rejected due to low difficulty"}"#;
 				let err = e.to_string();
 				return (err, true);
 			}
@@ -485,7 +485,7 @@ impl StratumServer {
 						e
 					);
 					worker_stats.num_rejected += 1;
-					let e = r#"{"code": -1, "message": "Failed to validate solution"}"#;
+					let e = r#"{"code": -32502, "message": "Failed to validate solution"}"#;
 					let err = e.to_string();
 					return (err, true);
 				}
@@ -503,7 +503,7 @@ impl StratumServer {
 						b.header.nonce
 					);
 					worker_stats.num_rejected += 1;
-					let e = r#"{"code": -1, "message": "Failed to validate share"}"#;
+					let e = r#"{"code": -32502, "message": "Failed to validate share"}"#;
 					let err = e.to_string();
 					return (err, true);
 				}
@@ -517,7 +517,7 @@ impl StratumServer {
 				submit_params.height
 			);
 			worker_stats.num_stale += 1;
-			let e = r#"{"code": -1, "message": "Solution submitted too late"}"#;
+			let e = r#"{"code": -32503, "message": "Solution submitted too late"}"#;
 			let err = e.to_string();
 			return (err, true);
 		}


### PR DESCRIPTION
It seemed easy to call this existing function, so I did.

But maybe its very inefficient to create a new Cuckoo object for each share and should only build one for each new block?