### PR TITLE
[WIP, DNM] BIP32 Wallet Compliance

### DIFF
--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -85,30 +85,30 @@ pub trait BIP32Hasher {
 }
 
 /// Implementation of the above that uses the standard BIP32 Hash algorithms
-pub struct BIP32ReferenceHasher {
+pub struct BIP32GrinHasher {
 	hmac_sha512: Hmac<Sha512>,
 }
 
-impl BIP32ReferenceHasher {
+impl BIP32GrinHasher {
 	/// New empty hasher
-	pub fn new() -> BIP32ReferenceHasher {
-		BIP32ReferenceHasher {
+	pub fn new() -> BIP32GrinHasher {
+		BIP32GrinHasher {
 			hmac_sha512: Hmac::new(Sha512::new(), &[0u8]),
 		}
 	}
 }
 
-impl BIP32Hasher for BIP32ReferenceHasher {
+impl BIP32Hasher for BIP32GrinHasher {
 	fn network_priv() -> [u8; 4] {
-		// bitcoin network (xprv) (for test vectors)
+		// xprv
 		[0x04, 0x88, 0xAD, 0xE4]
 	}
 	fn network_pub() -> [u8; 4] {
-		// bitcoin network (xpub) (for test vectors)
+		// xpub
 		[0x04, 0x88, 0xB2, 0x1E]
 	}
 	fn master_seed() -> [u8; 12] {
-		b"Bitcoin seed".to_owned()
+		b"IamVoldemort".to_owned()
 	}
 	fn init_sha512(&mut self, seed: &[u8]) {
 		self.hmac_sha512 = Hmac::new(Sha512::new(), seed);
@@ -652,9 +652,66 @@ mod tests {
 
 	use super::ChildNumber::{Hardened, Normal};
 	use super::Error;
-	use super::{ChildNumber, ExtendedPrivKey, ExtendedPubKey};
+	use super::{BIP32Hasher, ChildNumber, ExtendedPrivKey, ExtendedPubKey};
 
-	use super::BIP32ReferenceHasher;
+	use crypto::digest::Digest;
+	use crypto::hmac::Hmac;
+	use crypto::mac::Mac;
+	use crypto::ripemd160::Ripemd160;
+	use crypto::sha2::{Sha256, Sha512};
+
+	/// Implementation of the above that uses the standard BIP32 Hash algorithms
+	pub struct BIP32ReferenceHasher {
+		hmac_sha512: Hmac<Sha512>,
+	}
+
+	impl BIP32ReferenceHasher {
+		/// New empty hasher
+		pub fn new() -> BIP32ReferenceHasher {
+			BIP32ReferenceHasher {
+				hmac_sha512: Hmac::new(Sha512::new(), &[0u8]),
+			}
+		}
+	}
+
+	impl BIP32Hasher for BIP32ReferenceHasher {
+		fn network_priv() -> [u8; 4] {
+			// bitcoin network (xprv) (for test vectors)
+			[0x04, 0x88, 0xAD, 0xE4]
+		}
+		fn network_pub() -> [u8; 4] {
+			// bitcoin network (xpub) (for test vectors)
+			[0x04, 0x88, 0xB2, 0x1E]
+		}
+		fn master_seed() -> [u8; 12] {
+			b"Bitcoin seed".to_owned()
+		}
+		fn init_sha512(&mut self, seed: &[u8]) {
+			self.hmac_sha512 = Hmac::new(Sha512::new(), seed);
+		}
+		fn append_sha512(&mut self, value: &[u8]) {
+			self.hmac_sha512.input(value);
+		}
+		fn result_sha512(&mut self) -> [u8; 64] {
+			let mut result = [0; 64];
+			self.hmac_sha512.raw_result(&mut result);
+			result
+		}
+		fn sha_256(&self, input: &[u8]) -> [u8; 32] {
+			let mut sha2_res = [0; 32];
+			let mut sha2 = Sha256::new();
+			sha2.input(input);
+			sha2.result(&mut sha2_res);
+			sha2_res
+		}
+		fn ripemd_160(&self, input: &[u8]) -> [u8; 20] {
+			let mut ripemd_res = [0; 20];
+			let mut ripemd = Ripemd160::new();
+			ripemd.input(input);
+			ripemd.result(&mut ripemd_res);
+			ripemd_res
+		}
+	}
 
 	fn test_path(
 		secp: &Secp256k1,

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -18,8 +18,8 @@ use rand::{thread_rng, Rng};
 
 use blake2;
 
-use extkey_bip32::{ExtendedPrivKey, Fingerprint, BIP32GrinHasher};
-use types::{BlindSum, BlindingFactor, ExtKeychainPath, Error, Keychain};
+use extkey_bip32::{BIP32GrinHasher, ExtendedPrivKey, Fingerprint};
+use types::{BlindSum, BlindingFactor, Error, ExtKeychainPath, Keychain};
 use util::logger::LOGGER;
 use util::secp::key::SecretKey;
 use util::secp::pedersen::Commitment;
@@ -75,26 +75,26 @@ impl Keychain for ExtKeychain {
 			.positive_key_ids
 			.iter()
 			.filter_map(|k| {
-					let res = self.derive_key_id(&k);
-					if let Ok(s) = res {
-						Some(s.secret_key)
-					} else {
-						None
-					}
-				})
+				let res = self.derive_key_id(&k);
+				if let Ok(s) = res {
+					Some(s.secret_key)
+				} else {
+					None
+				}
+			})
 			.collect();
 
 		let mut neg_keys: Vec<SecretKey> = blind_sum
 			.negative_key_ids
 			.iter()
 			.filter_map(|k| {
-					let res = self.derive_key_id(&k);
-					if let Ok(s) = res {
-						Some(s.secret_key)
-					} else {
-						None
-					}
-				})
+				let res = self.derive_key_id(&k);
+				if let Ok(s) = res {
+					Some(s.secret_key)
+				} else {
+					None
+				}
+			})
 			.collect();
 
 		pos_keys.extend(

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -15,13 +15,11 @@
 /// Implementation of the Keychain trait based on an extended key derivation
 /// scheme.
 use rand::{thread_rng, Rng};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
 use blake2;
 
-use extkey;
-use types::{BlindSum, BlindingFactor, Error, Identifier, Keychain};
+use extkey_bip32::{ExtendedPrivKey, Fingerprint, BIP32GrinHasher};
+use types::{BlindSum, BlindingFactor, ExtKeychainPath, Error, Keychain};
 use util::logger::LOGGER;
 use util::secp::key::SecretKey;
 use util::secp::pedersen::Commitment;
@@ -30,20 +28,17 @@ use util::secp::{self, Message, Secp256k1, Signature};
 #[derive(Clone, Debug)]
 pub struct ExtKeychain {
 	secp: Secp256k1,
-	extkey: extkey::ExtendedKey,
-	key_overrides: HashMap<Identifier, SecretKey>,
-	key_derivation_cache: Arc<RwLock<HashMap<Identifier, u32>>>,
+	master: ExtendedPrivKey,
 }
 
 impl Keychain for ExtKeychain {
 	fn from_seed(seed: &[u8]) -> Result<ExtKeychain, Error> {
+		let mut h = BIP32GrinHasher::new();
 		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-		let extkey = extkey::ExtendedKey::from_seed(&secp, seed)?;
+		let master = ExtendedPrivKey::new_master(&secp, &mut h, seed)?;
 		let keychain = ExtKeychain {
 			secp: secp,
-			extkey: extkey,
-			key_overrides: HashMap::new(),
-			key_derivation_cache: Arc::new(RwLock::new(HashMap::new())),
+			master: master,
 		};
 		Ok(keychain)
 	}
@@ -55,39 +50,23 @@ impl Keychain for ExtKeychain {
 		ExtKeychain::from_seed(seed.as_bytes())
 	}
 
-	fn root_key_id(&self) -> Identifier {
-		self.extkey.root_key_id.clone()
+	fn root_key_id(&self) -> Fingerprint {
+		let mut h = BIP32GrinHasher::new();
+		self.master.fingerprint(&mut h)
 	}
 
-	fn derive_key_id(&self, derivation: u32) -> Result<Identifier, Error> {
-		let child_key = self.extkey.derive(&self.secp, derivation)?;
-		Ok(child_key.key_id)
-	}
-
-	fn derived_key(&self, key_id: &Identifier) -> Result<SecretKey, Error> {
-		// first check our overrides and just return the key if we have one in there
-		if let Some(key) = self.key_overrides.get(key_id) {
-			trace!(
-				LOGGER,
-				"... Derived Key (using override) key_id: {}",
-				key_id
-			);
-			return Ok(*key);
+	fn derive_key_id(&self, p: &ExtKeychainPath) -> Result<ExtendedPrivKey, Error> {
+		let mut h = BIP32GrinHasher::new();
+		let mut sk = self.master;
+		for i in 0..p.depth {
+			sk = sk.ckd_priv(&self.secp, &mut h, p.path[i])?;
 		}
-
-		let child_key = self.derived_child_key(key_id)?;
-		Ok(child_key.key)
+		Ok(sk)
 	}
 
-	fn commit(&self, amount: u64, key_id: &Identifier) -> Result<Commitment, Error> {
-		let skey = self.derived_key(key_id)?;
-		let commit = self.secp.commit(amount, skey)?;
-		Ok(commit)
-	}
-
-	fn commit_with_key_index(&self, amount: u64, derivation: u32) -> Result<Commitment, Error> {
-		let child_key = self.derived_key_from_index(derivation)?;
-		let commit = self.secp.commit(amount, child_key.key)?;
+	fn commit(&self, amount: u64, derivation: &ExtKeychainPath) -> Result<Commitment, Error> {
+		let key = self.derive_key_id(derivation)?;
+		let commit = self.secp.commit(amount, key.secret_key)?;
 		Ok(commit)
 	}
 
@@ -95,13 +74,27 @@ impl Keychain for ExtKeychain {
 		let mut pos_keys: Vec<SecretKey> = blind_sum
 			.positive_key_ids
 			.iter()
-			.filter_map(|k| self.derived_key(&k).ok())
+			.filter_map(|k| {
+					let res = self.derive_key_id(&k);
+					if let Ok(s) = res {
+						Some(s.secret_key)
+					} else {
+						None
+					}
+				})
 			.collect();
 
 		let mut neg_keys: Vec<SecretKey> = blind_sum
 			.negative_key_ids
 			.iter()
-			.filter_map(|k| self.derived_key(&k).ok())
+			.filter_map(|k| {
+					let res = self.derive_key_id(&k);
+					if let Ok(s) = res {
+						Some(s.secret_key)
+					} else {
+						None
+					}
+				})
 			.collect();
 
 		pos_keys.extend(
@@ -124,9 +117,9 @@ impl Keychain for ExtKeychain {
 		Ok(BlindingFactor::from_secret_key(sum))
 	}
 
-	fn sign(&self, msg: &Message, key_id: &Identifier) -> Result<Signature, Error> {
-		let skey = self.derived_key(key_id)?;
-		let sig = self.secp.sign(msg, &skey)?;
+	fn sign(&self, msg: &Message, path: &ExtKeychainPath) -> Result<Signature, Error> {
+		let skey = self.derive_key_id(path)?;
+		let sig = self.secp.sign(msg, &skey.secret_key)?;
 		Ok(sig)
 	}
 
@@ -145,82 +138,10 @@ impl Keychain for ExtKeychain {
 	}
 }
 
-impl ExtKeychain {
-	// For tests and burn only, associate a key identifier with a known secret key.
-	pub fn burn_enabled(keychain: &ExtKeychain, burn_key_id: &Identifier) -> ExtKeychain {
-		let mut key_overrides = HashMap::new();
-		key_overrides.insert(
-			burn_key_id.clone(),
-			SecretKey::from_slice(&keychain.secp, &[1; 32]).unwrap(),
-		);
-		ExtKeychain {
-			key_overrides: key_overrides,
-			..keychain.clone()
-		}
-	}
-
-	fn derived_child_key(&self, key_id: &Identifier) -> Result<extkey::ChildKey, Error> {
-		trace!(LOGGER, "Derived Key by key_id: {}", key_id);
-
-		// then check the derivation cache to see if we have previously derived this key
-		// if so use the derivation from the cache to derive the key
-		{
-			let cache = self.key_derivation_cache.read().unwrap();
-			if let Some(derivation) = cache.get(key_id) {
-				trace!(
-					LOGGER,
-					"... Derived Key (cache hit) key_id: {}, derivation: {}",
-					key_id,
-					derivation
-				);
-				return Ok(self.derived_key_from_index(*derivation)?);
-			}
-		}
-
-		// otherwise iterate over a large number of derivations looking for our key
-		// cache the resulting derivations by key_id for faster lookup later
-		// TODO - remove hard limit (within reason)
-		// TODO - do we benefit here if we track our max known n_child?
-		{
-			let mut cache = self.key_derivation_cache.write().unwrap();
-			for i in 1..100_000 {
-				let child_key = self.extkey.derive(&self.secp, i)?;
-				// let child_key_id = extkey.identifier(&self.secp)?;
-
-				if !cache.contains_key(&child_key.key_id) {
-					trace!(
-						LOGGER,
-						"... Derived Key (cache miss) key_id: {}, derivation: {}",
-						child_key.key_id,
-						child_key.n_child,
-					);
-					cache.insert(child_key.key_id.clone(), child_key.n_child);
-				}
-
-				if child_key.key_id == *key_id {
-					return Ok(child_key);
-				}
-			}
-		}
-
-		Err(Error::KeyDerivation(format!(
-			"failed to derive child_key for {:?}",
-			key_id
-		)))
-	}
-
-	// if we know the derivation index we can just straight to deriving the key
-	fn derived_key_from_index(&self, derivation: u32) -> Result<extkey::ChildKey, Error> {
-		trace!(LOGGER, "Derived Key (fast) by derivation: {}", derivation);
-		let child_key = self.extkey.derive(&self.secp, derivation)?;
-		return Ok(child_key);
-	}
-}
-
 #[cfg(test)]
 mod test {
 	use keychain::ExtKeychain;
-	use types::{BlindSum, BlindingFactor, Keychain};
+	use types::{BlindSum, BlindingFactor, ExtKeychainPath, Keychain};
 	use util::secp;
 	use util::secp::key::SecretKey;
 
@@ -229,18 +150,20 @@ mod test {
 		let keychain = ExtKeychain::from_random_seed().unwrap();
 		let secp = keychain.secp();
 
+		let path = ExtKeychainPath::new(1, 1, 0, 0, 0);
+
 		// use the keychain to derive a "key_id" based on the underlying seed
-		let key_id = keychain.derive_key_id(1).unwrap();
+		let _key_id = keychain.derive_key_id(&path).unwrap();
 
 		let msg_bytes = [0; 32];
 		let msg = secp::Message::from_slice(&msg_bytes[..]).unwrap();
 
 		// now create a zero commitment using the key on the keychain associated with
 		// the key_id
-		let commit = keychain.commit(0, &key_id).unwrap();
+		let commit = keychain.commit(0, &path).unwrap();
 
 		// now check we can use our key to verify a signature from this zero commitment
-		let sig = keychain.sign(&msg, &key_id).unwrap();
+		let sig = keychain.sign(&msg, &path).unwrap();
 		secp.verify_from_commit(&msg, &sig, &commit).unwrap();
 	}
 

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -34,5 +34,7 @@ pub mod extkey_bip32;
 mod types;
 
 pub mod keychain;
-pub use keychain::{ExtKeychain};
-pub use types::{BlindSum, BlindingFactor, ExtKeychainPath, Error, Identifier, Keychain, IDENTIFIER_SIZE};
+pub use keychain::ExtKeychain;
+pub use types::{
+	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier, Keychain, IDENTIFIER_SIZE,
+};

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -29,10 +29,10 @@ extern crate crypto;
 extern crate uuid;
 
 mod base58;
-pub mod extkey;
+//pub mod extkey;
 pub mod extkey_bip32;
 mod types;
 
 pub mod keychain;
-pub use keychain::ExtKeychain;
-pub use types::{BlindSum, BlindingFactor, Error, Identifier, Keychain, IDENTIFIER_SIZE};
+pub use keychain::{ExtKeychain};
+pub use types::{BlindSum, BlindingFactor, ExtKeychainPath, Error, Identifier, Keychain, IDENTIFIER_SIZE};

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -21,8 +21,8 @@ use std::cmp::min;
 use std::{error, fmt};
 
 use blake2::blake2b::blake2b;
-use serde::{de, ser};
-use extkey_bip32::{self, ChildNumber, ExtendedPrivKey, Fingerprint}; //TODO: Convert errors to use ErrorKind
+use extkey_bip32::{self, ChildNumber, ExtendedPrivKey, Fingerprint};
+use serde::{de, ser}; //TODO: Convert errors to use ErrorKind
 
 use util;
 use util::secp::constants::SECRET_KEY_SIZE;
@@ -294,20 +294,22 @@ impl BlindSum {
 /// Encapsulates a max 4-level deep BIP32 path, which is the
 /// most we can currently fit into a rangeproof message
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct ExtKeychainPath{
+pub struct ExtKeychainPath {
 	pub depth: usize,
-	pub path: [extkey_bip32::ChildNumber;4]
+	pub path: [extkey_bip32::ChildNumber; 4],
 }
 
 impl ExtKeychainPath {
 	/// Return a new chain path with given derivation and depth
-	pub fn new(depth: usize, d0: u32, d1: u32, d2: u32, d3: u32) -> ExtKeychainPath{
+	pub fn new(depth: usize, d0: u32, d1: u32, d2: u32, d3: u32) -> ExtKeychainPath {
 		ExtKeychainPath {
 			depth: depth,
-			path: [ChildNumber::from(d0),
-			       ChildNumber::from(d1),
-			       ChildNumber::from(d2),
-			       ChildNumber::from(d3)],
+			path: [
+				ChildNumber::from(d0),
+				ChildNumber::from(d1),
+				ChildNumber::from(d2),
+				ChildNumber::from(d3),
+			],
 		}
 	}
 }


### PR DESCRIPTION
(Technically not consensus-breaking but will give everyone a bad day if this is merged. Intended for T4)

Modify wallet key derivation to be BIP-32 Compliant, involves: 

* Key derivation paths will have to become the identifier internally
* For the moment, just support a single derivation off of the master, m/0/1, m/0/2, m/0/3 etc, so the user functionality stays exactly as it is now
* Wallet can later be extended to support multiple accounts (at m/1, m/2 etc) 
* Derivation paths will be stored in the bullet proof (via https://github.com/mimblewimble/secp256k1-zkp/commit/e6f1191da78b031c5c7bd00527756b74adecf0e3), supporting up to 4 levels deep for now (m/0/0/0/0)
* Wallet restore can use these paths to avoid having to do any more key grinding (added bonus)

Please feel free to review and comment even as this is in progress, will be messing around with this a bit to get the path structure and KeyChain trait interface feeling right.

