### PR TITLE
Fix overage and fee overflow

### DIFF
--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -30,6 +30,7 @@ pub enum Error {
 	Secp(secp::Error),
 	/// Kernel sums do not equal output sums.
 	KernelSumMismatch,
+	InvalidValue,
 }
 
 impl From<secp::Error> for Error {
@@ -89,7 +90,8 @@ pub trait Committed {
 			let over_commit = {
 				let secp = static_secp_instance();
 				let secp = secp.lock().unwrap();
-				secp.commit_value(overage.abs() as u64).unwrap()
+				let overage_abs = overage.checked_abs().ok_or_else(|| Error::InvalidValue)? as u64;
+				secp.commit_value(overage_abs).unwrap()
 			};
 			if overage < 0 {
 				input_commits.push(over_commit);

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -397,7 +397,9 @@ impl Transaction {
 
 	/// Total fee for a transaction is the sum of fees of all kernels.
 	pub fn fee(&self) -> u64 {
-		self.kernels.iter().fold(0, |acc, ref x| acc + x.fee)
+		self.kernels
+			.iter()
+			.fold(0, |acc, ref x| acc.saturating_add(x.fee))
 	}
 
 	fn overage(&self) -> i64 {
@@ -994,9 +996,9 @@ mod test {
 			commit: commit,
 		};
 
-		let block_hash = Hash::from_hex(
-			"3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673",
-		).unwrap();
+		let block_hash =
+			Hash::from_hex("3a42e66e46dd7633b57d1f921780a1ac715e6b93c19ee52ab714178eb3a9f673")
+				.unwrap();
 
 		let nonce = 0;
 


### PR DESCRIPTION
2 issues were found by fuzzing.  Overage and fee come from the network and may cause overflow if a message was corrupted or crafted to attack a server.