### PR TITLE
Refactor rewind single header

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -490,7 +490,6 @@ pub fn rewind_and_apply_fork(
 		}
 	}
 
-	let head_header = store.head_header()?;
 	let forked_header = store.get_block_header(&current)?;
 
 	trace!(
@@ -503,7 +502,7 @@ pub fn rewind_and_apply_fork(
 	);
 
 	// rewind the sum trees up to the forking block
-	ext.rewind(&forked_header, &head_header)?;
+	ext.rewind(&forked_header)?;
 
 	trace!(
 		LOGGER,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -130,7 +130,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, E
 		b.hash(),
 		b.header.height,
 	);
-	add_block(b, ctx.store.clone(), &mut batch)?;
+	add_block(b, &mut batch)?;
 	let res = update_head(b, &ctx, &mut batch);
 	if res.is_ok() {
 		batch.commit()?;
@@ -372,14 +372,12 @@ fn validate_block_via_txhashset(b: &Block, ext: &mut txhashset::Extension) -> Re
 /// Officially adds the block to our chain.
 fn add_block(
 	b: &Block,
-	store: Arc<store::ChainStore>,
 	batch: &mut store::Batch,
 ) -> Result<(), Error> {
 	batch
 		.save_block(b)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save block".to_owned()))?;
-	let bitmap = store.build_and_cache_block_input_bitmap(&b)?;
-	batch.save_block_input_bitmap(&b.hash(), &bitmap)?;
+	batch.build_and_cache_block_input_bitmap(&b)?;
 	Ok(())
 }
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -371,9 +371,12 @@ fn validate_block_via_txhashset(b: &Block, ext: &mut txhashset::Extension) -> Re
 
 /// Officially adds the block to our chain.
 fn add_block(b: &Block, batch: &mut store::Batch) -> Result<(), Error> {
+	// Save the block itself to the db (via the batch).
 	batch
 		.save_block(b)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save block".to_owned()))?;
+
+	// Build the block_input_bitmap, save to the db (via the batch) and cache locally.
 	batch.build_and_cache_block_input_bitmap(&b)?;
 	Ok(())
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -370,10 +370,7 @@ fn validate_block_via_txhashset(b: &Block, ext: &mut txhashset::Extension) -> Re
 }
 
 /// Officially adds the block to our chain.
-fn add_block(
-	b: &Block,
-	batch: &mut store::Batch,
-) -> Result<(), Error> {
+fn add_block(b: &Block, batch: &mut store::Batch) -> Result<(), Error> {
 	batch
 		.save_block(b)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save block".to_owned()))?;

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -712,8 +712,7 @@ impl<'a> Extension<'a> {
 		);
 
 		// rewind to the specified block for a consistent view
-		let head_header = self.commit_index.head_header()?;
-		self.rewind(block_header, &head_header)?;
+		self.rewind(block_header)?;
 
 		// then calculate the Merkle Proof based on the known pos
 		let pos = self.batch.get_output_pos(&output.commit)?;
@@ -745,7 +744,6 @@ impl<'a> Extension<'a> {
 	pub fn rewind(
 		&mut self,
 		block_header: &BlockHeader,
-		head_header: &BlockHeader,
 	) -> Result<(), Error> {
 		trace!(
 			LOGGER,
@@ -754,6 +752,8 @@ impl<'a> Extension<'a> {
 			block_header.hash(),
 		);
 
+		let head_header = self.commit_index.head_header()?;
+
 		// We need to build bitmaps of added and removed output positions
 		// so we can correctly rewind all operations applied to the output MMR
 		// after the position we are rewinding to (these operations will be
@@ -761,7 +761,7 @@ impl<'a> Extension<'a> {
 		// Rewound output pos will be removed from the MMR.
 		// Rewound input (spent) pos will be added back to the MMR.
 		let rewind_rm_pos =
-			input_pos_to_rewind(self.commit_index.clone(), block_header, head_header)?;
+			input_pos_to_rewind(self.commit_index.clone(), block_header, &head_header)?;
 		if !rewind_rm_pos.0 {
 			self.batch
 				.save_block_input_bitmap(&head_header.hash(), &rewind_rm_pos.1)?;

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -234,8 +234,12 @@ impl TxHashSet {
 
 		let batch = self.commit_index.batch()?;
 
-		let rewind_rm_pos =
-			input_pos_to_rewind(self.commit_index.clone(), &horizon_header, &head_header, &batch)?;
+		let rewind_rm_pos = input_pos_to_rewind(
+			self.commit_index.clone(),
+			&horizon_header,
+			&head_header,
+			&batch,
+		)?;
 
 		{
 			let clean_output_index = |commit: &[u8]| {
@@ -756,8 +760,12 @@ impl<'a> Extension<'a> {
 		// undone during rewind).
 		// Rewound output pos will be removed from the MMR.
 		// Rewound input (spent) pos will be added back to the MMR.
-		let rewind_rm_pos =
-			input_pos_to_rewind(self.commit_index.clone(), block_header, &head_header, &self.batch)?;
+		let rewind_rm_pos = input_pos_to_rewind(
+			self.commit_index.clone(),
+			block_header,
+			&head_header,
+			&self.batch,
+		)?;
 
 		self.rewind_to_pos(
 			block_header.output_mmr_size,
@@ -1204,7 +1212,12 @@ fn input_pos_to_rewind(
 	let mut current = head_header.hash();
 
 	if head_header.height < block_header.height {
-		debug!(LOGGER, "input_pos_to_rewind: {} < {}, nothing to rewind", head_header.height, block_header.height);
+		debug!(
+			LOGGER,
+			"input_pos_to_rewind: {} < {}, nothing to rewind",
+			head_header.height,
+			block_header.height
+		);
 		return Ok(bitmap);
 	}
 

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -741,10 +741,7 @@ impl<'a> Extension<'a> {
 
 	/// Rewinds the MMRs to the provided block, rewinding to the last output pos
 	/// and last kernel pos of that block.
-	pub fn rewind(
-		&mut self,
-		block_header: &BlockHeader,
-	) -> Result<(), Error> {
+	pub fn rewind(&mut self, block_header: &BlockHeader) -> Result<(), Error> {
 		trace!(
 			LOGGER,
 			"Rewind to header {} @ {}",
@@ -989,8 +986,8 @@ impl<'a> Extension<'a> {
 	{
 		let now = Instant::now();
 
-		let mut commits:Vec<Commitment> = vec![];
-		let mut proofs:Vec<RangeProof> = vec![];
+		let mut commits: Vec<Commitment> = vec![];
+		let mut proofs: Vec<RangeProof> = vec![];
 
 		let mut proof_count = 0;
 		let total_rproofs = pmmr::n_leaves(self.output_pmmr.unpruned_size());
@@ -1132,7 +1129,8 @@ fn check_and_remove_files(txhashset_path: &PathBuf, header: &BlockHeader) -> Res
 					.file_name()
 					.and_then(|n| n.to_str().map(|s| String::from(s)))
 			})
-		}).collect();
+		})
+		.collect();
 
 	let dir_difference: Vec<String> = subdirectories_found
 		.difference(&subdirectories_expected)
@@ -1161,7 +1159,8 @@ fn check_and_remove_files(txhashset_path: &PathBuf, header: &BlockHeader) -> Res
 			} else {
 				String::from(s)
 			}
-		}).collect();
+		})
+		.collect();
 
 	let subdirectories = fs::read_dir(txhashset_path)?;
 	for subdirectory in subdirectories {
@@ -1174,7 +1173,8 @@ fn check_and_remove_files(txhashset_path: &PathBuf, header: &BlockHeader) -> Res
 						.file_name()
 						.and_then(|n| n.to_str().map(|s| String::from(s)))
 				})
-			}).collect();
+			})
+			.collect();
 		let difference: Vec<String> = pmmr_files_found
 			.difference(&pmmr_files_expected)
 			.cloned()

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate chrono;
 extern crate env_logger;
 extern crate grin_chain as chain;
 extern crate grin_core as core;
@@ -20,14 +21,13 @@ extern crate grin_store as store;
 extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 extern crate rand;
-extern crate chrono;
 
+use chrono::Duration;
 use std::fs;
 use std::sync::Arc;
-use chrono::Duration;
 
-use chain::Chain;
 use chain::types::{NoopAdapter, Tip};
+use chain::Chain;
 use core::core::target::Difficulty;
 use core::core::{Block, BlockHeader, Transaction};
 use core::global::{self, ChainTypes};

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -96,8 +96,6 @@ fn data_files() {
 				.process_block(b.clone(), chain::Options::MINE)
 				.unwrap();
 
-			let head = Tip::from_block(&b.header);
-
 			chain.validate(false).unwrap();
 		}
 	}

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -242,15 +242,12 @@ fn spend_in_fork_and_compact() {
 	// mine the first block and keep track of the block_hash
 	// so we can spend the coinbase later
 	let b = prepare_block(&kc, &fork_head, &chain, 2);
-	let block_hash = b.hash();
 	let out_id = OutputIdentifier::from_output(&b.outputs()[0]);
 	assert!(out_id.features.contains(OutputFeatures::COINBASE_OUTPUT));
 	fork_head = b.header.clone();
 	chain
 		.process_block(b.clone(), chain::Options::SKIP_POW)
 		.unwrap();
-
-	let merkle_proof = chain.get_merkle_proof(&out_id, &b.header).unwrap();
 
 	// now mine three further blocks
 	for n in 3..6 {

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -23,7 +23,7 @@ extern crate rand;
 use std::fs;
 use std::sync::Arc;
 
-use chain::{ChainStore, Tip};
+use chain::Tip;
 use core::core::hash::Hashed;
 use core::core::target::Difficulty;
 use core::core::{Block, BlockHeader};

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -26,7 +26,7 @@ use std::fs;
 use std::sync::Arc;
 
 use chain::types::NoopAdapter;
-use chain::{Error, ErrorKind};
+use chain::ErrorKind;
 use core::core::target::Difficulty;
 use core::core::{transaction, OutputIdentifier};
 use core::global::{self, ChainTypes};
@@ -86,16 +86,9 @@ fn test_coinbase_maturity() {
 			.contains(transaction::OutputFeatures::COINBASE_OUTPUT)
 	);
 
-	let out_id = OutputIdentifier::from_output(&coinbase_output);
-
-	// we will need this later when we want to spend the coinbase output
-	let block_hash = block.hash();
-
 	chain
 		.process_block(block.clone(), chain::Options::MINE)
 		.unwrap();
-
-	let merkle_proof = chain.get_merkle_proof(&out_id, &block.header).unwrap();
 
 	let prev = chain.head_header().unwrap();
 

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -83,11 +83,10 @@ impl BlockChain for ChainAdapter {
 			.store
 			.get_block_header(&block_hash)
 			.map_err(|_| PoolError::Other(format!("failed to get header")))?;
-		let head_header = self.chain_head()?;
 
 		let mut txhashset = self.txhashset.write().unwrap();
 		let res = txhashset::extending_readonly(&mut txhashset, |extension| {
-			extension.rewind(&header, &head_header)?;
+			extension.rewind(&header)?;
 			let valid_txs = extension.validate_raw_txs(txs, pre_tx)?;
 			Ok(valid_txs)
 		}).map_err(|e| PoolError::Other(format!("Error: test chain adapter: {:?}", e)))?;


### PR DESCRIPTION
* pass single header to `extension.rewind()`, no need to pass head_header each time
* safely handle the case where `head_header` is behind the header being rewound to (rewind during fast sync)

While working on this PR discovered we had introduced a bug in the way we were handling `block_input_bitmaps` when we moved to LMDB - 

https://github.com/mimblewimble/grin/blob/82a467ac3c4f9e1caf17540c72f2a8b584817484/chain/src/txhashset.rs#L765-L767

We introduced the concept of a `batch` as part of LMDB (for writing batches of updates to the db).
We should be saving a input_pos_bitmap to the db for _each_ block being rewound.
But this had been rewritten - passing a single `found` flag back and writing a _single_ aggregated `block_input_bitmap` for the head_header block hash only.

I'm having a hard time understanding what this is actually doing but it is not correct.
I don't really know what the impact of this is - I don't see how we haven't seen more serious problems in `testnet3` due to the fact we are not "unwinding" spent inputs correctly like this.

I _suspect_ we have got away with this so far because we have relatively few txs in `testnet3`...

Resolved this by moving the `block_input_bitmap` operations to the batch itself and simply handling read/write/cache of these via the current batch.
The batch gets committed at the end if everything is successful.

