### PR TITLE
Wallet API Test Client

### DIFF
--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -335,7 +335,7 @@ impl LocalServerContainer {
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let _ =
-			wallet::controller::owner_single_use(Box::new(wallet), |api| {
+			wallet::controller::owner_single_use(Arc::new(Mutex::new(Box::new(wallet))), |api| {
 				let result = api.issue_send_tx(
 					amount,
 					minimum_confirmations,

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -339,7 +339,6 @@ impl LocalServerContainer {
 		let _ =
 			wallet::controller::owner_single_use(
 				Arc::new(Mutex::new(Box::new(wallet))),
-				true,
 				|api| {
 					let result = api.issue_send_tx(
 						amount,
@@ -347,7 +346,6 @@ impl LocalServerContainer {
 						dest,
 						max_outputs,
 						selection_strategy == "all",
-						fluff,
 					);
 					match result {
 						Ok(_) => println!(

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -27,7 +27,7 @@ use std::default::Default;
 use std::sync::{Arc, Mutex};
 use std::{fs, thread, time};
 
-use wallet::{HTTPWalletClient, FileWallet, WalletConfig};
+use wallet::{FileWallet, HTTPWalletClient, WalletConfig};
 
 /// Just removes all results from previous runs
 pub fn clean_all_output(test_name_dir: &str) {
@@ -276,13 +276,15 @@ impl LocalServerContainer {
 				)
 			});
 
-		wallet::controller::foreign_listener(Box::new(wallet), &self.wallet_config.api_listen_addr())
-			.unwrap_or_else(|e| {
-				panic!(
-					"Error creating wallet listener: {:?} Config: {:?}",
-					e, self.wallet_config
-				)
-			});
+		wallet::controller::foreign_listener(
+			Box::new(wallet),
+			&self.wallet_config.api_listen_addr(),
+		).unwrap_or_else(|e| {
+			panic!(
+				"Error creating wallet listener: {:?} Config: {:?}",
+				e, self.wallet_config
+			)
+		});
 
 		self.wallet_is_running = true;
 	}
@@ -335,28 +337,32 @@ impl LocalServerContainer {
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let _ =
-			wallet::controller::owner_single_use(Arc::new(Mutex::new(Box::new(wallet))), |api| {
-				let result = api.issue_send_tx(
-					amount,
-					minimum_confirmations,
-					dest,
-					max_outputs,
-					selection_strategy == "all",
-					fluff,
-				);
-				match result {
-					Ok(_) => println!(
-						"Tx sent: {} grin to {} (strategy '{}')",
-						core::core::amount_to_hr_string(amount),
+			wallet::controller::owner_single_use(
+				Arc::new(Mutex::new(Box::new(wallet))),
+				true,
+				|api| {
+					let result = api.issue_send_tx(
+						amount,
+						minimum_confirmations,
 						dest,
-						selection_strategy,
-					),
-					Err(e) => {
-						println!("Tx not sent to {}: {:?}", dest, e);
-					}
-				};
-				Ok(())
-			}).unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
+						max_outputs,
+						selection_strategy == "all",
+						fluff,
+					);
+					match result {
+						Ok(_) => println!(
+							"Tx sent: {} grin to {} (strategy '{}')",
+							core::core::amount_to_hr_string(amount),
+							dest,
+							selection_strategy,
+						),
+						Err(e) => {
+							println!("Tx not sent to {}: {:?}", dest, e);
+						}
+					};
+					Ok(())
+				},
+			).unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 	}
 
 	/// Stops the running wallet server

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -665,7 +665,7 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 			passphrase,
 			use_db,
 		)));
-		let _res = wallet::controller::owner_single_use(wallet, |api| {
+		let _res = wallet::controller::owner_single_use(wallet, true, |api| {
 			match wallet_args.subcommand() {
 				("send", Some(send_args)) => {
 					let amount = send_args

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -89,7 +89,7 @@ pub enum ErrorKind {
 
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
-	GenericError(&'static str),
+	GenericError(String),
 }
 
 impl Fail for Error {

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -177,13 +177,12 @@ where
 		self.keychain = Some(keychain.context(libwallet::ErrorKind::CallbackImpl(
 			"Error deriving keychain",
 		))?);
-		// Just blow up password for now after it's been used
-		self.passphrase = String::from("");
 		Ok(())
 	}
 
 	/// Close wallet and remove any stored credentials (TBD)
 	fn close(&mut self) -> Result<(), libwallet::Error> {
+		debug!(LOGGER, "Closing wallet keychain");
 		self.keychain = None;
 		Ok(())
 	}

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -134,7 +134,7 @@ pub enum ErrorKind {
 
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
-	GenericError(&'static str),
+	GenericError(String),
 }
 
 impl Display for Error {

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -306,7 +306,7 @@ impl BlockIdentifier {
 
 	/// convert to hex string
 	pub fn from_hex(hex: &str) -> Result<BlockIdentifier, Error> {
-		let hash = Hash::from_hex(hex).context(ErrorKind::GenericError("Invalid hex"))?;
+		let hash = Hash::from_hex(hex).context(ErrorKind::GenericError("Invalid hex".to_owned()))?;
 		Ok(BlockIdentifier(hash))
 	}
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -78,8 +78,8 @@ impl WalletSeed {
 	}
 
 	fn from_hex(hex: &str) -> Result<WalletSeed, Error> {
-		let bytes =
-			util::from_hex(hex.to_string()).context(ErrorKind::GenericError("Invalid hex"))?;
+		let bytes = util::from_hex(hex.to_string())
+			.context(ErrorKind::GenericError("Invalid hex".to_owned()))?;
 		Ok(WalletSeed::from_bytes(&bytes))
 	}
 

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Common functions to facilitate wallet, walletlib and transaction testing
-use std::collections::HashMap;
-
 extern crate failure;
 extern crate grin_api as api;
 extern crate grin_chain as chain;
@@ -27,13 +24,11 @@ extern crate time;
 use std::sync::{Arc, Mutex};
 
 use chain::Chain;
-use core::core::{Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel};
-use core::{consensus, global, pow};
-use keychain::ExtKeychain;
+use core::core::{OutputFeatures, OutputIdentifier, Transaction};
+use core::{consensus, global, pow, ser};
 use wallet::file_wallet::FileWallet;
-use wallet::libwallet::internal::updater;
-use wallet::libwallet::types::{BlockFees, OutputStatus, WalletBackend, WalletClient};
-use wallet::libwallet::{Error, ErrorKind};
+use wallet::libwallet;
+use wallet::libwallet::types::{BlockFees, CbData, WalletBackend, WalletClient, WalletInst};
 use wallet::WalletConfig;
 
 use util;
@@ -41,102 +36,8 @@ use util::secp::pedersen;
 
 pub mod testclient;
 
-/// Mostly for testing, refreshes output state against a local chain instance
-/// instead of via an http API call
-pub fn refresh_output_state_local<T, C, K>(
-	wallet: &mut T,
-	chain: &chain::Chain,
-) -> Result<(), Error>
-where
-	T: WalletBackend<C, K>,
-	C: WalletClient,
-	K: keychain::Keychain,
-{
-	let wallet_outputs = updater::map_wallet_outputs(wallet)?;
-	let chain_outputs: Vec<Option<api::Output>> = wallet_outputs
-		.keys()
-		.map(|k| match get_output_local(chain, &k) {
-			Err(_) => None,
-			Ok(k) => Some(k),
-		})
-		.collect();
-	let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
-	for out in chain_outputs {
-		match out {
-			Some(o) => {
-				api_outputs.insert(o.commit.commit(), util::to_hex(o.commit.to_vec()));
-			}
-			None => {}
-		}
-	}
-	let height = chain.head().unwrap().height;
-	updater::apply_api_outputs(wallet, &wallet_outputs, &api_outputs, height)?;
-	Ok(())
-}
-
-pub fn refresh_output_state_local_boxed<T, C, K>(
-	wallet: Arc<Mutex<Box<T>>>,
-	chain: &Chain,
-) -> Result<(), Error>
-where
-	T: WalletBackend<C, K>,
-	C: WalletClient,
-	K: keychain::Keychain,
-{
-	let mut w = wallet.lock().unwrap();
-	refresh_output_state_local(&mut **w, chain)
-}
-
-/// Return the spendable wallet balance from the local chain
-/// (0:total, 1:amount_awaiting_confirmation, 2:confirmed but locked,
-/// 3:currently_spendable, 4:locked total) TODO: Should be a wallet lib
-/// function with nicer return values
-pub fn get_wallet_balances<T, C, K>(
-	wallet: &mut T,
-	height: u64,
-) -> Result<(u64, u64, u64, u64, u64), Error>
-where
-	T: WalletBackend<C, K>,
-	C: WalletClient,
-	K: keychain::Keychain,
-{
-	let mut unspent_total = 0;
-	let mut unspent_but_locked_total = 0;
-	let mut unconfirmed_total = 0;
-	let mut locked_total = 0;
-	let keychain = wallet.keychain().clone();
-	for out in wallet
-		.iter()
-		.filter(|out| out.root_key_id == keychain.root_key_id())
-	{
-		if out.status == OutputStatus::Unspent {
-			unspent_total += out.value;
-			if out.lock_height > height {
-				unspent_but_locked_total += out.value;
-			}
-		}
-		if out.status == OutputStatus::Unconfirmed && !out.is_coinbase {
-			unconfirmed_total += out.value;
-		}
-		if out.status == OutputStatus::Locked {
-			locked_total += out.value;
-		}
-	}
-
-	Ok((
-		unspent_total + unconfirmed_total,        //total
-		unconfirmed_total,                        //amount_awaiting_confirmation
-		unspent_but_locked_total,                 // confirmed but locked
-		unspent_total - unspent_but_locked_total, // currently spendable
-		locked_total,                             // locked total
-	))
-}
-
 /// Get an output from the chain locally and present it back as an API output
-fn get_output_local(
-	chain: &chain::Chain,
-	commit: &pedersen::Commitment,
-) -> Result<api::Output, Error> {
+fn get_output_local(chain: &chain::Chain, commit: &pedersen::Commitment) -> Option<api::Output> {
 	let outputs = [
 		OutputIdentifier::new(OutputFeatures::DEFAULT_OUTPUT, commit),
 		OutputIdentifier::new(OutputFeatures::COINBASE_OUTPUT, commit),
@@ -144,23 +45,25 @@ fn get_output_local(
 
 	for x in outputs.iter() {
 		if let Ok(_) = chain.is_unspent(&x) {
-			return Ok(api::Output::new(&commit));
+			return Some(api::Output::new(&commit));
 		}
 	}
-	Err(ErrorKind::GenericError(
-		"Can't get output from local instance of chain",
-	))?
+	None
 }
 
 /// Adds a block with a given reward to the chain and mines it
-pub fn add_block_with_reward(chain: &Chain, txs: Vec<&Transaction>, reward: (Output, TxKernel)) {
+pub fn add_block_with_reward(chain: &Chain, txs: Vec<&Transaction>, reward: CbData) {
 	let prev = chain.head_header().unwrap();
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
+	let out_bin = util::from_hex(reward.output).unwrap();
+	let kern_bin = util::from_hex(reward.kernel).unwrap();
+	let output = ser::deserialize(&mut &out_bin[..]).unwrap();
+	let kernel = ser::deserialize(&mut &kern_bin[..]).unwrap();
 	let mut b = core::core::Block::new(
 		&prev,
 		txs.into_iter().cloned().collect(),
 		difficulty.clone(),
-		reward,
+		(output, kernel),
 	).unwrap();
 	b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 	chain.set_txhashset_roots(&mut b, false).unwrap();
@@ -177,66 +80,58 @@ pub fn add_block_with_reward(chain: &Chain, txs: Vec<&Transaction>, reward: (Out
 /// adds a reward output to a wallet, includes that reward in a block, mines
 /// the block and adds it to the chain, with option transactions included.
 /// Helpful for building up precise wallet balances for testing.
-pub fn award_block_to_wallet<T, C, K>(chain: &Chain, txs: Vec<&Transaction>, wallet: &mut T)
+pub fn award_block_to_wallet<C, K>(
+	chain: &Chain,
+	txs: Vec<&Transaction>,
+	wallet: Arc<Mutex<Box<WalletInst<C, K>>>>,
+) -> Result<(), libwallet::Error>
 where
-	T: WalletBackend<C, K>,
 	C: WalletClient,
 	K: keychain::Keychain,
 {
+	// build block fees
 	let prev = chain.head_header().unwrap();
 	let fee_amt = txs.iter().map(|tx| tx.fee()).sum();
-	let fees = BlockFees {
+	let block_fees = BlockFees {
 		fees: fee_amt,
 		key_id: None,
 		height: prev.height + 1,
 	};
-	let coinbase_tx = wallet::libwallet::internal::updater::receive_coinbase(wallet, &fees);
-	let (coinbase_tx, fees) = match coinbase_tx {
-		Ok(t) => ((t.0, t.1), t.2),
-		Err(e) => {
-			panic!("Unable to create block reward: {:?}", e);
-		}
-	};
-	add_block_with_reward(chain, txs, coinbase_tx.clone());
-	let output = wallet.get(&fees.key_id.unwrap()).unwrap();
-	let mut batch = wallet.batch().unwrap();
-	batch.save(output).unwrap();
-	batch.commit().unwrap();
+	// build coinbase (via api) and add block
+	libwallet::controller::foreign_single_use(wallet.clone(), false, |api| {
+		let coinbase_tx = api.build_coinbase(&block_fees)?;
+		add_block_with_reward(chain, txs, coinbase_tx.clone());
+		Ok(())
+	})?;
+	Ok(())
 }
 
 /// Award a blocks to a wallet directly
-pub fn award_blocks_to_wallet_boxed<T, C, K>(
+pub fn award_blocks_to_wallet<C, K>(
 	chain: &Chain,
-	wallet: Arc<Mutex<Box<T>>>,
+	wallet: Arc<Mutex<Box<WalletInst<C, K>>>>,
 	number: usize,
-) where
-	T: WalletBackend<C, K>,
+) -> Result<(), libwallet::Error>
+where
 	C: WalletClient,
 	K: keychain::Keychain,
 {
-	let mut w = wallet.lock().unwrap();
-	award_blocks_to_wallet(chain, &mut **w, number);
+	for _ in 0..number {
+		award_block_to_wallet(chain, vec![], wallet.clone())?;
+	}
+	Ok(())
 }
 
-/// adds many block rewards to a wallet, no transactions
-pub fn award_blocks_to_wallet<T, C, K>(chain: &Chain, wallet: &mut T, num_rewards: usize)
+/// dispatch a wallet (extend later to optionally dispatch a db wallet)
+pub fn create_wallet<C, K>(dir: &str, client: C) -> Arc<Mutex<Box<WalletInst<C, K>>>>
 where
-	T: WalletBackend<C, K>,
-	C: WalletClient,
-	K: keychain::Keychain,
-{
-	for _ in 0..num_rewards {
-		award_block_to_wallet(chain, vec![], wallet);
-	}
-}
-pub fn create_file_wallet<C>(dir: &str, client: C) -> FileWallet<C, ExtKeychain>
-where
-	C: WalletClient,
+	C: WalletClient + 'static,
+	K: keychain::Keychain + 'static,
 {
 	let mut wallet_config = WalletConfig::default();
 	wallet_config.data_file_dir = String::from(dir);
 	let _ = wallet::WalletSeed::init_file(&wallet_config);
-	let mut wallet = FileWallet::new(wallet_config.clone(), "", client)
+	let mut wallet: FileWallet<C, K> = FileWallet::new(wallet_config.clone(), "", client)
 		.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, wallet_config));
 	wallet.open_with_credentials().unwrap_or_else(|e| {
 		panic!(
@@ -244,15 +139,5 @@ where
 			e, wallet_config
 		)
 	});
-	wallet
-}
-/// Create a new wallet in a particular directory
-pub fn create_file_wallet_boxed<C>(
-	dir: &str,
-	client: C,
-) -> Arc<Mutex<Box<FileWallet<C, ExtKeychain>>>>
-where
-	C: WalletClient,
-{
-	Arc::new(Mutex::new(Box::new(create_file_wallet(dir, client))))
+	Arc::new(Mutex::new(Box::new(wallet)))
 }

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -108,7 +108,7 @@ where
 		height: prev.height + 1,
 	};
 	// build coinbase (via api) and add block
-	libwallet::controller::foreign_single_use(wallet.clone(), false, |api| {
+	libwallet::controller::foreign_single_use(wallet.clone(), |api| {
 		let coinbase_tx = api.build_coinbase(&block_fees)?;
 		add_block_with_reward(chain, txs, coinbase_tx.clone());
 		Ok(())

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -14,7 +14,6 @@
 
 //! Common functions to facilitate wallet, walletlib and transaction testing
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 
 extern crate grin_api as api;
 extern crate grin_chain as chain;
@@ -24,23 +23,26 @@ extern crate grin_wallet as wallet;
 extern crate time;
 
 use chain::Chain;
-use core::core::hash::Hashed;
 use core::core::{Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel};
 use core::{consensus, global, pow};
 use keychain::ExtKeychain;
-use wallet::{HTTPWalletClient, WalletConfig};
 use wallet::file_wallet::FileWallet;
 use wallet::libwallet::internal::updater;
-use wallet::libwallet::types::{BlockFees, BlockIdentifier, OutputStatus,
-                               WalletBackend, WalletClient};
+use wallet::libwallet::types::{BlockFees, OutputStatus, WalletBackend, WalletClient};
 use wallet::libwallet::{Error, ErrorKind};
+use wallet::WalletConfig;
 
 use util;
 use util::secp::pedersen;
 
+pub mod testclient;
+
 /// Mostly for testing, refreshes output state against a local chain instance
 /// instead of via an http API call
-pub fn refresh_output_state_local<T, C, K>(wallet: &mut T, chain: &chain::Chain) -> Result<(), Error>
+pub fn refresh_output_state_local<T, C, K>(
+	wallet: &mut T,
+	chain: &chain::Chain,
+) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
 	C: WalletClient,
@@ -198,7 +200,10 @@ where
 }
 
 /// Create a new wallet in a particular directory
-pub fn create_wallet(dir: &str, client: HTTPWalletClient) -> FileWallet<HTTPWalletClient, ExtKeychain> {
+pub fn create_wallet<C>(dir: &str, client: C) -> FileWallet<C, ExtKeychain>
+where
+	C: WalletClient,
+{
 	let mut wallet_config = WalletConfig::default();
 	wallet_config.data_file_dir = String::from(dir);
 	wallet::WalletSeed::init_file(&wallet_config).expect("Failed to create wallet seed file.");

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -204,7 +204,7 @@ where
 		}
 		let w = dest_wallet.unwrap().1.clone();
 		let mut slate = serde_json::from_str(&m.body).unwrap();
-		libwallet::controller::foreign_single_use(w.clone(), false, |listener_api| {
+		libwallet::controller::foreign_single_use(w.clone(), |listener_api| {
 			listener_api.receive_tx(&mut slate)?;
 			Ok(())
 		})?;

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -17,48 +17,86 @@
 //! Operates directly on a chain instance
 
 use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
+use common::api;
+use common::serde_json;
 use store;
-use util;
+use util::secp::pedersen::Commitment;
+use util::{self, LOGGER};
+
+use common::failure::ResultExt;
 
 use chain::types::NoopAdapter;
 use chain::Chain;
+use core::core::Transaction;
 use core::global::{set_mining_mode, ChainTypes};
-use core::pow;
+use core::{pow, ser};
 use keychain::Keychain;
 
 use util::secp::pedersen;
 use wallet::libtx::slate::Slate;
 use wallet::libwallet;
-use wallet::libwallet::api::APIForeign;
 use wallet::libwallet::types::*;
-use wallet::FileWallet;
 
 use common;
 
-#[derive(Clone)]
-pub struct TestWalletClient<'a, K>
+/// Messages to simulate wallet requests/responses
+#[derive(Clone, Debug)]
+pub struct WalletProxyMessage {
+	/// sender ID
+	pub sender_id: String,
+	/// destination wallet (or server)
+	pub dest: String,
+	/// method (like a GET url)
+	pub method: String,
+	/// payload (json body)
+	pub body: String,
+}
+
+/// communicates with a chain instance or other wallet
+/// listener APIs via message queues
+pub struct WalletProxy<W, C, K>
 where
-	K: Keychain + 'a,
+	W: WalletBackend<C, K>,
+	C: WalletClient,
+	K: Keychain,
 {
-	/// dir to create chain in
+	/// directory to create the chain in
 	pub chain_dir: String,
 	/// handle to chain itself
 	pub chain: Arc<Chain>,
-	/// set this to provide a recipient API for the tx_send function
-	pub tx_recipient: Option<Arc<Mutex<Box<FileWallet<TestWalletClient<'a, K>, K>>>>>,
+	/// list of interested wallets
+	pub wallets: HashMap<String, (Sender<WalletProxyMessage>, Arc<Mutex<Box<W>>>)>,
+	/// simulate json send to another client
+	/// address, method, payload (simulate HTTP request)
+	pub tx: Sender<WalletProxyMessage>,
+	/// simulate json receiving
+	pub rx: Receiver<WalletProxyMessage>,
+	/// queue control
+	pub running: Arc<AtomicBool>,
+	/// Phantom
+	phantom_c: PhantomData<C>,
+	/// Phantom
+	phantom_k: PhantomData<K>,
 }
 
-impl<'a, K> TestWalletClient<'a, K>
+impl<W, C, K> WalletProxy<W, C, K>
 where
-	K: Keychain + 'a,
+	W: WalletBackend<C, K>,
+	C: WalletClient,
+	K: Keychain,
 {
 	/// Create a new client that will communicate with the given grin node
 	pub fn new(chain_dir: &str) -> Self {
 		set_mining_mode(ChainTypes::AutomatedTesting);
 		let genesis_block = pow::mine_genesis_block().unwrap();
-		let dir_name = format!("{}", chain_dir);
+		let dir_name = format!("{}/.grin", chain_dir);
 		let db_env = Arc::new(store::new_env(dir_name.to_string()));
 		let c = Chain::init(
 			dir_name.to_string(),
@@ -67,30 +105,187 @@ where
 			genesis_block,
 			pow::verify_size,
 		).unwrap();
-
-		TestWalletClient {
+		let (tx, rx) = channel();
+		let retval = WalletProxy {
 			chain_dir: chain_dir.to_owned(),
 			chain: Arc::new(c),
-			tx_recipient: None,
+			tx: tx,
+			rx: rx,
+			wallets: HashMap::new(),
+			running: Arc::new(AtomicBool::new(false)),
+			phantom_c: PhantomData,
+			phantom_k: PhantomData,
+		};
+		retval
+	}
+
+	/// Add wallet with a given "address"
+	pub fn add_wallet(
+		&mut self,
+		addr: &str,
+		tx: Sender<WalletProxyMessage>,
+		wallet: Arc<Mutex<Box<W>>>,
+	) {
+		self.wallets.insert(addr.to_owned(), (tx, wallet));
+	}
+
+	/// Run the incoming message queue and respond more or less
+	/// synchronously
+	pub fn run(&mut self) -> Result<(), libwallet::Error> {
+		self.running.store(true, Ordering::Relaxed);
+		loop {
+			thread::sleep(Duration::from_millis(10));
+			// read queue
+			let m = self.rx.recv().unwrap();
+			trace!(LOGGER, "Wallet Client Proxy Received: {:?}", m);
+			let resp = match m.method.as_ref() {
+				"get_chain_height" => self.get_chain_height(m)?,
+				"get_outputs_from_node" => self.get_outputs_from_node(m)?,
+				"send_tx_slate" => self.send_tx_slate(m)?,
+				"post_tx" => self.post_tx(m)?,
+				_ => panic!("Unknown Wallet Proxy Message"),
+			};
+
+			self.respond(resp);
+			if !self.running.load(Ordering::Relaxed) {
+				return Ok(());
+			}
 		}
 	}
 
-	/// Set the wallet for the client send
-	pub fn set_tx_recipient(
+	/// Return a message to a given wallet client
+	fn respond(&mut self, m: WalletProxyMessage) {
+		if let Some(s) = self.wallets.get_mut(&m.dest) {
+			if let Err(e) = s.0.send(m.clone()) {
+				panic!("Error sending response from proxy: {:?}, {}", m, e);
+			}
+		} else {
+			panic!("Unknown wallet recipient for response message: {:?}", m);
+		}
+	}
+
+	/// post transaction to the chain (and mine it, taking the reward)
+	fn post_tx(&mut self, m: WalletProxyMessage) -> Result<WalletProxyMessage, libwallet::Error> {
+		let mut dest_wallet = self.wallets
+			.get_mut(&m.sender_id)
+			.unwrap()
+			.1
+			.lock()
+			.unwrap();
+		let wrapper: TxWrapper = serde_json::from_str(&m.body).context(
+			libwallet::ErrorKind::ClientCallback("Error parsing TxWrapper"),
+		)?;
+
+		let tx_bin = util::from_hex(wrapper.tx_hex).context(libwallet::ErrorKind::ClientCallback(
+			"Error parsing TxWrapper: tx_bin",
+		))?;
+
+		let tx: Transaction = ser::deserialize(&mut &tx_bin[..]).context(
+			libwallet::ErrorKind::ClientCallback("Error parsing TxWrapper: tx"),
+		)?;
+
+		common::award_block_to_wallet(&self.chain, vec![&tx], &mut **dest_wallet);
+
+		Ok(WalletProxyMessage {
+			sender_id: "node".to_owned(),
+			dest: m.sender_id,
+			method: m.method,
+			body: "".to_owned(),
+		})
+	}
+
+	/// send tx slate
+	fn send_tx_slate(
 		&mut self,
-		w: Arc<Mutex<Box<FileWallet<TestWalletClient<'a, K>, K>>>>,
-	) -> Result<(), libwallet::Error> {
-		self.tx_recipient = Some(w);
-		Ok(())
+		m: WalletProxyMessage,
+	) -> Result<WalletProxyMessage, libwallet::Error> {
+		let dest_wallet = self.wallets.get_mut(&m.dest);
+		if let None = dest_wallet {
+			panic!("Unknown wallet destination for send_tx_slate: {:?}", m);
+		}
+		let w = dest_wallet.unwrap().1.clone();
+		let mut slate = serde_json::from_str(&m.body).unwrap();
+		libwallet::controller::foreign_single_use(w.clone(), |listener_api| {
+			listener_api.receive_tx(&mut slate)?;
+			Ok(())
+		})?;
+		Ok(WalletProxyMessage {
+			sender_id: m.dest,
+			dest: m.sender_id,
+			method: m.method,
+			body: serde_json::to_string(&slate).unwrap(),
+		})
+	}
+
+	/// get chain height
+	fn get_chain_height(
+		&mut self,
+		m: WalletProxyMessage,
+	) -> Result<WalletProxyMessage, libwallet::Error> {
+		Ok(WalletProxyMessage {
+			sender_id: "node".to_owned(),
+			dest: m.sender_id,
+			method: m.method,
+			body: format!("{}", self.chain.head().unwrap().height).to_owned(),
+		})
+	}
+
+	/// get api outputs
+	fn get_outputs_from_node(
+		&mut self,
+		m: WalletProxyMessage,
+	) -> Result<WalletProxyMessage, libwallet::Error> {
+		let split = m.body.split(",");
+		//let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
+		let mut outputs: Vec<api::Output> = vec![];
+		for o in split {
+			let c = util::from_hex(String::from(o)).unwrap();
+			let commit = Commitment::from_vec(c);
+			let out = common::get_output_local(&self.chain.clone(), &commit).unwrap();
+			outputs.push(out);
+		}
+		Ok(WalletProxyMessage {
+			sender_id: "node".to_owned(),
+			dest: m.sender_id,
+			method: m.method,
+			body: serde_json::to_string(&outputs).unwrap(),
+		})
 	}
 }
 
-impl<'a, K> WalletClient for TestWalletClient<'a, K>
-where
-	K: Keychain + 'a,
-{
+#[derive(Clone)]
+pub struct LocalWalletClient {
+	/// wallet identifier for the proxy queue
+	pub id: String,
+	/// proxy's tx queue (recieve messsages from other wallets or node
+	pub proxy_tx: Arc<Mutex<Sender<WalletProxyMessage>>>,
+	/// my rx queue
+	pub rx: Arc<Mutex<Receiver<WalletProxyMessage>>>,
+	/// my tx queue
+	pub tx: Arc<Mutex<Sender<WalletProxyMessage>>>,
+}
+
+impl LocalWalletClient {
+	/// new
+	pub fn new(id: &str, proxy_rx: Sender<WalletProxyMessage>) -> Self {
+		let (tx, rx) = channel();
+		LocalWalletClient {
+			id: id.to_owned(),
+			proxy_tx: Arc::new(Mutex::new(proxy_rx)),
+			rx: Arc::new(Mutex::new(rx)),
+			tx: Arc::new(Mutex::new(tx)),
+		}
+	}
+
+	/// get an instance of the send queue for other senders
+	pub fn get_send_instance(&self) -> Sender<WalletProxyMessage> {
+		self.tx.lock().unwrap().clone()
+	}
+}
+
+impl WalletClient for LocalWalletClient {
 	fn node_url(&self) -> &str {
-		&self.chain_dir
+		"node"
 	}
 
 	/// Call the wallet API to create a coinbase output for the given
@@ -98,33 +293,81 @@ where
 	/// behavior.
 	fn create_coinbase(
 		&self,
-		dest: &str,
-		block_fees: &BlockFees,
+		_dest: &str,
+		_block_fees: &BlockFees,
 	) -> Result<CbData, libwallet::Error> {
 		unimplemented!();
 	}
 
 	/// Send the slate to a listening wallet instance
 	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, libwallet::Error> {
-		let mut slate = slate.clone();
-		libwallet::controller::foreign_single_use(
-			self.tx_recipient.as_ref().unwrap().clone(),
-			|listener_api| {
-				listener_api.receive_tx(&mut slate);
-				Ok(())
-			},
-		)?;
-		Ok(slate.clone())
+		let m = WalletProxyMessage {
+			sender_id: self.id.clone(),
+			dest: dest.to_owned(),
+			method: "send_tx_slate".to_owned(),
+			body: serde_json::to_string(slate).unwrap(),
+		};
+		{
+			let p = self.proxy_tx.lock().unwrap();
+			p.send(m)
+				.context(libwallet::ErrorKind::ClientCallback("Send TX Slate"))?;
+		}
+		let r = self.rx.lock().unwrap();
+		let m = r.recv().unwrap();
+		trace!(LOGGER, "Received send_tx_slate response: {:?}", m.clone());
+		Ok(
+			serde_json::from_str(&m.body).context(libwallet::ErrorKind::ClientCallback(
+				"Parsing send_tx_slate response",
+			))?,
+		)
 	}
 
 	/// Posts a transaction to a grin node
-	fn post_tx(&self, tx: &TxWrapper, fluff: bool) -> Result<(), libwallet::Error> {
-		unimplemented!()
+	/// In this case it will create a new block with award rewarded to
+	fn post_tx(&self, tx: &TxWrapper, _fluff: bool) -> Result<(), libwallet::Error> {
+		let m = WalletProxyMessage {
+			sender_id: self.id.clone(),
+			dest: self.node_url().to_owned(),
+			method: "post_tx".to_owned(),
+			body: serde_json::to_string(tx).unwrap(),
+		};
+		{
+			let p = self.proxy_tx.lock().unwrap();
+			p.send(m)
+				.context(libwallet::ErrorKind::ClientCallback("post_tx send"))?;
+		}
+		let r = self.rx.lock().unwrap();
+		let m = r.recv().unwrap();
+		trace!(LOGGER, "Received post_tx response: {:?}", m.clone());
+		Ok(())
 	}
 
 	/// Return the chain tip from a given node
 	fn get_chain_height(&self) -> Result<u64, libwallet::Error> {
-		Ok(self.chain.head().unwrap().height)
+		let m = WalletProxyMessage {
+			sender_id: self.id.clone(),
+			dest: self.node_url().to_owned(),
+			method: "get_chain_height".to_owned(),
+			body: "".to_owned(),
+		};
+		{
+			let p = self.proxy_tx.lock().unwrap();
+			p.send(m).context(libwallet::ErrorKind::ClientCallback(
+				"Get chain height send",
+			))?;
+		}
+		let r = self.rx.lock().unwrap();
+		let m = r.recv().unwrap();
+		trace!(
+			LOGGER,
+			"Received get_chain_height response: {:?}",
+			m.clone()
+		);
+		Ok(m.body
+			.parse::<u64>()
+			.context(libwallet::ErrorKind::ClientCallback(
+				"Parsing get_height response",
+			))?)
 	}
 
 	/// Retrieve outputs from node
@@ -132,9 +375,28 @@ where
 		&self,
 		wallet_outputs: Vec<pedersen::Commitment>,
 	) -> Result<HashMap<pedersen::Commitment, String>, libwallet::Error> {
+		let query_params: Vec<String> = wallet_outputs
+			.iter()
+			.map(|commit| format!("{}", util::to_hex(commit.as_ref().to_vec())))
+			.collect();
+		let query_str = query_params.join(",");
+		let m = WalletProxyMessage {
+			sender_id: self.id.clone(),
+			dest: self.node_url().to_owned(),
+			method: "get_outputs_from_node".to_owned(),
+			body: query_str,
+		};
+		{
+			let p = self.proxy_tx.lock().unwrap();
+			p.send(m).context(libwallet::ErrorKind::ClientCallback(
+				"Get outputs from node send",
+			))?;
+		}
+		let r = self.rx.lock().unwrap();
+		let m = r.recv().unwrap();
+		let outputs: Vec<api::Output> = serde_json::from_str(&m.body).unwrap();
 		let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
-		for c in wallet_outputs.iter() {
-			let out = common::get_output_local(&self.chain.clone(), c)?;
+		for out in outputs {
 			api_outputs.insert(out.commit.commit(), util::to_hex(out.commit.to_vec()));
 		}
 		Ok(api_outputs)
@@ -142,8 +404,8 @@ where
 
 	fn get_outputs_by_pmmr_index(
 		&self,
-		start_height: u64,
-		max_outputs: u64,
+		_start_height: u64,
+		_max_outputs: u64,
 	) -> Result<
 		(
 			u64,

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -1,0 +1,157 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test client that acts against a local instance of a node
+//! so that wallet API can be fully exercised
+//! Operates directly on a chain instance
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use store;
+use util;
+
+use chain::types::NoopAdapter;
+use chain::Chain;
+use core::global::{set_mining_mode, ChainTypes};
+use core::pow;
+use keychain::Keychain;
+
+use util::secp::pedersen;
+use wallet::libtx::slate::Slate;
+use wallet::libwallet;
+use wallet::libwallet::api::APIForeign;
+use wallet::libwallet::types::*;
+use wallet::FileWallet;
+
+use common;
+
+#[derive(Clone)]
+pub struct TestWalletClient<'a, K>
+where
+	K: Keychain + 'a,
+{
+	/// dir to create chain in
+	pub chain_dir: String,
+	/// handle to chain itself
+	pub chain: Arc<Chain>,
+	/// set this to provide a recipient API for the tx_send function
+	pub tx_recipient: Option<Arc<Mutex<Box<FileWallet<TestWalletClient<'a, K>, K>>>>>,
+}
+
+impl<'a, K> TestWalletClient<'a, K>
+where
+	K: Keychain + 'a,
+{
+	/// Create a new client that will communicate with the given grin node
+	pub fn new(chain_dir: &str) -> Self {
+		set_mining_mode(ChainTypes::AutomatedTesting);
+		let genesis_block = pow::mine_genesis_block().unwrap();
+		let dir_name = format!("{}", chain_dir);
+		let db_env = Arc::new(store::new_env(dir_name.to_string()));
+		let c = Chain::init(
+			dir_name.to_string(),
+			db_env,
+			Arc::new(NoopAdapter {}),
+			genesis_block,
+			pow::verify_size,
+		).unwrap();
+
+		TestWalletClient {
+			chain_dir: chain_dir.to_owned(),
+			chain: Arc::new(c),
+			tx_recipient: None,
+		}
+	}
+
+	/// Set the wallet for the client send
+	pub fn set_tx_recipient(
+		&mut self,
+		w: Arc<Mutex<Box<FileWallet<TestWalletClient<'a, K>, K>>>>,
+	) -> Result<(), libwallet::Error> {
+		self.tx_recipient = Some(w);
+		Ok(())
+	}
+}
+
+impl<'a, K> WalletClient for TestWalletClient<'a, K>
+where
+	K: Keychain + 'a,
+{
+	fn node_url(&self) -> &str {
+		&self.chain_dir
+	}
+
+	/// Call the wallet API to create a coinbase output for the given
+	/// block_fees. Will retry based on default "retry forever with backoff"
+	/// behavior.
+	fn create_coinbase(
+		&self,
+		dest: &str,
+		block_fees: &BlockFees,
+	) -> Result<CbData, libwallet::Error> {
+		unimplemented!();
+	}
+
+	/// Send the slate to a listening wallet instance
+	fn send_tx_slate(&self, dest: &str, slate: &Slate) -> Result<Slate, libwallet::Error> {
+		let mut slate = slate.clone();
+		libwallet::controller::foreign_single_use(
+			self.tx_recipient.as_ref().unwrap().clone(),
+			|listener_api| {
+				listener_api.receive_tx(&mut slate);
+				Ok(())
+			},
+		)?;
+		Ok(slate.clone())
+	}
+
+	/// Posts a transaction to a grin node
+	fn post_tx(&self, tx: &TxWrapper, fluff: bool) -> Result<(), libwallet::Error> {
+		unimplemented!()
+	}
+
+	/// Return the chain tip from a given node
+	fn get_chain_height(&self) -> Result<u64, libwallet::Error> {
+		Ok(self.chain.head().unwrap().height)
+	}
+
+	/// Retrieve outputs from node
+	fn get_outputs_from_node(
+		&self,
+		wallet_outputs: Vec<pedersen::Commitment>,
+	) -> Result<HashMap<pedersen::Commitment, String>, libwallet::Error> {
+		let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
+		for c in wallet_outputs.iter() {
+			let out = common::get_output_local(&self.chain.clone(), c)?;
+			api_outputs.insert(out.commit.commit(), util::to_hex(out.commit.to_vec()));
+		}
+		Ok(api_outputs)
+	}
+
+	fn get_outputs_by_pmmr_index(
+		&self,
+		start_height: u64,
+		max_outputs: u64,
+	) -> Result<
+		(
+			u64,
+			u64,
+			Vec<(pedersen::Commitment, pedersen::RangeProof, bool)>,
+		),
+		libwallet::Error,
+	> {
+		unimplemented!();
+	}
+}


### PR DESCRIPTION
Trying to implement a test client that acts on an in-memory chain directly, so as to make exercising the wallet API in tests far easier. Also some changes to the underlying API structs to support this.