### PR TITLE
fix: proper tx confirmation calculation

### DIFF
--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -248,7 +248,7 @@ impl OutputData {
 	/// so we do not actually know how many confirmations this output had (and
 	/// never will).
 	pub fn num_confirmations(&self, current_height: u64) -> u64 {
-		if self.height >= current_height {
+		if self.height > current_height {
 			return 0;
 		}
 		if self.status == OutputStatus::Unconfirmed {


### PR DESCRIPTION
fixes #1507 

The method `num_confirmation` on the struct `OutputData` had a small error. The check

```rust
if self.height >= current_height {
	return 0;
}
```

returned # of confirmations = 0 when `self.height == current_height` though @antiochp explained that confirmations should = 1 in this state. The fix required replacing `>=` with `>`.