### PR TITLE
Simulnet test fix

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -146,9 +146,6 @@ pub const BLOCK_TIME_WINDOW: u64 = DIFFICULTY_ADJUST_WINDOW * BLOCK_TIME_SEC;
 /// Maximum size time window used for difficulty adjustments
 pub const UPPER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW * 2;
 
-/// Minimum size time window used for difficulty adjustments
-pub const LOWER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW / 2;
-
 /// Dampening factor to use for difficulty adjustment
 pub const DAMP_FACTOR: u64 = 3;
 
@@ -242,9 +239,7 @@ where
 	};
 
 	// Apply time bounds
-	let adj_ts = if ts_damp < LOWER_TIME_BOUND {
-		LOWER_TIME_BOUND
-	} else if ts_damp > UPPER_TIME_BOUND {
+	let adj_ts = if ts_damp > UPPER_TIME_BOUND {
 		UPPER_TIME_BOUND
 	} else {
 		ts_damp

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -242,7 +242,6 @@ where
 	};
 
 	// Apply time bounds
-
 	let adj_ts = if ts_damp < LOWER_TIME_BOUND {
 		LOWER_TIME_BOUND
 	} else if ts_damp > UPPER_TIME_BOUND {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -146,6 +146,9 @@ pub const BLOCK_TIME_WINDOW: u64 = DIFFICULTY_ADJUST_WINDOW * BLOCK_TIME_SEC;
 /// Maximum size time window used for difficulty adjustments
 pub const UPPER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW * 2;
 
+/// Minimum size time window used for difficulty adjustments
+pub const LOWER_TIME_BOUND: u64 = BLOCK_TIME_WINDOW / 2;
+
 /// Dampening factor to use for difficulty adjustment
 pub const DAMP_FACTOR: u64 = 3;
 
@@ -239,7 +242,10 @@ where
 	};
 
 	// Apply time bounds
-	let adj_ts = if ts_damp > UPPER_TIME_BOUND {
+
+	let adj_ts = if ts_damp < LOWER_TIME_BOUND {
+		LOWER_TIME_BOUND
+	} else if ts_damp > UPPER_TIME_BOUND {
 		UPPER_TIME_BOUND
 	} else {
 		ts_damp

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -17,7 +17,7 @@ extern crate grin_core as core;
 extern crate time;
 
 use core::consensus::{next_difficulty, valid_header_version, TargetError,
-                      DIFFICULTY_ADJUST_WINDOW, MEDIAN_TIME_WINDOW, LOWER_TIME_BOUND,
+                      DIFFICULTY_ADJUST_WINDOW, MEDIAN_TIME_WINDOW,
                       UPPER_TIME_BOUND, BLOCK_TIME_WINDOW, DAMP_FACTOR, MEDIAN_TIME_INDEX};
 use core::core::target::Difficulty;
 use std::fmt::{self, Display};
@@ -268,7 +268,6 @@ fn print_chain_sim(
 	println!("DIFFICULTY_ADJUST_WINDOW: {}", DIFFICULTY_ADJUST_WINDOW);
 	println!("BLOCK_TIME_WINDOW: {}", BLOCK_TIME_WINDOW);
 	println!("MEDIAN_TIME_WINDOW: {}", MEDIAN_TIME_WINDOW);
-	println!("LOWER_TIME_BOUND: {}", LOWER_TIME_BOUND);
 	println!("UPPER_TIME_BOUND: {}", UPPER_TIME_BOUND);
 	println!("DAMP_FACTOR: {}", DAMP_FACTOR);
 	chain_sim.iter().enumerate().for_each(|(i, b)| {

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -220,7 +220,7 @@ impl LocalServerContainer {
 				"starting test Miner on port {}",
 				self.config.p2p_server_port
 			);
-			s.start_test_miner(Some(self.config.coinbase_wallet_address.clone()));
+			s.start_test_miner(wallet_url);
 		}
 
 		for p in &mut self.peer_list {


### PR DESCRIPTION
Cleanup following from https://github.com/mimblewimble/grin/issues/1212 LOWER_TIME_BOUND is redundant and can never be attained with the current adjustment algorithm and timestamp resolution.