### PR TITLE
fix: deprecated warning for env::home_dir, when upgrading rust to 1.29.0

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 serde = "1"
 serde_derive = "1"
 toml = "0.4"
-dirs = "1"
+dirs = "1.0.3"
 
 grin_servers = { path = "../servers" }
 grin_p2p = { path = "../p2p" }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -14,6 +14,7 @@
 
 //! Configuration file management
 
+use dirs;
 use std::env;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -43,7 +44,7 @@ const GRIN_WALLET_DIR: &'static str = "wallet_data";
 fn get_grin_path() -> Result<PathBuf, ConfigError> {
 	// Check if grin dir exists
 	let grin_path = {
-		match env::home_dir() {
+		match dirs::home_dir() {
 			Some(mut p) => {
 				p.push(GRIN_HOME);
 				p


### PR DESCRIPTION
fix for build warning:

```
warning: use of deprecated item 'std::env::home_dir': This function's behavior is unexpected and probably not what you want. Consider using the home_dir function from https://crates.io/crates/dirs instead.
  --> config/src/config.rs:46:9
   |
46 |         match env::home_dir() {
   |               ^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default
```