### PR TITLE
improve logging when receiving blocks and txs (msg_len)

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -148,7 +148,8 @@ impl OutputHandler {
 			.filter(|output| commitments.is_empty() || commitments.contains(&output.commit))
 			.map(|output| {
 				OutputPrintable::from_output(output, w(&self.chain), Some(&header), include_proof)
-			}).collect();
+			})
+			.collect();
 
 		Ok(BlockOutputs {
 			header: BlockHeaderInfo::from_header(&header),
@@ -725,10 +726,12 @@ where
 				.and_then(move |wrapper: TxWrapper| {
 					util::from_hex(wrapper.tx_hex)
 						.map_err(|_| ErrorKind::RequestError("Bad request".to_owned()).into())
-				}).and_then(move |tx_bin| {
+				})
+				.and_then(move |tx_bin| {
 					ser::deserialize(&mut &tx_bin[..])
 						.map_err(|_| ErrorKind::RequestError("Bad request".to_owned()).into())
-				}).and_then(move |tx: Transaction| {
+				})
+				.and_then(move |tx: Transaction| {
 					let source = pool::TxSource {
 						debug_name: "push-api".to_string(),
 						identifier: "?.?.?.?".to_string(),

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -735,9 +735,10 @@ where
 					};
 					info!(
 						LOGGER,
-						"Pushing transaction with {} inputs and {} outputs to pool.",
+						"Pushing transaction, inputs: {}, outputs: {}, kernels: {}, to pool.",
 						tx.inputs().len(),
-						tx.outputs().len()
+						tx.outputs().len(),
+						tx.kernels().len(),
 					);
 
 					//  Push to tx pool.

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -84,12 +84,14 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::Transaction => {
+				debug!(LOGGER, "handle_payload: received tx: msg_len: {}", msg.header.msg_len);
 				let tx: core::Transaction = msg.body()?;
 				adapter.transaction_received(tx, false);
 				Ok(None)
 			}
 
 			Type::StemTransaction => {
+				debug!(LOGGER, "handle_payload: received stem tx: msg_len: {}", msg.header.msg_len);
 				let tx: core::Transaction = msg.body()?;
 				adapter.transaction_received(tx, true);
 				Ok(None)
@@ -107,10 +109,9 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::Block => {
+				debug!(LOGGER, "handle_payload: received block: msg_len: {}", msg.header.msg_len);
 				let b: core::Block = msg.body()?;
 				let bh = b.hash();
-
-				trace!(LOGGER, "handle_payload: Block {}", bh);
 
 				adapter.block_received(b, self.addr);
 				Ok(None)
@@ -118,7 +119,6 @@ impl MessageHandler for Protocol {
 
 			Type::GetCompactBlock => {
 				let h: Hash = msg.body()?;
-				debug!(LOGGER, "handle_payload: GetCompactBlock: {}", h);
 
 				if let Some(b) = adapter.get_block(h) {
 					let cb = b.as_compact_block();
@@ -147,9 +147,9 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::CompactBlock => {
+				debug!(LOGGER, "handle_payload: received compact block: msg_len: {}", msg.header.msg_len);
 				let b: core::CompactBlock = msg.body()?;
 				let bh = b.hash();
-				debug!(LOGGER, "handle_payload: CompactBlock: {}", bh);
 
 				adapter.compact_block_received(b, self.addr);
 				Ok(None)

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -84,14 +84,20 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::Transaction => {
-				debug!(LOGGER, "handle_payload: received tx: msg_len: {}", msg.header.msg_len);
+				debug!(
+					LOGGER,
+					"handle_payload: received tx: msg_len: {}", msg.header.msg_len
+				);
 				let tx: core::Transaction = msg.body()?;
 				adapter.transaction_received(tx, false);
 				Ok(None)
 			}
 
 			Type::StemTransaction => {
-				debug!(LOGGER, "handle_payload: received stem tx: msg_len: {}", msg.header.msg_len);
+				debug!(
+					LOGGER,
+					"handle_payload: received stem tx: msg_len: {}", msg.header.msg_len
+				);
 				let tx: core::Transaction = msg.body()?;
 				adapter.transaction_received(tx, true);
 				Ok(None)
@@ -109,7 +115,10 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::Block => {
-				debug!(LOGGER, "handle_payload: received block: msg_len: {}", msg.header.msg_len);
+				debug!(
+					LOGGER,
+					"handle_payload: received block: msg_len: {}", msg.header.msg_len
+				);
 				let b: core::Block = msg.body()?;
 				let bh = b.hash();
 
@@ -147,7 +156,10 @@ impl MessageHandler for Protocol {
 			}
 
 			Type::CompactBlock => {
-				debug!(LOGGER, "handle_payload: received compact block: msg_len: {}", msg.header.msg_len);
+				debug!(
+					LOGGER,
+					"handle_payload: received compact block: msg_len: {}", msg.header.msg_len
+				);
 				let b: core::CompactBlock = msg.body()?;
 				let bh = b.hash();
 
@@ -161,10 +173,9 @@ impl MessageHandler for Protocol {
 				let headers = adapter.locate_headers(loc.hashes);
 
 				// serialize and send all the headers over
-				Ok(Some(msg.respond(
-					Type::Headers,
-					Headers { headers: headers },
-				)))
+				Ok(Some(
+					msg.respond(Type::Headers, Headers { headers: headers }),
+				))
 			}
 
 			// "header first" block propagation - if we have not yet seen this block
@@ -268,7 +279,8 @@ impl MessageHandler for Protocol {
 				);
 
 				let tmp_zip = File::open(tmp)?;
-				let res = self.adapter
+				let res = self
+					.adapter
 					.txhashset_write(sm_arch.hash, tmp_zip, self.addr);
 
 				debug!(

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -129,10 +129,13 @@ where
 	) -> Result<(), PoolError> {
 		debug!(
 			LOGGER,
-			"pool [{}]: add_to_pool: {}, {:?}",
+			"pool [{}]: add_to_pool: {}, {:?}, inputs: {}, outputs: {}, kernels: {}",
 			self.name,
 			entry.tx.hash(),
 			entry.src,
+			entry.tx.inputs().len(),
+			entry.tx.outputs().len(),
+			entry.tx.kernels().len(),
 		);
 
 		// Combine all the txs from the pool with any extra txs provided.

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -97,14 +97,6 @@ where
 		tx: Transaction,
 		stem: bool,
 	) -> Result<(), PoolError> {
-		debug!(
-			LOGGER,
-			"pool: add_to_pool: {:?}, kernels - {}, stem? {}",
-			tx.hash(),
-			tx.kernels().len(),
-			stem,
-		);
-
 		// Do we have the capacity to accept this transaction?
 		self.is_acceptable(&tx)?;
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -78,14 +78,16 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			identifier: "?.?.?.?".to_string(),
 		};
 
+		let h = tx.hash();
+
 		debug!(
 			LOGGER,
-			"Received tx {} from {:?}, going to process.",
-			tx.hash(),
-			source,
+			"Received tx {}, inputs: {}, outputs: {}, kernels: {}, going to process.",
+			h,
+			tx.inputs().len(),
+			tx.outputs().len(),
+			tx.kernels().len(),
 		);
-
-		let h = tx.hash();
 
 		let res = {
 			let mut tx_pool = self.tx_pool.write().unwrap();
@@ -100,10 +102,13 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 	fn block_received(&self, b: core::Block, addr: SocketAddr) -> bool {
 		debug!(
 			LOGGER,
-			"Received block {} at {} from {}, going to process.",
+			"Received block {} at {} from {}, inputs: {}, outputs: {}, kernels: {}, going to process.",
 			b.hash(),
 			b.header.height,
 			addr,
+			b.inputs().len(),
+			b.outputs().len(),
+			b.kernels().len(),
 		);
 		self.process_block(b, addr)
 	}
@@ -112,10 +117,13 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		let bhash = cb.hash();
 		debug!(
 			LOGGER,
-			"Received compact_block {} at {} from {}, going to process.",
+			"Received compact_block {} at {} from {}, outputs: {}, kernels: {}, kern_ids: {}, going to process.",
 			bhash,
 			cb.header.height,
 			addr,
+			cb.out_full.len(),
+			cb.kern_full.len(),
+			cb.kern_ids.len(),
 		);
 
 		if cb.kern_ids.is_empty() {


### PR DESCRIPTION
Improve the logging when receiving txs and blocks.
Log the `msg_len` at protocol level.
Log number of inputs, outputs, kernels in the tx or block.

```
Aug 19 13:03:34.296 DEBG handle_payload: received tx: msg_len: 9655
Aug 19 13:03:56.787 DEBG handle_payload: received compact block: msg_len: 1192
Aug 19 13:03:57.064 DEBG handle_payload: received block: msg_len: 10777
```

```
Aug 19 12:59:18.150 DEBG pool [stempool]: add_to_pool: 1647de35, TxSource { debug_name: "p2p", identifier: "?.?.?.?" }, inputs: 12, outputs: 4, kernels: 1
Aug 19 12:59:21.848 DEBG pool [txpool]: add_to_pool: 589e5502, TxSource { debug_name: "p2p", identifier: "?.?.?.?" }, inputs: 13, outputs: 4, kernels: 1
Aug 19 12:59:34.032 DEBG pool [txpool]: add_to_pool: 1647de35, TxSource { debug_name: "fluff", identifier: "?.?.?.?" }, inputs: 12, outputs: 4, kernels: 1
```