### PR TITLE
remove break from msg read_exact

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -138,8 +138,6 @@ pub fn read_exact(
 		if !buf.is_empty() {
 			thread::sleep(sleep_time);
 			count += 1;
-		} else {
-			break;
 		}
 		if count > timeout {
 			return Err(io::Error::new(


### PR DESCRIPTION
What is this `break` for?

https://github.com/mimblewimble/grin/blob/105bfacaa6ff2f5dbc24c00e0b3164999d025c8b/p2p/src/msg.rs#L138-L143

Right now if we hit an `Interrupted` or a `WouldBlock` earlier and we have 0 bytes in the buffer (not yet successfully read anything) then we just `break` and do not keep looping.

This feels wrong but likely I'm misunderstanding something?
Wrong as in there is a _huge_ edge case here where we just stop reading msgs before we have even started.

@ignopeverell 