### PR TITLE
Fix get outputs call in wallet

### DIFF
--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -141,7 +141,6 @@ impl Router {
 		for key in keys {
 			node_id = self.find(node_id, key).ok_or(RouterError::RouteNotFound)?;
 			if self.node(node_id).key == *WILDCARD_STOP_HASH {
-				debug!(LOGGER, "ROUTER stop card");
 				break;
 			}
 		}

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -5,7 +5,6 @@ use hyper::{Body, Method, Request, Response, StatusCode};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use util::LOGGER;
 
 lazy_static! {
 	static ref WILDCARD_HASH: u64 = calculate_hash(&"*");

--- a/wallet/src/libwallet/controller.rs
+++ b/wallet/src/libwallet/controller.rs
@@ -32,7 +32,7 @@ use keychain::Keychain;
 use libtx::slate::Slate;
 use libwallet::api::{APIForeign, APIOwner};
 use libwallet::types::{
-	BlockFees, CbData, OutputData, SendTXArgs, TxLogEntry, WalletBackend, WalletClient, WalletInfo,
+	CbData, OutputData, SendTXArgs, TxLogEntry, WalletBackend, WalletClient, WalletInfo,
 };
 use libwallet::{Error, ErrorKind};
 use url::form_urlencoded;


### PR DESCRIPTION
It generates an invalid url if there are 1000+ outputs.
* Also switched to async http client for performance reasons (see below)
* Couple unrelated cleanups

I time-d the existing sequential version of the client code vs async (both in debug profile), the later is more scalable, but it brings some complexity to the code. Currently most of the wallets produces 1-5 chunks (chunk requires a separate request) and difference is around 0.1 sec.

Sync version (200 chunks):
```
real    0m4.001s
user    0m2.248s
sys     0m0.249s
```

Async version (200 chunks):
```
real    0m3.636s
user    0m1.572s
sys     0m0.132s
```

Sync (1000 chunks):
```
real     0m5.620s
user     0m6.610s
sys      0m0.899s
```

Async (1000 chunks):
```
real    0m4.104s
user    0m3.470s
sys     0m0.503s
```
