### PR TITLE
Record ideal miner behavior based on job_id value

### DIFF
--- a/doc/stratum.md
+++ b/doc/stratum.md
@@ -145,6 +145,7 @@ Example:
 
 A message initiated by the Stratum server.
 Stratum server will send job automatically to connected miners.
+The miner SHOULD interrupt current job if job_id = 0, and SHOULD replace the current job with this one after the current graph is complete.
 
 #### Request
 


### PR DESCRIPTION
We have a very low default value for "attempt_time_per_block", which exposed an issue with the miner.  This change documents the correct / ideal behavior.