### PR TITLE
Validate block size

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -90,11 +90,20 @@ pub const MAX_BLOCK_WEIGHT: usize = 80_000;
 
 /// Reused consistently for various max lengths below.
 /// Max transaction is effectively a full block of data.
+/// Soft fork down when too high.
+/// Likely we will need to tweak these all individually, but using a single constant for now.
 const MAX_INP_OUT_KERN_LEN: usize = 300_000;
 
-/// Maximum inputs for a block (issue#261)
-/// Hundreds of inputs + 1 output might be slow to validate (issue#258)
-pub const MAX_BLOCK_INPUTS: usize = MAX_INP_OUT_KERN_LEN; // soft fork down when too_high
+/// Maximum inputs for a block.
+pub const MAX_BLOCK_INPUTS: usize = MAX_INP_OUT_KERN_LEN;
+
+/// Maximum outputs for a block (max tx + single output for coinbase).
+/// This is just a starting point - need to discuss this further.
+pub const MAX_BLOCK_OUTPUTS: usize = MAX_INP_OUT_KERN_LEN + 1;
+
+/// Maximum kernels for a block (max tx + single output for coinbase).
+/// This is just a starting point - need to discuss this further.
+pub const MAX_BLOCK_KERNELS: usize = MAX_INP_OUT_KERN_LEN + 1;
 
 /// Maximum inputs in a transaction.
 pub const MAX_TX_INPUTS: usize = MAX_INP_OUT_KERN_LEN;
@@ -107,9 +116,11 @@ pub const MAX_TX_KERNELS: usize = MAX_INP_OUT_KERN_LEN;
 
 /// Whether a block exceeds the maximum acceptable weight
 pub fn exceeds_weight(input_len: usize, output_len: usize, kernel_len: usize) -> bool {
-	input_len * BLOCK_INPUT_WEIGHT
-		+ output_len * BLOCK_OUTPUT_WEIGHT
-		+ kernel_len * BLOCK_KERNEL_WEIGHT > MAX_BLOCK_WEIGHT || input_len > MAX_BLOCK_INPUTS
+	let weight =
+		input_len * BLOCK_INPUT_WEIGHT +
+		output_len * BLOCK_OUTPUT_WEIGHT +
+		kernel_len * BLOCK_KERNEL_WEIGHT;
+	weight > MAX_BLOCK_WEIGHT
 }
 
 /// Fork every 250,000 blocks for first 2 years, simple number and just a

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -114,15 +114,6 @@ pub const MAX_TX_OUTPUTS: usize = MAX_INP_OUT_KERN_LEN;
 /// Maximum kernels in a transaction.
 pub const MAX_TX_KERNELS: usize = MAX_INP_OUT_KERN_LEN;
 
-/// Whether a block exceeds the maximum acceptable weight
-pub fn exceeds_weight(input_len: usize, output_len: usize, kernel_len: usize) -> bool {
-	let weight =
-		input_len * BLOCK_INPUT_WEIGHT +
-		output_len * BLOCK_OUTPUT_WEIGHT +
-		kernel_len * BLOCK_KERNEL_WEIGHT;
-	weight > MAX_BLOCK_WEIGHT
-}
-
 /// Fork every 250,000 blocks for first 2 years, simple number and just a
 /// little less than 6 months.
 pub const HARD_FORK_INTERVAL: u64 = 250_000;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::iter::FromIterator;
 
-use consensus::{self, exceeds_weight, reward, VerifySortOrder, REWARD};
+use consensus::{self, reward, VerifySortOrder, REWARD};
 use core::committed::{self, Committed};
 use core::hash::{Hash, HashWriter, Hashed, ZERO_HASH};
 use core::id::ShortIdentifiable;
@@ -760,7 +760,12 @@ impl Block {
 	}
 
 	fn verify_weight(&self) -> Result<(), Error> {
-		if exceeds_weight(self.inputs.len(), self.outputs.len(), self.kernels.len()) {
+		let weight =
+			self.inputs.len() * consensus::BLOCK_INPUT_WEIGHT +
+			self.outputs.len() * consensus::BLOCK_OUTPUT_WEIGHT +
+			self.kernels.len() * consensus::BLOCK_KERNEL_WEIGHT;
+
+		if weight > consensus::MAX_BLOCK_WEIGHT {
 			return Err(Error::WeightExceeded);
 		}
 		Ok(())


### PR DESCRIPTION
~Depends on #1334 (this PR include changes from there also as I branched off from it).~
~This changeset will be smaller once #1334 is merged in.~

We were verifying the max number of block inputs in `verify_weight()` but it was hidden at the end of a larger comparison and it was not that clear what was happening.

This PR introduces a `verify_size()` to be consistent with tx validation.

As discussed in #1327 we allow a tx to have up to `30_000` inputs, outputs and kernels.
This PR allows a single enormous tx to be included in a block iff it is the only tx in the block.
To allow this we ned to allow the following in the block itself -
* max `30_000` inputs
* max `30_000 + 1` outputs (`30_000` outputs from the tx + a single coinbase output for the block)
* max `30_000 + 1` kernels (`30_000` kernels from the tx + a single coinbase kernel for the block)

We should discuss these max counts. This works for now but I'm not sure if these number make sense in the greater scheme of things.
Maybe we want more flexibility baked into the max block sizes to allow for some more flexibility when dealing with enormous (aggregated or otherwise) txs close to the max tx size.

