### PR TITLE
LMDB Wallet Transaction Log + LMDB Migration for all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -775,6 +776,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bodyparser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/grin.toml
+++ b/grin.toml
@@ -65,11 +65,6 @@ run_tui = true
 #Whether to run the wallet listener with the server by default
 run_wallet_listener = true
 
-#whether to use the database backend storage for the default listener wallet
-#true = lmdb storage
-#false = files storage
-use_db_wallet = false
-
 # Whether to run the web-wallet API (will only run on localhost)
 run_wallet_owner_api = true
 

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -53,10 +53,7 @@ use core::core::amount_to_hr_string;
 use core::global;
 use tui::ui;
 use util::{init_logger, LoggingConfig, LOGGER};
-use wallet::{
-	libwallet, HTTPWalletClient, LMDBBackend, WalletConfig,
-	WalletInst,
-};
+use wallet::{libwallet, HTTPWalletClient, LMDBBackend, WalletConfig, WalletInst};
 
 // include build information
 pub mod built_info {
@@ -557,7 +554,7 @@ fn instantiate_wallet(
 	if wallet::needs_migrate(&wallet_config.data_file_dir) {
 		// Migrate wallet automatically
 		warn!(LOGGER, "Migrating legacy File-Based wallet to LMDB Format");
-		if let Err(e) = wallet::migrate(&wallet_config.data_file_dir, passphrase){
+		if let Err(e) = wallet::migrate(&wallet_config.data_file_dir, passphrase) {
 			error!(LOGGER, "Error while trying to migrate wallet: {:?}", e);
 			error!(LOGGER, "Please ensure your file wallet files exist and are not corrupted, and that your password is correct");
 			panic!();

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -54,7 +54,7 @@ use core::global;
 use tui::ui;
 use util::{init_logger, LoggingConfig, LOGGER};
 use wallet::{
-	libwallet, wallet_db_exists, FileWallet, HTTPWalletClient, LMDBBackend, WalletConfig,
+	libwallet, HTTPWalletClient, LMDBBackend, WalletConfig,
 	WalletInst,
 };
 
@@ -301,11 +301,8 @@ fn main() {
 			.about("basic wallet contents summary"))
 
 		.subcommand(SubCommand::with_name("init")
-			.about("Initialize a new wallet seed file.")
-			.arg(Arg::with_name("db")
-				.help("Use database backend. (Default: false)")
-				.short("d")
-				.long("db")))
+			.about("Initialize a new wallet seed file and database."))
+
 		.subcommand(SubCommand::with_name("restore")
 			.about("Attempt to restore wallet contents from the chain using seed and password. \
 				NOTE: Backup wallet.* and run `wallet listen` before running restore.")))
@@ -445,14 +442,13 @@ fn server_command(server_args: Option<&ArgMatches>, mut global_config: GlobalCon
 	}
 
 	if let Some(true) = server_config.run_wallet_listener {
-		let use_db = server_config.use_db_wallet == Some(true);
 		let mut wallet_config = global_config.members.as_ref().unwrap().wallet.clone();
 		init_wallet_seed(wallet_config.clone());
+		let wallet = instantiate_wallet(wallet_config.clone(), "");
 
 		let _ = thread::Builder::new()
 			.name("wallet_listener".to_string())
 			.spawn(move || {
-				let wallet = instantiate_wallet(wallet_config.clone(), "", use_db);
 				wallet::controller::foreign_listener(wallet, &wallet_config.api_listen_addr())
 					.unwrap_or_else(|e| {
 						panic!(
@@ -463,14 +459,13 @@ fn server_command(server_args: Option<&ArgMatches>, mut global_config: GlobalCon
 			});
 	}
 	if let Some(true) = server_config.run_wallet_owner_api {
-		let use_db = server_config.use_db_wallet == Some(true);
 		let mut wallet_config = global_config.members.unwrap().wallet;
+		let wallet = instantiate_wallet(wallet_config.clone(), "");
 		init_wallet_seed(wallet_config.clone());
 
 		let _ = thread::Builder::new()
 			.name("wallet_owner_listener".to_string())
 			.spawn(move || {
-				let wallet = instantiate_wallet(wallet_config.clone(), "", use_db);
 				wallet::controller::owner_listener(wallet, "127.0.0.1:13420").unwrap_or_else(|e| {
 					panic!(
 						"Error creating wallet api listener: {:?} Config: {:?}",
@@ -558,24 +553,30 @@ fn init_wallet_seed(wallet_config: WalletConfig) {
 fn instantiate_wallet(
 	wallet_config: WalletConfig,
 	passphrase: &str,
-	use_db: bool,
 ) -> Box<WalletInst<HTTPWalletClient, keychain::ExtKeychain>> {
-	let client = HTTPWalletClient::new(&wallet_config.check_node_api_http_addr);
-	if use_db {
-		let db_wallet = LMDBBackend::new(wallet_config.clone(), "", client).unwrap_or_else(|e| {
-			panic!(
-				"Error creating DB wallet: {} Config: {:?}",
-				e, wallet_config
-			);
-		});
-		info!(LOGGER, "Using LMDB Backend for wallet");
-		Box::new(db_wallet)
-	} else {
-		let file_wallet = FileWallet::new(wallet_config.clone(), passphrase, client)
-			.unwrap_or_else(|e| panic!("Error creating wallet: {} Config: {:?}", e, wallet_config));
-		info!(LOGGER, "Using File Backend for wallet");
-		Box::new(file_wallet)
+	if wallet::needs_migrate(&wallet_config.data_file_dir) {
+		// Migrate wallet automatically
+		warn!(LOGGER, "Migrating legacy File-Based wallet to LMDB Format");
+		if let Err(e) = wallet::migrate(&wallet_config.data_file_dir, passphrase){
+			error!(LOGGER, "Error while trying to migrate wallet: {:?}", e);
+			error!(LOGGER, "Please ensure your file wallet files exist and are not corrupted, and that your password is correct");
+			panic!();
+		} else {
+			warn!(LOGGER, "Migration successful. Using LMDB Wallet backend");
+		}
+		warn!(LOGGER, "Please check the results of the migration process using `grin wallet info` and `grin wallet outputs`");
+		warn!(LOGGER, "If anything went wrong, you can try again by deleting the `wallet_data` directory and running a wallet command");
+		warn!(LOGGER, "If all is okay, you can move/backup/delete all files in the wallet directory EXCEPT FOR wallet.seed");
 	}
+	let client = HTTPWalletClient::new(&wallet_config.check_node_api_http_addr);
+	let db_wallet = LMDBBackend::new(wallet_config.clone(), "", client).unwrap_or_else(|e| {
+		panic!(
+			"Error creating DB wallet: {} Config: {:?}",
+			e, wallet_config
+		);
+	});
+	info!(LOGGER, "Using LMDB Backend for wallet");
+	Box::new(db_wallet)
 }
 
 fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
@@ -601,25 +602,18 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 
 	// Derive the keychain based on seed from seed file and specified passphrase.
 	// Generate the initial wallet seed if we are running "wallet init".
-	if let ("init", Some(init_args)) = wallet_args.subcommand() {
-		let mut use_db = false;
-		if init_args.is_present("db") {
-			info!(LOGGER, "Use db");
-			use_db = true;
-		}
+	if let ("init", Some(_)) = wallet_args.subcommand() {
 		wallet::WalletSeed::init_file(&wallet_config).expect("Failed to init wallet seed file.");
 		info!(LOGGER, "Wallet seed file created");
-		if use_db {
-			let client = HTTPWalletClient::new(&wallet_config.check_node_api_http_addr);
-			let _: LMDBBackend<HTTPWalletClient, keychain::ExtKeychain> =
-				LMDBBackend::new(wallet_config.clone(), "", client).unwrap_or_else(|e| {
-					panic!(
-						"Error creating DB wallet: {} Config: {:?}",
-						e, wallet_config
-					);
-				});
-			info!(LOGGER, "Wallet database backend created");
-		}
+		let client = HTTPWalletClient::new(&wallet_config.check_node_api_http_addr);
+		let _: LMDBBackend<HTTPWalletClient, keychain::ExtKeychain> =
+			LMDBBackend::new(wallet_config.clone(), "", client).unwrap_or_else(|e| {
+				panic!(
+					"Error creating DB for wallet: {} Config: {:?}",
+					e, wallet_config
+				);
+			});
+		info!(LOGGER, "Wallet database backend created");
 		// give logging thread a moment to catch up
 		thread::sleep(Duration::from_millis(200));
 		// we are done here with creating the wallet, so just return
@@ -630,12 +624,9 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 		.value_of("pass")
 		.expect("Failed to read passphrase.");
 
-	// use database if one exists, otherwise use file
-	let use_db = wallet_db_exists(wallet_config.clone());
-
 	// Handle listener startup commands
 	{
-		let wallet = instantiate_wallet(wallet_config.clone(), passphrase, use_db);
+		let wallet = instantiate_wallet(wallet_config.clone(), passphrase);
 		match wallet_args.subcommand() {
 			("listen", Some(listen_args)) => {
 				if let Some(port) = listen_args.value_of("port") {
@@ -665,7 +656,6 @@ fn wallet_command(wallet_args: &ArgMatches, global_config: GlobalConfig) {
 	let wallet = Arc::new(Mutex::new(instantiate_wallet(
 		wallet_config.clone(),
 		passphrase,
-		use_db,
 	)));
 	let res = wallet::controller::owner_single_use(wallet, |api| {
 		match wallet_args.subcommand() {

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -191,6 +191,12 @@ impl<'a> Batch<'a> {
 		self.store.get(key)
 	}
 
+	/// Produces an iterator of `Readable` types moving forward from the
+	/// provided key.
+	pub fn iter<T: ser::Readable>(&self, from: &[u8]) -> Result<SerIterator<T>, Error> {
+		self.store.iter(from)
+	}
+
 	/// Gets a `Readable` value from the db, provided its key, taking the
 	/// content of the current batch into account.
 	pub fn get_ser<T: ser::Readable>(&self, key: &[u8]) -> Result<Option<T>, Error> {

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -26,6 +26,7 @@ tokio-core = "0.1"
 tokio-retry = "0.1"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 urlencoded = "0.5"
+chrono = { version = "0.4", features = ["serde"] }
 
 grin_api = { path = "../api" }
 grin_core = { path = "../core" }

--- a/wallet/src/db_migrate.rs
+++ b/wallet/src/db_migrate.rs
@@ -1,0 +1,150 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Temporary utility to migrate wallet data from file to a database
+
+use keychain::{ExtKeychain, Identifier, Keychain};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, MAIN_SEPARATOR};
+/// Migrate wallet data. Assumes current directory contains a set of wallet
+/// files
+use std::sync::Arc;
+
+use error::{Error, ErrorKind};
+use failure::ResultExt;
+
+use serde_json;
+
+use libwallet::types::WalletDetails;
+use types::WalletSeed;
+
+use libwallet::types::OutputData;
+use store::{self, to_key};
+
+const DETAIL_FILE: &'static str = "wallet.det";
+const DAT_FILE: &'static str = "wallet.dat";
+const SEED_FILE: &'static str = "wallet.seed";
+const DB_DIR: &'static str = "wallet_data";
+const OUTPUT_PREFIX: u8 = 'o' as u8;
+const DERIV_PREFIX: u8 = 'd' as u8;
+const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;
+
+// determine whether we have wallet files but no file wallet
+pub fn needs_migrate(data_dir: &str) -> bool {
+	let db_path = Path::new(data_dir).join(DB_DIR);
+	let data_path = Path::new(data_dir).join(DAT_FILE);
+	if !db_path.exists() && data_path.exists() {
+		return true;
+	}
+	false
+}
+
+pub fn migrate(data_dir: &str, pwd: &str) -> Result<(), Error> {
+	let data_file_path = format!("{}{}{}", data_dir, MAIN_SEPARATOR, DAT_FILE);
+	let details_file_path = format!("{}{}{}", data_dir, MAIN_SEPARATOR, DETAIL_FILE);
+	let seed_file_path = format!("{}{}{}", data_dir, MAIN_SEPARATOR, SEED_FILE);
+	let outputs = read_outputs(&data_file_path)?;
+	let details = read_details(&details_file_path)?;
+
+	let mut file = File::open(seed_file_path).context(ErrorKind::IO)?;
+	let mut buffer = String::new();
+	file.read_to_string(&mut buffer).context(ErrorKind::IO)?;
+	let wallet_seed = WalletSeed::from_hex(&buffer)?;
+	let keychain: ExtKeychain = wallet_seed.derive_keychain(pwd)?;
+	let root_key_id = keychain.root_key_id();
+
+	//open db
+	let db_path = Path::new(data_dir).join(DB_DIR);
+	let lmdb_env = Arc::new(store::new_env(db_path.to_str().unwrap().to_string()));
+
+	// open store
+	let store = store::Store::open(lmdb_env, DB_DIR);
+	let batch = store.batch().unwrap();
+
+	// write
+	for out in outputs {
+		save_output(&batch, out.clone())?;
+	}
+	save_details(&batch, root_key_id, details)?;
+
+	let res = batch.commit();
+	if let Err(e) = res {
+		panic!("Unable to commit db: {:?}", e);
+	}
+
+	Ok(())
+}
+
+/// save output in db
+fn save_output(batch: &store::Batch, out: OutputData) -> Result<(), Error> {
+	let key = to_key(OUTPUT_PREFIX, &mut out.key_id.to_bytes().to_vec());
+	if let Err(e) = batch.put_ser(&key, &out) {
+		Err(ErrorKind::GenericError(format!(
+			"Error inserting output: {:?}",
+			e
+		)))?;
+	}
+	Ok(())
+}
+
+/// save details in db
+fn save_details(
+	batch: &store::Batch,
+	root_key_id: Identifier,
+	d: WalletDetails,
+) -> Result<(), Error> {
+	let deriv_key = to_key(DERIV_PREFIX, &mut root_key_id.to_bytes().to_vec());
+	let height_key = to_key(
+		CONFIRMED_HEIGHT_PREFIX,
+		&mut root_key_id.to_bytes().to_vec(),
+	);
+	if let Err(e) = batch.put_ser(&deriv_key, &d.last_child_index) {
+		Err(ErrorKind::GenericError(format!(
+			"Error saving last_child_index: {:?}",
+			e
+		)))?;
+	}
+	if let Err(e) = batch.put_ser(&height_key, &d.last_confirmed_height) {
+		Err(ErrorKind::GenericError(format!(
+			"Error saving last_confirmed_height: {:?}",
+			e
+		)))?;
+	}
+	Ok(())
+}
+
+/// Read output_data vec from disk.
+fn read_outputs(data_file_path: &str) -> Result<Vec<OutputData>, Error> {
+	let data_file = File::open(data_file_path.clone())
+		.context(ErrorKind::FileWallet(&"Could not open wallet file"))?;
+	serde_json::from_reader(data_file)
+		.context(ErrorKind::Format)
+		.map_err(|e| e.into())
+}
+
+/// Read details file from disk
+fn read_details(details_file_path: &str) -> Result<WalletDetails, Error> {
+	let details_file = File::open(details_file_path.clone())
+		.context(ErrorKind::FileWallet(&"Could not open wallet details file"))?;
+	serde_json::from_reader(details_file)
+		.context(ErrorKind::Format)
+		.map_err(|e| e.into())
+}
+
+#[ignore]
+#[test]
+fn migrate_db() {
+	let _ = migrate("test_wallet", "");
+}

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -21,6 +21,7 @@ use serde_json;
 use tokio_core::reactor;
 use tokio_retry::strategy::FibonacciBackoff;
 use tokio_retry::Retry;
+use uuid::Uuid;
 
 use failure::ResultExt;
 
@@ -31,7 +32,9 @@ use error::{Error, ErrorKind};
 
 use libwallet;
 
-use libwallet::types::{OutputData, WalletBackend, WalletClient, WalletDetails, WalletOutputBatch};
+use libwallet::types::{
+	OutputData, TxLogEntry, WalletBackend, WalletClient, WalletDetails, WalletOutputBatch,
+};
 
 use types::{WalletConfig, WalletSeed};
 
@@ -75,6 +78,15 @@ impl<'a> WalletOutputBatch for FileBatch<'a> {
 
 	fn save_details(&mut self, _r: Identifier, w: WalletDetails) -> Result<(), libwallet::Error> {
 		self.details = w;
+		Ok(())
+	}
+
+	fn next_tx_log_id(&mut self, _root_key_id: Identifier) -> Result<u32, libwallet::Error> {
+		Ok(0)
+	}
+
+	fn save_tx_log_entry(&self, _t: TxLogEntry) -> Result<(), libwallet::Error> {
+		// not implemented for file wallets
 		Ok(())
 	}
 
@@ -141,6 +153,8 @@ pub struct FileWallet<C, K> {
 	passphrase: String,
 	/// List of outputs
 	pub outputs: HashMap<String, OutputData>,
+	/// Tx log
+	pub tx_log: Vec<TxLogEntry>,
 	/// Details
 	pub details: WalletDetails,
 	/// Data file path
@@ -192,6 +206,14 @@ where
 		Box::new(self.outputs.values().cloned())
 	}
 
+	fn get_tx_log_entry(&self, _u: &Uuid) -> Result<Option<TxLogEntry>, libwallet::Error> {
+		Ok(None)
+	}
+
+	fn tx_log_iter<'a>(&'a self) -> Box<Iterator<Item = TxLogEntry> + 'a> {
+		Box::new(self.tx_log.iter().cloned())
+	}
+
 	fn get(&self, id: &Identifier) -> Result<OutputData, libwallet::Error> {
 		self.outputs
 			.get(&id.to_hex())
@@ -240,7 +262,6 @@ where
 		Ok(details.last_child_index)
 	}
 
-	/// Return current metadata
 	fn details(&mut self, _root_key_id: Identifier) -> Result<WalletDetails, libwallet::Error> {
 		self.batch()?;
 		Ok(self.details.clone())
@@ -265,6 +286,7 @@ where
 			config: config.clone(),
 			passphrase: String::from(passphrase),
 			outputs: HashMap::new(),
+			tx_log: Vec::new(),
 			details: WalletDetails::default(),
 			data_file_path: format!("{}{}{}", config.data_file_dir, MAIN_SEPARATOR, DAT_FILE),
 			backup_file_path: format!("{}{}{}", config.data_file_dir, MAIN_SEPARATOR, BCK_FILE),

--- a/wallet/src/file_wallet.rs
+++ b/wallet/src/file_wallet.rs
@@ -99,6 +99,14 @@ impl<'a> WalletOutputBatch for FileBatch<'a> {
 		Ok(())
 	}
 
+	fn iter(&self) -> Box<Iterator<Item = OutputData>> {
+		unimplemented!()
+	}
+
+	fn tx_log_iter(&self) -> Box<Iterator<Item = TxLogEntry>> {
+		unimplemented!()
+	}
+
 	fn commit(&self) -> Result<(), libwallet::Error> {
 		let mut data_file = File::create(self.data_file_path.clone())
 			.context(libwallet::ErrorKind::CallbackImpl("Could not create"))?;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -55,6 +55,7 @@ pub mod file_wallet;
 pub mod libtx;
 pub mod libwallet;
 pub mod lmdb_wallet;
+mod db_migrate;
 mod types;
 
 pub use client::{create_coinbase, HTTPWalletClient};
@@ -66,3 +67,6 @@ pub use libwallet::types::{
 };
 pub use lmdb_wallet::{wallet_db_exists, LMDBBackend};
 pub use types::{WalletConfig, WalletSeed};
+
+// temporary
+pub use db_migrate::{migrate, needs_migrate};

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -49,13 +49,13 @@ extern crate grin_store as store;
 extern crate grin_util as util;
 
 mod client;
+mod db_migrate;
 pub mod display;
 mod error;
 pub mod file_wallet;
 pub mod libtx;
 pub mod libwallet;
 pub mod lmdb_wallet;
-mod db_migrate;
 mod types;
 
 pub use client::{create_coinbase, HTTPWalletClient};

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -25,6 +25,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate slog;
+extern crate chrono;
 extern crate term;
 extern crate urlencoded;
 extern crate uuid;

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -75,7 +75,6 @@ where
 			validated = self.update_outputs(&mut w);
 		}
 
-
 		let res = Ok((
 			validated,
 			updater::retrieve_outputs(&mut **w, include_spent)?,

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -75,6 +75,7 @@ where
 			validated = self.update_outputs(&mut w);
 		}
 
+
 		let res = Ok((
 			validated,
 			updater::retrieve_outputs(&mut **w, include_spent)?,

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -213,6 +213,7 @@ where
 				height: output.height,
 				lock_height: output.lock_height,
 				is_coinbase: output.is_coinbase,
+				tx_log_entry: None,
 			});
 		} else {
 			warn!(

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -15,6 +15,7 @@
 //! Types and traits that should be provided by a wallet
 //! implementation
 
+use chrono::prelude::*;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -22,6 +23,7 @@ use serde;
 use serde_json;
 
 use failure::ResultExt;
+use uuid::Uuid;
 
 use core::core::hash::Hash;
 use core::ser;
@@ -75,6 +77,12 @@ where
 	/// Get output data by id
 	fn get(&self, id: &Identifier) -> Result<OutputData, Error>;
 
+	/// Get an (Optional) tx log entry by uuid
+	fn get_tx_log_entry(&self, uuid: &Uuid) -> Result<Option<TxLogEntry>, Error>;
+
+	/// Iterate over all output data stored by the backend
+	fn tx_log_iter<'a>(&'a self) -> Box<Iterator<Item = TxLogEntry> + 'a>;
+
 	/// Create a new write batch to update or remove output data
 	fn batch<'a>(&'a mut self) -> Result<Box<WalletOutputBatch + 'a>, Error>;
 
@@ -91,6 +99,8 @@ where
 /// Batch trait to update the output data backend atomically. Trying to use a
 /// batch after commit MAY result in a panic. Due to this being a trait, the
 /// commit method can't take ownership.
+/// TODO: Should these be split into separate batch objects, for outputs,
+/// tx_log entries and meta/details?
 pub trait WalletOutputBatch {
 	/// Add or update data about an output to the backend
 	fn save(&mut self, out: OutputData) -> Result<(), Error>;
@@ -103,6 +113,12 @@ pub trait WalletOutputBatch {
 
 	/// save wallet details
 	fn save_details(&mut self, r: Identifier, w: WalletDetails) -> Result<(), Error>;
+
+	/// get next tx log entry
+	fn next_tx_log_id(&mut self, root_key_id: Identifier) -> Result<u32, Error>;
+
+	/// save a tx log entry
+	fn save_tx_log_entry(&self, t: TxLogEntry) -> Result<(), Error>;
 
 	/// Save an output as locked in the backend
 	fn lock_output(&mut self, out: &mut OutputData) -> Result<(), Error>;
@@ -178,6 +194,8 @@ pub struct OutputData {
 	pub lock_height: u64,
 	/// Is this a coinbase output? Is it subject to coinbase locktime?
 	pub is_coinbase: bool,
+	/// Optional corresponding internal entry in tx entry log
+	pub tx_log_entry: Option<u32>,
 }
 
 impl ser::Writeable for OutputData {
@@ -400,6 +418,94 @@ impl Default for WalletDetails {
 			last_confirmed_height: 0,
 			last_child_index: 0,
 		}
+	}
+}
+
+/// Types of transactions that can be contained within a TXLog entry
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum TxLogEntryType {
+	/// A coinbase transaction becomes confirmed
+	ConfirmedCoinbase,
+	/// Outputs created when a transaction is received
+	TxReceived,
+	/// Inputs locked + change outputs when a transaction is created
+	TxSent,
+}
+
+impl fmt::Display for TxLogEntryType {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			TxLogEntryType::ConfirmedCoinbase => write!(f, "Confirmed Coinbase"),
+			TxLogEntryType::TxReceived => write!(f, "Recieved Tx"),
+			TxLogEntryType::TxSent => write!(f, "Sent Tx"),
+		}
+	}
+}
+
+/// Optional transaction information, recorded when an event happens
+/// to add or remove funds from a wallet. One Transaction log entry
+/// maps to one or many outputs
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TxLogEntry {
+	/// Local id for this transaction (distinct from a slate transaction id)
+	pub id: u32,
+	/// Slate transaction this entry is associated with, if any
+	pub tx_slate_id: Option<Uuid>,
+	/// Transaction type (as above)
+	pub tx_type: TxLogEntryType,
+	/// Time this tx entry was created
+	/// #[serde(with = "tx_date_format")]
+	pub creation_ts: DateTime<Utc>,
+	/// Time this tx was confirmed (by this wallet)
+	/// #[serde(default, with = "opt_tx_date_format")]
+	pub confirmation_ts: Option<DateTime<Utc>>,
+	/// Whether the inputs+outputs involved in this transaction have been
+	/// confirmed (In all cases either all outputs involved in a tx should be
+	/// confirmed, or none should be; otherwise there's a deeper problem)
+	pub confirmed: bool,
+	/// number of inputs involved in TX
+	pub num_inputs: usize,
+	/// number of outputs involved in TX
+	pub num_outputs: usize,
+	/// Amount credited via this transaction
+	pub amount_credited: u64,
+	/// Amount debited via this transaction
+	pub amount_debited: u64,
+}
+
+impl ser::Writeable for TxLogEntry {
+	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_bytes(&serde_json::to_vec(self).map_err(|_| ser::Error::CorruptedData)?)
+	}
+}
+
+impl ser::Readable for TxLogEntry {
+	fn read(reader: &mut ser::Reader) -> Result<TxLogEntry, ser::Error> {
+		let data = reader.read_vec()?;
+		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
+	}
+}
+
+impl TxLogEntry {
+	/// Return a new blank with TS initialised with next entry
+	pub fn new(t: TxLogEntryType, id: u32) -> Self {
+		TxLogEntry {
+			tx_type: t,
+			id: id,
+			tx_slate_id: None,
+			creation_ts: Utc::now(),
+			confirmation_ts: None,
+			confirmed: false,
+			amount_credited: 0,
+			amount_debited: 0,
+			num_inputs: 0,
+			num_outputs: 0,
+		}
+	}
+
+	/// Update confirmation TS with now
+	pub fn update_confirmation_ts(&mut self) {
+		self.confirmation_ts = Some(Utc::now());
 	}
 }
 

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -223,6 +223,9 @@ impl OutputData {
 	/// so we do not actually know how many confirmations this output had (and
 	/// never will).
 	pub fn num_confirmations(&self, current_height: u64) -> u64 {
+		if self.height >= current_height {
+			return 0;
+		}
 		if self.status == OutputStatus::Unconfirmed {
 			0
 		} else if self.height == 0 {

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -108,6 +108,9 @@ pub trait WalletOutputBatch {
 	/// Gets output data by id
 	fn get(&self, id: &Identifier) -> Result<OutputData, Error>;
 
+	/// Iterate over all output data stored by the backend
+	fn iter(&self) -> Box<Iterator<Item = OutputData>>;
+
 	/// Delete data about an output to the backend
 	fn delete(&mut self, id: &Identifier) -> Result<(), Error>;
 
@@ -116,6 +119,9 @@ pub trait WalletOutputBatch {
 
 	/// get next tx log entry
 	fn next_tx_log_id(&mut self, root_key_id: Identifier) -> Result<u32, Error>;
+
+	/// Iterate over all output data stored by the backend
+	fn tx_log_iter(&self) -> Box<Iterator<Item = TxLogEntry>>;
 
 	/// save a tx log entry
 	fn save_tx_log_entry(&self, t: TxLogEntry) -> Result<(), Error>;

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -17,9 +17,10 @@ use std::sync::Arc;
 use std::{fs, path};
 
 use failure::ResultExt;
+use uuid::Uuid;
 
 use keychain::{Identifier, Keychain};
-use store::{self, option_to_not_found, to_key};
+use store::{self, option_to_not_found, to_key, u64_to_key};
 
 use libwallet::types::*;
 use libwallet::{internal, Error, ErrorKind};
@@ -30,6 +31,8 @@ pub const DB_DIR: &'static str = "wallet_data";
 const OUTPUT_PREFIX: u8 = 'o' as u8;
 const DERIV_PREFIX: u8 = 'd' as u8;
 const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;
+const TX_LOG_ENTRY_PREFIX: u8 = 't' as u8;
+const TX_LOG_ID_PREFIX: u8 = 'i' as u8;
 
 impl From<store::Error> for Error {
 	fn from(error: store::Error) -> Error {
@@ -120,6 +123,15 @@ where
 		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap())
 	}
 
+	fn get_tx_log_entry(&self, u: &Uuid) -> Result<Option<TxLogEntry>, Error> {
+		let key = to_key(TX_LOG_ENTRY_PREFIX, &mut u.as_bytes().to_vec());
+		self.db.get_ser(&key).map_err(|e| e.into())
+	}
+
+	fn tx_log_iter<'a>(&'a self) -> Box<Iterator<Item = TxLogEntry> + 'a> {
+		Box::new(self.db.iter(&[TX_LOG_ENTRY_PREFIX]).unwrap())
+	}
+
 	fn batch<'a>(&'a mut self) -> Result<Box<WalletOutputBatch + 'a>, Error> {
 		Ok(Box::new(Batch {
 			_store: self,
@@ -200,6 +212,21 @@ where
 		Ok(())
 	}
 
+	fn next_tx_log_id(&mut self, root_key_id: Identifier) -> Result<u32, Error> {
+		let tx_id_key = to_key(TX_LOG_ID_PREFIX, &mut root_key_id.to_bytes().to_vec());
+		let mut last_tx_log_id = match self.db.borrow().as_ref().unwrap().get_ser(&tx_id_key)? {
+			Some(t) => t,
+			None => 0,
+		};
+		last_tx_log_id = last_tx_log_id + 1;
+		self.db
+			.borrow()
+			.as_ref()
+			.unwrap()
+			.put_ser(&tx_id_key, &last_tx_log_id)?;
+		Ok(last_tx_log_id)
+	}
+
 	fn save_details(&mut self, root_key_id: Identifier, d: WalletDetails) -> Result<(), Error> {
 		let deriv_key = to_key(DERIV_PREFIX, &mut root_key_id.to_bytes().to_vec());
 		let height_key = to_key(
@@ -216,6 +243,12 @@ where
 			.as_ref()
 			.unwrap()
 			.put_ser(&height_key, &d.last_confirmed_height)?;
+		Ok(())
+	}
+
+	fn save_tx_log_entry(&self, t: TxLogEntry) -> Result<(), Error> {
+		let tx_log_key = u64_to_key(TX_LOG_ENTRY_PREFIX, t.id as u64);
+		self.db.borrow().as_ref().unwrap().put_ser(&tx_log_key, &t)?;
 		Ok(())
 	}
 

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -206,6 +206,17 @@ where
 		).map_err(|e| e.into())
 	}
 
+	fn iter(&self) -> Box<Iterator<Item = OutputData>> {
+		Box::new(
+			self.db
+				.borrow()
+				.as_ref()
+				.unwrap()
+				.iter(&[OUTPUT_PREFIX])
+				.unwrap(),
+		)
+	}
+
 	fn delete(&mut self, id: &Identifier) -> Result<(), Error> {
 		let key = to_key(OUTPUT_PREFIX, &mut id.to_bytes().to_vec());
 		self.db.borrow().as_ref().unwrap().delete(&key)?;
@@ -225,6 +236,17 @@ where
 			.unwrap()
 			.put_ser(&tx_id_key, &last_tx_log_id)?;
 		Ok(last_tx_log_id)
+	}
+
+	fn tx_log_iter(&self) -> Box<Iterator<Item = TxLogEntry>> {
+		Box::new(
+			self.db
+				.borrow()
+				.as_ref()
+				.unwrap()
+				.iter(&[TX_LOG_ENTRY_PREFIX])
+				.unwrap(),
+		)
 	}
 
 	fn save_details(&mut self, root_key_id: Identifier, d: WalletDetails) -> Result<(), Error> {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -77,7 +77,7 @@ impl WalletSeed {
 		WalletSeed(seed)
 	}
 
-	fn from_hex(hex: &str) -> Result<WalletSeed, Error> {
+	pub fn from_hex(hex: &str) -> Result<WalletSeed, Error> {
 		let bytes = util::from_hex(hex.to_string())
 			.context(ErrorKind::GenericError("Invalid hex".to_owned()))?;
 		Ok(WalletSeed::from_bytes(&bytes))


### PR DESCRIPTION
WIP transaction log + FileWallet to DB Wallet Migration
* All operations that create outputs are logged by the transaction log (implemented for DB Wallet backend only), with a new 'TxLogEntry' created. Outputs are linked to TxLogEntries in a many-to-one relationship.
* `grin wallet txs` displays the contents of the transaction log
* Also included here is a FileWallet-LMDBBackend Migration Utility.. when the server is started or a wallet command is invoked, file wallets will be migrated to an LMDBWallet (a simple data copy) and the new LMDBWallet will be instantiated. This is non destructive, with plenty of warnings given to the user about what's happening.
* Outputs within a wallet will not update if the node's chain height is less than whatever height the wallet was last updated at (to prevent everything being marked as spent if someone runs `grin wallet info` against an unsynced node)