### PR TITLE
default to 10 confirms before spendable

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -198,7 +198,7 @@ fn main() {
 				.help("Minimum number of confirmations required for an output to be spendable.")
 				.short("c")
 				.long("min_conf")
-				.default_value("1")
+				.default_value("10")
 				.takes_value(true))
 			.arg(Arg::with_name("selection_strategy")
 				.help("Coin/Output selection strategy.")
@@ -259,7 +259,7 @@ fn main() {
 				.help("Minimum number of confirmations required for an output to be spendable.")
 				.short("c")
 				.long("min_conf")
-				.default_value("1")
+				.default_value("10")
 				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("outputs")


### PR DESCRIPTION
TODO - 

- [x] `grin wallet send` now defaults to 10 confirmations during coin selection
- [ ] Does `grin wallet info` also need to be aware of this?
  - [ ] In a flexible way of just hard-coded to the default 10 confirmations?

