### PR TITLE
Resolve correct block height for UTXO during `wallet restore`

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -543,7 +543,7 @@ pub struct HeaderRangeHandler {
 }
 
 impl HeaderRangeHandler {
-	fn get_header_by_range(&self, start_height: u64, max: u64) -> Result<Vec<BlockHeaderPrintable>, Error> {
+	fn get_header_by_range(&self, start_height: u64, max: u64) -> Result<HeaderListing, Error> {
 		let head = w(&self.chain).head().unwrap();
 
 		if start_height > head.height {
@@ -555,7 +555,7 @@ impl HeaderRangeHandler {
 			end_height = head.height;
 		}
 
-		(start_height..end_height)
+		let headers = (start_height..end_height)
 			.map(|h| w(&self.chain).get_header_by_height(h))
 			.map(|res| {
 				res.map(|h| BlockHeaderPrintable::from_header(&h))
@@ -568,7 +568,13 @@ impl HeaderRangeHandler {
 				else {
 					Error::from(ErrorKind::Internal(err.to_string()))
 				}
-			)
+			)?;
+
+		Ok(HeaderListing {
+			tip_height: head.height,
+			last_retrieved_height: headers.last().unwrap().height,
+			headers,
+		})
 	}
 }
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -135,6 +135,7 @@ impl OutputHandler {
 						w(&self.chain),
 						Some(&header),
 						include_proof,
+						None,
 					)
 				})
 				.collect();
@@ -281,7 +282,7 @@ impl TxHashSetHandler {
 			outputs: outputs
 				.2
 				.iter()
-				.map(|x| OutputPrintable::from_output(x, w(&self.chain), None, true))
+				.map(|x| OutputPrintable::from_output(&x.1, w(&self.chain), None, true, Some(x.0)))
 				.collect(),
 		}
 	}
@@ -302,6 +303,7 @@ impl TxHashSetHandler {
 			proof: None,
 			proof_hash: "".to_string(),
 			merkle_proof: Some(merkle_proof),
+			mmr_index: None,
 		})
 	}
 }

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -489,6 +489,12 @@ pub struct BlockHeaderPrintable {
 	pub total_difficulty: u64,
 	/// Total kernel offset since genesis block
 	pub total_kernel_offset: String,
+	/// Total accumulated sum of kernel commitments since genesis block.
+	pub total_kernel_sum: PrintableCommitment,
+	/// Total size of the output MMR after applying this block
+	pub output_mmr_size: u64,
+	/// Total size of the kernel MMR after applying this block
+	pub kernel_mmr_size: u64,
 }
 
 impl BlockHeaderPrintable {
@@ -507,6 +513,9 @@ impl BlockHeaderPrintable {
 			cuckoo_solution: h.pow.nonces.clone(),
 			total_difficulty: h.total_difficulty.to_num(),
 			total_kernel_offset: h.total_kernel_offset.to_hex(),
+			total_kernel_sum: PrintableCommitment { commit: h.total_kernel_sum },
+			output_mmr_size: h.output_mmr_size,
+			kernel_mmr_size: h.kernel_mmr_size,
 		}
 	}
 }

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -347,7 +347,7 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 			Proof,
 			ProofHash,
 			MerkleProof,
-			PmmrIndex,
+			MmrIndex,
 		}
 
 		struct OutputPrintableVisitor;
@@ -407,7 +407,7 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 								}
 							}
 						}
