### PR TITLE
[DNM] kernel height index

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -625,7 +625,6 @@ impl Chain {
 			batch.save_body_head(&head)?;
 			batch.save_header_height(&header)?;
 			batch.build_by_height_index(&header, true)?;
-
 		}
 
 		batch.commit()?;
@@ -893,13 +892,15 @@ fn setup_kernel_height_index(
 	txhashset: &mut txhashset::TxHashSet,
 ) -> Result<(), Error> {
 	let header = store.head_header()?;
-	let kernel = txhashset::extending_readonly(txhashset, |extension| {
-		extension.kernel_for_block_height(1)
-	});
+	let kernel =
+		txhashset::extending_readonly(txhashset, |extension| extension.kernel_for_block_height(1));
 
 	if let Ok(kernel) = kernel {
 		if let Err(_) = store.get_kernel_height(&kernel) {
-			warn!(LOGGER, "***** backfilling kernel height index from chain init...");
+			warn!(
+				LOGGER,
+				"***** backfilling kernel height index from chain init..."
+			);
 			let mut batch = store.batch()?;
 			txhashset::extending(txhashset, &mut batch, |extension| {
 				extension.rebuild_kernel_height_index(header)?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -158,8 +158,10 @@ impl ChainStore {
 
 	pub fn get_kernel_height(&self, kernel: &TxKernel) -> Result<u64, Error> {
 		option_to_not_found(
-			self.db
-				.get_ser(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec())),
+			self.db.get_ser(&to_key(
+				KERNEL_HEIGHT_PREFIX,
+				&mut kernel.excess.as_ref().to_vec(),
+			)),
 			&format!("Kernel height for: {:?}", kernel),
 		)
 	}
@@ -282,8 +284,10 @@ impl<'a> Batch<'a> {
 
 	pub fn get_kernel_height(&self, kernel: &TxKernel) -> Result<u64, Error> {
 		option_to_not_found(
-			self.db
-				.get_ser(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec())),
+			self.db.get_ser(&to_key(
+				KERNEL_HEIGHT_PREFIX,
+				&mut kernel.excess.as_ref().to_vec(),
+			)),
 			&format!("Kernel height for: {:?}", kernel),
 		)
 	}
@@ -294,8 +298,10 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn delete_kernel_height(&self, kernel: &TxKernel) -> Result<(), Error> {
-		self.db
-			.delete(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec()))
+		self.db.delete(&to_key(
+			KERNEL_HEIGHT_PREFIX,
+			&mut kernel.excess.as_ref().to_vec(),
+		))
 	}
 
 	pub fn get_block_header_db(&self, h: &Hash) -> Result<BlockHeader, Error> {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -25,7 +25,7 @@ use util::secp::pedersen::Commitment;
 use core::consensus::TargetError;
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
-use core::core::{Block, BlockHeader};
+use core::core::{Block, BlockHeader, TxKernel};
 use grin_store as store;
 use grin_store::{option_to_not_found, to_key, u64_to_key, Error};
 use types::Tip;
@@ -40,6 +40,7 @@ const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const HEADER_HEIGHT_PREFIX: u8 = '8' as u8;
 const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const BLOCK_INPUT_BITMAP_PREFIX: u8 = 'B' as u8;
+const KERNEL_HEIGHT_PREFIX: u8 = 'k' as u8;
 
 /// All chain-related database operations
 pub struct ChainStore {
@@ -155,6 +156,14 @@ impl ChainStore {
 		)
 	}
 
+	pub fn get_kernel_height(&self, kernel: &TxKernel) -> Result<u64, Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec())),
+			&format!("Kernel height for: {:?}", kernel),
+		)
+	}
+
 	/// Builds a new batch to be used with this store.
 	pub fn batch(&self) -> Result<Batch, Error> {
 		Ok(Batch {
@@ -256,6 +265,13 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	pub fn save_kernel_height(&self, kernel: &TxKernel, height: u64) -> Result<(), Error> {
+		self.db.put_ser(
+			&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec())[..],
+			&height,
+		)
+	}
+
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		option_to_not_found(
 			self.db
@@ -264,9 +280,22 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	pub fn get_kernel_height(&self, kernel: &TxKernel) -> Result<u64, Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec())),
+			&format!("Kernel height for: {:?}", kernel),
+		)
+	}
+
 	pub fn delete_output_pos(&self, commit: &[u8]) -> Result<(), Error> {
 		self.db
 			.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
+	}
+
+	pub fn delete_kernel_height(&self, kernel: &TxKernel) -> Result<(), Error> {
+		self.db
+			.delete(&to_key(KERNEL_HEIGHT_PREFIX, &mut kernel.excess.as_ref().to_vec()))
 	}
 
 	pub fn get_block_header_db(&self, h: &Hash) -> Result<BlockHeader, Error> {

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -379,6 +379,7 @@ pub struct Extension<'a> {
 
 	commit_index: Arc<ChainStore>,
 	new_output_commits: HashMap<Commitment, u64>,
+	new_kernel_heights: HashMap<TxKernel, u64>,
 	rollback: bool,
 
 	/// Batch in which the extension occurs, public so it can be used within
@@ -439,6 +440,7 @@ impl<'a> Extension<'a> {
 			),
 			commit_index,
 			new_output_commits: HashMap::new(),
+			new_kernel_heights: HashMap::new(),
 			rollback: false,
 			batch,
 		}
