### PR TITLE
Force user to either specify an absolute path or set .grin($HOME/.grin) in grin.toml

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -29,7 +29,7 @@ use wallet::WalletConfig;
 /// the config file location
 
 const CONFIG_FILE_NAME: &'static str = "grin.toml";
-const GRIN_HOME: &'static str = ".grin";
+pub const GRIN_HOME: &'static str = ".grin";
 
 /// Returns the defaults, as strewn throughout the code
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -34,3 +34,4 @@ pub mod config;
 pub mod types;
 
 pub use types::{ConfigError, ConfigMembers, GlobalConfig};
+pub use config::GRIN_HOME;


### PR DESCRIPTION
#1257 
currently commenting out `db_root` in `grin.toml` causes error. should be fixed in a separate pull req for #1256 