### PR TITLE
pin croaring to version 0.3.2 until we get the clang conflict sorted out

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bitflags = "1"
 byteorder = "1"
-croaring = "0.3"
+croaring = "=0.3.2"
 slog = { version = "~2.2", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "1"
 serde_derive = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 bitflags = "1"
 blake2-rfc = "0.2"
 byteorder = "1"
-croaring = "0.3"
+croaring = "=0.3.2"
 lazy_static = "1"
 num-bigint = "0.2"
 rand = "0.3"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 byteorder = "1"
-croaring = "0.3"
+croaring = "=0.3.2"
 env_logger = "0.5"
 libc = "0.2"
 memmap = { git = "https://github.com/danburkert/memmap-rs", tag = "0.6.2" }


### PR DESCRIPTION
0.3.4 is just released and is causing build issues as it depends on a different version of clang vs. the one specified by rocksdb.

Pinning croaring to `=0.3.2` for the time being.

