### PR TITLE
Fix amount parsing (from string)

### DIFF
--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -28,7 +28,6 @@ pub mod verifier_cache;
 use consensus::GRIN_BASE;
 #[allow(dead_code)]
 use rand::{thread_rng, Rng};
-use std::num::ParseFloatError;
 use std::{fmt, iter};
 
 use util::secp::pedersen::Commitment;
@@ -40,7 +39,7 @@ pub use self::id::ShortId;
 pub use self::transaction::*;
 use core::hash::Hashed;
 use global;
-use ser::{self, Error, Readable, Reader, Writeable, Writer};
+use ser::{self, Readable, Reader, Writeable, Writer};
 
 /// A Cuckoo Cycle proof of work, consisting of the shift to get the graph
 /// size (i.e. 31 for Cuckoo31 with a 2^31 or 1<<31 graph size) and the nonces
@@ -124,10 +123,10 @@ impl Proof {
 }
 
 impl Readable for Proof {
-	fn read(reader: &mut Reader) -> Result<Proof, Error> {
+	fn read(reader: &mut Reader) -> Result<Proof, ser::Error> {
 		let cuckoo_sizeshift = reader.read_u8()?;
 		if cuckoo_sizeshift == 0 || cuckoo_sizeshift > 64 {
-			return Err(Error::CorruptedData);
+			return Err(ser::Error::CorruptedData);
 		}
 
 		let mut nonces = Vec::with_capacity(global::proofsize());
@@ -152,7 +151,7 @@ impl Readable for Proof {
 }
 
 impl Writeable for Proof {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		if writer.serialization_mode() != ser::SerializationMode::Hash {
 			writer.write_u8(self.cuckoo_sizeshift)?;
 		}
@@ -198,12 +197,56 @@ impl BitVec {
 	}
 }
 
+/// Common errors
+#[derive(Fail, Debug)]
+pub enum Error {
+	/// Human readable represenation of amount is invalid
+	#[fail(display = "Amount string was invalid")]
+	InvalidAmountString,
+}
+
 /// Common method for parsing an amount from human-readable, and converting
 /// to internally-compatible u64
 
-pub fn amount_from_hr_string(amount: &str) -> Result<u64, ParseFloatError> {
-	let amount = amount.parse::<f64>()?;
-	Ok((amount * GRIN_BASE as f64) as u64)
+pub fn amount_from_hr_string(amount: &str) -> Result<u64, Error> {
+	// no i18n yet, make sure we use '.' as the separator
+	if amount.find(',').is_some() {
+		return Err(Error::InvalidAmountString);
+	}
+	let (grins, ngrins) = match amount.find('.') {
+		None => (
+			amount
+				.parse::<u64>()
+				.map_err(|_| Error::InvalidAmountString)?,
+			0,
+		),
+		Some(pos) => {
+			let (gs, tail) = amount.split_at(pos);
+			(parse_grins(gs)?, parse_ngrins(&tail[1..])?)
+		}
+	};
+	Ok(grins * GRIN_BASE + ngrins)
+}
+
+fn parse_grins(amount: &str) -> Result<u64, Error> {
+	if amount == "" {
+		Ok(0)
+	} else {
+		amount
+			.parse::<u64>()
+			.map_err(|_| Error::InvalidAmountString)
+	}
+}
+
+fn parse_ngrins(amount: &str) -> Result<u64, Error> {
+	let mut b = GRIN_BASE / 10;
+	let mut res = 0;
+	for c in amount.chars() {
+		let d = c.to_digit(10).ok_or(Error::InvalidAmountString)?;
+		res += (d as u64) * b;
+		b /= 10;
+	}
+	Ok(res)
 }
 
 /// Common method for converting an amount to a human-readable string
@@ -229,7 +272,7 @@ mod test {
 	use super::*;
 
 	#[test]
-	pub fn test_amount_to_hr() {
+	pub fn test_amount_from_hr() {
 		assert!(50123456789 == amount_from_hr_string("50.123456789").unwrap());
 		assert!(50 == amount_from_hr_string(".000000050").unwrap());
 		assert!(1 == amount_from_hr_string(".000000001").unwrap());
@@ -238,10 +281,11 @@ mod test {
 		assert!(
 			5_000_000_000_000_000_000 == amount_from_hr_string("5000000000.00000000000").unwrap()
 		);
+		assert!(66_600_000_000 == amount_from_hr_string("66.6").unwrap());
 	}
 
 	#[test]
-	pub fn test_hr_to_amount() {
+	pub fn test_amount_to_hr() {
 		assert!("50.123456789" == amount_to_hr_string(50123456789, false));
 		assert!("50.123456789" == amount_to_hr_string(50123456789, true));
 		assert!("0.000000050" == amount_to_hr_string(50, false));
@@ -252,6 +296,7 @@ mod test {
 		assert!("500.0" == amount_to_hr_string(500_000_000_000, true));
 		assert!("5000000000.000000000" == amount_to_hr_string(5_000_000_000_000_000_000, false));
 		assert!("5000000000.0" == amount_to_hr_string(5_000_000_000_000_000_000, true));
+		assert!("66.6" == amount_to_hr_string(66600000000, true));
 	}
 
 }


### PR DESCRIPTION
Fixes #1384

I decided to split string into 2 parts (grins and nanogrins) and then parse it separately. Unfortunately for nanogrins I had to implement conversion from the scratch, I hope we don't need to parse billions of strings.