### PR TITLE
fix misbehaving simulnet fastsync test

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -546,21 +546,24 @@ impl Chain {
 
 		// validate against a read-only extension first (some of the validation
 		// runs additional rewinds)
+		debug!(LOGGER, "chain: txhashset_write: rewinding and validating (read-only)");
 		txhashset::extending_readonly(&mut txhashset, |extension| {
 			extension.rewind(&header, &header)?;
-			extension.validate(&header, false, status)
+			extension.validate(&header, false, status)?;
+			Ok(())
 		})?;
 
 		// all good, prepare a new batch and update all the required records
+		debug!(LOGGER, "chain: txhashset_write: rewinding and validating a 2nd time (writeable)");
 		let mut batch = self.store.batch()?;
 		txhashset::extending(&mut txhashset, &mut batch, |extension| {
-			// TODO do we need to rewind here? We have no blocks to rewind
-			// (and we need them for the pos to unremove)
 			extension.rewind(&header, &header)?;
 			extension.validate(&header, false, status)?;
 			extension.rebuild_index()?;
 			Ok(())
 		})?;
+
+		debug!(LOGGER, "chain: txhashset_write: finished validating and rebuilding");
 
 		status.on_save();
 		// replace the chain txhashset with the newly built one
@@ -577,6 +580,8 @@ impl Chain {
 			batch.build_by_height_index(&header, true)?;
 		}
 		batch.commit()?;
+
+		debug!(LOGGER, "chain: txhashset_write: finished committing the batch (head etc.)");
 
 		self.check_orphans(header.height + 1);
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -49,7 +49,7 @@ pub struct TxHashSetRoots {
 /// blockchain tree. References the max height and the latest and previous
 /// blocks
 /// for convenience and the total difficulty.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tip {
 	/// Height of the tip (max height of the fork)
 	pub height: u64,

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -67,7 +67,6 @@ where
 	fn rewind(
 		&mut self,
 		position: u64,
-		rewind_add_pos: &Bitmap,
 		rewind_rm_pos: &Bitmap,
 	) -> Result<(), String>;
 
@@ -301,7 +300,6 @@ where
 	pub fn rewind(
 		&mut self,
 		position: u64,
-		rewind_add_pos: &Bitmap,
 		rewind_rm_pos: &Bitmap,
 	) -> Result<(), String> {
 		// Identify which actual position we should rewind to as the provided
@@ -312,7 +310,7 @@ where
 			pos += 1;
 		}
 
-		self.backend.rewind(pos, rewind_add_pos, rewind_rm_pos)?;
+		self.backend.rewind(pos, rewind_rm_pos)?;
 		self.last_pos = pos;
 		Ok(())
 	}

--- a/core/tests/vec_backend/mod.rs
+++ b/core/tests/vec_backend/mod.rs
@@ -121,7 +121,6 @@ where
 	fn rewind(
 		&mut self,
 		position: u64,
-		_rewind_add_pos: &Bitmap,
 		_rewind_rm_pos: &Bitmap,
 	) -> Result<(), String> {
 		self.elems = self.elems[0..(position as usize) + 1].to_vec();

--- a/servers/tests/stratum.rs
+++ b/servers/tests/stratum.rs
@@ -87,7 +87,7 @@ fn basic_stratum_server() {
 	workers.remove(4);
 
 	// Swallow the genesis block
-	thread::sleep(time::Duration::from_secs(1)); // Wait for the server to broadcast
+	thread::sleep(time::Duration::from_secs(5)); // Wait for the server to broadcast
 	let mut response = String::new();
 	for n in 0..workers.len() {
 		let _result = workers[n].read_line(&mut response);

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -81,6 +81,7 @@ impl TUIStatusListener for TUIStatusView {
 				"Waiting for peers".to_string()
 			} else {
 				match stats.sync_status {
+					SyncStatus::Initial => "Initializing".to_string(),
 					SyncStatus::NoSync => "Running".to_string(),
 					SyncStatus::HeaderSync {
 						current_height,

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -124,7 +124,7 @@ fn pmmr_compact_leaf_sibling() {
 
 	// aggressively compact the PMMR files
 	backend
-		.check_compact(1, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(1, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	// check pos 1, 2, 3 are in the state we expect after compacting
@@ -182,7 +182,7 @@ fn pmmr_prune_compact() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	// recheck the root and stored data
@@ -228,7 +228,7 @@ fn pmmr_reload() {
 
 		// now check and compact the backend
 		backend
-			.check_compact(1, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+			.check_compact(1, &Bitmap::create(), &prune_noop)
 			.unwrap();
 		backend.sync().unwrap();
 
@@ -241,7 +241,7 @@ fn pmmr_reload() {
 		backend.sync().unwrap();
 
 		backend
-			.check_compact(4, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+			.check_compact(4, &Bitmap::create(), &prune_noop)
 			.unwrap();
 		backend.sync().unwrap();
 
@@ -340,7 +340,7 @@ fn pmmr_rewind() {
 
 	// and compact the MMR to remove the pruned elements
 	backend
-		.check_compact(6, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(6, &Bitmap::create(), &prune_noop)
 		.unwrap();
 	backend.sync().unwrap();
 
@@ -354,7 +354,7 @@ fn pmmr_rewind() {
 	// rewind and check the roots still match
 	{
 		let mut pmmr: PMMR<TestElem, _> = PMMR::at(&mut backend, mmr_size);
-		pmmr.rewind(9, &Bitmap::of(&vec![11, 12, 16]), &Bitmap::create())
+		pmmr.rewind(9, &Bitmap::of(&vec![11, 12, 16]))
 			.unwrap();
 		assert_eq!(pmmr.unpruned_size(), 10);
 
@@ -399,7 +399,7 @@ fn pmmr_rewind() {
 
 	{
 		let mut pmmr: PMMR<TestElem, _> = PMMR::at(&mut backend, 10);
-		pmmr.rewind(5, &Bitmap::create(), &Bitmap::create())
+		pmmr.rewind(5, &Bitmap::create())
 			.unwrap();
 		assert_eq!(pmmr.root(), root1);
 	}
@@ -440,7 +440,7 @@ fn pmmr_compact_single_leaves() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	{
@@ -453,7 +453,7 @@ fn pmmr_compact_single_leaves() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	teardown(data_dir);
@@ -484,7 +484,7 @@ fn pmmr_compact_entire_peak() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	// now check we have pruned up to and including the peak at pos 7
@@ -557,7 +557,7 @@ fn pmmr_compact_horizon() {
 
 		// compact
 		backend
-			.check_compact(4, &Bitmap::create(), &Bitmap::of(&vec![1, 2]), &prune_noop)
+			.check_compact(4, &Bitmap::of(&vec![1, 2]), &prune_noop)
 			.unwrap();
 		backend.sync().unwrap();
 
@@ -612,7 +612,7 @@ fn pmmr_compact_horizon() {
 
 		// compact some more
 		backend
-			.check_compact(9, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+			.check_compact(9, &Bitmap::create(), &prune_noop)
 			.unwrap();
 	}
 
@@ -675,7 +675,7 @@ fn compact_twice() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	// recheck the root and stored data
@@ -704,7 +704,7 @@ fn compact_twice() {
 
 	// compact
 	backend
-		.check_compact(2, &Bitmap::create(), &Bitmap::create(), &prune_noop)
+		.check_compact(2, &Bitmap::create(), &prune_noop)
 		.unwrap();
 
 	// recheck the root and stored data

--- a/store/tests/utxo_set_perf.rs
+++ b/store/tests/utxo_set_perf.rs
@@ -83,7 +83,7 @@ fn test_leaf_set_performance() {
 		let from_pos = x * 1_000 + 1;
 		let to_pos = from_pos + 1_000;
 		let bitmap: Bitmap = (from_pos..to_pos).collect();
-		leaf_set.rewind(&Bitmap::create(), &bitmap);
+		leaf_set.rewind(1_000_000, &bitmap);
 	}
 	assert_eq!(leaf_set.len(), 1_000_000);
 	println!(


### PR DESCRIPTION
This test `simulate_fast_sync` now correctly runs a fast sync as expected (and passes successfully).

Resolves #1175. 💥 
Resolves #1220. 💥 
Resolves #1221. 💥 

* Added `Initial` sync_state
* Added some debug logging around sync_state state changes
* Changed behavior so `skip_sync_wait` still waits (for a shorter period of time)
    * `simulate_fast_sync` was not waiting for peers before deciding to disable the sync
* reworked the `rewind()` and `check_compact()` params 
    * remove `rewind_add_pos`
    * build `rewind_add_pos` from the cutoff pos passed in
* fixed bug where we were passing in the output bitmap to the kernel rewind
    * just pass in empty bitmap now (kernels never get pruned)
    * surprised this ever worked
* pass in `skip_kernel_hist` to txhashset extension validate()
* add an `assert!()` in `verify_kernel_history()` to guarantee a read-only extension 

TODO - 
- [x] more local testing
- [x] fix failing tests (params changed)


Something weird is going on here. We appear to be able to reliably hit a problem where the roots are not matching on the block immediately after we complete the fast sync -
The output and rproof roots are correct, but there is a mismatch in the kernel root. 

```
Jul 08 11:48:22.791 DEBG chain: txhashset_write: rewinding and validating (read-only)
Jul 08 11:48:22.793 DEBG txhashset: validated the output|rproof|kernel mmrs, took 0s
Jul 08 11:48:22.879 DEBG txhashset: verified 23 kernel signatures, pmmr size 42, took 0s
Jul 08 11:48:25.216 DEBG txhashset: verified 23 rangeproofs, pmmr size 42, took 2s
Jul 08 11:48:25.217 DEBG chain: txhashset_write: rewinding and validating a 2nd time (writeable)
Jul 08 11:48:25.218 DEBG txhashset: validated the output|rproof|kernel mmrs, took 0s
Jul 08 11:48:25.237 DEBG txhashset: verified 23 kernel signatures, pmmr size 42, took 0s
Jul 08 11:48:27.696 DEBG txhashset: verified 23 rangeproofs, pmmr size 42, took 2s
Jul 08 11:48:27.701 DEBG chain: txhashset_write: finished validating and rebuilding
Jul 08 11:48:27.701 DEBG sync_state: sync_status: TxHashsetValidation { kernels: 22, kernel_total: 23, rproofs: 22, rproof_total: 23 } -> TxHashsetSave
Jul 08 11:48:27.703 DEBG chain: txhashset_write: finished committing the batch (head etc.)
Jul 08 11:48:27.704 DEBG pipe: process_block 8fc86514 at 24 with 0 inputs, 1 outputs, 1 kernels
Jul 08 11:48:27.741 DEBG body_sync: body_head - 046e9b5b, 23, header_head - deb2a4d5, 42, sync_head - deb2a4d5, 42
Jul 08 11:48:27.744 DEBG block_sync: 23/42 requesting blocks [8fc86514] from 1 peers
Jul 08 11:48:27.744 DEBG Requesting block 8fc86514 from peer 127.0.0.1:13414.
Jul 08 11:48:27.744 DEBG sync_state: sync_status: TxHashsetSave -> BodySync { current_height: 23, highest_height: 42 }
Jul 08 11:48:27.835 DEBG -- outputs --
Jul 08 11:48:27.835 DEBG -- range proofs --
Jul 08 11:48:27.836 DEBG -- kernels --
Jul 08 11:48:27.836 DEBG validate_block_via_txhashset: output roots - ce4eb87b, ce4eb87b
Jul 08 11:48:27.836 DEBG validate_block_via_txhashset: rproof roots - 4a3a1514, 4a3a1514
Jul 08 11:48:27.836 DEBG validate_block_via_txhashset: kernel roots - f3e0b28d, d25d6c2f
Jul 08 11:48:27.836 DEBG Error returned, discarding txhashset extension: Invalid Root 
```
