### PR TITLE
fix: exit code 1 on `wallet send` fail

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -39,6 +39,8 @@ extern crate grin_wallet;
 mod cmd;
 pub mod tui;
 
+use std::process::exit;
+
 use clap::{App, Arg, SubCommand};
 
 use config::config::{SERVER_CONFIG_FILE_NAME, WALLET_CONFIG_FILE_NAME};
@@ -355,7 +357,7 @@ fn main() {
 				if let ("init", Some(_)) = wallet_args.subcommand() {
 				} else {
 					println!("Wallet seed file doesn't exist. Run `grin wallet -p [password] init` first");
-					return;
+					exit(1);
 				}
 			}
 			let mut l = w.members.as_mut().unwrap().logging.clone().unwrap();


### PR DESCRIPTION
fixes #1504 

@bladedoyle wrote:

> "grin wallet send" command fails due to missing wallet seed.
> An appropriate message is printed, but
> The process exits with "0" success status.

I made as few changes as possible for this PR. I think it would be better to move the error handling logic into `src/bin/cmd/wallet.rs`--I'll happily do this on this PR if the regular contributors think it's a good idea.

FYI: I am new to Rust, happy to get feedback of any sort.