-						Field::PmmrIndex => {
+						Field::MmrIndex => {
 							no_dup!(mmr_index);
 							mmr_index = map.next_value()?
 						}
@@ -641,6 +641,17 @@ pub struct OutputListing {
 	pub last_retrieved_index: u64,
 	/// A printable version of the outputs
 	pub outputs: Vec<OutputPrintable>,
+}
+
+// For traversing all block headers
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HeaderListing {
+	/// The last available output index
+	pub tip_height: u64,
+	/// The last insertion index retrieved
+	pub last_retrieved_height: u64,
+	/// A printable version of the outputs
+	pub headers: Vec<BlockHeaderPrintable>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -701,7 +701,7 @@ impl Chain {
 		&self,
 		start_index: u64,
 		max: u64,
-	) -> Result<(u64, u64, Vec<Output>), Error> {
+	) -> Result<(u64, u64, Vec<(u64, Output)>), Error> {
 		let mut txhashset = self.txhashset.write().unwrap();
 		let max_index = txhashset.highest_output_insertion_index();
 		let outputs = txhashset.outputs_by_insertion_index(start_index, max);
@@ -711,13 +711,13 @@ impl Chain {
 				"Output and rangeproof sets don't match",
 			)).into());
 		}
-		let mut output_vec: Vec<Output> = vec![];
+		let mut output_vec: Vec<(u64,Output)> = vec![];
 		for (ref x, &y) in outputs.1.iter().zip(rangeproofs.1.iter()) {
-			output_vec.push(Output {
-				commit: x.commit,
-				features: x.features,
-				proof: y,
-			});
+			output_vec.push((x.0, Output {
+				commit: x.1.commit,
+				features: x.1.features,
+				proof: y.1,
+			}));
 		}
 		Ok((outputs.0, max_index, output_vec))
 	}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -181,7 +181,7 @@ impl TxHashSet {
 		&mut self,
 		start_index: u64,
 		max_count: u64,
-	) -> (u64, Vec<OutputIdentifier>) {
+	) -> (u64, Vec<(u64, OutputIdentifier)>) {
 		let output_pmmr: PMMR<OutputIdentifier, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		output_pmmr.elements_from_insertion_index(start_index, max_count)
@@ -197,7 +197,7 @@ impl TxHashSet {
 		&mut self,
 		start_index: u64,
 		max_count: u64,
-	) -> (u64, Vec<RangeProof>) {
+	) -> (u64, Vec<(u64, RangeProof)>) {
 		let rproof_pmmr: PMMR<RangeProof, _> =
 			PMMR::at(&mut self.rproof_pmmr_h.backend, self.rproof_pmmr_h.last_pos);
 		rproof_pmmr.elements_from_insertion_index(start_index, max_count)

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -409,7 +409,7 @@ where
 	/// Helper function which returns un-pruned nodes from the insertion index
 	/// forward
 	/// returns last insertion index returned along with data
-	pub fn elements_from_insertion_index(&self, mut index: u64, max_count: u64) -> (u64, Vec<T>) {
+	pub fn elements_from_insertion_index(&self, mut index: u64, max_count: u64) -> (u64, Vec<(u64, T)>) {
 		let mut return_vec = vec![];
 		if index == 0 {
 			index = 1;
@@ -418,7 +418,7 @@ where
 		let mut pmmr_index = insertion_to_pmmr_index(index);
 		while return_vec.len() < max_count as usize && pmmr_index <= self.last_pos {
 			if let Some(t) = self.get_data(pmmr_index) {
-				return_vec.push(t);
+				return_vec.push((pmmr_index, t));
 				return_index = index;
 			}
 			index += 1;

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -512,22 +512,22 @@ fn check_elements_from_insertion_index() {
 	let res = pmmr.elements_from_insertion_index(1, 100);
 	assert_eq!(res.0, 100);
 	assert_eq!(res.1.len(), 100);
-	assert_eq!(res.1[0].0[3], 1);
-	assert_eq!(res.1[99].0[3], 100);
+	assert_eq!((res.1[0].1).0[3], 1);
+	assert_eq!((res.1[99].1).0[3], 100);
 
 	// middle of pack
 	let res = pmmr.elements_from_insertion_index(351, 70);
 	assert_eq!(res.0, 420);
 	assert_eq!(res.1.len(), 70);
-	assert_eq!(res.1[0].0[3], 351);
-	assert_eq!(res.1[69].0[3], 420);
+	assert_eq!((res.1[0].1).0[3], 351);
+	assert_eq!((res.1[69].1).0[3], 420);
 
 	// past the end
 	let res = pmmr.elements_from_insertion_index(650, 1000);
 	assert_eq!(res.0, 999);
 	assert_eq!(res.1.len(), 350);
-	assert_eq!(res.1[0].0[3], 650);
-	assert_eq!(res.1[349].0[3], 999);
+	assert_eq!((res.1[0].1).0[3], 650);
+	assert_eq!((res.1[349].1).0[3], 999);
 
 	// pruning a few nodes should get consistent results
 	pmmr.prune(pmmr::insertion_to_pmmr_index(650)).unwrap();
@@ -538,6 +538,6 @@ fn check_elements_from_insertion_index() {
 	let res = pmmr.elements_from_insertion_index(650, 1000);
 	assert_eq!(res.0, 999);
 	assert_eq!(res.1.len(), 345);
-	assert_eq!(res.1[0].0[3], 652);
-	assert_eq!(res.1[344].0[3], 999);
+	assert_eq!((res.1[0].1).0[3], 652);
+	assert_eq!((res.1[344].1).0[3], 999);
 }

--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -196,7 +196,7 @@ impl WalletClient for HTTPWalletClient {
 		libwallet::Error,
 	> {
 		let addr = self.node_url();
-		let query_param = format!("start_index={}&max={}", start_height, max_headers);
+		let query_param = format!("start_height={}&max={}", start_height, max_headers);
 
 		let url = format!("{}/v1/headers?{}", addr, query_param,);
 		let mut api_outputs: Vec<(u64, u64)> = Vec::new();
@@ -224,22 +224,22 @@ impl WalletClient for HTTPWalletClient {
 
 	fn get_outputs_by_pmmr_index(
 		&self,
-		start_height: u64,
+		start_index: u64,
 		max_outputs: u64,
 	) -> Result<
 		(
 			u64,
 			u64,
-			Vec<(pedersen::Commitment, pedersen::RangeProof, bool)>,
+			Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64)>,
 		),
 		libwallet::Error,
 	> {
 		let addr = self.node_url();
-		let query_param = format!("start_index={}&max={}", start_height, max_outputs);
+		let query_param = format!("start_index={}&max={}", start_index, max_outputs);
 
 		let url = format!("{}/v1/txhashset/outputs?{}", addr, query_param,);
 
-		let mut api_outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool)> = Vec::new();
+		let mut api_outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64)> = Vec::new();
 
 		match api::client::get::<api::OutputListing>(url.as_str()) {
 			Ok(o) => {
@@ -248,7 +248,7 @@ impl WalletClient for HTTPWalletClient {
 						api::OutputType::Coinbase => true,
 						api::OutputType::Transaction => false,
 					};
-					api_outputs.push((out.commit, out.range_proof().unwrap(), is_coinbase));
+					api_outputs.push((out.commit, out.range_proof().unwrap(), is_coinbase, out.mmr_index.unwrap()));
 				}
 
 				Ok((o.highest_index, o.last_retrieved_index, api_outputs))

--- a/wallet/src/client.rs
+++ b/wallet/src/client.rs
@@ -191,7 +191,7 @@ impl WalletClient for HTTPWalletClient {
 		(
 			u64,
 			u64,
-			Vec<(u64, u64)>,
+			Vec<(u64, u64, String)>, // height, mmr_size, timestamp
 		),
 		libwallet::Error,
 	> {
@@ -199,12 +199,12 @@ impl WalletClient for HTTPWalletClient {
 		let query_param = format!("start_height={}&max={}", start_height, max_headers);
 
 		let url = format!("{}/v1/headers?{}", addr, query_param,);
-		let mut api_outputs: Vec<(u64, u64)> = Vec::new();
+		let mut api_outputs: Vec<(u64, u64, String)> = Vec::new();
 
 		match api::client::get::<api::HeaderListing>(url.as_str()) {
 			Ok(o) => {
 				for h in o.headers {
-					api_outputs.push((h.height, h.output_mmr_size));
+					api_outputs.push((h.height, h.output_mmr_size, h.timestamp));
 				}
 
 				Ok((o.tip_height, o.last_retrieved_height, api_outputs))

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //! Functions to restore a wallet's outputs from just the master seed
 
+#![allow(unreachable_code)]
+
 use core::global;
 use keychain::{Identifier, Keychain};
 use libtx::proof;
@@ -20,6 +22,8 @@ use libwallet::types::*;
 use libwallet::Error;
 use util::secp::{key::SecretKey, pedersen};
 use util::LOGGER;
+use std::time::{Duration, Instant};
+use libwallet::internal::updater;
 
 /// Utility struct for return values from below
 struct OutputResult {
@@ -39,11 +43,13 @@ struct OutputResult {
 	pub is_coinbase: bool,
 	///
 	pub blinding: SecretKey,
+	///
+	pub mmr_index: u64,
 }
 
 fn identify_utxo_outputs<T, C, K>(
 	wallet: &mut T,
-	outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool)>,
+	outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64)>,
 ) -> Result<Vec<OutputResult>, Error>
 where
 	T: WalletBackend<C, K>,
@@ -54,16 +60,15 @@ where
 
 	info!(
 		LOGGER,
-		"Scanning {} outputs in the current Grin utxo set",
+		"Scanning {} outputs in the current Grin UTXO set",
 		outputs.len(),
 	);
-	let current_chain_height = wallet.client().get_chain_height()?;
 
-	for output in outputs.iter() {
-		let (commit, proof, is_coinbase) = output;
+	for output in outputs.into_iter() {
+		let (commit, proof, is_coinbase, mmr_index) = output;
 		// attempt to unwind message from the RP and get a value
 		// will fail if it's not ours
-		let info = proof::rewind(wallet.keychain(), *commit, None, *proof)?;
+		let info = proof::rewind(wallet.keychain(), commit, None, proof)?;
 
 		if !info.success {
 			continue;
@@ -71,25 +76,19 @@ where
 
 		info!(
 			LOGGER,
-			"Output found: {:?}, amount: {:?}", commit, info.value
+			"Output found: {:?}, amount: {:?}, coinbase: {:?}, mmr_index: {}", commit, info.value, is_coinbase, mmr_index
 		);
 
-		let height = current_chain_height;
-		let lock_height = if *is_coinbase {
-			height + global::coinbase_maturity()
-		} else {
-			height
-		};
-
 		wallet_outputs.push(OutputResult {
-			commit: *commit,
+			commit: commit,
 			key_id: None,
 			n_child: None,
 			value: info.value,
-			height: height,
-			lock_height: lock_height,
-			is_coinbase: *is_coinbase,
+			height: 0,
+			lock_height: 0,
+			is_coinbase: is_coinbase,
 			blinding: info.blinding,
+			mmr_index: mmr_index,
 		});
 	}
 	Ok(wallet_outputs)
@@ -154,6 +153,7 @@ where
 	C: WalletClient,
 	K: Keychain,
 {
+
 	let max_derivations = 1_000_000;
 
 	// Don't proceed if wallet.dat has anything in it
@@ -175,15 +175,17 @@ where
 		let (highest_index, last_retrieved_index, outputs) = wallet
 			.client()
 			.get_outputs_by_pmmr_index(start_index, batch_size)?;
+
 		info!(
 			LOGGER,
 			"Retrieved {} outputs, up to index {}. (Highest index: {})",
 			outputs.len(),
-			highest_index,
 			last_retrieved_index,
+			highest_index,
 		);
 
-		result_vec.append(&mut identify_utxo_outputs(wallet, outputs.clone())?);
+		let mut my_utxo_outputs = identify_utxo_outputs(wallet, outputs)?;
+		result_vec.append(&mut my_utxo_outputs);
 
 		if highest_index == last_retrieved_index {
 			break;
@@ -193,36 +195,121 @@ where
 
 	info!(
 		LOGGER,
-		"Identified {} wallet_outputs as belonging to this wallet",
+		"Identified {} wallet_outputs as belonging to this wallet. Resolving block heights.",
 		result_vec.len(),
 	);
+
+	{
+		let batch_size = 1000;
+		let mut start_height = 1;
+		let mut cur_block_mmr = (0, 0); // (height, mmr_size)
+		let mut result_iter = result_vec.iter_mut().peekable();
+
+		'outer: loop {
+			info!(
+				LOGGER,
+				"Fetching headers... start_height({})",
+				start_height,
+			);
+
+			let (tip_height, last_retrieved_height, headers) = wallet
+				.client()
+				.get_block_output_mmr_size(start_height, batch_size)?;
+			info!(
+				LOGGER,
+				"Retrieved {} headers for mmr_size, up to height {}. (Tip height: {})",
+				headers.len(),
+				last_retrieved_height,
+				tip_height,
+			);
+			start_height = last_retrieved_height + 1;
+
+			let mut header_iter = headers.iter();
+			'inner: loop {
+				if let Some(output) = result_iter.peek() {
+					// mmr_index starts with 1
+					while output.mmr_index > cur_block_mmr.1 {
+						if let Some(h) = header_iter.next() {
+							cur_block_mmr = *h;
+							debug!(
+								LOGGER,
+								"HEADER height({}) mmr_size({}) mmr_index({})", cur_block_mmr.0, cur_block_mmr.1, output.mmr_index
+							);
+						} else {
+							// no more header
+							debug!(
+								LOGGER,
+								"no more header continue to 'outer loop..."
+							);
+							continue 'outer;
+						}
+					}
+				} else {
+					// no more result
+					debug!(
+						LOGGER,
+						"breaking 'outer"	,
+					);
+					break 'outer;
+				}
+
+				let out = result_iter.next().unwrap();
+				out.height = cur_block_mmr.0;
+
+				out.lock_height = if out.is_coinbase {
+					out.height + global::coinbase_maturity()
+				} else {
+					out.height
+				};
+
+				info!(
+					LOGGER,
+					"Found height({}), {:?}, mmr({}|{}), cb({})",
+					out.height,
+					out.commit,
+					out.mmr_index,
+					cur_block_mmr.1,
+					out.is_coinbase,
+				);
+			}
+			panic!("should not reach here!");
+		}
+	}
 
 	populate_child_indices(wallet, &mut result_vec, max_derivations)?;
 
 	// Now save what we have
-	let root_key_id = wallet.keychain().root_key_id();
-	let mut batch = wallet.batch()?;
-	for output in result_vec {
-		if output.key_id.is_some() && output.n_child.is_some() {
-			let _ = batch.save(OutputData {
-				root_key_id: root_key_id.clone(),
-				key_id: output.key_id.unwrap(),
-				n_child: output.n_child.unwrap(),
-				value: output.value,
-				status: OutputStatus::Unconfirmed,
-				height: output.height,
-				lock_height: output.lock_height,
-				is_coinbase: output.is_coinbase,
-				tx_log_entry: None,
-			});
-		} else {
-			warn!(
-				LOGGER,
-				"Commit {:?} identified but unable to recover key. Output has not been restored.",
-				output.commit
-			);
+	{
+		// Now save what we have
+		let root_key_id = wallet.keychain().root_key_id();
+		let mut batch = wallet.batch()?;
+		for output in result_vec {
+			if output.key_id.is_some() && output.n_child.is_some() {
+				let _ = batch.save(OutputData {
+					root_key_id: root_key_id.clone(),
+					key_id: output.key_id.unwrap(),
+					n_child: output.n_child.unwrap(),
+					value: output.value,
+					status: OutputStatus::Unconfirmed,
+					height: output.height,
+					lock_height: output.lock_height,
+					is_coinbase: output.is_coinbase,
+					tx_log_entry: None,
+				});
+			} else {
+				warn!(
+					LOGGER,
+					"Commit {:?} identified but unable to recover key. Output has not been restored.",
+					output.commit
+				);
+			}
 		}
+		batch.commit()?;
 	}
-	batch.commit()?;
+	info!(
+		LOGGER,
+		"Refreshing outputs"
+	);
+	updater::refresh_outputs(wallet)?;
 	Ok(())
 }

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -172,7 +172,7 @@ pub trait WalletClient: Sync + Send + Clone {
 		(
 			u64,
 			u64,
-			Vec<(pedersen::Commitment, pedersen::RangeProof, bool)>,
+			Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64)>,
 		),
 		Error,
 	>;

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -180,7 +180,7 @@ pub trait WalletClient: Sync + Send + Clone {
 	/// Get a list of output mmr size for headers
 	/// Returns
 	/// (tip height, last height retrieved,
-	/// (height, output_mmr_size)
+	/// (height, output_mmr_size, timestamp)
 	fn get_block_output_mmr_size(
 		&self,
 		start_height: u64,
@@ -189,7 +189,7 @@ pub trait WalletClient: Sync + Send + Clone {
 		(
 			u64,
 			u64,
-			Vec<(u64, u64)>,
+			Vec<(u64, u64, String)>,
 		),
 		Error,
 	>;

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -176,6 +176,23 @@ pub trait WalletClient: Sync + Send + Clone {
 		),
 		Error,
 	>;
+
+	/// Get a list of output mmr size for headers
+	/// Returns
+	/// (tip height, last height retrieved,
+	/// (height, output_mmr_size)
+	fn get_block_output_mmr_size(
+		&self,
+		start_height: u64,
+		max_headers: u64,
+	) -> Result<
+		(
+			u64,
+			u64,
+			Vec<(u64, u64)>,
+		),
+		Error,
+	>;
 }
 
 /// Information about an output that's being tracked by the wallet. Must be

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -430,7 +430,7 @@ impl WalletClient for LocalWalletClient {
     (
       u64,
       u64,
-      Vec<(u64, u64)>,
+      Vec<(u64, u64, String)>,
     ),
     libwallet::Error,
   > {

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -415,10 +415,25 @@ impl WalletClient for LocalWalletClient {
 		(
 			u64,
 			u64,
-			Vec<(pedersen::Commitment, pedersen::RangeProof, bool)>,
+			Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64)>,
 		),
 		libwallet::Error,
 	> {
+		unimplemented!();
+	}
+
+  fn get_block_output_mmr_size(
+    &self,
+    start_height: u64,
+    max_headers: u64,
+  ) -> Result<
+    (
+      u64,
+      u64,
+      Vec<(u64, u64)>,
+    ),
+    libwallet::Error,
+  > {
 		unimplemented!();
 	}
 }


### PR DESCRIPTION
Fix to make `grin wallet restore` correctly restore the block heights for the identified UTXOs.


related to #1239 and comments there
closing #1261 as this PR containing the same commit.

#### TODO
- [x] batch block header fetching & expose output mmr_size in the REST API
- [x] REST client code in wallet side
- [x] expose mmr_index in txhashet/outputs REST call for UTXO outputs
- [x] resolve block height for each UTXO using mmr_size in the header and mmr_index of the UTXO
- [x] warning message still shows `wallet.dat` instead of `wallet_data` directory.
- [x] Issue with the transaction log ID not in increasing order when restored.
- [x] Restoring creation & confirmation time using the timestamps of block headers. 


~I will rebase when #1268 comes in.~ rebased with #1268 