### PR TITLE
Fix empty candidate txs case

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -102,7 +102,10 @@ where
 			.filter(|x| x.state == from_state)
 			.collect::<Vec<_>>();
 
-		let candidate_txs = entries.iter().map(|x| x.tx.clone()).collect();
+		let candidate_txs: Vec<Transaction> = entries.iter().map(|x| x.tx.clone()).collect();
+		if candidate_txs.is_empty() {
+			return Ok(vec![]);
+		}
 		let valid_txs = self.blockchain.validate_raw_txs(candidate_txs, extra_tx)?;
 
 		// Update state on all entries included in final vec of valid txs.


### PR DESCRIPTION
Fix a bug where the dandelion monitor try to process an empty ```Vec``` as seen here https://travis-ci.org/mimblewimble/grin/jobs/392326600