### PR TITLE
fix bug on block sync (#1271)

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -52,7 +52,7 @@ pub enum ErrorKind {
 	#[fail(display = "Invalid PoW")]
 	InvalidPow,
 	/// Peer abusively sending us an old block we already have
-	#[fail(display = "Invalid PoW")]
+	#[fail(display = "Old Block")]
 	OldBlock,
 	/// The block doesn't sum correctly or a tx signature is invalid
 	#[fail(display = "Invalid Block Proof")]


### PR DESCRIPTION
To fix block sync issue on https://github.com/mimblewimble/grin/issues/1271 

2 bugs found and fixed:

1. function `check_header_known()` is using `ctx.block_hashes_cache`, but function `check_known()` is using `ctx.block_hashes_cache`,  which should be reversed.
2. `pipe` function `process_block()` will call `check_known()` and ignore the blocks if already received before (i.e. `known`), which is the source of those logs "`unfit at this time: already known`". But for block sync, it's quite normal that blocks received not in ideal sequence, then a lot of blocks will go into cache (orphans, by chain `&self.orphans.add(orphan);` ).  When node receive a block and sequence is ok, block is valid, saved and appended to chain, it will trigger calling chain `check_orphans()` function, which will release some blocks from cache (so-called `orphans`), by calling chain `process_block_no_orphans()`, and eventually call to `pipe` function `process_block()` again. At this time, `check_known()` function will ignore the blocks which is already known in `ctx.block_hashes_cache`,  then, problem happen! sometimes a cache(so-called `orphan`) block is in still in `ctx.block_hashes_cache` but sometimes not, because there's HASHES_CACHE_SIZE (now it's 50) limitation. So only the lucky cached block can be accepted if it's not in `ctx.block_hashes_cache`.

The fix solution is to add a `from_cache` parameter for pipe `process_block()` function.

Please take a code review on this fix before merging it, since it's the core logic on block syncing.
