### PR TITLE
Missing logic in preferred peers connection

### DIFF
--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -174,9 +174,11 @@ fn monitor_peers(
 		Some(preferred_peers) => {
 			for mut p in preferred_peers {
 				if !connected_peers.is_empty() {
-					if connected_peers.contains(&p) {
+					if !connected_peers.contains(&p) {
 						tx.send(p).unwrap();
 					}
+				} else {
+					tx.send(p).unwrap();
 				}
 			}
 		}


### PR DESCRIPTION
Logic was previously incorrect...
- We want to connect to preferred peers we are not currently connected to.
- If the connected peers list is empty we should try to connect to these peers.
