### PR TITLE
fix for unstable travis-ci test on servers module

### DIFF
--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -144,7 +144,7 @@ impl Server {
 	/// we're already connected to the provided address.
 	pub fn connect(&self, addr: &SocketAddr) -> Result<Arc<RwLock<Peer>>, Error> {
 		if Peer::is_denied(&self.config, &addr) {
-			debug!(LOGGER, "Peer {} denied, not connecting.", addr);
+			debug!(LOGGER, "connect_peer: peer {} denied, not connecting.", addr);
 			return Err(Error::ConnectionClose);
 		}
 
@@ -154,7 +154,13 @@ impl Server {
 			return Ok(p);
 		}
 
-		trace!(LOGGER, "connect_peer: connecting to {}", addr);
+		trace!(
+			LOGGER,
+			"connect_peer: {}:{} connecting to {}",
+			self.config.host,
+			self.config.port,
+			addr
+		);
 		match TcpStream::connect_timeout(addr, Duration::from_secs(10)) {
 			Ok(mut stream) => {
 				let addr = SocketAddr::new(self.config.host, self.config.port);
@@ -176,7 +182,14 @@ impl Server {
 				Ok(added)
 			}
 			Err(e) => {
-				debug!(LOGGER, "Could not connect to {}: {:?}", addr, e);
+				debug!(
+					LOGGER,
+					"connect_peer: {}:{} could not connect to {}: {:?}",
+					self.config.host,
+					self.config.port,
+					addr,
+					e
+				);
 				Err(Error::Connection(e))
 			}
 		}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -151,10 +151,12 @@ impl Server {
 			return Err(Error::ConnectionClose);
 		}
 
+		// check ip and port to see if we are trying to connect to ourselves
+		// todo: this can't detect all cases of PeerWithSelf, for example config.host is '0.0.0.0'
+		//
 		if self.config.port == addr.port()
 			&& (addr.ip().is_loopback() || addr.ip() == self.config.host)
 		{
-			debug!(LOGGER, "connect_peer: peer {} denied, PeerWithSelf.", addr);
 			return Err(Error::PeerWithSelf);
 		}
 
@@ -166,7 +168,7 @@ impl Server {
 
 		trace!(
 			LOGGER,
-			"connect_peer: {}:{} connecting to {}",
+			"connect_peer: on {}:{}. connecting to {}",
 			self.config.host,
 			self.config.port,
 			addr
@@ -194,7 +196,7 @@ impl Server {
 			Err(e) => {
 				debug!(
 					LOGGER,
-					"connect_peer: {}:{} could not connect to {}: {:?}",
+					"connect_peer: on {}:{}. Could not connect to {}: {:?}",
 					self.config.host,
 					self.config.port,
 					addr,

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -144,8 +144,18 @@ impl Server {
 	/// we're already connected to the provided address.
 	pub fn connect(&self, addr: &SocketAddr) -> Result<Arc<RwLock<Peer>>, Error> {
 		if Peer::is_denied(&self.config, &addr) {
-			debug!(LOGGER, "connect_peer: peer {} denied, not connecting.", addr);
+			debug!(
+				LOGGER,
+				"connect_peer: peer {} denied, not connecting.", addr
+			);
 			return Err(Error::ConnectionClose);
+		}
+
+		if self.config.port == addr.port()
+			&& (addr.ip().is_loopback() || addr.ip() == self.config.host)
+		{
+			debug!(LOGGER, "connect_peer: peer {} denied, PeerWithSelf.", addr);
+			return Err(Error::PeerWithSelf);
 		}
 
 		if let Some(p) = self.peers.get_connected_peer(addr) {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -18,6 +18,7 @@
 
 use chrono::prelude::Utc;
 use chrono::Duration;
+use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -130,8 +131,10 @@ fn monitor_peers(
 
 	debug!(
 		LOGGER,
-		"monitor_peers: {} connected ({} most_work). \
+		"monitor_peers: on {}:{}, {} connected ({} most_work). \
 		 all {} = {} healthy + {} banned + {} defunct",
+		config.host,
+		config.port,
 		peers.peer_count(),
 		peers.most_work_peers().len(),
 		total_count,
@@ -153,7 +156,13 @@ fn monitor_peers(
 	let mut connected_peers: Vec<SocketAddr> = vec![];
 	for p in peers.connected_peers() {
 		if let Ok(p) = p.try_read() {
-			debug!(LOGGER, "monitor_peers: ask {} for more peers", p.info.addr);
+			debug!(
+				LOGGER,
+				"monitor_peers: {}:{} ask {} for more peers",
+				config.host,
+				config.port,
+				p.info.addr,
+			);
 			let _ = p.send_peer_request(capabilities);
 			connected_peers.push(p.info.addr)
 		} else {
@@ -183,7 +192,13 @@ fn monitor_peers(
 		config.peer_max_count() as usize,
 	);
 	for p in new_peers.iter().filter(|p| !peers.is_known(&p.addr)) {
-		debug!(LOGGER, "monitor_peers: queue to soon try {}", p.addr);
+		debug!(
+			LOGGER,
+			"monitor_peers: on {}:{}, queue to soon try {}",
+			config.host,
+			config.port,
+			p.addr,
+		);
 		tx.send(p.addr).unwrap();
 	}
 }
@@ -256,18 +271,58 @@ fn listen_for_addrs(
 			let _ = thread::Builder::new()
 				.name("peer_connect".to_string())
 				.spawn(move || {
-					let connect_peer = p2p_c.connect(&addr);
-					match connect_peer {
-						Ok(p) => {
-							trace!(LOGGER, "connect_and_req: ok. attempting send_peer_request");
-							if let Ok(p) = p.try_read() {
-								let _ = p.send_peer_request(capab);
+					let mut connect_retry_count = 0;
+					loop {
+						let connect_peer = p2p_c.connect(&addr);
+						match connect_peer {
+							Ok(p) => {
+								trace!(
+									LOGGER,
+									"connect_and_req: from {}:{} to {}, ok. attempting send_peer_request",
+									p2p_c.config.host,
+									p2p_c.config.port,
+									addr
+								);
+								if let Ok(p) = p.try_read() {
+									let _ = p.send_peer_request(capab);
+								}
+								let _ = peers_c.update_state(addr, p2p::State::Healthy);
+								break;
+							}
+							Err(e) => {
+								debug!(
+									LOGGER,
+									"connect_and_req: from {}:{} to {}, is Defunct. {:?}",
+									p2p_c.config.host,
+									p2p_c.config.port,
+									addr,
+									e,
+								);
+								let _ = peers_c.update_state(addr, p2p::State::Defunct);
+
+								// don't retry if connection refused
+								if let p2p::Error::Connection(io_err) = e {
+									if io::ErrorKind::ConnectionRefused == io_err.kind() {
+										break;
+									}
+								}
 							}
 						}
-						Err(e) => {
-							debug!(LOGGER, "connect_and_req: {} is Defunct; {:?}", addr, e);
-							let _ = peers_c.update_state(addr, p2p::State::Defunct);
+
+						// retry for 3 times
+						thread::sleep(time::Duration::from_secs(1));
+						connect_retry_count += 1;
+						if connect_retry_count >= 3 {
+							break;
 						}
+						debug!(
+							LOGGER,
+							"connect_and_req: from {}:{} to {}, retrying {}",
+							p2p_c.config.host,
+							p2p_c.config.port,
+							addr,
+							connect_retry_count,
+						);
 					}
 				});
 		}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -272,7 +272,7 @@ fn listen_for_addrs(
 							Ok(p) => {
 								trace!(
 									LOGGER,
-									"connect_and_req: from {}:{} to {}, ok. attempting send_peer_request",
+									"connect_and_req: on {}:{}. connect to {} ok. attempting send_peer_request",
 									p2p_c.config.host,
 									p2p_c.config.port,
 									addr
@@ -286,7 +286,7 @@ fn listen_for_addrs(
 							Err(e) => {
 								debug!(
 									LOGGER,
-									"connect_and_req: from {}:{} to {}, is Defunct. {:?}",
+									"connect_and_req: on {}:{}. connect to {} is Defunct. {:?}",
 									p2p_c.config.host,
 									p2p_c.config.port,
 									addr,
@@ -315,7 +315,7 @@ fn listen_for_addrs(
 						}
 						debug!(
 							LOGGER,
-							"connect_and_req: from {}:{} to {}, retrying {}",
+							"connect_and_req: on {}:{}. connect to {} retrying {}",
 							p2p_c.config.host,
 							p2p_c.config.port,
 							addr,

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -225,7 +225,7 @@ impl LocalServerContainer {
 
 		for p in &mut self.peer_list {
 			println!("{} connecting to peer: {}", self.config.p2p_server_port, p);
-			s.connect_peer(p.parse().unwrap()).unwrap();
+			let _ = s.connect_peer(p.parse().unwrap());
 		}
 
 		if self.wallet_is_running {

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -208,6 +208,8 @@ fn simulate_block_propagation() {
 
 	// monitor for a change of head on a different server and check whether
 	// chain height has changed
+	let mut success = false;
+	let mut time_spent = 0;
 	loop {
 		let mut count = 0;
 		for n in 0..5 {
@@ -216,13 +218,22 @@ fn simulate_block_propagation() {
 			}
 		}
 		if count == 5 {
+			success = true;
 			break;
 		}
 		thread::sleep(time::Duration::from_millis(1_000));
+		time_spent += 1;
+		if time_spent >= 60 {
+			break;
+		}
 	}
 	for n in 0..5 {
 		servers[n].stop();
 	}
+	assert_eq!(true, success);
+
+	// wait servers fully stop before start next automated test
+	thread::sleep(time::Duration::from_millis(1_000));
 }
 
 /// Creates 2 different disconnected servers, mine a few blocks on one, connect
@@ -248,8 +259,14 @@ fn simulate_full_sync() {
 	let s1_header = s1.chain.head_header().unwrap();
 
 	// Wait for s2 to sync up to and including the header from s1.
+	let mut time_spent = 0;
 	while s2.head().height < s1_header.height {
 		thread::sleep(time::Duration::from_millis(1_000));
+		time_spent += 1;
+		if time_spent >= 60 {
+			println!("sync fail. s2.head().height: {}, s1_header.height: {}", s2.head().height, s1_header.height);
+			break;
+		}
 	}
 
 	// Confirm both s1 and s2 see a consistent header at that height.
@@ -259,6 +276,9 @@ fn simulate_full_sync() {
 	// Stop our servers cleanly.
 	s1.stop();
 	s2.stop();
+
+	// wait servers fully stop before start next automated test
+	thread::sleep(time::Duration::from_millis(1_000));
 }
 
 /// Creates 2 different disconnected servers, mine a few blocks on one, connect
@@ -307,6 +327,9 @@ fn simulate_fast_sync() {
 	// Stop our servers cleanly.
 	s1.stop();
 	s2.stop();
+
+	// wait servers fully stop before start next automated test
+	thread::sleep(time::Duration::from_millis(1_000));
 }
 
 // #[test]
@@ -346,6 +369,9 @@ fn simulate_fast_sync_double() {
 	}
 	s1.stop();
 	s2.stop();
+
+	// wait servers fully stop before start next automated test
+	thread::sleep(time::Duration::from_millis(1_000));
 }
 
 pub fn create_wallet(


### PR DESCRIPTION
This is one of the 3 fixing PRs for https://github.com/mimblewimble/grin/issues/1424 .

One of the root causes of unstable `travis-ci` test is clear now:
```
DEBG monitor_peers: 0 connected (0 most_work). all 0 = 0 healthy + 0 banned + 0 defunct
...
WARN sync: no peers available, disabling sync
DEBG sync_state: sync_status: Initial -> NoSync
```
The root cause of this `no peers` is peer connect for seeds fail for some reason.

My fix solution:
- allow 3 times retry in case of peer connect fail, on `connect_and_monitor()` function.
- but don't retry if this fail is because a connection refused.

Another major change is in `servers/tests/simulnet.rs`, to avoid infinite loop on test:
- 60 seconds maximum time limitation for `simulate_block_propagation()`
- 60 seconds maximum time limitation for `simulate_full_sync()`




