### PR TITLE
Fix LocalServerContainer and remove backtraces

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -214,7 +214,12 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		let res = w(&self.chain).process_block_header(&bh, self.chain_opts());
 
 		if let &Err(ref e) = &res {
-			debug!(LOGGER, "Block header {} refused by chain: {:?}", bhash, e);
+			debug!(
+				LOGGER,
+				"Block header {} refused by chain: {:?}",
+				bhash,
+				e.kind()
+			);
 			if e.is_bad_data() {
 				debug!(
 					LOGGER,
@@ -480,7 +485,9 @@ impl NetToChainAdapter {
 					_ => {
 						debug!(
 							LOGGER,
-							"adapter: process_block: block {} refused by chain: {}", bhash, e
+							"adapter: process_block: block {} refused by chain: {}",
+							bhash,
+							e.kind()
 						);
 						true
 					}

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -33,9 +33,8 @@ use wallet::{FileWallet, HTTPWalletClient, WalletConfig};
 /// Just removes all results from previous runs
 pub fn clean_all_output(test_name_dir: &str) {
 	let target_dir = format!("target/tmp/{}", test_name_dir);
-	let result = fs::remove_dir_all(target_dir);
-	if let Err(e) = result {
-		println!("{}", e);
+	if let Err(e) = fs::remove_dir_all(target_dir) {
+		println!("can't remove output from previous test :{}, may be ok", e);
 	}
 }
 
@@ -154,10 +153,10 @@ pub struct LocalServerContainer {
 impl LocalServerContainer {
 	/// Create a new local server container with defaults, with the given name
 	/// all related files will be created in the directory
-	/// target/tmp/test_servers/{name}
+	/// target/tmp/{name}
 
 	pub fn new(config: LocalServerContainerConfig) -> Result<LocalServerContainer, Error> {
-		let working_dir = format!("target/tmp/test_servers/{}", config.name);
+		let working_dir = format!("target/tmp/{}", config.name);
 		let mut wallet_config = WalletConfig::default();
 
 		wallet_config.api_listen_port = config.wallet_port;


### PR DESCRIPTION
* LocalServerContainer used a different folder than regular server, so test could not find txhashset files
* Error stacktrace was printed in cases when error was expected, which created some noise and confusion