### PR TITLE
cannot use unstable rustfmt features outside nightly toolchain

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -30,7 +30,7 @@ printf "[pre_commit] rustfmt "
 for file in $(git diff --name-only --cached); do
 	if [ ${file: -3} == ".rs" ]; then
 		# first collect all the files that need reformatting
-		rustfmt --unstable-options --skip-children --write-mode=diff $file &>/dev/null
+		rustfmt --check $file &>/dev/null
 		if [ $? != 0 ]; then
 			problem_files+=($file)
 			result=1
@@ -40,7 +40,7 @@ done
 
 # now reformat all the files that need reformatting
 for file in ${problem_files[@]}; do
-	rustfmt --unstable-options --skip-children --write-mode=overwrite $file
+	rustfmt $file
 done
 
 # and let the user know what just happened (and which files were affected)

--- a/api/rustfmt.toml
+++ b/api/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/api/rustfmt.toml
+++ b/api/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/chain/rustfmt.toml
+++ b/chain/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/chain/rustfmt.toml
+++ b/chain/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/core/rustfmt.toml
+++ b/core/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/core/rustfmt.toml
+++ b/core/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/keychain/rustfmt.toml
+++ b/keychain/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/keychain/rustfmt.toml
+++ b/keychain/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/p2p/rustfmt.toml
+++ b/p2p/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/p2p/rustfmt.toml
+++ b/p2p/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/pool/rustfmt.toml
+++ b/pool/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/pool/rustfmt.toml
+++ b/pool/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/servers/rustfmt.toml
+++ b/servers/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/servers/rustfmt.toml
+++ b/servers/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/store/rustfmt.toml
+++ b/store/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/store/rustfmt.toml
+++ b/store/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true

--- a/wallet/rustfmt.toml
+++ b/wallet/rustfmt.toml
@@ -1,1 +1,0 @@
-hard_tabs = true

--- a/wallet/rustfmt.toml
+++ b/wallet/rustfmt.toml
@@ -1,2 +1,1 @@
 hard_tabs = true
-wrap_comments = true


### PR DESCRIPTION
Fixes #1335.

* `--skip-children` is only available in nightly rust toolchain now
* `wrap_comments` is also nightly only

Downside of this is rustfmt potentially reformats everything beneath a touched `mod.rs` or `lib.rs`.
(Some may see this as an upside 🤷‍♀️ ).

with this PR our precommit hook is working again.
If too noisy/invasive then we can revisit.

TODO - 
- [x] all those crate specific rustfmt.toml files are basically redundant (one in project root dir will be used).

