### PR TITLE
automatic setting up git hooks for the project: rustfmt, etc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,16 @@ There is a basic git [pre-commit](../.hooks/pre-commit) hook in the repo.
 The pre-commit hook will not prevent commits if style issues are present but it will
 indicate any files that need formatting.
 
-To enable this, create a symlink in `.git/hooks` (note the relative path) -
-
+This pre-commit hook will be **automatically** configured in this project, once you run `cargo build` for the 1st time.
+  
+Or you can config it manually with the following command without building, and check it:
 ```
-cd .git/hooks
-ln -s -f ../../.hooks/pre-commit
+git config core.hooksPath ./.hooks
+git config --list | grep hook
+```
+The output will be:
+```
+core.hookspath=./.hooks
 ```
 
 ## Running rustfmt

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -25,11 +25,31 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::Read;
 use std::path::{self, Path, PathBuf};
+use std::process::Command;
+
 use tar::Archive;
 
 const WEB_WALLET_TAG: &str = "0.3.0.1";
 
 fn main() {
+	// Setting up git hooks in the project: rustfmt and so on.
+	let git_hooks = format!(
+		"git config core.hooksPath {}",
+		PathBuf::from("./.hooks").to_str().unwrap()
+	);
+
+	if cfg!(target_os = "windows") {
+		Command::new("cmd")
+			.args(&["/C", &git_hooks])
+			.output()
+			.expect("failed to execute git config for hooks");
+	} else {
+		Command::new("sh")
+			.args(&["-c", &git_hooks])
+			.output()
+			.expect("failed to execute git config for hooks");
+	}
+
 	// build and versioning information
 	let mut opts = built::Options::default();
 	opts.set_dependencies(true);


### PR DESCRIPTION
When launching a new clone, I always forgot to manually create that symlink for `rustfmt`:
```
cd .git/hooks
ln -s -f ../../.hooks/pre-commit
```

I should not the only one:)

So, here giving an automatic way to have this git hook, and let's gracefully forget that manual link command~