### PR TITLE
validate block against previous total_kernel_offset

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -45,4 +45,4 @@ pub mod types;
 // Re-export the base interface
 
 pub use chain::{Chain, MAX_ORPHAN_SIZE};
-pub use types::{BlockSums, ChainAdapter, ChainStore, Error, Options, Tip};
+pub use types::{ChainAdapter, ChainStore, Error, Options, Tip};

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -26,7 +26,7 @@ use core::global;
 use grin_store;
 use store;
 use txhashset;
-use types::{BlockSums, ChainStore, Error, Options, Tip};
+use types::{ChainStore, Error, Options, Tip};
 use util::LOGGER;
 
 /// Contextual information required to process a new block and either reject or
@@ -308,25 +308,9 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 }
 
 fn validate_block(b: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
-	// If this is the first block then we have no previous block sums stored.
-	let block_sums = if b.header.height == 1 {
-		BlockSums::default()
-	} else {
-		ctx.store.get_block_sums(&b.header.previous)?
-	};
-
-	let (new_output_sum, new_kernel_sum) =
-		b.validate(&block_sums.output_sum, &block_sums.kernel_sum)
-			.map_err(&Error::InvalidBlockProof)?;
-
-	ctx.store.save_block_sums(
-		&b.hash(),
-		&BlockSums {
-			output_sum: new_output_sum,
-			kernel_sum: new_kernel_sum,
-		},
-	)?;
-
+	let prev_header = ctx.store.get_block_header(&b.header.previous)?;
+	b.validate(&prev_header.total_kernel_offset)
+		.map_err(&Error::InvalidBlockProof)?;
 	Ok(())
 }
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -25,7 +25,7 @@ use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use core::core::{Block, BlockHeader};
 use grin_store::{self, option_to_not_found, to_key, u64_to_key, Error};
-use types::{BlockMarker, BlockSums, ChainStore, Tip};
+use types::{BlockMarker, ChainStore, Tip};
 
 const STORE_SUBPATH: &'static str = "chain";
 
@@ -37,7 +37,6 @@ const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const BLOCK_MARKER_PREFIX: u8 = 'm' as u8;
-const BLOCK_SUMS_PREFIX: u8 = 'M' as u8;
 
 /// An implementation of the ChainStore trait backed by a simple key-value
 /// store.
@@ -237,22 +236,6 @@ impl ChainStore for ChainKVStore {
 	fn delete_block_marker(&self, bh: &Hash) -> Result<(), Error> {
 		self.db
 			.delete(&to_key(BLOCK_MARKER_PREFIX, &mut bh.to_vec()))
-	}
-
-	fn save_block_sums(&self, bh: &Hash, marker: &BlockSums) -> Result<(), Error> {
-		self.db
-			.put_ser(&to_key(BLOCK_SUMS_PREFIX, &mut bh.to_vec())[..], &marker)
-	}
-
-	fn get_block_sums(&self, bh: &Hash) -> Result<BlockSums, Error> {
-		option_to_not_found(
-			self.db
-				.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut bh.to_vec())),
-		)
-	}
-
-	fn delete_block_sums(&self, bh: &Hash) -> Result<(), Error> {
-		self.db.delete(&to_key(BLOCK_SUMS_PREFIX, &mut bh.to_vec()))
 	}
 
 	/// Maintain consistency of the "header_by_height" index by traversing back

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -18,7 +18,6 @@ use std::{error, fmt, io};
 
 use util::secp;
 use util::secp::pedersen::Commitment;
-use util::secp_static;
 
 use core::core::committed;
 use core::core::hash::{Hash, Hashed};
