### PR TITLE
fixed list of requirements (pkg-config)

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -16,7 +16,7 @@ What's working so far?
 - clang
 - ncurses and libs (ncurses, ncursesw5)
 - zlib libs (zlib1g-dev or zlib-devel)
-- pkc-config
+- pkg-config
 - libssl-dev
 - linux-headers (reported needed on Alpine linux)
 


### PR DESCRIPTION
pkg-config was incorrectly spelled pkc-config