### PR TITLE
Add config option to prevent 'slog-async: logger dropped messages...' for debugging

### DIFF
--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -77,8 +77,14 @@ lazy_static! {
 			let file_decorator = slog_term::PlainDecorator::new(file);
 			let file_drain = slog_term::FullFormat::new(file_decorator).build().fuse();
 			let file_drain = LevelFilter::new(file_drain, slog_level_file).fuse();
-			let file_drain_final = slog_async::Async::new(file_drain).build().fuse();
-
+			let file_drain_final = slog_async::Async::new(file_drain)
+				.overflow_strategy(
+						if slog_level_file == Level::Trace {
+							slog_async::OverflowStrategy::Block
+						} else {
+							slog_async::OverflowStrategy::DropAndReport // Default
+						}
+				).build().fuse();
 			let composite_drain = Duplicate::new(terminal_drain, file_drain_final).fuse();
 
 			Logger::root(composite_drain, o!())


### PR DESCRIPTION
Fix #458
https://docs.rs/slog-async/2.3.0/slog_async/enum.OverflowStrategy.html
Add an **optional** config in `grin.toml` (`log_no_drop`) to prevent slog dropping log messages but instead blocking on log producer to prevent log messages when debugging.
