### PR TITLE
improve "check known" steps during process_block()

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -416,16 +416,9 @@ fn apply_block_to_txhashset(b: &Block, ext: &mut txhashset::Extension) -> Result
 
 	// Check the output and rangeproof MMR sizes here against the header.
 	let (output_mmr_size, _, kernel_mmr_size) = ext.sizes();
-<<<<<<< HEAD
 	if b.header.output_mmr_size != output_mmr_size || b.header.kernel_mmr_size != kernel_mmr_size {
 		return Err(ErrorKind::InvalidMMRSize.into());
 	}
-=======
-	if b.header.output_mmr_size != output_mmr_size ||
-		b.header.kernel_mmr_size != kernel_mmr_size {
-			return Err(ErrorKind::InvalidMMRSize.into());
-		}
->>>>>>> document what we do during pipe::apply_block()
 
 	Ok(())
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -465,11 +465,13 @@ fn validate_block(
 	verifier_cache: Arc<RwLock<VerifierCache>>,
 ) -> Result<(), Error> {
 	let prev = ctx.store.get_block_header(&block.header.previous)?;
-	block.validate(
-		&prev.total_kernel_offset,
-		&prev.total_kernel_sum,
-		verifier_cache,
-	).map_err(|e| ErrorKind::InvalidBlockProof(e))?;
+	block
+		.validate(
+			&prev.total_kernel_offset,
+			&prev.total_kernel_sum,
+			verifier_cache,
+		)
+		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
 	Ok(())
 }
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -275,9 +275,7 @@ fn check_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
 // Check if this block is in the store already.
 fn check_known_store(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
 	match ctx.store.block_exists(&bh) {
-		Ok(true) => {
-			Err(ErrorKind::Unfit("already known in store".to_string()).into())
-		}
+		Ok(true) => Err(ErrorKind::Unfit("already known in store".to_string()).into()),
 		Ok(false) => {
 			// Not yet processed this block, we can proceed.
 			Ok(())

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -61,8 +61,6 @@ fn is_next_block(header: &BlockHeader, ctx: &mut BlockContext) -> bool {
 	header.previous == ctx.head.last_block_h
 }
 
-
-
 /// Runs the block processing pipeline, including validation and finding a
 /// place for the new block in the chain. Returns the new chain head if
 /// updated.
@@ -282,9 +280,7 @@ fn check_prev_store(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), 
 			// this block is an orphan (for now).
 			Err(ErrorKind::Orphan.into())
 		}
-		Err(e) => {
-			Err(ErrorKind::StoreErr(e, "pipe get previous".to_owned()).into())
-		}
+		Err(e) => Err(ErrorKind::StoreErr(e, "pipe get previous".to_owned()).into()),
 	}
 }
 
