### PR TITLE
minor fix: prefix code conflict between 'COMMITMENT_PREFIX' and 'CONFIRMED_HEIGHT_PREFIX'

### DIFF
--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -29,7 +29,7 @@ use util::secp::pedersen;
 
 pub const DB_DIR: &'static str = "wallet_data";
 
-const COMMITMENT_PREFIX: u8 = 'c' as u8;
+const COMMITMENT_PREFIX: u8 = 'C' as u8;
 const OUTPUT_PREFIX: u8 = 'o' as u8;
 const DERIV_PREFIX: u8 = 'd' as u8;
 const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;


### PR DESCRIPTION
In @antiochp  recent PR: https://github.com/mimblewimble/grin/pull/1365, a new prefix had been added in wallet database:
> const COMMITMENT_PREFIX: u8 = 'c' as u8;
> ...
> const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;

But this new prefix used an existing prefix code **'c'**. I'm not sure what's the exact side effect for that, but I feel it's not a good thing, so remind to fix this 'issue':)