@@ -484,9 +486,14 @@ impl<'a> Extension<'a> {
 			.collect();
 
 		for ref output in tx.outputs() {
-			if let Err(e) = self.apply_output(output) {
-				self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
-				return Err(e);
+			match self.apply_output(output) {
+				Ok(pos) => {
+					self.new_output_commits.insert(output.commitment(), pos);
+				},
+				Err(e) => {
+					self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
+					return Err(e);
+				}
 			}
 		}
 
@@ -595,7 +602,8 @@ impl<'a> Extension<'a> {
 		// So we can safely apply outputs first (we will not spend these in the same
 		// block).
 		for out in b.outputs() {
-			self.apply_output(out)?;
+			let pos = self.apply_output(out)?;
+			self.new_output_commits.insert(out.commitment(), pos);
 		}
 
 		for input in b.inputs() {
@@ -604,15 +612,21 @@ impl<'a> Extension<'a> {
 
 		for kernel in b.kernels() {
 			self.apply_kernel(kernel)?;
+			self.new_kernel_heights.insert(kernel.clone(), b.header.height);
 		}
 
 		Ok(())
 	}
 
-	// Store all new output pos in the index.
+	// Store the following in the index -
+	// * new output pos
+	// * new kernel heights
 	fn save_indexes(&self) -> Result<(), Error> {
 		for (commit, pos) in &self.new_output_commits {
 			self.batch.save_output_pos(commit, *pos)?;
+		}
+		for (kernel, height) in &self.new_kernel_heights {
+			self.batch.save_kernel_height(kernel, *height)?;
 		}
 		Ok(())
 	}
@@ -655,7 +669,7 @@ impl<'a> Extension<'a> {
 		Ok(())
 	}
 
-	fn apply_output(&mut self, out: &Output) -> Result<(), Error> {
+	fn apply_output(&mut self, out: &Output) -> Result<(u64), Error> {
 		let commit = out.commitment();
 
 		if let Ok(pos) = self.batch.get_output_pos(&commit) {
@@ -679,13 +693,12 @@ impl<'a> Extension<'a> {
 			.push(OutputIdentifier::from_output(out))
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		self.batch.save_output_pos(&out.commitment(), pos)?;
-		self.new_output_commits.insert(out.commitment(), pos);
 
 		// push range proofs in their MMR and file
 		self.rproof_pmmr
 			.push(out.proof)
 			.map_err(&ErrorKind::TxHashSetErr)?;
-		Ok(())
+		Ok(pos)
 	}
 
 	fn apply_kernel(&mut self, kernel: &TxKernel) -> Result<(), Error> {
@@ -693,7 +706,6 @@ impl<'a> Extension<'a> {
 		self.kernel_pmmr
 			.push(kernel.clone())
 			.map_err(&ErrorKind::TxHashSetErr)?;
-
 		Ok(())
 	}
 
@@ -806,11 +818,23 @@ impl<'a> Extension<'a> {
 		Ok(())
 	}
 
-	fn get_output_pos(&self, commit: &Commitment) -> Result<u64, grin_store::Error> {
+	fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		if let Some(pos) = self.new_output_commits.get(commit) {
 			Ok(*pos)
 		} else {
 			self.commit_index.get_output_pos(commit)
+				.map_err(|e| ErrorKind::StoreErr(e, format!("output not found")).into())
+		}
+	}
+
+	/// Returns a kernel (one of possibly multiple kernels) at the specified block height.
+	pub fn kernel_for_block_height(&self, height: u64) -> Result<TxKernel, Error> {
+		let header = self.commit_index.get_header_by_height(height)?;
+		let pos = pmmr::n_leaves(header.kernel_mmr_size);
+		if let Some(kernel) = self.kernel_pmmr.get_data(pos) {
+			Ok(kernel)
+		} else {
+			Err(ErrorKind::TxHashSetErr(format!("kernel not found")).into())
 		}
 	}
 
@@ -897,13 +921,48 @@ impl<'a> Extension<'a> {
 		Ok((output_sum, kernel_sum))
 	}
 
+	/// (Re)build the index of kernel to block height.
+	/// We call this during fast-sync once we have the full kernel MMR.
+	pub fn rebuild_kernel_height_index(&self, header: BlockHeader) -> Result<(), Error> {
+		debug!(LOGGER, "txhashset: rebuild_kernel_height_index: from height: {}", header.height);
+
+		let mut curr = header;
+
+		loop {
+			let prev_size = if curr.height > 1 {
+				let prev = self.commit_index.get_block_header(&curr.previous)?;
+				prev.kernel_mmr_size
+			} else {
+				0
+			};
+
+			let mut pos = curr.kernel_mmr_size;
+			while pos > prev_size {
+				if pmmr::is_leaf(pos) {
+					if let Some(kernel) = self.kernel_pmmr.get_data(pos) {
+						self.batch.save_kernel_height(&kernel, curr.height)?;
+					}
+				}
+				pos -= 1;
+			}
+			if prev_size == 0 {
+				break;
+			}
+			curr = self.commit_index.get_block_header(&curr.previous)?;
+		}
+
+		debug!(LOGGER, "txhashset: rebuild_kernel_height_index: done");
+
+		Ok(())
+	}
+
 	/// Rebuild the index of MMR positions to the corresponding Output and
 	/// kernel by iterating over the whole MMR data. This is a costly operation
 	/// performed only when we receive a full new chain state.
 	pub fn rebuild_index(&self) -> Result<(), Error> {
 		for n in 1..self.output_pmmr.unpruned_size() + 1 {
 			// non-pruned leaves only
-			if pmmr::bintree_postorder_height(n) == 0 {
+			if pmmr::is_leaf(n) {
 				if let Some(out) = self.output_pmmr.get_data(n) {
 					self.batch.save_output_pos(&out.commit, n)?;
 				}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -489,7 +489,7 @@ impl<'a> Extension<'a> {
 			match self.apply_output(output) {
 				Ok(pos) => {
 					self.new_output_commits.insert(output.commitment(), pos);
-				},
+				}
 				Err(e) => {
 					self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
 					return Err(e);
@@ -612,7 +612,8 @@ impl<'a> Extension<'a> {
 
 		for kernel in b.kernels() {
 			self.apply_kernel(kernel)?;
-			self.new_kernel_heights.insert(kernel.clone(), b.header.height);
+			self.new_kernel_heights
+				.insert(kernel.clone(), b.header.height);
 		}
 
 		Ok(())
@@ -822,7 +823,8 @@ impl<'a> Extension<'a> {
 		if let Some(pos) = self.new_output_commits.get(commit) {
 			Ok(*pos)
 		} else {
-			self.commit_index.get_output_pos(commit)
+			self.commit_index
+				.get_output_pos(commit)
 				.map_err(|e| ErrorKind::StoreErr(e, format!("output not found")).into())
 		}
 	}
@@ -924,7 +926,10 @@ impl<'a> Extension<'a> {
 	/// (Re)build the index of kernel to block height.
 	/// We call this during fast-sync once we have the full kernel MMR.
 	pub fn rebuild_kernel_height_index(&self, header: BlockHeader) -> Result<(), Error> {
-		debug!(LOGGER, "txhashset: rebuild_kernel_height_index: from height: {}", header.height);
+		debug!(
+			LOGGER,
+			"txhashset: rebuild_kernel_height_index: from height: {}", header.height
+		);
 
 		let mut curr = header;
 


### PR DESCRIPTION
* add a new kernel height index in lmdb (block height per kernel excess)
  * given a kernel we can now quickly find the corresponding block height

If we do go down the path of "relative kernels" as a way to get relative lock heights we need this index to be able to quickly find the block height for a given kernel.

* new index
* update the index when we apply_kernel on an extension
* update the index during fast sync
* backfill the index on `chain::init()` if not already populated (backward compatibility on existing nodes)

Note: An alternative implementation would be to index block hashes by kernel and do it via an additional level of indirection, but this seemed unnecessary.

Edit: The simple height index is insufficient. We also need an index to the kernel by pos (as we do for outputs) as we need to locate the kernel in the MMR to show it exists.
This also implies uniqueness of kernels in the MMR (as we do for outputs).