@@ -337,15 +336,6 @@ pub trait ChainStore: Send + Sync {
 	/// Deletes a block marker associated with the provided hash
 	fn delete_block_marker(&self, bh: &Hash) -> Result<(), store::Error>;
 
-	/// Save block sums for the given block hash.
-	fn save_block_sums(&self, bh: &Hash, marker: &BlockSums) -> Result<(), store::Error>;
-
-	/// Get block sums for the given block hash.
-	fn get_block_sums(&self, bh: &Hash) -> Result<BlockSums, store::Error>;
-
-	/// Delete block sums for the given block hash.
-	fn delete_block_sums(&self, bh: &Hash) -> Result<(), store::Error>;
-
 	/// Saves the provided block header at the corresponding height. Also check
 	/// the consistency of the height chain in store by assuring previous
 	/// headers are also at their respective heights.
@@ -404,45 +394,6 @@ impl Default for BlockMarker {
 		BlockMarker {
 			output_pos: 0,
 			kernel_pos: 0,
-		}
-	}
-}
-
-/// The output_sum and kernel_sum for a given block.
-/// This is used to validate the next block being processed by applying
-/// the inputs, outputs, kernels and kernel_offset from the new block
-/// and checking everything sums correctly.
-#[derive(Debug, Clone)]
-pub struct BlockSums {
-	/// The total output sum so far.
-	pub output_sum: Commitment,
-	/// The total kernel sum so far.
-	pub kernel_sum: Commitment,
-}
-
-impl Writeable for BlockSums {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		writer.write_fixed_bytes(&self.output_sum)?;
-		writer.write_fixed_bytes(&self.kernel_sum)?;
-		Ok(())
-	}
-}
-
-impl Readable for BlockSums {
-	fn read(reader: &mut Reader) -> Result<BlockSums, ser::Error> {
-		Ok(BlockSums {
-			output_sum: Commitment::read(reader)?,
-			kernel_sum: Commitment::read(reader)?,
-		})
-	}
-}
-
-impl Default for BlockSums {
-	fn default() -> BlockSums {
-		let zero_commit = secp_static::commit_to_zero_value();
-		BlockSums {
-			output_sum: zero_commit.clone(),
-			kernel_sum: zero_commit.clone(),
 		}
 	}
 }

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -26,8 +26,8 @@ use grin_core::core::block::Error::KernelLockHeight;
 use grin_core::core::hash::{Hashed, ZERO_HASH};
 use grin_core::core::{aggregate, deaggregate, KernelFeatures, Output, Transaction};
 use grin_core::ser;
-use keychain::{ExtKeychain, Keychain};
-use util::{secp_static, static_secp_instance};
+use keychain::{BlindingFactor, ExtKeychain, Keychain};
+use util::static_secp_instance;
 use wallet::libtx::build::{self, initial_tx, input, output, with_excess, with_fee,
                            with_lock_height};
 
@@ -389,23 +389,17 @@ fn reward_empty_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
 	let key_id = keychain.derive_key_id(1).unwrap();
 
-	let zero_commit = secp_static::commit_to_zero_value();
-
 	let previous_header = BlockHeader::default();
 
 	let b = new_block(vec![], &keychain, &previous_header, &key_id);
 
-	b.cut_through()
-		.validate(&zero_commit, &zero_commit)
-		.unwrap();
+	b.cut_through().validate(&BlindingFactor::zero()).unwrap();
 }
 
 #[test]
 fn reward_with_tx_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
 	let key_id = keychain.derive_key_id(1).unwrap();
-
-	let zero_commit = secp_static::commit_to_zero_value();
 
 	let mut tx1 = tx2i1o();
 	tx1.validate().unwrap();
@@ -415,7 +409,7 @@ fn reward_with_tx_block() {
 	let block = new_block(vec![&mut tx1], &keychain, &previous_header, &key_id);
 	block
 		.cut_through()
-		.validate(&zero_commit, &zero_commit)
+		.validate(&BlindingFactor::zero())
 		.unwrap();
 }
 
@@ -423,8 +417,6 @@ fn reward_with_tx_block() {
 fn simple_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
 	let key_id = keychain.derive_key_id(1).unwrap();
-
-	let zero_commit = secp_static::commit_to_zero_value();
 
 	let mut tx1 = tx2i1o();
 	let mut tx2 = tx1i1o();
@@ -437,7 +429,7 @@ fn simple_block() {
 		&key_id,
 	);
 
-	b.validate(&zero_commit, &zero_commit).unwrap();
+	b.validate(&BlindingFactor::zero()).unwrap();
 }
 
 #[test]
