### PR TITLE
Fix issues found by fuzz test

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -18,6 +18,7 @@ use rand::{thread_rng, Rng};
 use std::collections::HashSet;
 use std::fmt;
 use std::iter::FromIterator;
+use chrono::naive::{MAX_DATE, MIN_DATE};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 
 use consensus::{self, exceeds_weight, reward, VerifySortOrder, REWARD};
@@ -190,7 +191,7 @@ impl Readable for BlockHeader {
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 		let pow = Proof::read(reader)?;
 
-		if timestamp > (1 << 55) || timestamp < -(1 << 55) {
+		if timestamp > MAX_DATE.and_hms(0,0,0).timestamp() || timestamp <MIN_DATE.and_hms(0,0,0).timestamp(){
 			return Err(ser::Error::CorruptedData);
 		}
 

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -123,6 +123,9 @@ impl Proof {
 impl Readable for Proof {
 	fn read(reader: &mut Reader) -> Result<Proof, Error> {
 		let cuckoo_sizeshift = reader.read_u8()?;
+		if cuckoo_sizeshift == 0  ||  cuckoo_sizeshift > 64 {
+			return Err(Error::CorruptedData);
+		}
 
 		let mut nonces = Vec::with_capacity(global::proofsize());
 		let nonce_bits = cuckoo_sizeshift as usize - 1;


### PR DESCRIPTION
Fuzz test found the folowing issues with reading block header:
* Unbounded cuckou_sizeshift field in Proof
* Different timestamp range after migration to chrono crate