### PR TITLE
return an Err when read return 0

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -118,10 +118,19 @@ pub fn read_exact(
 	let sleep_time = time::Duration::from_micros(10);
 	let mut count = time::Duration::new(0, 0);
 
+	let exact = buf.len();
 	let mut read = 0;
 	loop {
 		match conn.read(buf) {
-			Ok(0) => break,
+			Ok(0) => {
+				if read < exact {
+					return Err(io::Error::new(
+						io::ErrorKind::ConnectionAborted,
+						"read_exact",
+					));
+				}
+				break;
+			}
 			Ok(n) => {
 				let tmp = buf;
 				buf = &mut tmp[n..];

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -118,18 +118,14 @@ pub fn read_exact(
 	let sleep_time = time::Duration::from_micros(10);
 	let mut count = time::Duration::new(0, 0);
 
-	let exact = buf.len();
 	let mut read = 0;
 	loop {
 		match conn.read(buf) {
 			Ok(0) => {
-				if read < exact {
-					return Err(io::Error::new(
-						io::ErrorKind::ConnectionAborted,
-						"read_exact",
-					));
-				}
-				break;
+				return Err(io::Error::new(
+					io::ErrorKind::ConnectionAborted,
+					"read_exact",
+				));
 			}
 			Ok(n) => {
 				let tmp = buf;


### PR DESCRIPTION
Fix:  Return an Err when read return 0, instead of return an all zeroed buff without any error.

This PR is partially related to https://github.com/mimblewimble/grin/issues/1464 , but in #1464, there's  also another existing issue to be tracked there. 

It's clear now why we often see such kind of Error:
```
Serialization(UnexpectedData { expected: [30], received: [0] })
```
(BTW, `30` means the 1st byte of the magic word `0x1e, 0xc5` which we're using for the Grin message.)


It's because of one case of `read_exact()`:
```
		match conn.read(buf) {
			Ok(0) => break,       <<<< problem is here!
			Ok(n) => {
				...
			}
```

If we `break` at the `Ok(0)`, that means we will successfully return the `read_exact()` function call with the read buffer but all zeroed.

But actually, it's indeed an Error case, could be caused by some reasons, such as `connection reset`, `connection close`, etc.   Unfortunately, in these cases, we don't get the following case matched:
```
			Err(e) => return Err(e),
```
then we don't get the official `io::ErrorKind::ConnectionAborted` or `io::ErrorKind::NotConnected`.

I'm not sure which one is the real matched `io::ErrorKind`.  But it doesn't matter here if I use `ConnectionAborted` for `Ok(0)`.