@@ -320,9 +316,7 @@ fn check_known_mmr(
 
 		// We want to return an error here (block already known)
 		// if we *successfully validate the MMR roots and sizes.
-		if extension.validate_roots(header).is_ok()
-			&& extension.validate_sizes(header).is_ok()
-		{
+		if extension.validate_roots(header).is_ok() && extension.validate_sizes(header).is_ok() {
 			return Err(ErrorKind::Unfit("already known on most work chain".to_string()).into());
 		}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -416,9 +416,16 @@ fn apply_block_to_txhashset(b: &Block, ext: &mut txhashset::Extension) -> Result
 
 	// Check the output and rangeproof MMR sizes here against the header.
 	let (output_mmr_size, _, kernel_mmr_size) = ext.sizes();
+<<<<<<< HEAD
 	if b.header.output_mmr_size != output_mmr_size || b.header.kernel_mmr_size != kernel_mmr_size {
 		return Err(ErrorKind::InvalidMMRSize.into());
 	}
+=======
+	if b.header.output_mmr_size != output_mmr_size ||
+		b.header.kernel_mmr_size != kernel_mmr_size {
+			return Err(ErrorKind::InvalidMMRSize.into());
+		}
+>>>>>>> document what we do during pipe::apply_block()
 
 	Ok(())
 }

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -837,9 +837,28 @@ impl<'a> Extension<'a> {
 			|| roots.rproof_root != header.range_proof_root
 			|| roots.kernel_root != header.kernel_root
 		{
-			return Err(ErrorKind::InvalidRoot.into());
+			Err(ErrorKind::InvalidRoot.into())
+		} else {
+			Ok(())
 		}
-		Ok(())
+	}
+
+	/// Validate the output and kernel MMR sizes against the block header.
+	pub fn validate_sizes(&self, header: &BlockHeader) -> Result<(), Error> {
+		// If we are validating the genesis block then we have no outputs or
+		// kernels. So we are done here.
+		if header.height == 0 {
+			return Ok(());
+		}
+
+		let (output_mmr_size, _, kernel_mmr_size) = self.sizes();
+		if output_mmr_size != header.output_mmr_size
+			|| kernel_mmr_size != header.kernel_mmr_size
+		{
+			Err(ErrorKind::InvalidMMRSize.into())
+		} else {
+			Ok(())
+		}
 	}
 
 	fn validate_mmrs(&self) -> Result<(), Error> {
@@ -874,6 +893,7 @@ impl<'a> Extension<'a> {
 	) -> Result<((Commitment, Commitment)), Error> {
 		self.validate_mmrs()?;
 		self.validate_roots(header)?;
+		self.validate_sizes(header)?;
 
 		if header.height == 0 {
 			let zero_commit = secp_static::commit_to_zero_value();

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -852,9 +852,7 @@ impl<'a> Extension<'a> {
 		}
 
 		let (output_mmr_size, _, kernel_mmr_size) = self.sizes();
-		if output_mmr_size != header.output_mmr_size
-			|| kernel_mmr_size != header.kernel_mmr_size
-		{
+		if output_mmr_size != header.output_mmr_size || kernel_mmr_size != header.kernel_mmr_size {
 			Err(ErrorKind::InvalidMMRSize.into())
 		} else {
 			Ok(())

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -352,7 +352,8 @@ where
 	}
 
 	/// Helper function to get the last N nodes inserted, i.e. the last
-	/// n nodes along the bottom of the tree
+	/// n nodes along the bottom of the tree.
+	/// May return less than n items if the MMR has been pruned/compacted.
 	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(Hash, T)> {
 		let mut return_vec = vec![];
 		let mut last_leaf = self.last_pos;
@@ -361,10 +362,12 @@ where
 				break;
 			}
 			last_leaf = bintree_rightmost(last_leaf);
-			return_vec.push((
-				self.backend.get_hash(last_leaf).unwrap(),
-				self.backend.get_data(last_leaf).unwrap(),
-			));
+
+			if let Some(hash) = self.backend.get_hash(last_leaf) {
+				if let Some(data) = self.backend.get_data(last_leaf) {
+					return_vec.push((hash, data));
+				}
+			}
 			last_leaf -= 1;
 		}
 		return_vec


### PR DESCRIPTION
Currently we do a fast in-memory check `check_known()` during `process_block`.

This checks block hashes against the 200 most recent blocks in `block_hash_cache`.

We can do an additional check against the full block index for the case where we see an "old" block that is beyond the scope of `block_hash_cache`.
This will be more expensive than the in-memory check but still considerably faster than full block validation on the duplicate block.
This PR introduces an additional `check_known_store()` to do this.

For even older blocks (on the main chain) there is an additional way we can know if we are processing a "known" block - we can look in the txhashset MMRs.
Rather than rewinding past the block and reapplying it we can rewind _to_ the block and check the MMR roots and sizes.
This PR adds a `check_known_mmr()` that accomplishes this.

We now have 3 steps during `process_block` where we check if the block being processed is already known (with increasing cost of doing the check) -

    * check_known() # fast in-memory check for recent blocks (200 recent blocks)
    * check_known_store() # slower (but still fast) lookup against full block index (2,000 recent blocks on fast sync node)
    * check_known_mmr() # leverage our MMRs for old blocks on most work chain (limited to most work chain, no forks supported)

If a block is not "known" via any of these then we can proceed to validating the block and applying it to the txhashset.

