### PR TITLE
disable chain compaction on archive nodes

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -140,6 +140,7 @@ pub struct Chain {
 	verifier_cache: Arc<RwLock<VerifierCache>>,
 	// POW verification function
 	pow_verifier: fn(&BlockHeader, u8) -> bool,
+	archive_mode: bool,
 }
 
 unsafe impl Sync for Chain {}
@@ -156,6 +157,7 @@ impl Chain {
 		genesis: Block,
 		pow_verifier: fn(&BlockHeader, u8) -> bool,
 		verifier_cache: Arc<RwLock<VerifierCache>>,
+		archive_mode: bool,
 	) -> Result<Chain, Error> {
 		let chain_store = store::ChainStore::new(db_env)?;
 
@@ -187,6 +189,7 @@ impl Chain {
 			pow_verifier,
 			verifier_cache,
 			block_hashes_cache: Arc::new(RwLock::new(VecDeque::with_capacity(HASHES_CACHE_SIZE))),
+			archive_mode,
 		})
 	}
 
@@ -664,6 +667,11 @@ impl Chain {
 	/// Meanwhile, the chain will not be able to accept new blocks. It should
 	/// therefore be called judiciously.
 	pub fn compact(&self) -> Result<(), Error> {
+		if self.archive_mode {
+			debug!(LOGGER, "Blockchain compaction disabled, node running in archive mode.");
+			return Ok(());
+		}
+
 		debug!(LOGGER, "Starting blockchain compaction.");
 		// Compact the txhashset via the extension.
 		{

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -668,7 +668,10 @@ impl Chain {
 	/// therefore be called judiciously.
 	pub fn compact(&self) -> Result<(), Error> {
 		if self.archive_mode {
-			debug!(LOGGER, "Blockchain compaction disabled, node running in archive mode.");
+			debug!(
+				LOGGER,
+				"Blockchain compaction disabled, node running in archive mode."
+			);
 			return Ok(());
 		}
 

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -55,6 +55,7 @@ fn setup(dir_name: &str) -> Chain {
 		genesis_block,
 		pow::verify_size,
 		verifier_cache,
+		false,
 	).unwrap()
 }
 
@@ -68,6 +69,7 @@ fn reload_chain(dir_name: &str) -> Chain {
 		genesis::genesis_dev(),
 		pow::verify_size,
 		verifier_cache,
+		false,
 	).unwrap()
 }
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -52,6 +52,7 @@ fn setup(dir_name: &str, genesis: Block) -> Chain {
 		genesis,
 		pow::verify_size,
 		verifier_cache,
+		false,
 	).unwrap()
 }
 
@@ -497,6 +498,7 @@ fn actual_diff_iter_output() {
 		genesis_block,
 		pow::verify_size,
 		verifier_cache,
+		false,
 	).unwrap();
 	let iter = chain.difficulty_iter();
 	let mut last_time = 0;

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -57,6 +57,7 @@ fn test_coinbase_maturity() {
 		genesis_block,
 		pow::verify_size,
 		verifier_cache,
+		false,
 	).unwrap();
 
 	let prev = chain.head_header().unwrap();

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -165,6 +165,7 @@ impl Server {
 			genesis.clone(),
 			pow::verify_size,
 			verifier_cache.clone(),
+			archive_mode,
 		)?);
 
 		pool_adapter.set_chain(Arc::downgrade(&shared_chain));

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -111,6 +111,7 @@ where
 			genesis_block,
 			pow::verify_size,
 			verifier_cache,
+			false,
 		).unwrap();
 		let (tx, rx) = channel();
 		let retval = WalletProxy {


### PR DESCRIPTION
Resolves #1447.

`/chain/compact` API endpoint is now a no-op when node running in archival mode.
This should help maintain archival nodes on the network and not accidentally compact them...

