### PR TITLE
fix: all fast sync nodes report to peers as full nodes

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -189,7 +189,8 @@ impl GlobalConfig {
 		file.read_to_string(&mut contents)?;
 		let decoded: Result<ConfigMembers, toml::de::Error> = toml::from_str(&contents);
 		match decoded {
-			Ok(gc) => {
+			Ok(mut gc) => {
+				gc.server.validation_check();
 				self.members = Some(gc);
 				return Ok(self);
 			}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -54,12 +54,12 @@ impl Server {
 		adapter: Arc<ChainAdapter>,
 		genesis: Hash,
 		stop: Arc<AtomicBool>,
-		archive_mode: bool,
+		_archive_mode: bool,
 		block_1_hash: Option<Hash>,
 	) -> Result<Server, Error> {
 		// In the case of an archive node, check that we do have the first block.
 		// In case of first sync we do not perform this check.
-		if archive_mode && adapter.total_height() > 0 {
+		if capab.contains(Capabilities::FULL_HIST) && adapter.total_height() > 0 {
 			// Check that we have block 1
 			match block_1_hash {
 				Some(hash) => match adapter.get_block(hash) {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -128,7 +128,7 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::FAST_NODE,
+			capabilities: Capabilities::FAST_SYNC_NODE,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,
@@ -202,7 +202,7 @@ bitflags! {
 	/// Can provide a list of healthy peers
 	const PEER_LIST = 0b00000100;
 
-	const FAST_NODE = Capabilities::TXHASHSET_HIST.bits
+	const FAST_SYNC_NODE = Capabilities::TXHASHSET_HIST.bits
 		| Capabilities::PEER_LIST.bits;
 
 	const FULL_NODE = Capabilities::FULL_HIST.bits

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -128,7 +128,7 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::FULL_NODE,
+			capabilities: Capabilities::FAST_NODE,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,
@@ -201,6 +201,9 @@ bitflags! {
 	const TXHASHSET_HIST = 0b00000010;
 	/// Can provide a list of healthy peers
 	const PEER_LIST = 0b00000100;
+
+	const FAST_NODE = Capabilities::TXHASHSET_HIST.bits
+		| Capabilities::PEER_LIST.bits;
 
 	const FULL_NODE = Capabilities::FULL_HIST.bits
 		| Capabilities::TXHASHSET_HIST.bits

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -157,6 +157,26 @@ pub struct ServerConfig {
 	pub stratum_mining_config: Option<StratumServerConfig>,
 }
 
+impl ServerConfig {
+	/// Configuration items validation check
+	pub fn validation_check(&mut self) {
+		// check [server.p2p_config.capabilities] with 'archive_mode' in [server]
+		if let Some(archive) = self.archive_mode {
+			// note: slog not available before config loaded, only print here.
+			if archive != self.p2p_config.capabilities.contains(p2p::Capabilities::FULL_HIST) {
+				// if conflict, 'archive_mode' win
+				self.p2p_config.capabilities.toggle(p2p::Capabilities::FULL_HIST);
+				println!("ServerConfig - capabilities conflict with archive_mode: {}, force to: {:?}",
+					archive,
+					self.p2p_config.capabilities,
+				);	// note: slog not available before config loaded, only print here.
+			}
+		}
+
+		// todo: other checks if needed
+	}
+}
+
 impl Default for ServerConfig {
 	fn default() -> ServerConfig {
 		ServerConfig {

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -163,13 +163,19 @@ impl ServerConfig {
 		// check [server.p2p_config.capabilities] with 'archive_mode' in [server]
 		if let Some(archive) = self.archive_mode {
 			// note: slog not available before config loaded, only print here.
-			if archive != self.p2p_config.capabilities.contains(p2p::Capabilities::FULL_HIST) {
+			if archive != self
+				.p2p_config
+				.capabilities
+				.contains(p2p::Capabilities::FULL_HIST)
+			{
 				// if conflict, 'archive_mode' win
-				self.p2p_config.capabilities.toggle(p2p::Capabilities::FULL_HIST);
-				println!("ServerConfig - capabilities conflict with archive_mode: {}, force to: {:?}",
-					archive,
-					self.p2p_config.capabilities,
-				);	// note: slog not available before config loaded, only print here.
+				self.p2p_config
+					.capabilities
+					.toggle(p2p::Capabilities::FULL_HIST);
+				println!(
+					"ServerConfig - capabilities conflict with archive_mode: {}, force to: {:?}",
+					archive, self.p2p_config.capabilities,
+				); // note: slog not available before config loaded, only print here.
 			}
 		}
 


### PR DESCRIPTION
It's strange that I always see all the connected peers are full archive node. After some investigation, it's  a bug:

The default config of `capability` is **7** (or `FULL_NODE`), and default `archive_mode` is **false**, that's a conflict configuration.

And in current code, only when `archive_mode` is true, we will check if it's indeed an archive node, that's why we always see connected peers as full node, but actually I believe most of them are just fast sync node.

```
[{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"52.23.180.2:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"109.74.202.16:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"52.203.10.175:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"94.130.64.25:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"54.198.222.93:13414","total_difficulty":44548549,"height":100006,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"165.227.109.134:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"89.115.152.211:13414","total_difficulty":44742473,"height":100266,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"178.62.100.159:13414","total_difficulty":44813526,"height":100424,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"139.162.168.18:13414","total_difficulty":44813526,"height":100424,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"198.245.50.26:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"199.116.118.212:13414","total_difficulty":44813526,"height":100424,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"46.4.91.48:13414","total_difficulty":42861179,"height":97959,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"167.99.53.226:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"216.126.238.14:13414","total_difficulty":30000,"height":0,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"51.15.219.12:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"167.99.87.54:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"54.90.220.136:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"108.196.200.233:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"45.61.156.122:13414","total_difficulty":44813526,"height":100424,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"185.80.129.70:13414","total_difficulty":43002110,"height":98121,"direction":"Outbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"89.176.114.72:13414","total_difficulty":44813526,"height":100424,"direction":"Inbound"}
,{"capabilities":{"bits":7},"user_agent":"MW/Grin 0.3.0","version":1,"addr":"204.48.26.36:13414","total_difficulty":44813526,"height":100424,"direction":"Inbound"}]
```

This also explains that why the full node syncing from scratch have very low ratio returning blocks by requests.

