### PR TITLE
fast check for duplicate tx in the pool

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -179,6 +179,12 @@ where
 
 		// Combine all the txs from the pool with any extra txs provided.
 		let mut txs = self.all_transactions();
+
+		// Quick check to see if we have seen this tx before.
+		if txs.contains(&entry.tx) {
+			return Err(PoolError::DuplicateTx);
+		}
+
 		txs.extend(extra_txs);
 
 		let agg_tx = if txs.is_empty() {

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -174,6 +174,8 @@ pub enum PoolError {
 	LowFeeTransaction(u64),
 	/// Attempt to add a duplicate output to the pool.
 	DuplicateCommitment,
+	/// Attempt to add a duplicate tx to the pool.
+	DuplicateTx,
 	/// Other kinds of error (not yet pulled out into meaningful errors).
 	Other(String),
 }


### PR DESCRIPTION
We were relying on the tx pool aggregation logic to make sure we rejected duplicate txs (the commitments would not sum correctly).
This is kind of an expensive way of identifying a duplicate tx.

This PR adds a quick initial check and returns the new PoolError::DuplicateTx if we have already seen it before.

```
Aug 20 22:07:39.446 DEBG Received tx 7f51a4dc, inputs: 8, outputs: 4, kernels: 1, going to process.
Aug 20 22:07:39.517 DEBG pool [txpool]: add_to_pool: 7f51a4dc, TxSource { debug_name: "p2p", identifier: "?.?.?.?" }, inputs: 8, outputs: 4, kernels: 1 (at block 121ef378)
Aug 20 22:07:39.518 DEBG Transaction 7f51a4dc rejected: DuplicateTx
```