### PR TITLE
use chrono for timestamp in with_reward

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -555,10 +555,13 @@ impl Block {
 			secp.commit_sum(excesses, vec![])?
 		};
 
+		let now = Utc::now().timestamp();
+		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);
+
 		Block {
 			header: BlockHeader {
 				height: prev.height + 1,
-				timestamp: Utc::now(),
+				timestamp,
 				previous: prev.hash(),
 				total_difficulty: difficulty + prev.total_difficulty,
 				total_kernel_offset,


### PR DESCRIPTION
We were just defaulting to `Utc::now()` to initialize block header timestamp in `Block::with_reward()`.
In some of the tests we do not then overwrite this value with a "real" timestamp.

This meant we were needing to jump through some hoops to strip off the nanos from the timestamp in tests because serialization/deserialization was stripping the nanos off (expected behavior).

I'm proposing we use `NaiveDateTime::from_timestamp(now, 0)` here to be consistent with other timestamp usage in Grin and to keep "local" block headers identical to deserialized block headers.

Example of how the timestamp changes pre- and post- serialization/deserialization - 
```
---- serialize_deserialize_block stdout ----
thread 'serialize_deserialize_block' panicked at 'assertion failed: `(left == right)`
  left: `BlockHeader { version: 1, height: 1, previous: cd27d5a8, timestamp: 2018-08-22T13:27:29.649338Z, total_difficulty: Difficulty { num: 2 }, output_root: 00000000, range_proof_root: 00000000, kernel_root: 00000000, total_kernel_offset: 0000000000000000000000000000000000000000000000000000000000000000, total_kernel_sum: Commitment(09f122f40d5b027aeb9aeb828ffdcc4eccdefdab5852c036df89f18d8bd7c38d0d), output_mmr_size: 0, kernel_mmr_size: 0, nonce: 0, pow: Cuckoo30(99fdb2 f43446 1d27486 1ff2067 1ff75ad 2041b24 2450f3d 2671853 28fdef2 3e802e9 409e017 53f067d 5d256cb 610ff16 6c74716 6d17e75 785d485 80dc0e8 9418d56 b82317a c8a5104 d5f7d7e d60aa0a ed5d04f fa5820e 10874586 10eaa565 1208cadc 12572d53 128665db 131ea0ad 13d9965f 16bdf55a 17fb657e 1a5a5b1f 1ae16f59 1c744e90 1d8bfb51 1f6cfb96 1f99b3ee 1fcf9a35 1fec31e4) }`,
 right: `BlockHeader { version: 1, height: 1, previous: cd27d5a8, timestamp: 2018-08-22T13:27:29Z, total_difficulty: Difficulty { num: 2 }, output_root: 00000000, range_proof_root: 00000000, kernel_root: 00000000, total_kernel_offset: 0000000000000000000000000000000000000000000000000000000000000000, total_kernel_sum: Commitment(09f122f40d5b027aeb9aeb828ffdcc4eccdefdab5852c036df89f18d8bd7c38d0d), output_mmr_size: 0, kernel_mmr_size: 0, nonce: 0, pow: Cuckoo30(99fdb2 f43446 1d27486 1ff2067 1ff75ad 2041b24 2450f3d 2671853 28fdef2 3e802e9 409e017 53f067d 5d256cb 610ff16 6c74716 6d17e75 785d485 80dc0e8 9418d56 b82317a c8a5104 d5f7d7e d60aa0a ed5d04f fa5820e 10874586 10eaa565 1208cadc 12572d53 128665db 131ea0ad 13d9965f 16bdf55a 17fb657e 1a5a5b1f 1ae16f59 1c744e90 1d8bfb51 1f6cfb96 1f99b3ee 1fcf9a35 1fec31e4) }`', core/tests/block.rs:227:2
```