### PR TITLE
lightweight validation during deserialization

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -301,8 +301,11 @@ impl Readable for Block {
 
 		let body = TransactionBody::read(reader)?;
 
-		// Now validate the body and treat any validation error as corrupted data.
-		body.validate(true).map_err(|_| ser::Error::CorruptedData)?;
+		// Now "lightweight" validation of the block.
+		// Treat any validation issues as data corruption.
+		// An example of this would be reading a block
+		// that exceeded the allowed number of inputs.
+		body.validate_read(true).map_err(|_| ser::Error::CorruptedData)?;
 
 		Ok(Block {
 			header: header,
@@ -526,6 +529,18 @@ impl Block {
 			header: self.header,
 			body,
 		})
+	}
+
+	/// "Lightweight" validation that we can perform quickly during read/deserialization.
+	/// Subset of full validation that skips expensive verification steps, specifically -
+	/// * rangeproof verification (on the body)
+	/// * kernel signature verification (on the body)
+	/// * coinbase sum verification
+	/// * kernel sum verification
+	pub fn validate_read(&self) -> Result<(), Error> {
+		self.body.validate_read(true)?;
+		self.verify_kernel_lock_heights()?;
+		Ok(())
 	}
 
 	/// Validates all the elements in a block that can be checked without

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -305,7 +305,8 @@ impl Readable for Block {
 		// Treat any validation issues as data corruption.
 		// An example of this would be reading a block
 		// that exceeded the allowed number of inputs.
-		body.validate_read(true).map_err(|_| ser::Error::CorruptedData)?;
+		body.validate_read(true)
+			.map_err(|_| ser::Error::CorruptedData)?;
 
 		Ok(Block {
 			header: header,

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -68,7 +68,8 @@ impl CompactBlockBody {
 		self.kern_ids.sort();
 	}
 
-	fn validate(&self) -> Result<(), Error> {
+	/// "Lightweight" validation.
+	fn validate_read(&self) -> Result<(), Error> {
 		self.verify_sorted()?;
 		Ok(())
 	}
@@ -138,8 +139,9 @@ pub struct CompactBlock {
 }
 
 impl CompactBlock {
-	fn validate(&self) -> Result<(), Error> {
-		self.body.validate()?;
+	/// "Lightweight" validation.
+	fn validate_read(&self) -> Result<(), Error> {
+		self.body.validate_read()?;
 		Ok(())
 	}
 
@@ -225,7 +227,7 @@ impl Readable for CompactBlock {
 		};
 
 		// Now validate the compact block and treat any validation error as corrupted data.
-		cb.validate().map_err(|_| ser::Error::CorruptedData)?;
+		cb.validate_read().map_err(|_| ser::Error::CorruptedData)?;
 
 		Ok(cb)
 	}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -544,6 +544,17 @@ impl TransactionBody {
 		Ok(())
 	}
 
+	/// "Lightweight" validation that we can perform quickly during read/deserialization.
+	/// Subset of full validation that skips expensive verification steps, specifically -
+	/// * rangeproof verification
+	/// * kernel signature verification
+	pub fn validate_read(&self, with_reward: bool) -> Result<(), Error> {
+		self.verify_weight(with_reward)?;
+		self.verify_sorted()?;
+		self.verify_cut_through()?;
+		Ok(())
+	}
+
 	/// Validates all relevant parts of a transaction body. Checks the
 	/// excess value against the signature as well as range proofs for each
 	/// output.
@@ -598,11 +609,11 @@ impl Readable for Transaction {
 		let body = TransactionBody::read(reader)?;
 		let tx = Transaction { offset, body };
 
-		// Now validate the tx.
+		// Now "lightweight" validation of the tx.
 		// Treat any validation issues as data corruption.
 		// An example of this would be reading a tx
 		// that exceeded the allowed number of inputs.
-		tx.validate(false).map_err(|_| ser::Error::CorruptedData)?;
+		tx.validate_read(false).map_err(|_| ser::Error::CorruptedData)?;
 
 		Ok(tx)
 	}
@@ -730,6 +741,19 @@ impl Transaction {
 	/// Lock height of a transaction is the max lock height of the kernels.
 	pub fn lock_height(&self) -> u64 {
 		self.body.lock_height()
+	}
+
+	/// "Lightweight" validation that we can perform quickly during read/deserialization.
+	/// Subset of full validation that skips expensive verification steps, specifically -
+	/// * rangeproof verification (on the body)
+	/// * kernel signature verification (on the body)
+	/// * kernel sum verification
+	pub fn validate_read(&self, with_reward: bool) -> Result<(), Error> {
+		self.body.validate_read(with_reward)?;
+		if !with_reward {
+			self.body.verify_features()?;
+		}
+		Ok(())
 	}
 
 	/// Validates all relevant parts of a fully built transaction. Checks the

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -613,7 +613,8 @@ impl Readable for Transaction {
 		// Treat any validation issues as data corruption.
 		// An example of this would be reading a tx
 		// that exceeded the allowed number of inputs.
-		tx.validate_read(false).map_err(|_| ser::Error::CorruptedData)?;
+		tx.validate_read(false)
+			.map_err(|_| ser::Error::CorruptedData)?;
 
 		Ok(tx)
 	}


### PR DESCRIPTION
We are currently performing a full validation of txs and blocks when deserializing them in `read()`.
This PR introduces a lightweight `validate_read()` that performs weight and sort validation steps, but skips the expensive steps like rangeproof verification and kernel summing.

This was one of the complicating factors when tackling #1419 so addressing this separately to simplify the main validation path.

