### PR TITLE
fix: reset sync_head to header_head on initial transition to HeaderSync (#1524)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -931,6 +931,14 @@ impl Chain {
 			.block_exists(&h)
 			.map_err(|e| ErrorKind::StoreErr(e, "chain block exists".to_owned()).into())
 	}
+
+	/// reset sync_head to header_head
+	pub fn init_sync_head(&self, header_head: &Tip) -> Result<(), Error> {
+		let batch = self.store.batch()?;
+		batch.init_sync_head(header_head)?;
+		batch.commit()?;
+		Ok(())
+	}
 }
 
 fn setup_head(

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -352,20 +352,6 @@ impl Chain {
 		res
 	}
 
-	/// Update sync head
-	/// This is only used for Independent HeaderSync
-	pub fn update_sync_head(&self, bh: &BlockHeader, opts: Options) -> Result<Option<Tip>, Error> {
-		let sync_head = self.get_sync_head()?;
-		let mut sync_ctx = self.ctx_from_head(sync_head, opts)?;
-		let mut batch = self.store.batch()?;
-		let res = pipe::update_sync_head(bh, &mut sync_ctx, &mut batch);
-
-		if res.is_ok() {
-			batch.commit()?;
-		}
-		res
-	}
-
 	fn ctx_from_head<'a>(&self, head: Tip, opts: Options) -> Result<pipe::BlockContext, Error> {
 		Ok(pipe::BlockContext {
 			opts: opts,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -856,14 +856,6 @@ impl Chain {
 			.map_err(|e| ErrorKind::StoreErr(e, "chain get header".to_owned()).into())
 	}
 
-	/// Gets hash of a block header by height
-	///   Only available if this height <= height of header head (tip of the header chain)
-	pub fn get_header_hash(&self, height: u64) -> Result<Hash, Error> {
-		self.store
-			.get_hash_by_height(height)
-			.map_err(|e| ErrorKind::StoreErr(e, "chain get hash by height".to_owned()).into())
-	}
-
 	/// Gets the block header at the provided height
 	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
 		self.store

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -215,9 +215,15 @@ pub fn sync_block_header(
 	validate_header(&bh, sync_ctx)?;
 	add_block_header(bh, batch)?;
 
-	// now update the header_head (if new header with most work) and the sync_head
-	// (always)
+	// Update header_head (but only if this header increases our total known work).
+	// i.e. Only if this header is now the head of the current "most work" chain.
 	update_header_head(bh, header_ctx, batch)?;
+
+	// Update sync_head regardless of total work.
+	// We may be syncing a long fork that will *eventually* increase the work
+	// and become the "most work" chain.
+	// header_head and sync_head will diverge in this situation until we switch to
+	// a single "most work" chain.
 	update_sync_head(bh, sync_ctx, batch)
 }
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -568,7 +568,7 @@ fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
 }
 
 /// Update the sync head so we can keep syncing from where we left off.
-fn update_sync_head(
+pub fn update_sync_head(
 	bh: &BlockHeader,
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -483,8 +483,7 @@ fn validate_block(
 			&prev.total_kernel_offset,
 			&prev.total_kernel_sum,
 			verifier_cache,
-		)
-		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
+		).map_err(|e| ErrorKind::InvalidBlockProof(e))?;
 	Ok(())
 }
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -483,7 +483,8 @@ fn validate_block(
 			&prev.total_kernel_offset,
 			&prev.total_kernel_sum,
 			verifier_cache,
-		).map_err(|e| ErrorKind::InvalidBlockProof(e))?;
+		)
+		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
 	Ok(())
 }
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -568,7 +568,7 @@ fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
 }
 
 /// Update the sync head so we can keep syncing from where we left off.
