### PR TITLE
add validation to tx to ensure we have no coinbase outputs or kernels in there

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -75,6 +75,12 @@ pub enum Error {
 	/// Validation error relating to cut-through (tx is spending its own
 	/// output).
 	CutThrough,
+	/// Validation error relating to output features.
+	/// It is invalid for a transaction to contain a coinbase output, for example.
+	InvalidOutputFeatures,
+	/// Validation error relating to kernel features.
+	/// It is invalid for a transaction to contain a coinbase kernel, for example.
+	InvalidKernelFeatures,
 }
 
 impl error::Error for Error {
@@ -429,6 +435,7 @@ impl Transaction {
 		if self.inputs.len() > consensus::MAX_BLOCK_INPUTS {
 			return Err(Error::TooManyInputs);
 		}
+		self.verify_features()?;
 		self.verify_sorted()?;
 		self.verify_cut_through()?;
 		self.verify_kernel_sums(self.overage(), self.offset)?;
@@ -469,6 +476,26 @@ impl Transaction {
 			{
 				return Err(Error::CutThrough);
 			}
+		}
+		Ok(())
+	}
+
+	fn verify_features(&self) -> Result<(), Error> {
+		self.verify_output_features()?;
+		self.verify_kernel_features()?;
+		Ok(())
+	}
+
+	fn verify_output_features(&self) -> Result<(), Error> {
+		if self.outputs.iter().any(|x| x.features.contains(OutputFeatures::COINBASE_OUTPUT)) {
+			return Err(Error::InvalidOutputFeatures);
+		}
+		Ok(())
+	}
+
+	fn verify_kernel_features(&self) -> Result<(), Error> {
+		if self.kernels.iter().any(|x| x.features.contains(KernelFeatures::COINBASE_KERNEL)) {
+			return Err(Error::InvalidKernelFeatures);
 		}
 		Ok(())
 	}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -480,12 +480,16 @@ impl Transaction {
 		Ok(())
 	}
 
+	// Verify we have no invalid outputs or kernels in the transaction
+	// due to invalid features.
+	// Specifically, a transaction cannot contain a coinbase output or a coinbase kernel.
 	fn verify_features(&self) -> Result<(), Error> {
 		self.verify_output_features()?;
 		self.verify_kernel_features()?;
 		Ok(())
 	}
 
+	// Verify we have no outputs tagged as COINBASE_OUTPUT.
 	fn verify_output_features(&self) -> Result<(), Error> {
 		if self.outputs.iter().any(|x| x.features.contains(OutputFeatures::COINBASE_OUTPUT)) {
 			return Err(Error::InvalidOutputFeatures);
@@ -493,6 +497,7 @@ impl Transaction {
 		Ok(())
 	}
 
+	// Verify we have no kernels tagged as COINBASE_KERNEL.
 	fn verify_kernel_features(&self) -> Result<(), Error> {
 		if self.kernels.iter().any(|x| x.features.contains(KernelFeatures::COINBASE_KERNEL)) {
 			return Err(Error::InvalidKernelFeatures);


### PR DESCRIPTION
I think it may be possible to cause a fair amount of havoc by building a carefully constructed tx that contained an output flagged as `COINBASE_OUTPUT` and a corresponding tx kernel flagged as `COINBASE_KERNEL`.

The block containing this tx might (but I'm not completely sure) be valid in isolation.
Blocks validate that coinbase outputs sum to match coinbase kernels, which would still hold in the presence of one of these "bad" txs.
But we will have significantly messed up the supply, which we only check on a full chain state validation.
We're not creating coins from nothing but we are incorrectly labelling outputs as coinbase at this point (which definitely should not be allowed).

This may actually not be an issue, we may catch this somewhere else before anything catastrophic happens.
But this is a simple and cheap validation step to add to tx validation.

