### PR TITLE
Don't wait 30 seconds in case of a quick restart

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -37,16 +37,18 @@ pub struct Peers {
 	store: PeerStore,
 	peers: RwLock<HashMap<SocketAddr, Arc<RwLock<Peer>>>>,
 	dandelion_relay: RwLock<HashMap<i64, Arc<RwLock<Peer>>>>,
+	config: P2PConfig,
 }
 
 unsafe impl Send for Peers {}
 unsafe impl Sync for Peers {}
 
 impl Peers {
-	pub fn new(store: PeerStore, adapter: Arc<ChainAdapter>, _config: P2PConfig) -> Peers {
+	pub fn new(store: PeerStore, adapter: Arc<ChainAdapter>, config: P2PConfig) -> Peers {
 		Peers {
 			adapter,
 			store,
+			config,
 			peers: RwLock::new(HashMap::new()),
 			dandelion_relay: RwLock::new(HashMap::new()),
 		}
@@ -499,6 +501,10 @@ impl Peers {
 			let peer = peer.read().unwrap();
 			peer.stop();
 		}
+	}
+
+	pub fn enough_peers(&self) -> bool {
+		self.connected_peers().len() >= self.config.peer_min_preferred_count() as usize
 	}
 }
 


### PR DESCRIPTION
Currently on startup we wait for 30 secs if we don't have at least 4 peers with more work. If a node was quickly restarted it is already fully synced so thereare no peers with more work at all. This pr assumes that if we've done some work already and we have enough peers but still 0 with more work we are fully synced and good to go.