### PR TITLE
Faster tx known check

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -57,6 +57,11 @@ impl Pool {
 		}
 	}
 
+	/// Does the transaction pool contain an entry for the given transaction?
+	pub fn contains_tx(&self, tx: &Transaction) -> bool {
+		self.entries.iter().any(|x| x.tx.hash() == tx.hash())
+	}
+
 	/// Query the tx pool for all known txs based on kernel short_ids
 	/// from the provided compact_block.
 	/// Note: does not validate that we return the full set of required txs.

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -101,6 +101,13 @@ impl TransactionPool {
 		stem: bool,
 		block_hash: &Hash,
 	) -> Result<(), PoolError> {
+
+		// Quick check to deal with common case of seeing the *same* tx
+		// broadcast from multiple peers simultaneously.
+		if !stem && self.txpool.contains_tx(&tx) {
+			return Err(PoolError::DuplicateTx);
+		}
+
 		// Do we have the capacity to accept this transaction?
 		self.is_acceptable(&tx)?;
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -101,7 +101,6 @@ impl TransactionPool {
 		stem: bool,
 		block_hash: &Hash,
 	) -> Result<(), PoolError> {
-
 		// Quick check to deal with common case of seeing the *same* tx
 		// broadcast from multiple peers simultaneously.
 		if !stem && self.txpool.contains_tx(&tx) {


### PR DESCRIPTION
Add a fast initial check for "already known" when adding a tx to the pool.
Only do this when `stem==false` and only look in the `txpool` (not the `stempool`).

This avoids running potentially expensive tx validation multiple times when we see the same tx broadcast from multiple peers.

Logs now look like this - 

```
Sep 03 10:34:10.144 DEBG handle_payload: received tx: msg_len: 1672
Sep 03 10:34:10.144 DEBG Received tx ae580063, inputs: 2, outputs: 2, kernels: 1, going to process.
Sep 03 10:34:10.144 DEBG lru_verifier_cache: rangeproofs: 2, not cached (must verify): 2
Sep 03 10:34:10.195 DEBG lru_verifier_cache: kernel sigs: 1, not cached (must verify): 1
Sep 03 10:34:10.197 DEBG pool [txpool]: add_to_pool: ae580063, TxSource { debug_name: "p2p", identifier: "?.?.?.?" }, inputs: 2, outputs: 2, kernels: 1 (at block 10561bfa)
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 185.8.164.6:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 94.130.229.193:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 108.196.200.233:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 94.130.64.25:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 185.53.158.12:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 46.4.91.48:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 89.221.215.219:13414
Sep 03 10:34:10.203 DEBG Send tx ae580063 to 54.87.134.196:13414
Sep 03 10:34:10.321 DEBG handle_payload: received tx: msg_len: 1672
Sep 03 10:34:10.321 DEBG Received tx ae580063, inputs: 2, outputs: 2, kernels: 1, going to process.
Sep 03 10:34:10.321 DEBG Transaction ae580063 rejected: DuplicateTx
Sep 03 10:34:10.330 DEBG handle_payload: received tx: msg_len: 1672
Sep 03 10:34:10.330 DEBG Received tx ae580063, inputs: 2, outputs: 2, kernels: 1, going to process.
Sep 03 10:34:10.330 DEBG Transaction ae580063 rejected: DuplicateTx
Sep 03 10:34:10.683 DEBG handle_payload: received tx: msg_len: 1672
Sep 03 10:34:10.683 DEBG Received tx ae580063, inputs: 2, outputs: 2, kernels: 1, going to process.
Sep 03 10:34:10.684 DEBG Transaction ae580063 rejected: DuplicateTx
Sep 03 10:34:11.065 DEBG handle_payload: received tx: msg_len: 1672
Sep 03 10:34:11.065 DEBG Received tx ae580063, inputs: 2, outputs: 2, kernels: 1, going to process.
Sep 03 10:34:11.065 DEBG Transaction ae580063 rejected: DuplicateTx
```

