### PR TITLE
fix: wrong location of p2p config comments

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -191,33 +191,11 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"seeding_type".to_string(),
 		"
-#How to seed this server, can be None, List, WebStatic or DNSSeed
 #If the seeding type is List, the list of peers to connect to can
 #be specified as follows:
 #seeds = [\"192.168.0.1:13414\",\"192.168.0.2:13414\"]
-"
-			.to_string(),
-	);
 
-	retval.insert(
-		"seeds".to_string(),
-		"
-#If seeding_type = List, the list of peers to connect to.
-"
-			.to_string(),
-	);
-
-	retval.insert(
-		"[server.p2p_config.capabilities]".to_string(),
-		"#7 = Bit flags for FULL_NODE, this structure needs to be changed
-#internally to make it more configurable
-"
-			.to_string(),
-	);
-
-	retval.insert(
-		"[server.pool_config]".to_string(),
-		"#hardcoded peer lists for allow/deny
+#hardcoded peer lists for allow/deny
 #will *only* connect to peers in allow list
 #peers_allow = [\"192.168.0.1:13414\", \"192.168.0.2:13414\"]
 #will *never* connect to peers in deny list
@@ -235,6 +213,22 @@ fn comments() -> HashMap<String, String> {
 #until we get to at least this number
 #peer_min_preferred_count = 8
 
+#How to seed this server, can be None, List, WebStatic or DNSSeed
+"
+			.to_string(),
+	);
+
+	retval.insert(
+		"[server.p2p_config.capabilities]".to_string(),
+		"#7 = Bit flags for FULL_NODE, this structure needs to be changed
+#internally to make it more configurable
+"
+			.to_string(),
+	);
+
+	retval.insert(
+		"[server.pool_config]".to_string(),
+		"
 #########################################
 ### MEMPOOL CONFIGURATION             ###
 #########################################

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -213,7 +213,7 @@ fn comments() -> HashMap<String, String> {
 #until we get to at least this number
 #peer_min_preferred_count = 8
 
-#How to seed this server, can be None, List, WebStatic or DNSSeed
+#How to seed this server, can be None, List or DNSSeed
 "
 			.to_string(),
 	);


### PR DESCRIPTION
In the auto generated toml config file, the following comments are put in wrong place, which make the config of `peer_min_preferred_count` taking no effect:
```
#maximum number of peers
#peer_max_count = 25

#preferred minimum number of peers (we'll actively keep trying to add peers
#until we get to at least this number
#peer_min_preferred_count = 8
```