### PR TITLE
optimization for txhashset rewind

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -140,6 +140,13 @@ impl ChainStore {
 		}
 	}
 
+	pub fn get_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
+		option_to_not_found(
+			self.db.get_ser(&u64_to_key(HEADER_HEIGHT_PREFIX, height)),
+			&format!("Hash at height: {}", height),
+		)
+	}
+
 	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
 		option_to_not_found(
 			self.db.get_ser(&u64_to_key(HEADER_HEIGHT_PREFIX, height)),

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -1214,8 +1214,8 @@ fn input_pos_to_rewind(
 	head_header: &BlockHeader,
 	batch: &Batch,
 ) -> Result<Bitmap, Error> {
-	let mut bitmap = Bitmap::create();
 	let mut current = head_header.hash();
+	let mut height = head_header.height;
 
 	if head_header.height < block_header.height {
 		debug!(
@@ -1224,27 +1224,41 @@ fn input_pos_to_rewind(
 			head_header.height,
 			block_header.height
 		);
-		return Ok(bitmap);
+		return Ok(Bitmap::create());
 	}
 
-	//
-	// TODO - rework this loop to use Bitmap::fast_or() on a vec of bitmaps.
-	//
-	loop {
-		if current == block_header.hash() {
-			break;
+	let bitmap_fast_or = |b_res, block_input_bitmaps: &mut Vec<Bitmap>| -> Option<Bitmap> {
+		if let Some(b) = b_res {
+			block_input_bitmaps.push(b);
+			if block_input_bitmaps.len() < 256 {
+				return None;
+			}
 		}
+		let bitmap =
+			Bitmap::fast_or(&block_input_bitmaps.iter().map(|x| x).collect::<Vec<&Bitmap>>());
+		block_input_bitmaps.clear();
+		block_input_bitmaps.push(bitmap.clone());
+		Some(bitmap)
+	};
 
+	let mut block_input_bitmaps: Vec<Bitmap> = vec![];
+	let bh = block_header.hash();
+
+	while current != bh {
 		// We cache recent block headers and block_input_bitmaps
 		// internally in our db layer (commit_index).
 		// I/O should be minimized or eliminated here for most
 		// rewind scenarios.
-		let current_header = commit_index.get_block_header(&current)?;
-		let input_bitmap_res = batch.get_block_input_bitmap(&current);
-		if let Ok(b) = input_bitmap_res {
-			bitmap.or_inplace(&b);
+		if let Ok(b_res) = batch.get_block_input_bitmap(&current) {
+			bitmap_fast_or(Some(b_res), &mut block_input_bitmaps);
 		}
-		current = current_header.previous;
+		if height == 0 {
+			break;
+		}
+		height -= 1;
+		current = commit_index.get_hash_by_height(height)?;
 	}
+
+	let bitmap = bitmap_fast_or(None, &mut block_input_bitmaps).unwrap();
 	Ok(bitmap)
 }

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -1227,6 +1227,8 @@ fn input_pos_to_rewind(
 		return Ok(Bitmap::create());
 	}
 
+	// Batching up the block input bitmaps, and running fast_or() on every batch of 256 bitmaps.
+	// so to avoid maintaining a huge vec of bitmaps.
 	let bitmap_fast_or = |b_res, block_input_bitmaps: &mut Vec<Bitmap>| -> Option<Bitmap> {
 		if let Some(b) = b_res {
 			block_input_bitmaps.push(b);
@@ -1237,7 +1239,6 @@ fn input_pos_to_rewind(
 		let bitmap = Bitmap::fast_or(
 			&block_input_bitmaps
 				.iter()
-				.map(|x| x)
 				.collect::<Vec<&Bitmap>>(),
 		);
 		block_input_bitmaps.clear();

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -1236,11 +1236,7 @@ fn input_pos_to_rewind(
 				return None;
 			}
 		}
-		let bitmap = Bitmap::fast_or(
-			&block_input_bitmaps
-				.iter()
-				.collect::<Vec<&Bitmap>>(),
-		);
+		let bitmap = Bitmap::fast_or(&block_input_bitmaps.iter().collect::<Vec<&Bitmap>>());
 		block_input_bitmaps.clear();
 		block_input_bitmaps.push(bitmap.clone());
 		Some(bitmap)

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -1234,8 +1234,12 @@ fn input_pos_to_rewind(
 				return None;
 			}
 		}
-		let bitmap =
-			Bitmap::fast_or(&block_input_bitmaps.iter().map(|x| x).collect::<Vec<&Bitmap>>());
+		let bitmap = Bitmap::fast_or(
+			&block_input_bitmaps
+				.iter()
+				.map(|x| x)
+				.collect::<Vec<&Bitmap>>(),
+		);
 		block_input_bitmaps.clear();
 		block_input_bitmaps.push(bitmap.clone());
 		Some(bitmap)


### PR DESCRIPTION
Optimization for `rewind()` function in `chain/src/txhashset.rs`. It's about as 700% faster as the old version, for this function call, in case the rewind block is very far from the Tip.

Compare between old version and new version:

- Test with block height 40,000:
```
# curl -0 -XGET  http://127.0.0.1:13413/v1/blocks/40000

Old Version:
Sep 14 20:09:05.106 DEBG txhashset: merkle_proof: output: Commitment(09d84a9c6b5939fbd12739421e6c99d26fc313f269046353d8eecf7879cbef1d56), block: 007453cb
Sep 14 20:09:06.070 DEBG merkle_proof  99312, last_pos 99312
                    <<<< 964ms spent

New Version:
Sep 14 20:31:54.413 DEBG txhashset: merkle_proof: output: Commitment(09d84a9c6b5939fbd12739421e6c99d26fc313f269046353d8eecf7879cbef1d56), block: 007453cb
Sep 14 20:31:54.548 DEBG merkle_proof  99312, last_pos 99312
                    <<<< 135ms spent
```
- Test with block height 50,000:
```
# curl -0 -XGET  http://127.0.0.1:13413/v1/blocks/50000

Old Version:
Sep 14 20:05:18.304 DEBG txhashset: merkle_proof: output: Commitment(09994dd2a6dd7cd7fbf9104e10c304cd8eaf16f74ae5d405e2b26c7e0e3b85c816), block: 02e79e8f
Sep 14 20:05:19.084 DEBG merkle_proof  119420, last_pos 119421
                    <<<<  780ms spent

New Version:
Sep 14 20:30:14.842 DEBG txhashset: merkle_proof: output: Commitment(09994dd2a6dd7cd7fbf9104e10c304cd8eaf16f74ae5d405e2b26c7e0e3b85c816), block: 02e79e8f
Sep 14 20:30:14.948 DEBG merkle_proof  119420, last_pos 119421
                    <<<< 106ms spent
```
- Test with block height 80,000:
```
# curl -0 -XGET  http://127.0.0.1:13413/v1/blocks/80000

Old Version:
Sep 14 20:04:21.345 DEBG txhashset: merkle_proof: output: Commitment(093941106eb2c3392e0f839dbd2d19926f71ae81d2368492f8b6b4b5854bb9bd79), block: 1316d80e
Sep 14 20:04:21.612 DEBG merkle_proof  185971, last_pos 185977
                    <<<< 267ms spent

New Version:
Sep 14 20:28:56.290 DEBG txhashset: merkle_proof: output: Commitment(093941106eb2c3392e0f839dbd2d19926f71ae81d2368492f8b6b4b5854bb9bd79), block: 1316d80e
Sep 14 20:28:56.325 DEBG merkle_proof  185971, last_pos 185977
                    <<<< 35ms spent
```

**another** optimization is for `Bitmap`, use `Bitmap::fast_or()` to replace `or_inplace()`. This was a `TODO` item in the old code. I also add a bench test for it:
```
$ cd store
$ cargo test --release bench_fast_or -- --nocapture

running 1 test
  or_inplace():     5.098ms. bitmap cardinality: 225785
     fast_or():     0.778ms. bitmap cardinality: 226018
fast_or_heap():     9.203ms. bitmap cardinality: 225628
```

A main optimization is using `get_hash_by_height()` instead of `get_block_header()`.

BTW, this PR came from the analysis result of issue: https://github.com/mimblewimble/grin/issues/1477


