### PR TITLE
complete the 'simulate_seeding' test case for automatic test

### DIFF
--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -105,6 +105,9 @@ fn simulate_seeding() {
 
 	pool.create_server(&mut server_config);
 
+	// wait the seed server fully start up before start remaining servers
+	thread::sleep(time::Duration::from_millis(1_000));
+
 	// point next servers at first seed
 	server_config.is_seeding = false;
 	server_config.seed_addr = String::from(format!(
@@ -116,10 +119,27 @@ fn simulate_seeding() {
 		pool.create_server(&mut server_config);
 	}
 
-	// pool.connect_all_peers();
-
 	let servers = pool.run_all_servers();
+	thread::sleep(time::Duration::from_secs(5));
+
+	// Check they all end up connected.
+	let url = format!("http://{}:{}/v1/peers/all", &server_config.base_addr, 30020);
+	let peers_all = api::client::get::<Vec<p2p::PeerData>>(url.as_str()).map_err(|e| Error::API(e));
+	assert!(peers_all.is_ok());
+	assert_eq!(
+		peers_all
+			.unwrap()
+			.iter()
+			.filter(|x| x.flags == p2p::State::Healthy)
+			.collect::<Vec<&p2p::PeerData>>()
+			.len(),
+		4
+	);
+
 	stop_all_servers(servers);
+
+	// wait servers fully stop before start next automated test
+	thread::sleep(time::Duration::from_millis(1_000));
 }
 
 /// Create 1 server, start it mining, then connect 4 other peers mining and
@@ -459,4 +479,11 @@ fn replicate_tx_fluff_failure() {
 		assert_eq!(res.1.amount_currently_spendable, amount);
 		Ok(())
 	}).unwrap();
+}
+
+/// Error type wrapping underlying module errors.
+#[derive(Debug)]
+enum Error {
+	/// Error originating from HTTP API calls.
+	API(api::Error),
 }

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -124,7 +124,7 @@ fn simulate_seeding() {
 
 	// Check they all end up connected.
 	let url = format!("http://{}:{}/v1/peers/all", &server_config.base_addr, 30020);
-	let peers_all = api::client::get::<Vec<p2p::PeerData>>(url.as_str()).map_err(|e| Error::API(e));
+	let peers_all = api::client::get::<Vec<p2p::PeerData>>(url.as_str());
 	assert!(peers_all.is_ok());
 	assert_eq!(
 		peers_all
@@ -479,11 +479,4 @@ fn replicate_tx_fluff_failure() {
 		assert_eq!(res.1.amount_currently_spendable, amount);
 		Ok(())
 	}).unwrap();
-}
-
-/// Error type wrapping underlying module errors.
-#[derive(Debug)]
-enum Error {
-	/// Error originating from HTTP API calls.
-	API(api::Error),
 }


### PR DESCRIPTION
Test case `simulate_seeding` looks like an unfinished job: 
```
#[test]
fn simulate_seeding() {
	...
	let servers = pool.run_all_servers();
	stop_all_servers(servers);	<<<< run servers then stop server immediately!
	...
```
 Just add a small piece of code to complete this test case.

**Note**:
1. This test case need the fix in https://github.com/mimblewimble/grin/pull/1434, otherwise it will have 50% probability to fail for:
```
thread 'simulate_seeding' panicked at 'assertion failed: `(left == right)`
  left: `3`,
 right: `4`', servers/tests/simulnet.rs:129:2
```

2. Please feel free to ignore this PR. But at least add a `#[ignore]` before it, if it's not useful anymore.

