### PR TITLE
Simplify block broadcast

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -303,23 +303,6 @@ impl Peers {
 		count
 	}
 
-	/// Broadcasts the provided block to PEER_PREFERRED_COUNT of our peers.
-	/// We may be connected to PEER_MAX_COUNT peers so we only
-	/// want to broadcast to a random subset of peers.
-	/// A peer implementation may drop the broadcast request
-	/// if it knows the remote peer already has the block.
-	pub fn broadcast_block(&self, b: &core::Block) {
-		let count = self.broadcast("block", |p| p.send_block(b));
-		debug!(
-			LOGGER,
-			"broadcast_block: {} @ {} [{}] was sent to {} peers.",
-			b.header.pow.total_difficulty,
-			b.header.height,
-			b.hash(),
-			count,
-		);
-	}
-
 	/// Broadcasts the provided compact block to PEER_PREFERRED_COUNT of our peers.
 	/// We may be connected to PEER_MAX_COUNT peers so we only
 	/// want to broadcast to a random subset of peers.

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -130,8 +130,7 @@ impl Peers {
 			.filter(|x| match x.try_read() {
 				Ok(peer) => peer.info.direction == Direction::Outbound,
 				Err(_) => false,
-			})
-			.collect::<Vec<_>>();
+			}).collect::<Vec<_>>();
 		res
 	}
 
@@ -165,8 +164,7 @@ impl Peers {
 			.filter(|x| match x.try_read() {
 				Ok(peer) => peer.info.total_difficulty > total_difficulty,
 				Err(_) => false,
-			})
-			.collect::<Vec<_>>();
+			}).collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
 		max_peers
@@ -190,8 +188,7 @@ impl Peers {
 						&& peer.info.capabilities.contains(Capabilities::FULL_HIST)
 				}
 				Err(_) => false,
-			})
-			.collect::<Vec<_>>();
+			}).collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
 		max_peers
@@ -220,8 +217,7 @@ impl Peers {
 			.map(|x| match x.try_read() {
 				Ok(peer) => peer.info.total_difficulty.clone(),
 				Err(_) => Difficulty::zero(),
-			})
-			.max()
+			}).max()
 			.unwrap();
 
 		let mut max_peers = peers
@@ -229,8 +225,7 @@ impl Peers {
 			.filter(|x| match x.try_read() {
 				Ok(peer) => peer.info.total_difficulty == max_total_difficulty,
 				Err(_) => false,
-			})
-			.collect::<Vec<_>>();
+			}).collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
 		max_peers
@@ -472,8 +467,7 @@ impl Peers {
 				.map(|x| {
 					let p = x.read().unwrap();
 					p.info.addr.clone()
-				})
-				.collect::<Vec<_>>()
+				}).collect::<Vec<_>>()
 		};
 
 		// now remove them taking a short-lived write lock each time

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -27,7 +27,6 @@ use msg::{
 	read_exact, BanReason, GetPeerAddrs, Headers, Locator, PeerAddrs, Ping, Pong, SockAddr,
 	TxHashSetArchive, TxHashSetRequest, Type,
 };
-use rand::{self, Rng};
 use types::{Error, NetAdapter};
 use util::LOGGER;
 
@@ -107,7 +106,12 @@ impl MessageHandler for Protocol {
 
 			Type::GetBlock => {
 				let h: Hash = msg.body()?;
-				trace!(LOGGER, "handle_payload: GetBlock {}", h);
+				debug!(
+					LOGGER,
+					"handle_payload: Getblock: {}, msg_len: {}",
+					h,
+					msg.header.msg_len,
+				);
 
 				let bo = adapter.get_block(h);
 				if let Some(b) = bo {
@@ -129,25 +133,9 @@ impl MessageHandler for Protocol {
 
 			Type::GetCompactBlock => {
 				let h: Hash = msg.body()?;
-
 				if let Some(b) = adapter.get_block(h) {
-					// if we have txs in the block send a compact block
-					// but if block is empty -
-					// to allow us to test all code paths, randomly choose to send
-					// either the block or the compact block
-					let mut rng = rand::thread_rng();
-
-					if b.kernels().len() == 1 && rng.gen() {
-						debug!(
-							LOGGER,
-							"handle_payload: GetCompactBlock: empty block, sending full block",
-						);
-
-						Ok(Some(msg.respond(Type::Block, b)))
-					} else {
-						let cb: CompactBlock = b.into();
-						Ok(Some(msg.respond(Type::CompactBlock, cb)))
-					}
+					let cb: CompactBlock = b.into();
+					Ok(Some(msg.respond(Type::CompactBlock, cb)))
 				} else {
 					Ok(None)
 				}

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -108,9 +108,7 @@ impl MessageHandler for Protocol {
 				let h: Hash = msg.body()?;
 				debug!(
 					LOGGER,
-					"handle_payload: Getblock: {}, msg_len: {}",
-					h,
-					msg.header.msg_len,
+					"handle_payload: Getblock: {}, msg_len: {}", h, msg.header.msg_len,
 				);
 
 				let bo = adapter.get_block(h);


### PR DESCRIPTION
We were doing some random choosing of "block vs compact_block" and "header vs compact_block" in header and block propagation.

This was just to make sure things were still working correctly when working on compact blocks originally.
We don't need to be doing this and its unnecessary complexity.