@@ -447,8 +439,6 @@ fn test_block_with_timelocked_tx() {
 	let key_id1 = keychain.derive_key_id(1).unwrap();
 	let key_id2 = keychain.derive_key_id(2).unwrap();
 	let key_id3 = keychain.derive_key_id(3).unwrap();
-
-	let zero_commit = secp_static::commit_to_zero_value();
 
 	// first check we can add a timelocked tx where lock height matches current
 	// block height and that the resulting block is valid
@@ -465,7 +455,7 @@ fn test_block_with_timelocked_tx() {
 	let previous_header = BlockHeader::default();
 
 	let b = new_block(vec![&tx1], &keychain, &previous_header, &key_id3.clone());
-	b.validate(&zero_commit, &zero_commit).unwrap();
+	b.validate(&BlindingFactor::zero()).unwrap();
 
 	// now try adding a timelocked tx where lock height is greater than current
 	// block height
@@ -482,7 +472,7 @@ fn test_block_with_timelocked_tx() {
 	let previous_header = BlockHeader::default();
 	let b = new_block(vec![&tx1], &keychain, &previous_header, &key_id3.clone());
 
-	match b.validate(&zero_commit, &zero_commit) {
+	match b.validate(&BlindingFactor::zero()) {
 		Err(KernelLockHeight(height)) => {
 			assert_eq!(height, 2);
 		}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -140,8 +140,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				.upgrade()
 				.expect("failed to upgrade weak ref to chain");
 
-			if let Ok(sums) = chain.get_block_sums(&cb.header.previous) {
-				if block.validate(&sums.output_sum, &sums.kernel_sum).is_ok() {
+			if let Ok(prev_header) = chain.get_block_header(&cb.header.previous) {
+				if block.validate(&prev_header).is_ok() {
 					debug!(LOGGER, "adapter: successfully hydrated block from tx pool!");
 					self.process_block(block, addr)
 				} else {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -141,7 +141,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				.expect("failed to upgrade weak ref to chain");
 
 			if let Ok(prev_header) = chain.get_block_header(&cb.header.previous) {
-				if block.validate(&prev_header).is_ok() {
+				if block.validate(&prev_header.total_kernel_offset).is_ok() {
 					debug!(LOGGER, "adapter: successfully hydrated block from tx pool!");
 					self.process_block(block, addr)
 				} else {

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -163,7 +163,7 @@ fn build_block(
 	let mut b = core::Block::with_reward(&head, txs, output, kernel, difficulty.clone())?;
 
 	// making sure we're not spending time mining a useless block
-	b.validate(&head)?;
+	b.validate(&head.total_kernel_offset)?;
 
 	let mut rng = rand::OsRng::new().unwrap();
 	b.header.nonce = rng.gen();

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -22,10 +22,9 @@ use std::thread;
 use std::time::Duration;
 use time;
 
-use chain::{self, types::BlockSums};
+use chain;
 use common::adapters::PoolToChainAdapter;
 use common::types::Error;
-use core::core::hash::Hashed;
 use core::ser::{self, AsFixedBytes};
 use core::{consensus, core};
 use keychain::{ExtKeychain, Identifier, Keychain};
@@ -135,12 +134,6 @@ fn build_block(
 	// prepare the block header timestamp
 	let head = chain.head_header()?;
 
-	let prev_sums = if head.height == 0 {
-		BlockSums::default()
-	} else {
-		chain.get_block_sums(&head.hash())?
-	};
-
 	let mut now_sec = time::get_time().sec;
 	let head_sec = head.timestamp.to_timespec().sec;
 	if now_sec <= head_sec {
@@ -170,7 +163,7 @@ fn build_block(
 	let mut b = core::Block::with_reward(&head, txs, output, kernel, difficulty.clone())?;
 
 	// making sure we're not spending time mining a useless block
-	b.validate(&prev_sums.output_sum, &prev_sums.kernel_sum)?;
+	b.validate(&head)?;
 
 	let mut rng = rand::OsRng::new().unwrap();
 	b.header.nonce = rng.gen();


### PR DESCRIPTION
Validate a block against previous `total_kernel_offset`.
This removes the need for `block_sums` and allows us to get rid of these from the db/index.

Resolves #1165.