### PR TITLE
Fix flakiness of simple_server_wallet test

### DIFF
--- a/servers/tests/api.rs
+++ b/servers/tests/api.rs
@@ -422,7 +422,7 @@ fn get_ids_from_block_outputs(block_outputs: Vec<api::BlockOutputs>) -> Vec<Stri
 			ids.push(util::to_hex(output.clone().commit.0.to_vec()));
 		}
 	}
-	ids
+	ids.into_iter().take(100).collect()
 }
 
 pub fn ban_peer(base_addr: &String, api_server_port: u16, peer_addr: &String) -> Result<(), Error> {


### PR DESCRIPTION
It produces 1000+ otputs on a fast machine (?) and generates invalid URL as result (too many paramaters). We don't care about sending all outputs in this test, we just need something.