-pub fn update_sync_head(
+fn update_sync_head(
 	bh: &BlockHeader,
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -177,8 +177,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 						&prev.total_kernel_offset,
 						&prev.total_kernel_sum,
 						self.verifier_cache.clone(),
-					)
-					.is_ok()
+					).is_ok()
 				{
 					debug!(LOGGER, "adapter: successfully hydrated block from tx pool!");
 					self.process_block(block, addr)
@@ -450,10 +449,9 @@ impl NetToChainAdapter {
 			let head = chain.head().unwrap();
 			// we have a fast sync'd node and are sent a block older than our horizon,
 			// only sync can do something with that
-			if b.header.height
-				< head
-					.height
-					.saturating_sub(global::cut_through_horizon() as u64)
+			if b.header.height < head
+				.height
+				.saturating_sub(global::cut_through_horizon() as u64)
 			{
 				return true;
 			}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -261,25 +261,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		}
 
 		// headers will just set us backward if even the last is unknown
-		let bhs_last = bhs.last().unwrap().clone();
-		if let Ok(_) = w(&self.chain).get_block_header(&bhs_last.hash()) {
+		let last_h = bhs.last().unwrap().hash();
+		if let Ok(_) = w(&self.chain).get_block_header(&last_h) {
 			info!(LOGGER, "All known, ignoring");
-
-			// Check if we need update sync head.
-			//   In case of header head already updated by blocks broadcasting.
-			let tip = w(&self.chain).get_sync_head().unwrap();
-			if bhs_last.height > tip.height || w(&self.chain).get_block_header(&tip.hash()).is_err()
-			{
-				let res = w(&self.chain).update_sync_head(&bhs_last, self.chain_opts());
-				if let &Err(ref e) = &res {
-					debug!(
-						LOGGER,
-						"Block header {} update_sync_head fail: {:?}",
-						bhs_last.hash(),
-						e
-					);
-				}
-			}
 			return true;
 		}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -177,7 +177,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 						&prev.total_kernel_offset,
 						&prev.total_kernel_sum,
 						self.verifier_cache.clone(),
-					).is_ok()
+					)
+					.is_ok()
 				{
 					debug!(LOGGER, "adapter: successfully hydrated block from tx pool!");
 					self.process_block(block, addr)
@@ -449,9 +450,10 @@ impl NetToChainAdapter {
 			let head = chain.head().unwrap();
 			// we have a fast sync'd node and are sent a block older than our horizon,
 			// only sync can do something with that
-			if b.header.height < head
-				.height
-				.saturating_sub(global::cut_through_horizon() as u64)
+			if b.header.height
+				< head
+					.height
+					.saturating_sub(global::cut_through_horizon() as u64)
 			{
 				return true;
 			}

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -93,8 +93,9 @@ pub fn run_sync(
 						// * timeout
 						if wp.len() > MIN_PEERS
 							|| (wp.len() == 0
-								&& peers.enough_peers()
-								&& head.total_difficulty > Difficulty::zero()) || n > wait_secs
+								&& peers.enough_peers() && head.total_difficulty
+								> Difficulty::zero())
+							|| n > wait_secs
 						{
 							break;
 						}
@@ -343,8 +344,7 @@ fn body_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, body_sync_info: &mut B
 			// only ask for blocks that we have not yet processed
 			// either successfully stored or in our orphan list
 			!chain.get_block(x).is_ok() && !chain.is_orphan(x)
-		})
-		.take(block_count)
+		}).take(block_count)
 		.collect::<Vec<_>>();
 
 	if hashes_to_get.len() > 0 {
@@ -524,11 +524,13 @@ fn get_locator(
 
 	// reset to header_head if sync_head is left behind
 	if header_head.height > tip.height {
-		debug!(LOGGER, "sync: get_locator reset to header_head. sync_head: {} at {}, header_head: {} at {}",
-			   tip.hash(),
-			   tip.height,
-			   header_head.hash(),
-			   header_head.height,
+		debug!(
+			LOGGER,
+			"sync: get_locator reset to header_head. sync_head: {} at {}, header_head: {} at {}",
+			tip.hash(),
+			tip.height,
+			header_head.hash(),
+			header_head.height,
 		);
 		tip = header_head;
 	}
@@ -686,7 +688,11 @@ impl SyncInfo {
 		let stalling = header_head.height == latest_height && now > timeout;
 
 		if all_headers_received || stalling {
-			self.prev_header_sync = (now + Duration::seconds(10), header_head.height, header_head.height);
+			self.prev_header_sync = (
+				now + Duration::seconds(10),
+				header_head.height,
+				header_head.height,
+			);
 			true
 		} else {
 			// resetting the timeout as long as we progress
@@ -761,9 +767,7 @@ mod test {
 		// headers
 		assert_eq!(
 			get_locator_heights(10000),
-			vec![
-				10000, 9998, 9994, 9986, 9970, 9938, 9874, 9746, 9490, 8978, 7954, 5906, 1810, 0,
-			]
+			vec![10000, 9998, 9994, 9986, 9970, 9938, 9874, 9746, 9490, 8978, 7954, 5906, 1810, 0,]
 		);
 	}
 }

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -144,8 +144,7 @@ pub fn run_sync(
 							let status = sync_state.status();
 							let update_sync_state = match status {
 								SyncStatus::TxHashsetDownload => false,
-								SyncStatus::NoSync
-								| SyncStatus::Initial => {
+								SyncStatus::NoSync | SyncStatus::Initial => {
 									// Reset sync_head to header_head on transition to HeaderSync,
 									// but ONLY on initial transition to HeaderSync state.
 									let sync_head = chain.get_sync_head().unwrap();
@@ -161,9 +160,7 @@ pub fn run_sync(
 									history_locators.clear();
 									true
 								}
-								_ => {
-									true
-								}
+								_ => true,
 							};
 							if update_sync_state {
 								sync_state.update(SyncStatus::HeaderSync {

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -683,11 +683,7 @@ impl SyncInfo {
 		let stalling = header_head.height == latest_height && now > timeout;
 
 		if all_headers_received || stalling {
-			self.prev_header_sync = (
-				now + max_timeout,
-				header_head.height,
-				header_head.height,
-			);
+			self.prev_header_sync = (now + max_timeout, header_head.height, header_head.height);
 			true
 		} else {
 			// resetting the timeout as long as we progress

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -147,16 +147,13 @@ pub fn run_sync(
 							let status = sync_state.status();
 							match status {
 								SyncStatus::TxHashsetDownload => (),
-								SyncStatus::HeaderSync { .. }
-								| SyncStatus::NoSync
-								| SyncStatus::Initial => {
+								_ => {
 									sync_state.update(SyncStatus::HeaderSync {
 										current_height: header_head.height,
 										highest_height: si.highest_height,
 									});
 								}
-								_ => (),
-							};
+							}
 						}
 
 						if fast_sync_enabled {
@@ -528,11 +525,11 @@ fn get_locator(
 		history_locators.clear();
 	}
 
-	// reset to header_head if sync_head is left behind
+	// when sync_head is left behind, use header_head as the sync_head for get_locator
 	if header_head.height > tip.height {
 		debug!(
 			LOGGER,
-			"sync: get_locator reset to header_head. sync_head: {} at {}, header_head: {} at {}",
+			"sync: get_locator use header_head as sync_head. sync_head: {} at {}, header_head: {} at {}",
 			tip.hash(),
 			tip.height,
 			header_head.hash(),

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -532,7 +532,7 @@ fn get_locator(
 			header_head.hash(),
 			header_head.height,
 		);
-		tip = header_head;
+		tip = header_head.clone();
 	}
 
 	let heights = get_locator_heights(tip.height);

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -93,9 +93,8 @@ pub fn run_sync(
 						// * timeout
 						if wp.len() > MIN_PEERS
 							|| (wp.len() == 0
-								&& peers.enough_peers() && head.total_difficulty
-								> Difficulty::zero())
-							|| n > wait_secs
+								&& peers.enough_peers()
+								&& head.total_difficulty > Difficulty::zero()) || n > wait_secs
 						{
 							break;
 						}
@@ -153,7 +152,7 @@ pub fn run_sync(
 										highest_height: si.highest_height,
 									});
 								}
-							}
+							};
 						}
 
 						if fast_sync_enabled {
@@ -341,7 +340,8 @@ fn body_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, body_sync_info: &mut B
 			// only ask for blocks that we have not yet processed
 			// either successfully stored or in our orphan list
 			!chain.get_block(x).is_ok() && !chain.is_orphan(x)
-		}).take(block_count)
+		})
+		.take(block_count)
 		.collect::<Vec<_>>();
 
 	if hashes_to_get.len() > 0 {
@@ -764,7 +764,9 @@ mod test {
 		// headers
 		assert_eq!(
 			get_locator_heights(10000),
-			vec![10000, 9998, 9994, 9986, 9970, 9938, 9874, 9746, 9490, 8978, 7954, 5906, 1810, 0,]
+			vec![
+				10000, 9998, 9994, 9986, 9970, 9938, 9874, 9746, 9490, 8978, 7954, 5906, 1810, 0,
+			]
 		);
 	}
 }

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -522,6 +522,12 @@ fn get_locator(
 	let mut tip = chain.get_sync_head()?;
 	let header_head = chain.get_header_head()?;
 
+	// for security, clear history_locators[] in any case of header chain rollback,
+	// the easiest way is to check whether the sync head and the header head are identical.
+	if history_locators.len() > 0 && tip.hash() != header_head.hash() {
+		history_locators.clear();
+	}
+
 	// reset to header_head if sync_head is left behind
 	if header_head.height > tip.height {
 		debug!(
@@ -537,12 +543,6 @@ fn get_locator(
 
 	let heights = get_locator_heights(tip.height);
 	let mut new_heights: Vec<u64> = vec![];
-
-	// for security, clear history_locators[] in any case of header chain rollback,
-	// the easiest way is to check whether the sync head and the header head are identical.
-	if history_locators.len() > 0 && tip.hash() != header_head.hash() {
-		history_locators.clear();
-	}
 
 	debug!(LOGGER, "sync: locator heights : {:?}", heights);
 


### PR DESCRIPTION
The root cause analysis is in https://github.com/mimblewimble/grin/issues/1524.

The fix solution:

1. In `sync.rs`, allow `header_sync()` always execute regardless the state of `SyncStatus`, even on `NoSync` state, but in 60s periodic instead of 10s.
2. The key part. In `adapter.rs`, `headers_received()` function, in case of "All known, ignoring", check the sync head and update it if needed.
```
	let tip = w(&self.chain).get_sync_head().unwrap();
	if bhs_last.height > tip.height || w(&self.chain).get_block_header(&tip.hash()).is_err()
	{
		let res = w(&self.chain).update_sync_head(&bhs_last, self.chain_opts());
	}
``` 

**Updated on 18th Sep. :**
The final fix solution in this PR is far from above, please look the comment here:  https://github.com/mimblewimble/grin/pull/1531#issuecomment-422221501
