### PR TITLE
[DNM] kernel pos index

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -181,6 +181,8 @@ impl Chain {
 
 		setup_head(genesis, store.clone(), &mut txhashset)?;
 
+		// Node may not have a kernel_pos index as this was introduced later.
+		// Build the index if missing.
 		build_missing_indices(store.clone(), &mut txhashset)?;
 
 		// Now reload the chain head (either existing head or genesis from above)
@@ -950,6 +952,7 @@ fn build_missing_indices(
 				extension.rebuild_kernel_pos_index()?;
 				Ok(())
 			})?;
+			batch.commit()?;
 		}
 	}
 	Ok(())

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -78,9 +78,12 @@ pub enum ErrorKind {
 	/// One of the inputs in the block has already been spent
 	#[fail(display = "Already Spent: {:?}", _0)]
 	AlreadySpent(Commitment),
-	/// An output with that commitment already exists (should be unique)
+	/// An output with that commitment already exists (must be unique)
 	#[fail(display = "Duplicate Commitment: {:?}", _0)]
 	DuplicateCommitment(Commitment),
+	/// An kernel with that excess already exists (must be unique)
+	#[fail(display = "Duplicate Kernel Excess: {:?}", _0)]
+	DuplicateKernelExcess(Commitment),
 	/// Attempt to spend a coinbase output before it sufficiently matures.
 	#[fail(display = "Attempt to spend immature coinbase")]
 	ImmatureCoinbase,

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -712,7 +712,10 @@ impl<'a> Extension<'a> {
 
 		// The output and rproof MMRs should be exactly the same size
 		// and we should have inserted to both in exactly the same pos.
-		assert_eq!(self.output_pmmr.unpruned_size(), self.kernel_pmmr.unpruned_size());
+		assert_eq!(
+			self.output_pmmr.unpruned_size(),
+			self.rproof_pmmr.unpruned_size()
+		);
 		assert_eq!(output_pos, rproof_pos);
 
 		Ok(output_pos)

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -691,8 +691,8 @@ impl<'a> Extension<'a> {
 		// We need to check the output commitment actually matches at the given pos
 		// for this to be a duplicate.
 		if let Ok(pos) = self.batch.get_output_pos(&commit) {
-			if let Some(out_mmr) = self.output_pmmr.get_data(pos) {
-				if out_mmr.commitment() == commit {
+			if let Some(mmr_out) = self.output_pmmr.get_data(pos) {
+				if mmr_out.commitment() == commit {
 					return Err(ErrorKind::DuplicateCommitment(commit).into());
 				}
 			}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -679,7 +679,7 @@ impl<'a> Extension<'a> {
 		}
 	}
 
-	// Checks output is not already in the output MMR
+	// Checks commitment is not already in the output MMR
 	// by looking for the pos in the output_pos index
 	// and then checking the output at that pos is actually a match.
 	// Pushes the new output onto the right hand side of the MMR.
@@ -712,7 +712,9 @@ impl<'a> Extension<'a> {
 
 		// The output and rproof MMRs should be exactly the same size
 		// and we should have inserted to both in exactly the same pos.
+		assert_eq!(self.output_pmmr.unpruned_size(), self.kernel_pmmr.unpruned_size());
 		assert_eq!(output_pos, rproof_pos);
+
 		Ok(output_pos)
 	}
 
@@ -726,8 +728,8 @@ impl<'a> Extension<'a> {
 		// We need to check the hash actually matches at the given pos
 		// for this to be a duplicate.
 		if let Ok(pos) = self.batch.get_kernel_pos(&excess) {
-			if let Some(hash) = self.kernel_pmmr.get_hash(pos) {
-				if hash == kernel.hash_with_index(pos - 1) {
+			if let Some(mmr_kernel) = self.kernel_pmmr.get_data(pos) {
+				if mmr_kernel.excess() == excess {
 					return Err(ErrorKind::DuplicateKernelExcess(excess).into());
 				}
 			}

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -954,7 +954,11 @@ impl<'a> Extension<'a> {
 	/// over the MMR data file. This is a costly operation
 	/// performed only when we receive a full new chain state.
 	pub fn rebuild_output_pos_index(&self) -> Result<(), Error> {
-		debug!(LOGGER, "txhashset: rebuilding the output_pos index (MMR size {})...", self.output_pmmr.unpruned_size());
+		debug!(
+			LOGGER,
+			"txhashset: rebuilding the output_pos index (MMR size {})...",
+			self.output_pmmr.unpruned_size()
+		);
 		for n in 1..self.output_pmmr.unpruned_size() + 1 {
 			if pmmr::is_leaf(n) {
 				if let Some(out) = self.output_pmmr.get_data(n) {
@@ -970,7 +974,11 @@ impl<'a> Extension<'a> {
 	/// over the MMR data file. This is a costly operation
 	/// performed only when we receive a full new chain state.
 	pub fn rebuild_kernel_pos_index(&self) -> Result<(), Error> {
-		debug!(LOGGER, "txhashset: rebuilding the kernel_pos index (MMR size {})...", self.kernel_pmmr.unpruned_size());
+		debug!(
+			LOGGER,
+			"txhashset: rebuilding the kernel_pos index (MMR size {})...",
+			self.kernel_pmmr.unpruned_size()
+		);
 		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
 			if pmmr::is_leaf(n) {
 				if let Some(kernel) = self.kernel_pmmr.get_data(n) {

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -594,7 +594,9 @@ pub fn peak_map_height(mut pos: u64) -> (u64, u64) {
 /// are built.
 
 pub fn bintree_postorder_height(num: u64) -> u64 {
-	if num == 0 { return 0; }
+	if num == 0 {
+		return 0;
+	}
 	peak_map_height(num - 1).1
 }
 

--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -594,9 +594,7 @@ pub fn peak_map_height(mut pos: u64) -> (u64, u64) {
 /// are built.
 
 pub fn bintree_postorder_height(num: u64) -> u64 {
-	if num == 0 {
-		return 0;
-	}
+	if num == 0 { return 0; }
 	peak_map_height(num - 1).1
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1141,7 +1141,7 @@ impl OutputIdentifier {
 		}
 	}
 
-	/// Our commitment.
+	/// Commitment for the output.
 	pub fn commitment(&self) -> Commitment {
 		self.commit
 	}


### PR DESCRIPTION
In preparation for "relative lock heights" this PR adds a `kernel_pos` index to go with the existing `output_pos` index.

* kernels are now unique in the MMR (unique position for any given kernel)
* given a kernel excess we can now quickly find the corresponding pos in the MMR
* rebuild the `kernel_pos` index during fast sync
* build the `kernel_pos` on chain init if it appears to be missing (backward compatibility for existing nodes)
* cleanup `new_output_commits` as the batch does this for us without needing to manage "pending" updates to the index ourselves

