### PR TITLE
Fix documented emission rate

### DIFF
--- a/doc/grin4bitcoiners.md
+++ b/doc/grin4bitcoiners.md
@@ -31,7 +31,7 @@ Maybe you've heard that MimbleWimble doesn't support scripts. And in some way, t
 
 ## Emission Rate
 
-Bitcoin's 10 minute block time has its initial 50 btc reward cut in half every 4 years until there are 21 million bitcoin in circulation. Grin's emission rate is linear, meaning it never drops. The block reward is currently set at 50 grin with a block goal of 60 seconds. This still works because 1) dilution trends toward zero and 2) a non-negligible amount of coins gets lost or destroyed every year.
+Bitcoin's 10 minute block time has its initial 50 btc reward cut in half every 4 years until there are 21 million bitcoin in circulation. Grin's emission rate is linear, meaning it never drops. The block reward is currently set at 60 grin with a block goal of 60 seconds. This still works because 1) dilution trends toward zero and 2) a non-negligible amount of coins gets lost or destroyed every year.
 
 ## FAQ
 


### PR DESCRIPTION
The emission rate was changed to 60 grin per minute (or approximately 1 grin/second) in #569. Unfortunately, I haven't been able to find an official statement on this outside of a [recent interview](https://medium.com/grin-mimblewimble/grin-mimblewimble-meetup-in-london-with-yeastplume-f11476b3a590) from @yeastplume:

> Q: What about the emission rate?
>
> A: Right now it’s planned to be linear. 60 grins every minute for the rest of eternity. […]

This PR only addresses the outdated Grin4bitcoiners document and I wasn't able to find anything else under `/doc`. Perhaps this is something that should be clarified in a separate document?