### PR TITLE
Wallet implementation dynamic dispatch

### DIFF
--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -186,6 +186,9 @@ pub struct ServerConfig {
 	/// Whether to run the web wallet owner listener
 	pub run_wallet_owner_api: Option<bool>,
 
+	/// Whether to use the DB wallet backend implementation
+	pub use_db_wallet: Option<bool>,
+
 	/// Whether to run the test miner (internal, cuckoo 16)
 	pub run_test_miner: Option<bool>,
 
@@ -212,6 +215,7 @@ impl Default for ServerConfig {
 			run_tui: None,
 			run_wallet_listener: Some(false),
 			run_wallet_owner_api: Some(false),
+			use_db_wallet: Some(false),
 			run_test_miner: Some(false),
 			test_miner_wallet_url: None,
 		}
@@ -323,9 +327,7 @@ impl SyncState {
 
 		debug!(
 			LOGGER,
-			"sync_state: sync_status: {:?} -> {:?}",
-			*status,
-			new_status,
+			"sync_state: sync_status: {:?} -> {:?}", *status, new_status,
 		);
 
 		*status = new_status;

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -274,7 +274,7 @@ impl LocalServerContainer {
 				)
 			});
 
-		wallet::controller::foreign_listener(wallet, &self.wallet_config.api_listen_addr())
+		wallet::controller::foreign_listener(Box::new(wallet), &self.wallet_config.api_listen_addr())
 			.unwrap_or_else(|e| {
 				panic!(
 					"Error creating wallet listener: {:?} Config: {:?}",
@@ -330,7 +330,7 @@ impl LocalServerContainer {
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let _ =
-			wallet::controller::owner_single_use(&mut wallet, |api| {
+			wallet::controller::owner_single_use(Box::new(wallet), |api| {
 				let result = api.issue_send_tx(
 					amount,
 					minimum_confirmations,

--- a/src/bin/tui/menu.rs
+++ b/src/bin/tui/menu.rs
@@ -14,16 +14,20 @@
 
 //! Main Menu definition
 
-use cursive::Cursive;
 use cursive::align::HAlign;
 use cursive::direction::Orientation;
 use cursive::event::{EventResult, Key};
 use cursive::view::Identifiable;
 use cursive::view::View;
-use cursive::views::{BoxView, LinearLayout, OnEventView, SelectView, StackView, TextView, ViewRef};
+use cursive::views::{
+	BoxView, LinearLayout, OnEventView, SelectView, StackView, TextView, ViewRef,
+};
+use cursive::Cursive;
 
-use tui::constants::{MAIN_MENU, ROOT_STACK, SUBMENU_MINING_BUTTON, VIEW_BASIC_STATUS, VIEW_MINING,
-                     VIEW_PEER_SYNC, VIEW_VERSION};
+use tui::constants::{
+	MAIN_MENU, ROOT_STACK, SUBMENU_MINING_BUTTON, VIEW_BASIC_STATUS, VIEW_MINING, VIEW_PEER_SYNC,
+	VIEW_VERSION,
+};
 
 pub fn create() -> Box<View> {
 	let mut main_menu = SelectView::new().h_align(HAlign::Left).with_id(MAIN_MENU);

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -16,18 +16,20 @@
 
 use std::cmp::Ordering;
 
-use cursive::Cursive;
 use cursive::direction::Orientation;
 use cursive::event::Key;
 use cursive::traits::{Boxable, Identifiable};
 use cursive::view::View;
-use cursive::views::{BoxView, Button, Dialog, LinearLayout, OnEventView, Panel, StackView,
-                     TextView};
+use cursive::views::{
+	BoxView, Button, Dialog, LinearLayout, OnEventView, Panel, StackView, TextView,
+};
+use cursive::Cursive;
 use std::time;
 use tui::chrono::prelude::{DateTime, NaiveDateTime, Utc};
 
-use tui::constants::{MAIN_MENU, SUBMENU_MINING_BUTTON, TABLE_MINING_DIFF_STATUS,
-                     TABLE_MINING_STATUS, VIEW_MINING};
+use tui::constants::{
+	MAIN_MENU, SUBMENU_MINING_BUTTON, TABLE_MINING_DIFF_STATUS, TABLE_MINING_STATUS, VIEW_MINING,
+};
 use tui::types::TUIStatusListener;
 
 use servers::{DiffBlock, ServerStats, WorkerStats};

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -18,11 +18,11 @@ use std::cmp::Ordering;
 
 use servers::{PeerStats, ServerStats};
 
-use cursive::Cursive;
 use cursive::direction::Orientation;
 use cursive::traits::{Boxable, Identifiable};
 use cursive::view::View;
 use cursive::views::{BoxView, Dialog, LinearLayout, TextView};
+use cursive::Cursive;
 
 use tui::constants::{TABLE_PEER_STATUS, VIEW_PEER_SYNC};
 use tui::table::{TableView, TableViewItem};

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -14,11 +14,11 @@
 
 //! Basic status view definition
 
-use cursive::Cursive;
 use cursive::direction::Orientation;
 use cursive::traits::Identifiable;
 use cursive::view::View;
 use cursive::views::{BoxView, LinearLayout, TextView};
+use cursive::Cursive;
 
 use tui::constants::VIEW_BASIC_STATUS;
 use tui::types::TUIStatusListener;

--- a/src/bin/tui/table.rs
+++ b/src/bin/tui/table.rs
@@ -54,7 +54,6 @@ use std::hash::Hash;
 use std::rc::Rc;
 
 // External Dependencies ------------------------------------------------------
-use cursive::With;
 use cursive::align::HAlign;
 use cursive::direction::Direction;
 use cursive::event::{Callback, Event, EventResult, Key};
@@ -62,6 +61,7 @@ use cursive::theme::ColorStyle;
 use cursive::theme::PaletteColor::{Highlight, HighlightInactive, Primary};
 use cursive::vec::Vec2;
 use cursive::view::{ScrollBase, View};
+use cursive::With;
 use cursive::{Cursive, Printer};
 
 /// A trait for displaying and sorting items inside a

--- a/src/bin/tui/types.rs
+++ b/src/bin/tui/types.rs
@@ -14,8 +14,8 @@
 
 //! Types specific to the UI module
 
-use cursive::Cursive;
 use cursive::view::View;
+use cursive::Cursive;
 use servers::ServerStats;
 
 /// Main message struct to communicate between the UI and

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -19,15 +19,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use time;
 
-use cursive::Cursive;
 use cursive::direction::Orientation;
 use cursive::theme::BaseColor::{Black, Blue, Cyan, White};
 use cursive::theme::Color::Dark;
-use cursive::theme::PaletteColor::{Background, Highlight, HighlightInactive, Primary, Shadow, View};
+use cursive::theme::PaletteColor::{
+	Background, Highlight, HighlightInactive, Primary, Shadow, View,
+};
 use cursive::theme::{BaseColor, BorderStyle, Color, Theme};
 use cursive::traits::Identifiable;
 use cursive::utils::markup::StyledString;
 use cursive::views::{LinearLayout, Panel, StackView, TextView, ViewBox};
+use cursive::Cursive;
 
 use servers::Server;
 

--- a/src/bin/tui/version.rs
+++ b/src/bin/tui/version.rs
@@ -14,11 +14,11 @@
 
 //! Version and build info
 
-use cursive::Cursive;
 use cursive::direction::Orientation;
 use cursive::traits::Identifiable;
 use cursive::view::View;
 use cursive::views::{BoxView, LinearLayout, TextView};
+use cursive::Cursive;
 
 use tui::constants::VIEW_VERSION;
 use tui::types::TUIStatusListener;

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use core::core::{self, amount_to_hr_string};
-use libwallet::Error;
 use libwallet::types::{OutputData, WalletInfo};
+use libwallet::Error;
 use prettytable;
 use std::io::prelude::Write;
 use term;

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -104,7 +104,19 @@ impl Fail for Error {
 
 impl Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		Display::fmt(&self.inner, f)
+		let cause = match self.cause() {
+			Some(c) => format!("{}", c),
+			None => String::from("Unknown"),
+		};
+		let backtrace = match self.backtrace() {
+			Some(b) => format!("{}", b),
+			None => String::from("Unknown"),
+		};
+		let output = format!(
+			"{} \n Cause: {} \n Backtrace: {}",
+			self.inner, cause, backtrace
+		);
+		Display::fmt(&output, f)
 	}
 }
 

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -19,14 +19,14 @@ use std::path::{Path, MAIN_SEPARATOR};
 
 use serde_json;
 use tokio_core::reactor;
-use tokio_retry::Retry;
 use tokio_retry::strategy::FibonacciBackoff;
+use tokio_retry::Retry;
 
 use failure::ResultExt;
 
 use keychain::{self, Identifier, Keychain};
-use util::LOGGER;
 use util::secp::pedersen;
+use util::LOGGER;
 
 use error::{Error, ErrorKind};
 
@@ -35,8 +35,8 @@ use libtx::slate::Slate;
 use libwallet;
 
 use libwallet::types::{
-	BlockFees, CbData, OutputData, TxWrapper, WalletBackend,
-	WalletClient, WalletDetails, WalletOutputBatch,
+	BlockFees, CbData, OutputData, TxWrapper, WalletBackend, WalletClient, WalletDetails,
+	WalletOutputBatch,
 };
 
 use types::{WalletConfig, WalletSeed};

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -60,5 +60,6 @@ pub use client::create_coinbase;
 pub use error::{Error, ErrorKind};
 pub use file_wallet::FileWallet;
 pub use libwallet::controller;
-pub use libwallet::types::{BlockFees, CbData, WalletInfo};
+pub use libwallet::types::{BlockFees, CbData, WalletInfo, WalletInst};
+pub use lmdb_wallet::{wallet_db_exists, LMDBBackend};
 pub use types::{WalletConfig, WalletSeed};

--- a/wallet/src/libtx/build.rs
+++ b/wallet/src/libtx/build.rs
@@ -47,11 +47,7 @@ pub type Append<K> = for<'a> Fn(&'a mut Context<K>, (Transaction, TxKernel, Blin
 
 /// Adds an input with the provided value and blinding key to the transaction
 /// being built.
-fn build_input<K>(
-	value: u64,
-	features: OutputFeatures,
-	key_id: Identifier,
-) -> Box<Append<K>>
+fn build_input<K>(value: u64, features: OutputFeatures, key_id: Identifier) -> Box<Append<K>>
 where
 	K: Keychain,
 {
@@ -78,10 +74,7 @@ where
 }
 
 /// Adds a coinbase input spending a coinbase output.
-pub fn coinbase_input<K>(
-	value: u64,
-	key_id: Identifier,
-) -> Box<Append<K>>
+pub fn coinbase_input<K>(value: u64, key_id: Identifier) -> Box<Append<K>>
 where
 	K: Keychain,
 {

--- a/wallet/src/libtx/slate.rs
+++ b/wallet/src/libtx/slate.rs
@@ -23,8 +23,8 @@ use keychain::{BlindSum, BlindingFactor, Keychain};
 use libtx::error::{Error, ErrorKind};
 use libtx::{aggsig, build, tx_fee};
 
-use util::secp::Signature;
 use util::secp::key::{PublicKey, SecretKey};
+use util::secp::Signature;
 use util::{secp, LOGGER};
 
 /// Public data for each participant in the slate
@@ -261,11 +261,7 @@ impl Slate {
 		// double check the fee amount included in the partial tx
 		// we don't necessarily want to just trust the sender
 		// we could just overwrite the fee here (but we won't) due to the sig
-		let fee = tx_fee(
-			self.tx.inputs.len(),
-			self.tx.outputs.len(),
-			None,
-		);
+		let fee = tx_fee(self.tx.inputs.len(), self.tx.outputs.len(), None);
 		if fee > self.tx.fee() {
 			return Err(ErrorKind::Fee(
 				format!("Fee Dispute Error: {}, {}", self.tx.fee(), fee,).to_string(),

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -48,8 +48,11 @@ pub enum ErrorKind {
 	},
 
 	/// Fee Exceeds amount
-	#[fail(display = "Fee exceeds amount: sender amount {}, recipient fee {}", sender_amount,
-	       recipient_fee)]
+	#[fail(
+		display = "Fee exceeds amount: sender amount {}, recipient fee {}",
+		sender_amount,
+		recipient_fee
+	)]
 	FeeExceedsAmount {
 		/// sender amount
 		sender_amount: u64,

--- a/wallet/src/libwallet/internal/keys.rs
+++ b/wallet/src/libwallet/internal/keys.rs
@@ -18,7 +18,7 @@ use libwallet::error::Error;
 use libwallet::types::WalletBackend;
 
 /// Get next available key in the wallet
-pub fn next_available_key<T, K>(wallet: &mut T) -> Result<(Identifier, u32), Error>
+pub fn next_available_key<T: ?Sized, K>(wallet: &mut T) -> Result<(Identifier, u32), Error>
 where
 	T: WalletBackend<K>,
 	K: Keychain,
@@ -30,7 +30,7 @@ where
 }
 
 /// Retrieve an existing key from a wallet
-pub fn retrieve_existing_key<T, K>(
+pub fn retrieve_existing_key<T: ?Sized, K>(
 	wallet: &T,
 	key_id: Identifier,
 ) -> Result<(Identifier, u32), Error>

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -16,9 +16,9 @@
 use core::global;
 use keychain::{Identifier, Keychain};
 use libtx::proof;
-use libwallet::Error;
 use libwallet::types::*;
-use util::secp::{pedersen, key::SecretKey};
+use libwallet::Error;
+use util::secp::{key::SecretKey, pedersen};
 use util::LOGGER;
 
 /// Utility struct for return values from below

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -15,7 +15,7 @@
 //! Selection of inputs for building transactions
 
 use keychain::{Identifier, Keychain};
-use libtx::{build, tx_fee, slate::Slate};
+use libtx::{build, slate::Slate, tx_fee};
 use libwallet::error::{Error, ErrorKind};
 use libwallet::internal::{keys, sigcontext};
 use libwallet::types::*;
@@ -25,7 +25,7 @@ use libwallet::types::*;
 /// and saves the private wallet identifiers of our selected outputs
 /// into our transaction context
 
-pub fn build_send_tx_slate<T, K>(
+pub fn build_send_tx_slate<T: ?Sized, K>(
 	wallet: &mut T,
 	num_participants: usize,
 	amount: u64,
@@ -122,7 +122,7 @@ where
 /// returning the key of the fresh output and a closure
 /// that actually performs the addition of the output to the
 /// wallet
-pub fn build_recipient_output_with_slate<T, K>(
+pub fn build_recipient_output_with_slate<T: ?Sized, K>(
 	wallet: &mut T,
 	slate: &mut Slate,
 ) -> Result<
@@ -182,7 +182,7 @@ where
 /// Builds a transaction to send to someone from the HD seed associated with the
 /// wallet and the amount to send. Handles reading through the wallet data file,
 /// selecting outputs to spend and building the change.
-pub fn select_send_tx<T, K>(
+pub fn select_send_tx<T: ?Sized, K>(
 	wallet: &mut T,
 	amount: u64,
 	current_height: u64,
@@ -287,7 +287,7 @@ where
 }
 
 /// Selects inputs and change for a transaction
-pub fn inputs_and_change<T, K>(
+pub fn inputs_and_change<T: ?Sized, K>(
 	coins: &Vec<OutputData>,
 	wallet: &mut T,
 	amount: u64,
@@ -313,10 +313,7 @@ where
 	for coin in coins {
 		let key_id = wallet.keychain().derive_key_id(coin.n_child)?;
 		if coin.is_coinbase {
-			parts.push(build::coinbase_input(
-				coin.value,
-				key_id,
-			));
+			parts.push(build::coinbase_input(coin.value, key_id));
 		} else {
 			parts.push(build::input(coin.value, key_id));
 		}

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -25,7 +25,7 @@ use util::LOGGER;
 
 /// Receive a transaction, modifying the slate accordingly (which can then be
 /// sent back to sender for posting)
-pub fn receive_tx<T, K>(wallet: &mut T, slate: &mut Slate) -> Result<(), Error>
+pub fn receive_tx<T: ?Sized, K>(wallet: &mut T, slate: &mut Slate) -> Result<(), Error>
 where
 	T: WalletBackend<K>,
 	K: Keychain,
@@ -53,7 +53,7 @@ where
 
 /// Issue a new transaction to the provided sender by spending some of our
 /// wallet
-pub fn create_send_tx<T, K>(
+pub fn create_send_tx<T: ?Sized, K>(
 	wallet: &mut T,
 	amount: u64,
 	minimum_confirmations: u64,
@@ -110,7 +110,7 @@ where
 }
 
 /// Complete a transaction as the sender
-pub fn complete_tx<T, K>(
+pub fn complete_tx<T: ?Sized, K>(
 	wallet: &mut T,
 	slate: &mut Slate,
 	context: &sigcontext::Context,
@@ -129,7 +129,7 @@ where
 }
 
 /// Issue a burn tx
-pub fn issue_burn_tx<T, K>(
+pub fn issue_burn_tx<T: ?Sized, K>(
 	wallet: &mut T,
 	amount: u64,
 	minimum_confirmations: u64,

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -26,13 +26,17 @@ use libtx::reward;
 use libwallet;
 use libwallet::error::{Error, ErrorKind};
 use libwallet::internal::keys;
-use libwallet::types::{BlockFees, CbData, OutputData, OutputStatus, WalletBackend, WalletClient,
-                       WalletInfo};
+use libwallet::types::{
+	BlockFees, CbData, OutputData, OutputStatus, WalletBackend, WalletClient, WalletInfo,
+};
 use util::secp::pedersen;
 use util::{self, LOGGER};
 
 /// Retrieve all of the outputs (doesn't attempt to update from node)
-pub fn retrieve_outputs<T, K>(wallet: &mut T, show_spent: bool) -> Result<Vec<OutputData>, Error>
+pub fn retrieve_outputs<T: ?Sized, K>(
+	wallet: &mut T,
+	show_spent: bool,
+) -> Result<Vec<OutputData>, Error>
 where
 	T: WalletBackend<K>,
 	K: Keychain,
@@ -57,7 +61,7 @@ where
 
 /// Refreshes the outputs in a wallet with the latest information
 /// from a node
-pub fn refresh_outputs<T, K>(wallet: &mut T) -> Result<(), Error>
+pub fn refresh_outputs<T: ?Sized, K>(wallet: &mut T) -> Result<(), Error>
 where
 	T: WalletBackend<K> + WalletClient,
 	K: Keychain,
@@ -69,7 +73,7 @@ where
 
 /// build a local map of wallet outputs keyed by commit
 /// and a list of outputs we want to query the node for
-pub fn map_wallet_outputs<T, K>(
+pub fn map_wallet_outputs<T: ?Sized, K>(
 	wallet: &mut T,
 ) -> Result<HashMap<pedersen::Commitment, Identifier>, Error>
 where
@@ -90,7 +94,7 @@ where
 }
 
 /// Apply refreshed API output data to the wallet
-pub fn apply_api_outputs<T, K>(
+pub fn apply_api_outputs<T: ?Sized, K>(
 	wallet: &mut T,
 	wallet_outputs: &HashMap<pedersen::Commitment, Identifier>,
 	api_outputs: &HashMap<pedersen::Commitment, String>,
@@ -125,7 +129,7 @@ where
 
 /// Builds a single api query to retrieve the latest output data from the node.
 /// So we can refresh the local wallet outputs.
-fn refresh_output_state<T, K>(wallet: &mut T, height: u64) -> Result<(), Error>
+fn refresh_output_state<T: ?Sized, K>(wallet: &mut T, height: u64) -> Result<(), Error>
 where
 	T: WalletBackend<K> + WalletClient,
 	K: Keychain,
@@ -144,7 +148,7 @@ where
 	Ok(())
 }
 
-fn clean_old_unconfirmed<T, K>(wallet: &mut T, height: u64) -> Result<(), Error>
+fn clean_old_unconfirmed<T: ?Sized, K>(wallet: &mut T, height: u64) -> Result<(), Error>
 where
 	T: WalletBackend<K>,
 	K: Keychain,
@@ -168,7 +172,7 @@ where
 
 /// Retrieve summary info about the wallet
 /// caller should refresh first if desired
-pub fn retrieve_info<T, K>(wallet: &mut T) -> Result<WalletInfo, Error>
+pub fn retrieve_info<T: ?Sized, K>(wallet: &mut T) -> Result<WalletInfo, Error>
 where
 	T: WalletBackend<K> + WalletClient,
 	K: Keychain,
@@ -209,7 +213,7 @@ where
 }
 
 /// Build a coinbase output and insert into wallet
-pub fn build_coinbase<T, K>(wallet: &mut T, block_fees: &BlockFees) -> Result<CbData, Error>
+pub fn build_coinbase<T: ?Sized, K>(wallet: &mut T, block_fees: &BlockFees) -> Result<CbData, Error>
 where
 	T: WalletBackend<K>,
 	K: Keychain,
@@ -234,7 +238,7 @@ where
 
 //TODO: Split up the output creation and the wallet insertion
 /// Build a coinbase output and the corresponding kernel
-pub fn receive_coinbase<T, K>(
+pub fn receive_coinbase<T: ?Sized, K>(
 	wallet: &mut T,
 	block_fees: &BlockFees,
 ) -> Result<(Output, TxKernel, BlockFees), Error>

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -33,6 +33,19 @@ use libwallet::error::{Error, ErrorKind};
 
 use util::secp::pedersen;
 
+/// Combined trait to allow dynamic wallet dispatch
+pub trait WalletInst<K>: WalletBackend<K> + WalletClient + Send + Sync + 'static
+where
+	K: Keychain,
+{
+}
+impl<T, K> WalletInst<K> for T
+where
+	T: WalletBackend<K> + WalletClient + Send + Sync + 'static,
+	K: Keychain,
+{
+}
+
 /// TODO:
 /// Wallets should implement this backend for their storage. All functions
 /// here expect that the wallet instance has instantiated itself or stored

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -29,7 +29,7 @@ use libwallet::{internal, Error, ErrorKind};
 use types::{WalletConfig, WalletSeed};
 use util::secp::pedersen;
 
-pub const DB_DIR: &'static str = "wallet";
+pub const DB_DIR: &'static str = "wallet_data";
 
 const OUTPUT_PREFIX: u8 = 'o' as u8;
 const DERIV_PREFIX: u8 = 'd' as u8;
@@ -38,6 +38,13 @@ impl From<store::Error> for Error {
 	fn from(error: store::Error) -> Error {
 		Error::from(ErrorKind::Backend(format!("{:?}", error)))
 	}
+}
+
+/// test to see if database files exist in the current directory. If so,
+/// use a DB backend for all operations
+pub fn wallet_db_exists(config: WalletConfig) -> bool {
+	let db_path = path::Path::new(&config.data_file_dir).join(DB_DIR);
+	db_path.exists()
 }
 
 pub struct LMDBBackend<K> {
@@ -63,6 +70,13 @@ impl<K> LMDBBackend<K> {
 			passphrase: String::from(passphrase),
 			keychain: None,
 		})
+	}
+
+	/// Just test to see if database files exist in the current directory. If
+	/// so, use a DB backend for all operations
+	pub fn exists(config: WalletConfig) -> bool {
+		let db_path = path::Path::new(&config.data_file_dir).join(DB_DIR);
+		db_path.exists()
 	}
 }
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -15,8 +15,8 @@
 use std::cmp::min;
 use std::fs::{self, File};
 use std::io::{Read, Write};
-use std::path::MAIN_SEPARATOR;
 use std::path::Path;
+use std::path::MAIN_SEPARATOR;
 
 use blake2;
 use rand::{thread_rng, Rng};


### PR DESCRIPTION
Was going to continue work with the database wallet implementation, however it took most of the day just to be able to instantiate wallet implementations dynamically. 

With these changes:
* If you run `grin wallet init -d (or --db)` it will instantiate the wallet seed as well as create a wallet data directory.
* If you run `grin wallet [anything]` and the db directory exists in the current directory, it will use the db version
* If you run the default wallet listener via the server, you can add `use_db_wallet = true` to grin.toml to force use of a db wallet. This obviously isn't ready, so I haven't inserted this option into grin.toml at all for the time being.

By default all should work as before with the file wallet.