### PR TITLE
improve: get_locator optimization (#1372)

### DIFF
--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -517,19 +517,25 @@ impl SyncInfo {
 	fn header_sync_due(&mut self, header_head: &chain::Tip) -> bool {
 		let now = Utc::now();
 		let (timeout, latest_height, prev_height) = self.prev_header_sync;
-		
+
 		// received all necessary headers, can ask for more
-		let all_headers_received = header_head.height >= prev_height + (p2p::MAX_BLOCK_HEADERS as u64) - 4;
+		let all_headers_received =
+			header_head.height >= prev_height + (p2p::MAX_BLOCK_HEADERS as u64) - 4;
 		// no headers processed and we're past timeout, need to ask for more
 		let stalling = header_head.height == latest_height && now > timeout;
 
 		if all_headers_received || stalling {
-			self.prev_header_sync = (now + Duration::seconds(10), header_head.height, header_head.height);
+			self.prev_header_sync = (
+				now + Duration::seconds(10),
+				header_head.height,
+				header_head.height,
+			);
 			true
 		} else {
 			// resetting the timeout as long as we progress
 			if header_head.height > latest_height {
-				self.prev_header_sync = (now + Duration::seconds(2), header_head.height, prev_height);
+				self.prev_header_sync =
+					(now + Duration::seconds(2), header_head.height, prev_height);
 			}
 			false
 		}

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -425,10 +425,10 @@ fn get_locator(
 	let heights = get_locator_heights(tip.height);
 	let mut new_heights: Vec<u64> = vec![];
 
-	// for security, clear history_locators[] in any case of header chain rollback
+	// for security, clear history_locators[] in any case of header chain rollback,
+	// the easiest way is to check whether the sync head and the header head are identical.
 	if history_locators.len() > 0
-		&& tip.height
-			!= history_locators[history_locators.len() - 1].0 + p2p::MAX_BLOCK_HEADERS as u64 - 1
+		&& tip.hash() != chain.get_header_head()?.hash()
 	{
 		history_locators.clear();
 	}

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -425,6 +425,14 @@ fn get_locator(
 	let heights = get_locator_heights(tip.height);
 	let mut new_heights: Vec<u64> = vec![];
 
+	// for security, clear history_locators[] in any case of header chain rollback
+	if history_locators.len() > 0
+		&& tip.height
+			!= history_locators[history_locators.len() - 1].0 + p2p::MAX_BLOCK_HEADERS as u64 - 1
+	{
+		history_locators.clear();
+	}
+
 	debug!(LOGGER, "sync: locator heights : {:?}", heights);
 
 	let mut locator: Vec<Hash> = vec![];


### PR DESCRIPTION
The `get_locator()` optimization according to the idea in https://github.com/mimblewimble/grin/issues/1372 .

> locator heights right now are always going to be:
> 
> [0, -2, -4, -8, -16, -32, -64, -128, -256, -512, -1024, -2048, ...]
> The further back you go, the more expensive it gets. When we only add 500 headers, it doesn't really matter whether the locator has block at -2048 or -2548. So we could reuse that hash instead of going -2048 back to get a new hash. In that scheme, only the recent part of the locator (0 to -512) gets update.

I use `prev_locators` to save the used locators and reuse it next time.