### PR TITLE
fix: in case txhashset validation fail, 'TxHashsetDownload' should retry (#1293)

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -66,6 +66,7 @@ pub enum Error {
 		peer: Hash,
 	},
 	Send(String),
+	PeerException,
 }
 
 impl From<ser::Error> for Error {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -24,7 +24,7 @@ use std::thread;
 use std::time::Instant;
 
 use chain::{self, ChainAdapter, Options, Tip};
-use common::types::{ChainValidationMode, ServerConfig, SyncState, SyncStatus};
+use common::types::{self, ChainValidationMode, ServerConfig, SyncState, SyncStatus};
 use core::{core, global};
 use core::core::block::BlockHeader;
 use core::core::hash::{Hash, Hashed};
@@ -361,7 +361,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			w(&self.chain).txhashset_write(h, txhashset_data, self.sync_state.as_ref())
 		{
 			error!(LOGGER, "Failed to save txhashset archive: {}", e);
-			!e.is_bad_data()
+			let is_good_data = !e.is_bad_data();
+			self.sync_state.set_sync_error(types::Error::Chain(e));
+			is_good_data
 		} else {
 			info!(LOGGER, "Received valid txhashset data for {}.", h);
 			true

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -337,8 +337,7 @@ impl SyncState {
 
 	/// Communicate sync error
 	pub fn set_sync_error(&self, error: Error){
-		let clone = Arc::clone(&self.sync_error);
-		*clone.write().unwrap() = Some(error);
+		*self.sync_error.write().unwrap() = Some(error);
 	}
 
 	/// Get sync error
@@ -348,8 +347,7 @@ impl SyncState {
 
 	/// Clear sync error
 	pub fn clear_sync_error(&self){
-		let clone = Arc::clone(&self.sync_error);
-		*clone.write().unwrap() = None;
+		*self.sync_error.write().unwrap() = None;
 	}
 
 }

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -296,6 +296,7 @@ pub enum SyncStatus {
 /// Current sync state. Encapsulates the current SyncStatus.
 pub struct SyncState {
 	current: RwLock<SyncStatus>,
+	sync_error: RwLock<Result<String, String>>,
 }
 
 impl SyncState {
@@ -303,6 +304,7 @@ impl SyncState {
 	pub fn new() -> SyncState {
 		SyncState {
 			current: RwLock::new(SyncStatus::Initial),
+			sync_error: RwLock::new(Ok("None".to_owned())),
 		}
 	}
 
@@ -332,6 +334,24 @@ impl SyncState {
 
 		*status = new_status;
 	}
+
+	/// Communicate sync error
+	pub fn set_sync_error(&self, error: Error){
+		let mut sync_error = self.sync_error.write().unwrap();
+		*sync_error = Err(format!("{:?}", error));
+	}
+
+	/// Get sync error
+	pub fn sync_error(&self) -> Result<String, String> {
+		self.sync_error.read().unwrap().clone()
+	}
+
+	/// Clear sync error
+	pub fn clear_sync_error(&self){
+		let mut sync_error = self.sync_error.write().unwrap();
+		*sync_error = Ok("None".to_owned());
+	}
+
 }
 
 impl chain::TxHashsetWriteStatus for SyncState {

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -132,16 +132,39 @@ pub fn run_sync(
 					}
 
 					if fast_sync_enabled {
-						if let Err(e) = sync_state.sync_error(){
-							error!(LOGGER, "fast_sync: error = {}. restart fast sync", e );
-							sync_state.clear_sync_error();
-							si.fast_sync_reset();
+
+						// check sync error
+						{
+							let mut sync_error_need_clear = false;
+							{
+								let clone = sync_state.sync_error();
+								if let Some(ref sync_error) = *clone.read().unwrap() {
+									error!(LOGGER, "fast_sync: error = {:?}. restart fast sync", sync_error);
+									si.fast_sync_reset();
+									sync_error_need_clear = true;
+								}
+								drop(clone);
+							}
+							if sync_error_need_clear {
+								sync_state.clear_sync_error();
+							}
 						}
 
-						// run fast sync if applicable, every 5 min
-						if header_head.height == si.highest_height && si.fast_sync_due() {
-							fast_sync(peers.clone(), chain.clone(), &header_head);
-							sync_state.update(SyncStatus::TxHashsetDownload);
+						// run fast sync if applicable, normally only run one-time, except restart in error
+						if header_head.height == si.highest_height {
+							let (go,download_timeout) = si.fast_sync_due();
+
+							if go {
+								if let Err(e) = fast_sync(peers.clone(), chain.clone(), &header_head) {
+									sync_state.set_sync_error(Error::P2P(e));
+								}
+								sync_state.update(SyncStatus::TxHashsetDownload);
+							}
+
+							if SyncStatus::TxHashsetDownload == sync_state.status() && download_timeout {
+								error!(LOGGER, "fast_sync: TxHashsetDownload status timeout in 10 minutes!");
+								sync_state.set_sync_error(Error::P2P(p2p::Error::Timeout));
+							}
 						}
 					} else {
 						// run the body_sync every 5s
@@ -261,7 +284,7 @@ fn header_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>) {
 	}
 }
 
-fn fast_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, header_head: &chain::Tip) {
+fn fast_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, header_head: &chain::Tip) -> Result<(), p2p::Error> {
 	let horizon = global::cut_through_horizon() as u64;
 
 	if let Some(peer) = peers.most_work_peer() {
@@ -282,10 +305,18 @@ fn fast_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, header_head: &chain::T
 				txhashset_head.height,
 				bhash
 			);
-			p.send_txhashset_request(txhashset_head.height, bhash)
-				.unwrap();
+			if let Err(e) = p.send_txhashset_request(txhashset_head.height, bhash) {
+				error!(
+					LOGGER,
+					"fast_sync: send_txhashset_request err! {:?}",
+					e
+				);
+				return Err(e);
+			}
+			return Ok(());
 		}
 	}
+	Err(p2p::Error::PeerException)
 }
 
 /// Request some block headers from a peer to advance us.
@@ -449,13 +480,21 @@ impl SyncInfo {
 	}
 
 	// For now this is a one-time thing (it can be slow) at initial startup.
-	fn fast_sync_due(&mut self) -> bool {
-		if let None = self.prev_fast_sync {
-			let now = Utc::now();
-			self.prev_fast_sync = Some(now);
-			true
-		} else {
-			false
+	fn fast_sync_due(&mut self) -> (bool,bool) {
+		let now = Utc::now();
+		let mut download_timeout = false;
+
+		match self.prev_fast_sync {
+			None => {
+				self.prev_fast_sync = Some(now);
+				(true,download_timeout)
+			}
+			Some(prev) => {
+				if now - prev > Duration::minutes(10) {
+					download_timeout = true;
+				}
+				(false,download_timeout)
+			}
 		}
 	}
 


### PR DESCRIPTION

1. To communicate the sync errors across parts of the system, enhance the `SyncState` structure to have a `sync_error` element.
2. In `txhashset_write()`, set this `sync_error` in case of failure. 
3. In `run_sync` thread, read this `sync_error` and give proper handling: for example in this case restart TxHashset download.

And one more related fix:

- When `header_sync_due` is due, must always launch `header_sync()`, otherwise, `if header_head.height == si.highest_height` could always fail and cause `fast_sync_due()` never executed.