### PR TITLE
fix: infinite loop of peer connect in case of some peer connect errors

### DIFF
--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -312,7 +312,7 @@ fn listen_for_addrs(
 										}
 									}
 									p2p::Error::PeerWithSelf => break,
-									_ => continue,
+									_ => (),
 								}
 							}
 						}


### PR DESCRIPTION
In case of 2 or more ip addresses if node have, easy to happen this. The root cause is the wrong `continue` in a `loop` statement.

```
Sep 10 19:46:46.589 DEBG monitor_peers: on 0.0.0.0:13414, queue to soon try 192.168.1.127:13414
Sep 10 19:46:46.590 WARN Error accepting peer 192.168.1.127:51479: PeerWithSelf
Sep 10 19:46:46.590 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:46:46.591 WARN Error accepting peer 192.168.1.127:51480: PeerWithSelf
Sep 10 19:46:46.592 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:46:46.593 WARN Error accepting peer 192.168.1.127:51481: PeerWithSelf
Sep 10 19:46:46.593 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:46:46.594 WARN Error accepting peer 192.168.1.127:51482: PeerWithSelf
...


Sep 10 19:47:08.416 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:18.417 DEBG connect_peer: on 0.0.0.0:13414. Could not connect to 192.168.1.127:13414: Custom { kind: TimedOut, error: StringError("connection timed out") }
Sep 10 19:47:18.417 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Connection(Custom { kind: TimedOut, error: StringError("connection timed out") })
Sep 10 19:47:18.417 DEBG connect_peer: on 0.0.0.0:13414. Could not connect to 192.168.1.127:13414: Custom { kind: TimedOut, error: StringError("connection timed out") }
Sep 10 19:47:18.417 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Connection(Custom { kind: TimedOut, error: StringError("connection timed out") })
Sep 10 19:47:19.418 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 retrying 1
Sep 10 19:47:19.419 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 retrying 1 
Sep 10 19:47:19.420 WARN Error accepting peer 192.168.1.127:51485: PeerWithSelf

...

Sep 10 19:47:47.223 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:47.224 WARN Error accepting peer 192.168.1.127:51479: PeerWithSelf
Sep 10 19:47:47.224 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:47.225 WARN Error accepting peer 192.168.1.127:51480: PeerWithSelf
Sep 10 19:47:47.225 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:47.226 WARN Error accepting peer 192.168.1.127:51481: PeerWithSelf
Sep 10 19:47:47.227 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:47.228 WARN Error accepting peer 192.168.1.127:51484: PeerWithSelf
Sep 10 19:47:47.228 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Serialization(UnexpectedData { expected: [30], received: [0] })
Sep 10 19:47:57.227 DEBG connect_peer: on 0.0.0.0:13414. Could not connect to 192.168.1.127:13414: Custom { kind: TimedOut, error: StringError("connection timed out") }
Sep 10 19:47:57.228 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Connection(Custom { kind: TimedOut, error: StringError("connection timed out") })
Sep 10 19:47:57.228 DEBG connect_peer: on 0.0.0.0:13414. Could not connect to 192.168.1.127:13414: Custom { kind: TimedOut, error: StringError("connection timed out") }
Sep 10 19:47:57.229 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 is Defunct. Connection(Custom { kind: TimedOut, error: StringError("connection timed out") })
Sep 10 19:47:58.232 DEBG connect_and_req: on 0.0.0.0:13414. connect to 192.168.1.127:13414 retrying 2
```