### PR TITLE
improve: use 10us sleep instead of 1ms in read_exact

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -82,7 +82,12 @@ impl<'a> Message<'a> {
 		while written < len {
 			let read_len = cmp::min(8000, len - written);
 			let mut buf = vec![0u8; read_len];
-			read_exact(&mut self.conn, &mut buf[..], 10000, true)?;
+			read_exact(
+				&mut self.conn,
+				&mut buf[..],
+				time::Duration::from_secs(10),
+				true,
+			)?;
 			writer.write_all(&mut buf)?;
 			written += read_len;
 		}
@@ -117,13 +122,13 @@ impl<'a> Response<'a> {
 		let mut msg =
 			ser::ser_vec(&MsgHeader::new(self.resp_type, self.body.len() as u64)).unwrap();
 		msg.append(&mut self.body);
-		write_all(&mut self.conn, &msg[..], 10000)?;
+		write_all(&mut self.conn, &msg[..], time::Duration::from_secs(10))?;
 		if let Some(mut file) = self.attachment {
 			let mut buf = [0u8; 8000];
 			loop {
 				match file.read(&mut buf[..]) {
 					Ok(0) => break,
-					Ok(n) => write_all(&mut self.conn, &buf[..n], 10000)?,
+					Ok(n) => write_all(&mut self.conn, &buf[..n], time::Duration::from_secs(10))?,
 					Err(e) => return Err(From::from(e)),
 				}
 			}

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -17,6 +17,7 @@ use std::fs::File;
 use std::io::{self, BufWriter};
 use std::net::{SocketAddr, TcpStream};
 use std::sync::Arc;
+use std::time;
 
 use conn::{Message, MessageHandler, Response};
 use core::core::{self, hash::Hash, CompactBlock};
@@ -317,7 +318,7 @@ impl MessageHandler for Protocol {
 fn headers_header_size(conn: &mut TcpStream, msg_len: u64) -> Result<u64, Error> {
 	let mut size = vec![0u8; 2];
 	// read size of Vec<BlockHeader>
-	read_exact(conn, &mut size, 20000, true)?;
+	read_exact(conn, &mut size, time::Duration::from_millis(10), true)?;
 
 	let total_headers = size[0] as u64 * 256 + size[1] as u64;
 	if total_headers == 0 || total_headers > 10_000 {
@@ -391,7 +392,7 @@ fn headers_streaming_body(
 	// 3rd part
 	let mut read_body = vec![0u8; read_size as usize];
 	if read_size > 0 {
-		read_exact(conn, &mut read_body, 20000, true)?;
+		read_exact(conn, &mut read_body, time::Duration::from_secs(20), true)?;
 		*total_read += read_size;
 	}
 	body.append(&mut read_body);


### PR DESCRIPTION
Upon the discussion which is recapped in https://github.com/mimblewimble/grin/issues/1404, it's better to sleep for some nanosecs instead of 1 ms in `read_exact()`.

This PR include 2 little changes:
1. use 10us sleep instead of 1ms in `read_exact`;
2. use `time::Duration` for the `timeout` parameter, instead of a counter of `10000`, `20000` and so on.