### PR TITLE
Retrieve header by output commit

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -596,7 +596,6 @@ impl HeaderHandler {
 			Ok(header) => return Ok(BlockHeaderPrintable::from_header(&header)),
 			Err(_) => return Err(ErrorKind::NotFound)?,
 		}
-		
 	}
 }
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -50,6 +50,31 @@ fn w<T>(weak: &Weak<T>) -> Arc<T> {
 	weak.upgrade().unwrap()
 }
 
+/// Retrieves an output from the chain given a commit id (a tiny bit iteratively)
+fn get_output(chain: &Weak<chain::Chain>, id: &str) -> Result<(Output, OutputIdentifier), Error> {
+	let c = util::from_hex(String::from(id)).context(ErrorKind::Argument(format!(
+		"Not a valid commitment: {}",
+		id
+	)))?;
+	let commit = Commitment::from_vec(c);
+
+	// We need the features here to be able to generate the necessary hash
+	// to compare against the hash in the output MMR.
+	// For now we can just try both (but this probably needs to be part of the api
+	// params)
+	let outputs = [
+		OutputIdentifier::new(OutputFeatures::DEFAULT_OUTPUT, &commit),
+		OutputIdentifier::new(OutputFeatures::COINBASE_OUTPUT, &commit),
+	];
+
+	for x in outputs.iter() {
+		if let Ok(_) = w(chain).is_unspent(&x) {
+			return Ok((Output::new(&commit), x.clone()));
+		}
+	}
+	Err(ErrorKind::NotFound)?
+}
+
 // RESTful index of available api endpoints
 // GET /v1/
 struct IndexHandler {
@@ -74,27 +99,8 @@ struct OutputHandler {
 
 impl OutputHandler {
 	fn get_output(&self, id: &str) -> Result<Output, Error> {
-		let c = util::from_hex(String::from(id)).context(ErrorKind::Argument(format!(
-			"Not a valid commitment: {}",
-			id
-		)))?;
-		let commit = Commitment::from_vec(c);
-
-		// We need the features here to be able to generate the necessary hash
-		// to compare against the hash in the output MMR.
-		// For now we can just try both (but this probably needs to be part of the api
-		// params)
-		let outputs = [
-			OutputIdentifier::new(OutputFeatures::DEFAULT_OUTPUT, &commit),
-			OutputIdentifier::new(OutputFeatures::COINBASE_OUTPUT, &commit),
-		];
-
-		for x in outputs.iter() {
-			if let Ok(_) = w(&self.chain).is_unspent(&x) {
-				return Ok(Output::new(&commit));
-			}
-		}
-		Err(ErrorKind::NotFound)?
+		let res = get_output(&self.chain, id)?;
+		Ok(res.0)
 	}
 
 	fn outputs_by_ids(&self, req: &Request<Body>) -> Result<Vec<Output>, Error> {
@@ -553,9 +559,10 @@ impl Handler for ChainCompactHandler {
 	}
 }
 
-/// Gets block headers given either a hash or height.
+/// Gets block headers given either a hash or height or an output commit.
 /// GET /v1/headers/<hash>
 /// GET /v1/headers/<height>
+/// GET /v1/headers/<output commit>
 ///
 pub struct HeaderHandler {
 	pub chain: Weak<chain::Chain>,
@@ -563,6 +570,10 @@ pub struct HeaderHandler {
 
 impl HeaderHandler {
 	fn get_header(&self, input: String) -> Result<BlockHeaderPrintable, Error> {
+		// will fail quick if the provided isn't a commitment
+		if let Ok(h) = self.get_header_for_output(input.clone()) {
+			return Ok(h);
+		}
 		if let Ok(height) = input.parse() {
 			match w(&self.chain).get_header_by_height(height) {
 				Ok(header) => return Ok(BlockHeaderPrintable::from_header(&header)),
@@ -578,11 +589,21 @@ impl HeaderHandler {
 			.context(ErrorKind::NotFound)?;
 		Ok(BlockHeaderPrintable::from_header(&header))
 	}
+
+	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {
+		let oid = get_output(&self.chain, &commit_id)?.1;
+		match w(&self.chain).get_header_for_output(&oid) {
+			Ok(header) => return Ok(BlockHeaderPrintable::from_header(&header)),
+			Err(_) => return Err(ErrorKind::NotFound)?,
+		}
+		
+	}
 }
 
-/// Gets block details given either a hash or height.
+/// Gets block details given either a hash or an unspent commit
 /// GET /v1/blocks/<hash>
 /// GET /v1/blocks/<height>
+/// GET /v1/blocks/<commit>
 ///
 /// Optionally return results as "compact blocks" by passing "?compact" query
 /// param GET /v1/blocks/<hash>?compact

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -25,7 +25,7 @@ use lmdb;
 use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::target::Difficulty;
-use core::core::{Block, BlockHeader, Output, OutputIdentifier, Transaction, TxKernel};
+use core::core::{Block, BlockHeader, Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel};
 use core::global;
 use error::{Error, ErrorKind};
 use grin_store::Error::NotFoundErr;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -25,7 +25,9 @@ use lmdb;
 use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::target::Difficulty;
-use core::core::{Block, BlockHeader, Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel};
+use core::core::{
+	Block, BlockHeader, Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel,
+};
 use core::global;
 use error::{Error, ErrorKind};
 use grin_store::Error::NotFoundErr;

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -30,6 +30,13 @@ pub fn to_hex(bytes: Vec<u8>) -> String {
 
 /// Decode a hex string into bytes.
 pub fn from_hex(hex_str: String) -> Result<Vec<u8>, num::ParseIntError> {
+	if hex_str.len() % 2 == 1 {
+		// TODO: other way to instantiate a ParseIntError?
+		let err = ("QQQ").parse::<u64>();
+		if let Err(e) = err {
+			return Err(e);
+		}
+	}
 	let hex_trim = if &hex_str[..2] == "0x" {
 		hex_str[2..].to_owned()
 	} else {


### PR DESCRIPTION
Adds functions to the Chain and the node API to retrieve a header from the header chain given an output commit. Compares the output position against the `output_mmr_size` in stored block headers. Uses a binary search to find the right block so should be an efficient enough call.

Should just need to call the /header function with the desired commit to retrieve the header, e.g:
```
http://localhost:13413/v1/headers/088c38429eab2705d468e8e0fb2a5363d675591204d7cd8164cfd54368abb9ceeb
```
Will only return the header if it's in the UTXO set, 404 otherwise.

Will be needed to ensure block heights within the wallet are correct during a wallet refresh, as block heights can't be deduced until associated transactions appear on the chain due to dandelion. Will also be very useful to have for wallet restore.
