### PR TITLE
Add API handler for fetching header by range of heights

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -489,6 +489,12 @@ pub struct BlockHeaderPrintable {
 	pub total_difficulty: u64,
 	/// Total kernel offset since genesis block
 	pub total_kernel_offset: String,
+	/// Total accumulated sum of kernel commitments since genesis block.
+	pub total_kernel_sum: PrintableCommitment,
+	/// Total size of the output MMR after applying this block
+	pub output_mmr_size: u64,
+	/// Total size of the kernel MMR after applying this block
+	pub kernel_mmr_size: u64,
 }
 
 impl BlockHeaderPrintable {
@@ -507,6 +513,9 @@ impl BlockHeaderPrintable {
 			cuckoo_solution: h.pow.nonces.clone(),
 			total_difficulty: h.total_difficulty.to_num(),
 			total_kernel_offset: h.total_kernel_offset.to_hex(),
+			total_kernel_sum: PrintableCommitment { commit: h.total_kernel_sum },
+			output_mmr_size: h.output_mmr_size,
+			kernel_mmr_size: h.kernel_mmr_size,
 		}
 	}
 }


### PR DESCRIPTION
- Extension of #1248 to handle range queries.
`GET /v1/headers/<hash|height>`
`GET /v1/headers?start_height=30&max=30`

- Added total_kernel_sum,output_mmr_size & kernel_mmr_size to Header json output.
Toward fixing #1239, where the batch of headers along with output_mmr_size needed to extract block information for each output commit. 

- Tried proper handling 404 instead of 500 (#1247)