### PR TITLE
a little bit speed-up for full node syncing

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -17,6 +17,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fs::File;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
@@ -59,6 +60,8 @@ pub struct OrphanBlockPool {
 	// additional index of height -> hash
 	// so we can efficiently identify a child block (ex-orphan) after processing a block
 	height_idx: RwLock<HashMap<u64, Vec<Hash>>>,
+	// accumulated number of evicted block because of MAX_ORPHAN_SIZE limitation
+	evicted: AtomicUsize,
 }
 
 impl OrphanBlockPool {
@@ -66,12 +69,17 @@ impl OrphanBlockPool {
 		OrphanBlockPool {
 			orphans: RwLock::new(HashMap::new()),
 			height_idx: RwLock::new(HashMap::new()),
+			evicted: AtomicUsize::new(0),
 		}
 	}
 
 	fn len(&self) -> usize {
 		let orphans = self.orphans.read().unwrap();
 		orphans.len()
+	}
+
+	fn len_evicted(&self) -> usize {
+		self.evicted.load(Ordering::Relaxed)
 	}
 
 	fn add(&self, orphan: Orphan) {
@@ -86,6 +94,8 @@ impl OrphanBlockPool {
 		}
 
 		if orphans.len() > MAX_ORPHAN_SIZE {
+			let old_len = orphans.len();
+
 			// evict too old
 			orphans.retain(|_, ref mut x| {
 				x.added.elapsed() < Duration::from_secs(MAX_ORPHAN_AGE_SECS)
@@ -105,6 +115,9 @@ impl OrphanBlockPool {
 			}
 			// cleanup index
 			height_idx.retain(|_, ref mut xs| xs.iter().any(|x| orphans.contains_key(&x)));
+
+			self.evicted
+				.fetch_add(old_len - orphans.len(), Ordering::Relaxed);
 		}
 	}
 
@@ -276,9 +289,14 @@ impl Chain {
 
 						debug!(
 							LOGGER,
-							"process_block: orphan: {:?}, # orphans {}",
+							"process_block: orphan: {:?}, # orphans {}{}",
 							block_hash,
 							self.orphans.len(),
+							if self.orphans.len_evicted() > 0 {
+								format!(", # evicted {}", self.orphans.len_evicted())
+							} else {
+								String::new()
+							},
 						);
 						Err(ErrorKind::Orphan.into())
 					}
@@ -346,6 +364,11 @@ impl Chain {
 	/// Check if hash is for a known orphan.
 	pub fn is_orphan(&self, hash: &Hash) -> bool {
 		self.orphans.contains(hash)
+	}
+
+	/// Get the OrphanBlockPool accumulated evicted number of blocks
+	pub fn orphans_evicted_len(&self) -> usize {
+		self.orphans.len_evicted()
 	}
 
 	/// Check for orphans, once a block is successfully added

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -249,10 +249,10 @@ impl BodySyncInfo {
 				}
 			}
 			None => {
-				if Utc::now() - self.sync_start_ts > Duration::milliseconds(1000) {
+				if Utc::now() - self.sync_start_ts > Duration::seconds(5) {
 					debug!(
 						LOGGER,
-						"body_sync: 0/{} blocks received in 1s",
+						"body_sync: 0/{} blocks received in 5s",
 						self.body_sync_hashes.len(),
 					);
 					return true;

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -233,20 +233,20 @@ impl BodySyncInfo {
 				if tip.last_block_h == self.prev_tip.last_block_h
 					&& chain.orphans_len() + chain.orphans_evicted_len() == self.prev_orphans_len
 					&& Utc::now() - prev_ts > Duration::milliseconds(200)
-					{
-						let hashes_not_get = self
-							.body_sync_hashes
-							.iter()
-							.filter(|x| !chain.get_block(*x).is_ok() && !chain.is_orphan(*x))
-							.collect::<Vec<_>>();
-						debug!(
-							LOGGER,
-							"body_sync: {}/{} blocks received, and no more in 200ms",
-							self.body_sync_hashes.len() - hashes_not_get.len(),
-							self.body_sync_hashes.len(),
-						);
-						return true;
-					}
+				{
+					let hashes_not_get = self
+						.body_sync_hashes
+						.iter()
+						.filter(|x| !chain.get_block(*x).is_ok() && !chain.is_orphan(*x))
+						.collect::<Vec<_>>();
+					debug!(
+						LOGGER,
+						"body_sync: {}/{} blocks received, and no more in 200ms",
+						self.body_sync_hashes.len() - hashes_not_get.len(),
+						self.body_sync_hashes.len(),
+					);
+					return true;
+				}
 			}
 			None => {
 				if Utc::now() - self.sync_start_ts > Duration::milliseconds(1000) {
@@ -262,11 +262,11 @@ impl BodySyncInfo {
 
 		if tip.last_block_h != self.prev_tip.last_block_h
 			|| chain.orphans_len() + chain.orphans_evicted_len() != self.prev_orphans_len
-			{
-				self.prev_tip = tip;
-				self.prev_body_received = Some(Utc::now());
-				self.prev_orphans_len = chain.orphans_len() + chain.orphans_evicted_len();
-			}
+		{
+			self.prev_tip = tip;
+			self.prev_body_received = Some(Utc::now());
+			self.prev_orphans_len = chain.orphans_len() + chain.orphans_evicted_len();
+		}
 
 		return false;
 	}


### PR DESCRIPTION
This PR can save > 60% time on full node syncing.

Today I need a full node syncing and find it always wait 5 seconds for every new block_sync requesting, but only 1st second or first 2 seconds has real downloading.

This change will detect the fact that there's no more new blocks downloaded in 200ms, and then allow a new block_sync requesting in this case.

