### PR TITLE
Refactor and optimise peers.rs

### DIFF
--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -168,7 +168,7 @@ impl Server {
 					&self.handshake,
 					self.peers.clone(),
 				)?;
-				let added = self.peers.add_connected(peer);
+				let added = self.peers.add_connected(peer)?;
 				{
 					let mut peer = added.write().unwrap();
 					peer.start(stream);
@@ -193,7 +193,7 @@ impl Server {
 			&self.handshake,
 			self.peers.clone(),
 		)?;
-		let added = self.peers.add_connected(peer);
+		let added = self.peers.add_connected(peer)?;
 		let mut peer = added.write().unwrap();
 		peer.start(stream);
 		Ok(())


### PR DESCRIPTION
* Use internal hashmap for count and contains methods instead of relying on
connected_peers method which is expensive (creates vector from hashmap)
* Reduce number of `clone()`
* Refactor broadcast_xxx