### PR TITLE
Wallet Transaction Info and Transaction Cancellation

### DIFF
--- a/wallet/src/libwallet/controller.rs
+++ b/wallet/src/libwallet/controller.rs
@@ -163,7 +163,7 @@ where
 				update_from_node = true;
 			}
 		}
-		api.retrieve_outputs(false, update_from_node)
+		api.retrieve_outputs(false, update_from_node, None)
 	}
 
 	fn retrieve_summary_info(

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -132,6 +132,18 @@ pub enum ErrorKind {
 	#[fail(display = "Wallet seed doesn't exist error")]
 	WalletSeedDoesntExist,
 
+	/// Transaction doesn't exist
+	#[fail(display = "Transaction {} doesn't exist", _0)]
+	TransactionDoesntExist(u32),
+
+	/// Transaction already rolled back
+	#[fail(display = "Transaction {} cannot be cancelled", _0)]
+	TransactionNotCancellable(u32),
+
+	/// Cancellation error
+	#[fail(display = "Cancellation Error: {}", _0)]
+	TransactionCancellationError(&'static str),
+
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -99,6 +99,7 @@ where
 		let log_id = batch.next_tx_log_id(root_key_id.clone())?;
 		let mut t = TxLogEntry::new(TxLogEntryType::TxSent, log_id);
 		t.tx_slate_id = Some(slate_id);
+		t.fee = Some(fee);
 		let mut amount_debited = 0;
 		t.num_inputs = lock_inputs.len();
 		for id in lock_inputs {

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -431,7 +431,7 @@ impl Default for WalletDetails {
 }
 
 /// Types of transactions that can be contained within a TXLog entry
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum TxLogEntryType {
 	/// A coinbase transaction becomes confirmed
 	ConfirmedCoinbase,
@@ -439,6 +439,10 @@ pub enum TxLogEntryType {
 	TxReceived,
 	/// Inputs locked + change outputs when a transaction is created
 	TxSent,
+	/// Received transaction that was rolled back by user
+	TxReceivedCancelled,
+	/// Sent transaction that was rolled back by user
+	TxSentCancelled,
 }
 
 impl fmt::Display for TxLogEntryType {
@@ -447,6 +451,8 @@ impl fmt::Display for TxLogEntryType {
 			TxLogEntryType::ConfirmedCoinbase => write!(f, "Confirmed Coinbase"),
 			TxLogEntryType::TxReceived => write!(f, "Recieved Tx"),
 			TxLogEntryType::TxSent => write!(f, "Sent Tx"),
+			TxLogEntryType::TxReceivedCancelled => write!(f, "Received Tx - Cancelled"),
+			TxLogEntryType::TxSentCancelled => write!(f, "Send Tx - Cancelled"),
 		}
 	}
 }
@@ -480,6 +486,8 @@ pub struct TxLogEntry {
 	pub amount_credited: u64,
 	/// Amount debited via this transaction
 	pub amount_debited: u64,
+	/// Fee
+	pub fee: Option<u64>,
 }
 
 impl ser::Writeable for TxLogEntry {
@@ -509,6 +517,7 @@ impl TxLogEntry {
 			amount_debited: 0,
 			num_inputs: 0,
 			num_outputs: 0,
+			fee: None,
 		}
 	}
 

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -238,7 +238,11 @@ where
 		//let mut api_outputs: HashMap<pedersen::Commitment, String> = HashMap::new();
 		let mut outputs: Vec<api::Output> = vec![];
 		for o in split {
-			let c = util::from_hex(String::from(o)).unwrap();
+			let o_str = String::from(o);
+			if o_str.len() == 0 {
+				continue;
+			}
+			let c = util::from_hex(o_str).unwrap();
 			let commit = Commitment::from_vec(c);
 			let out = common::get_output_local(&self.chain.clone(), &commit);
 			if let Some(o) = out {


### PR DESCRIPTION
This adds:

* `grin wallet txn -i [tx_id]` which displays a single transaction along with all outputs in the wallet associated with the transaction.
* `grin wallet cancel -i [tx_id]` which 'cancels' a transaction that was created but has not hit the chain for whatever reason. This changes all previously 'Locked' outputs associated with the transaction to 'Unconfirmed' and deletes all previously 'Unconfirmed' outputs associated with the transaction
* Tests for above

Note that we'll have to elegantly handle cases where someone cancels a transaction from their wallet, but then someone posts it anyhow. We probably can't just delete associated unconfirmed outputs for this reason (will most likely have to keep them and give them a separate status).