### PR TITLE
Fix non-atomic peer update

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -109,7 +109,8 @@ impl Peers {
 
 	/// Get vec of peers we are currently connected to.
 	pub fn connected_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
-		let mut res = self.peers
+		let mut res = self
+			.peers
 			.read()
 			.unwrap()
 			.values()
@@ -252,13 +253,6 @@ impl Peers {
 	pub fn ban_peer(&self, peer_addr: &SocketAddr, ban_reason: ReasonForBan) {
 		if let Err(e) = self.update_state(*peer_addr, State::Banned) {
 			error!(LOGGER, "Couldn't ban {}: {:?}", peer_addr, e);
-		}
-
-		if let Err(e) = self.update_last_banned(*peer_addr, Utc::now().timestamp()) {
-			error!(
-				LOGGER,
-				"Couldn't update last_banned time {}: {:?}", peer_addr, e
-			);
 		}
 
 		if let Some(peer) = self.get_connected_peer(peer_addr) {
@@ -440,13 +434,6 @@ impl Peers {
 	pub fn update_state(&self, peer_addr: SocketAddr, new_state: State) -> Result<(), Error> {
 		self.store
 			.update_state(peer_addr, new_state)
-			.map_err(From::from)
-	}
-
-	/// Updates the last banned time of a peer in store
-	pub fn update_last_banned(&self, peer_addr: SocketAddr, last_banned: i64) -> Result<(), Error> {
-		self.store
-			.update_last_banned(peer_addr, last_banned)
 			.map_err(From::from)
 	}
 


### PR DESCRIPTION
When we ban a peer we do it in 3 transaction: get peer (read tx), update the peer's state (write tx), update ban timestamp (write tx). At the same time we have a seeder thread which reads all peers from db from time to time. Among other things it unbans peers after 10 000 seconds. There is some probability to read a peer in an inconsistent state in the seeder thread, when it has been just banned, but timestamp is still 0, so the seeder thread will unban it.

Recently we switched to 1 seconds peer update at the start, which remains constant in the most of the tests (in production we switch to 20 secs after getting enough peers). In this case probability was increased up to 10%, so I was able to reproduce it by just having some persistence. 

This pr removes `update_last_banned` method (considered harmful) and put all ban operations under one write tx. I'll check for the same pattern in other parts of the code, didn't find anything like that on p2p yet.

Fixes https://github.com/mimblewimble/grin/issues/1424