### PR TITLE
improve: use batch verification for txhashset rangeproof validation (#1321)

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -993,6 +993,19 @@ impl Output {
 			Err(e) => Err(e),
 		}
 	}
+
+	/// Batch validates the range proofs using the commitments
+	pub fn batch_verify_proofs(
+		commits: &Vec<Commitment>,
+		proofs: &Vec<RangeProof>,
+	) -> Result<(), secp::Error> {
+		let secp = static_secp_instance();
+		let secp = secp.lock().unwrap();
+		match secp.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None) {
+			Ok(_) => Ok(()),
+			Err(e) => Err(e),
+		}
+	}
 }
 
 /// An output_identifier can be build from either an input _or_ an output and

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -20,6 +20,6 @@ zip = "0.4"
 
 [dependencies.secp256k1zkp]
 git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
-tag = "grin_integration_21"
+tag = "grin_integration_22"
 #path = "../../rust-secp256k1-zkp"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
Almost 35 times speed optimization totally.

Before:
```
Aug 07 11:35:31.781 DEBG txhashset: verified 23140 rangeproofs, pmmr size 95321, took 1034s
```

Now:
```
Aug 16 09:50:12.435 DEBG txhashset: verified 28278 rangeproofs, pmmr size 121240, took 35s
```