### PR TITLE
take write lock on txhashet earlier when processing blocks

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -181,13 +181,6 @@ pub fn process_block_header(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<
 		bh.hash()
 	); // keep this
 
-	// First thing we do is take a write lock on the txhashset.
-	// We may receive the same block (and/or header) from multiple peers simultaneously.
-	// We want to process the first one fully to avoid redundant work
-	// processing the duplicates.
-	let txhashset = ctx.txhashset.clone();
-	let _ = txhashset.write().unwrap();
-
 	check_header_known(bh.hash(), ctx)?;
 	validate_header(&bh, ctx)
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -75,6 +75,14 @@ pub fn process_block(
 		b.outputs().len(),
 		b.kernels().len(),
 	);
+
+	// First thing we do is take a write lock on the txhashset.
+	// We may receive the same block from multiple peers simultaneously.
+	// We want to process the first one fully to avoid redundant work
+	// processing the duplicates.
+	let txhashset = ctx.txhashset.clone();
+	let mut txhashset = txhashset.write().unwrap();
+
 	check_known(b.hash(), ctx)?;
 
 	validate_header(&b.header, ctx)?;
@@ -99,13 +107,7 @@ pub fn process_block(
 	}
 
 	// validate the block itself
-	// we can do this now before interacting with the txhashset
 	let _sums = validate_block(b, ctx, verifier_cache)?;
-
-	// header and block both valid, and we have a previous block
-	// so take the lock on the txhashset
-	let local_txhashset = ctx.txhashset.clone();
-	let mut txhashset = local_txhashset.write().unwrap();
 
 	// update head now that we're in the lock
 	ctx.head = ctx.store.head()?;
@@ -178,6 +180,13 @@ pub fn process_block_header(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<
 		bh.height,
 		bh.hash()
 	); // keep this
+
+	// First thing we do is take a write lock on the txhashset.
+	// We may receive the same block (and/or header) from multiple peers simultaneously.
+	// We want to process the first one fully to avoid redundant work
+	// processing the duplicates.
+	let txhashset = ctx.txhashset.clone();
+	let _ = txhashset.write().unwrap();
 
 	check_header_known(bh.hash(), ctx)?;
 	validate_header(&bh, ctx)


### PR DESCRIPTION
Block propagation on a healthy node with many peers means we see multiple copies of the same block/block_header/compact_block all in quick succession, sometimes effectively simultaneously.

This PR obtains the write lock on the txhashset earlier in `process_block()` to effectively serialize block processing.
Currently we see situations in the log where we are validating the same block multiple times simultaneously before we have had time to successfully accept the block (and update the known `block_hashes_cache`).

Logs now look more like this (process and accept the block the first time we see it, reject all subsequent sightings) - 

```
Aug 31 16:52:06.307 DEBG Received compact_block 0609565f at 75668 from 89.101.91.246:13414, outputs: 1, kernels: 1, kern_ids: 0, going to process.
Aug 31 16:52:06.307 DEBG pipe: process_block 0609565f at 75668 with 0 inputs, 1 outputs, 1 kernels
Aug 31 16:52:06.309 DEBG lru_verifier_cache: rangeproofs: 1, not cached (must verify): 1
Aug 31 16:52:06.318 DEBG lru_verifier_cache: kernel sigs: 1, not cached (must verify): 1
Aug 31 16:52:06.327 DEBG pipe: chain head 0609565f @ 75668
Aug 31 16:52:06.328 DEBG adapter: block_accepted: 0609565f
Aug 31 16:52:06.328 DEBG Send header 0609565f to 45.61.156.122:13414
Aug 31 16:52:06.328 DEBG Send header 0609565f to 94.130.229.193:13414
Aug 31 16:52:06.328 DEBG Send header 0609565f to 174.129.57.101:13414
Aug 31 16:52:06.328 DEBG Send header 0609565f to 94.130.64.25:13414
Aug 31 16:52:06.328 DEBG Send header 0609565f to 51.15.219.12:13414
Aug 31 16:52:06.329 DEBG Send header 0609565f to 198.245.50.26:13414
Aug 31 16:52:06.329 DEBG Send header 0609565f to 73.149.55.243:13414
Aug 31 16:52:06.383 DEBG handle_payload: received compact block: msg_len: 1260
Aug 31 16:52:06.383 DEBG Received compact_block 0609565f at 75668 from 94.130.229.193:13414, outputs: 1, kernels: 1, kern_ids: 0, going to process.
Aug 31 16:52:06.383 DEBG pipe: process_block 0609565f at 75668 with 0 inputs, 1 outputs, 1 kernels
Aug 31 16:52:06.383 DEBG Block 0609565f at 75668 is unfit at this time: already known
Aug 31 16:52:06.383 DEBG adapter: process_block: block 0609565f refused by chain: Block is unfit: already known
Aug 31 16:52:06.403 DEBG Received block header 0609565f at 75668 from 174.129.57.101:13414, going to process.
Aug 31 16:52:06.403 DEBG pipe: process_block_header at 75668 [0609565f]
Aug 31 16:52:06.403 DEBG Block header 0609565f refused by chain: Unfit("already known")
Aug 31 16:52:06.468 DEBG handle_payload: received compact block: msg_len: 1260
Aug 31 16:52:06.468 DEBG Received compact_block 0609565f at 75668 from 54.87.134.196:13414, outputs: 1, kernels: 1, kern_ids: 0, going to process.
Aug 31 16:52:06.468 DEBG pipe: process_block 0609565f at 75668 with 0 inputs, 1 outputs, 1 kernels
Aug 31 16:52:06.468 DEBG Block 0609565f at 75668 is unfit at this time: already known
Aug 31 16:52:06.468 DEBG adapter: process_block: block 0609565f refused by chain: Block is unfit: already known
```

This makes each individual call to `process_block()` more expensive as we need to obtain the exclusive write lock.
But we trade that for significantly less effort in validating the block multiple times.

