### PR TITLE
[WIP] TXHashset Validation problems

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -81,7 +81,7 @@ impl ChainStore {
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())),
-			&format!("BLOCK: {} ", h),
+			&format!("BLOCK: {}", h),
 		)
 	}
 


### PR DESCRIPTION
In chasing down the cause for #1207 on testnet3, I've uncovered a couple of issues, one an easy fix and the other needs some re-thought. Simple fix is below, but problem is as follows:

During validation of the kernel history after getting the txhashset during a fast-sync, rewind now relies upon building a bitmap of a particular block (through `get_block_input_bitmap`)... however, in the fast-sync case no block exists, just the header, so it would seem there's currently no way to rewind in order to do the validation.

Is this an oversight or am I missing something?