### PR TITLE
Fix logging configuration

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -333,16 +333,6 @@ fn main() {
 		panic!("Error parsing config file: {}", e);
 	});
 
-	if let Some(file_path) = &global_config.config_file_path {
-		info!(
-			LOGGER,
-			"Found configuration file at {}",
-			file_path.to_str().unwrap()
-		);
-	} else {
-		info!(LOGGER, "configuration file not found, using default");
-	}
-
 	// initialize the logger
 	let mut log_conf = global_config
 		.members
@@ -368,6 +358,16 @@ fn main() {
 	);
 
 	log_build_info();
+
+	if let Some(file_path) = &global_config.config_file_path {
+		info!(
+			LOGGER,
+			"Found configuration file at {}",
+			file_path.to_str().unwrap()
+		);
+	} else {
+		info!(LOGGER, "configuration file not found, using default");
+	}
 
 	match args.subcommand() {
 		// server commands and options

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -15,9 +15,9 @@
 //! Basic TUI to better output the overall system status and status
 //! of various subsystems
 
+use chrono::prelude::Utc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
-use chrono::prelude::{Utc};
 
 use cursive::direction::Orientation;
 use cursive::theme::BaseColor::{Black, Blue, Cyan, White};


### PR DESCRIPTION
One of the last commits introduced a regression, logging function was called before log subsystem was initialized, as result all logging configuration was not applied.