### PR TITLE
Improve API errors

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -739,11 +739,11 @@ impl PoolPushHandler {
 			parse_body(req)
 				.and_then(move |wrapper: TxWrapper| {
 					util::from_hex(wrapper.tx_hex)
-						.map_err(|_| ErrorKind::RequestError("Bad request".to_owned()).into())
+						.map_err(|e| ErrorKind::RequestError(format!("Bad request: {}", e)).into())
 				})
 				.and_then(move |tx_bin| {
 					ser::deserialize(&mut &tx_bin[..])
-						.map_err(|_| ErrorKind::RequestError("Bad request".to_owned()).into())
+						.map_err(|e| ErrorKind::RequestError(format!("Bad request: {}", e)).into())
 				})
 				.and_then(move |tx: Transaction| {
 					let source = pool::TxSource {
@@ -766,7 +766,7 @@ impl PoolPushHandler {
 						.add_to_pool(source, tx, !fluff, &header.hash())
 						.map_err(|e| {
 							error!(LOGGER, "update_pool: failed with error: {:?}", e);
-							ErrorKind::RequestError("Bad request".to_owned()).into()
+							ErrorKind::Internal(format!("Failed to update pool: {:?}", e)).into()
 						})
 				}),
 		)
@@ -893,10 +893,12 @@ where
 	Box::new(
 		req.into_body()
 			.concat2()
-			.map_err(|_e| ErrorKind::RequestError("Failed to read request".to_owned()).into())
+			.map_err(|e| ErrorKind::RequestError(format!("Failed to read request: {}", e)).into())
 			.and_then(|body| match serde_json::from_reader(&body.to_vec()[..]) {
 				Ok(obj) => ok(obj),
-				Err(_) => err(ErrorKind::RequestError("Invalid request body".to_owned()).into()),
+				Err(e) => {
+					err(ErrorKind::RequestError(format!("Invalid request body: {}", e)).into())
+				}
 			}),
 	)
 }

--- a/wallet/src/libwallet/controller.rs
+++ b/wallet/src/libwallet/controller.rs
@@ -566,7 +566,7 @@ fn create_error_response(e: Error) -> Response<Body> {
 		.status(StatusCode::INTERNAL_SERVER_ERROR)
 		.header("access-control-allow-origin", "*")
 		.header("access-control-allow-headers", "Content-Type")
-		.body(format!("{}", e.kind()).into())
+		.body(format!("{}", e).into())
 		.unwrap()
 }
 
@@ -584,9 +584,6 @@ fn response<T: Into<Body>>(status: StatusCode, text: T) -> Response<Body> {
 		.header("access-control-allow-origin", "*")
 		.body(text.into())
 		.unwrap()
-	//let mut resp = Response::new(text.into());
-	//*resp.status_mut() = status;
-	//resp
 }
 
 fn parse_params(req: &Request<Body>) -> HashMap<String, Vec<String>> {
@@ -615,7 +612,9 @@ where
 			.map_err(|_| ErrorKind::GenericError("Failed to read request".to_owned()).into())
 			.and_then(|body| match serde_json::from_reader(&body.to_vec()[..]) {
 				Ok(obj) => ok(obj),
-				Err(_) => err(ErrorKind::GenericError("Invalid request body".to_owned()).into()),
+				Err(e) => {
+					err(ErrorKind::GenericError(format!("Invalid request body: {}", e)).into())
+				}
 			}),
 	)
 }


### PR DESCRIPTION
Address ##1525 in particular and improve error messages in general.
Instead of `Request Error: Error { inner:` a client would get:
`Generic error: Invalid request body: missing field "method" at line 1 column 162`