### PR TITLE
add 2 more dns seeds

### DIFF
--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -35,7 +35,9 @@ use util::LOGGER;
 const SEEDS_URL: &'static str = "http://grin-tech.org/seeds.txt";
 // DNS Seeds with contact email associated
 const DNS_SEEDS: &'static [&'static str] = &[
-	"t3.seed.grin-tech.org", // igno.peverell@protonmail.com
+	"t3.seed.grin-tech.org",    // igno.peverell@protonmail.com
+	"seed.grin.lesceller.com",  // q.lesceller@gmail.com
+	"t3.grin-seed.prokapi.com", // info@prokapi.com
 ];
 
 pub fn connect_and_monitor(
@@ -359,6 +361,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 				),
 			}
 		}
+		debug!(LOGGER, "Retrieved seed addresses: {:?}", addresses);
 		addresses
 	})
 }
@@ -367,6 +370,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 /// http. Easy method until we have a set of DNS names we can rely on.
 pub fn web_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 	Box::new(|| {
+		debug!(LOGGER, "Retrieving seed nodes from {}", SEEDS_URL);
 		let text: String = api::client::get(SEEDS_URL).expect("Failed to resolve seeds");
 		let addrs = text
 			.split_whitespace()


### PR DESCRIPTION
Related to https://github.com/mimblewimble/grin/issues/1492
To give at least 3 dns seeds:

```
$ nslookup  t3.seed.grin-tech.org

Non-authoritative answer:
Name:	t3.seed.grin-tech.org
Address: 198.245.50.26
Name:	t3.seed.grin-tech.org
Address: 204.48.26.36
Name:	t3.seed.grin-tech.org
Address: 109.74.202.16

$ nslookup seed.grin.lesceller.com

Non-authoritative answer:
Name:    seed.grin.lesceller.com
Address: 198.245.50.26
Name:    seed.grin.lesceller.com
Address: 109.74.202.16
Name:    seed.grin.lesceller.com
Address: 46.4.91.48
Name:    seed.grin.lesceller.com
Address: 192.241.160.172

$ nslookup t3.grin-seed.prokapi.com

Name:    t3.grin-seed.prokapi.com
Address: 95.216.163.175 
Name:    t3.grin-seed.prokapi.com
Address: 195.201.38.140


```

After removing the duplication, actually, the seed nodes are:
1. `198.245.50.26`
2. `109.74.202.16`
3. `204.48.26.36`
4. `192.241.160.172`
5. `46.4.91.48`
6. `95.216.163.175`
7. `195.201.38.140`