### PR TITLE
add pretty print for BlindingFactor

### DIFF
--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -162,8 +162,14 @@ impl fmt::Display for Identifier {
 	}
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
+
+impl fmt::Debug for BlindingFactor {
+	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", self.to_hex())
+	}
+}
 
 impl AsRef<[u8]> for BlindingFactor {
 	fn as_ref(&self) -> &[u8] {
@@ -297,8 +303,8 @@ mod test {
 	use rand::thread_rng;
 
 	use types::BlindingFactor;
-	use util::secp::Secp256k1;
 	use util::secp::key::{SecretKey, ZERO_KEY};
+	use util::secp::Secp256k1;
 
 	#[test]
 	fn split_blinding_factor() {


### PR DESCRIPTION
minor debug improve.

`Transaction` has nice pretty print for all elements except `BlindingFactor`, let's kill this exception:)

```
tx=Transaction {
    offset: BlindingFactor(
        [
            69,
            241,
            169,
            29,
            28,
            154,
            255,
            26,
            58,
            186,
            68,
            178,
            198,
            85,
            163,
            129,
            141,
            183,
            49,
            236,
            111,
            209,
            92,
            79,
            175,
            115,
            184,
            196,
            87,
            56,
            9,
            26
        ]
    ),
    body: TransactionBody {
        inputs: [
            Input {
                features: DEFAULT_OUTPUT,
                commit: Commitment(088202e76529c429b8ed66aa9c365ce32bd76b616a6cf8591dbb1d4d30e81cef3f)
            },
            Input {
                features: DEFAULT_OUTPUT,
                commit: Commitment(086b8e4db3dae5c324625dcbefedff06b2039f9450d1675f27fb7355decada749a)
            }
        ],
        outputs: [
            Output {
                features: DEFAULT_OUTPUT,
                commit: Commitment(084c40f80ea365662a6fca981fa61f5ed607698a1daaa4c71460f441702c832506),
                proof: RangeProof(a83d108b23f6e1bc54a39169645244062c340691fd68b472e9caf5c9d4db29fb6f0cfc9c4cfe4bf85c35ecbd477506b4df92675d4e4823a87314d3de249ee9c80e6c81750da3851a16b3b7553d9bf40f319b5e3903ff14cc764b5069eea8335339afdddc11acb10e195dda6275150468f417ea78565c8c272f5adf7babdbca1c8ddc13545be12804cfceeb8559d71ff8e14dbcdd6683b191d30ac9f2f3c8ad0a203cad9b70d53c0cf67384d772d3c379be06643d82ad3ec14bda4f22e865640ba03754919f1b6a64a2331bd2c79ff9d04e58aa07a96a215981d4aadcce79af641c3fb252c4772df84ffe8d2748e3d266d6eb3bf683d5cefa04be570f2367f4b06e8e8902b3d03f996ec978fef5e8028644d23158a265eba6bed7766ae8a22315e1d6cb1c20bb8e3b6f094a8db16048c4d5b12982680e495817879b1052d08c7d10f29b886862e37983c54fd9aba83be0df46bf7af997eb5070f3268d290f9a4819fa035f8c82f40893af2e7dd4d6d3382537be855ff9f910cf75692ca0b7f9ffe0b6a74aa560bfcc2940b3430c33ff3a1012da6d6b2017fab6746cc5c8e779f764b56fb0873a8692c694462c62a61d36cb67296e02bd0ea20ebe0f51b24c8083676e6b6b56abaf01396d799544e9fc28b81450b2659ca13524c5ca99859ca9a42f7b756b67dc99805854cd45ff36d8a2c0f76d5e3c1ac91f1e3558aaad565a2fbe37f3bab701897176f2be4dba2ebdfb07c27a2a327fb1c075c0365f6da2e7255565d450fbf0b5ac1876bc3ec5da888acec1ca7fce09788d1805c6cd650ff4849be0b68e67455f15144b370ee42484fc0ffefc8092c7b868db7f483c796b569c0e943afc5d87213201424f323d25bdc9635309ea5cc23148b656dfc291b786c8143c6e75c56408a6880628b1c402aaebad881e72e83669a2036cc4c5ca3e5257705980)[675]
            }
        ],
        kernels: [
            TxKernel {
                features: DEFAULT_KERNEL,
                fee: 2,
                lock_height: 0,
                excess: Commitment(085908ab7472bbc712e802af4876fd309b1e8ef7d4c86d8540ecced705f59fd0fb),
                excess_sig: Signature(
                    190c28924b836ce8d8c51298d9894f0d541251089d4bf88d13f75fabf6d600000000000000000000000000000000000000000000000000000000000000000000
                )
            }
        ]
    }
}
```