### PR TITLE
Fixes #1299 -  Fails to send transaction when not enough funds for fee

### DIFF
--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -266,8 +266,8 @@ where
 		})?;
 	}
 
-	// Check if we need to use a change address
-	if total > amount_with_fee {
+	// We need to add a change address or amount with fee is more than total
+	if total != amount_with_fee {
 		fee = tx_fee(coins.len(), 2, None);
 		amount_with_fee = amount + fee;
 

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -258,6 +258,14 @@ where
 		})?;
 	}
 
+	// The amount with fee is more than the total values of our max outputs
+	if total < amount_with_fee && coins.len() == max_outputs {
+		return Err(ErrorKind::NotEnoughFunds {
+			available: total,
+			needed: amount_with_fee as u64,
+		})?;
+	}
+
 	// Check if we need to use a change address
 	if total > amount_with_fee {
 		fee = tx_fee(coins.len(), 2, None);


### PR DESCRIPTION
Add a verification if we don't have enough with fee when sending a transaction.