### PR TITLE
Reintroduce block sums, verify full kernel sums per block

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1029,6 +1029,13 @@ fn setup_head(
 			batch.setup_height(&genesis.header, &tip)?;
 			txhashset::extending(txhashset, &mut batch, |extension| {
 				extension.apply_block(&genesis)?;
+
+				// Save the block_sums to the db for use later.
+				extension.batch.save_block_sums(
+					&genesis.hash(),
+					&BlockSums::default(),
+				)?;
+
 				Ok(())
 			})?;
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -26,7 +26,7 @@ use lmdb;
 use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::verifier_cache::VerifierCache;
-use core::core::{Block, BlockHeader, Output, OutputIdentifier, Transaction, TxKernel};
+use core::core::{Block, BlockHeader, BlockSums, Output, OutputIdentifier, Transaction, TxKernel};
 use core::global;
 use core::pow::Difficulty;
 use error::{Error, ErrorKind};
@@ -616,16 +616,15 @@ impl Chain {
 		let mut txhashset =
 			txhashset::TxHashSet::open(self.db_root.clone(), self.store.clone(), Some(&header))?;
 
-		// Validate against a read-only extension first.
-		// The kernel history validation requires a read-only extension
+		// Validate kernel history against a readonly extension first.
+		// Kernel history validation requires a readonly extension
 		// due to the internal rewind behavior.
 		debug!(
 			LOGGER,
-			"chain: txhashset_write: rewinding and validating (read-only)"
+			"chain: txhashset_write: rewinding and validating kernel history (readonly)"
 		);
 		txhashset::extending_readonly(&mut txhashset, |extension| {
 			extension.rewind(&header)?;
-			extension.validate(&header, false, status)?;
 
 			// Now validate kernel sums at each historical header height
 			// so we know we can trust the kernel history.
@@ -642,6 +641,16 @@ impl Chain {
 		let mut batch = self.store.batch()?;
 		txhashset::extending(&mut txhashset, &mut batch, |extension| {
 			extension.rewind(&header)?;
+
+			// Validate the extension, generating the utxo_sum and kernel_sum.
+			let (utxo_sum, kernel_sum) = extension.validate(&header, false, status)?;
+			
+			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
+			extension.batch.save_block_sums(
+				&header.hash(),
+				&BlockSums{ utxo_sum, kernel_sum }
+			)?;
+
 			extension.rebuild_index()?;
 			Ok(())
 		})?;
@@ -739,6 +748,7 @@ impl Chain {
 					count += 1;
 					batch.delete_block(&b.hash())?;
 					batch.delete_block_input_bitmap(&b.hash())?;
+					batch.delete_block_sums(&b.hash())?;
 				}
 				Err(NotFoundErr(_)) => {
 					break;
@@ -955,6 +965,29 @@ fn setup_head(
 				let res = txhashset::extending(txhashset, &mut batch, |extension| {
 					extension.rewind(&header)?;
 					extension.validate_roots(&header)?;
+
+					// now check we have the "block sums" for the block in question
+					// if we have no sums (migrating an existing node) we need to go
+					// back to the txhashset and sum the outputs and kernels
+					if header.height > 0 && extension.batch.get_block_sums(&header.hash()).is_err() {
+						debug!(
+							LOGGER,
+							"chain: init: building (missing) block sums for {} @ {}",
+							header.height,
+							header.hash()
+						);
+
+						// Do a full (and slow) validation of the txhashset extension
+						// to calculate the utxo_sum and kernel_sum at this block height.
+						let (utxo_sum, kernel_sum) = extension.validate_kernel_sums(&header)?;
+
+						// Save the block_sums to the db for use later.
+						extension.batch.save_block_sums(
+							&header.hash(),
+							&BlockSums{ utxo_sum, kernel_sum },
+						)?;
+					}
+
 					debug!(
 						LOGGER,
 						"chain: init: rewinding and validating before we start... {} at {}",

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -644,11 +644,14 @@ impl Chain {
 
 			// Validate the extension, generating the utxo_sum and kernel_sum.
 			let (utxo_sum, kernel_sum) = extension.validate(&header, false, status)?;
-			
+
 			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 			extension.batch.save_block_sums(
 				&header.hash(),
-				&BlockSums{ utxo_sum, kernel_sum }
+				&BlockSums {
+					utxo_sum,
+					kernel_sum,
+				},
 			)?;
 
 			extension.rebuild_index()?;
@@ -969,7 +972,8 @@ fn setup_head(
 					// now check we have the "block sums" for the block in question
 					// if we have no sums (migrating an existing node) we need to go
 					// back to the txhashset and sum the outputs and kernels
-					if header.height > 0 && extension.batch.get_block_sums(&header.hash()).is_err() {
+					if header.height > 0 && extension.batch.get_block_sums(&header.hash()).is_err()
+					{
 						debug!(
 							LOGGER,
 							"chain: init: building (missing) block sums for {} @ {}",
@@ -984,7 +988,10 @@ fn setup_head(
 						// Save the block_sums to the db for use later.
 						extension.batch.save_block_sums(
 							&header.hash(),
-							&BlockSums{ utxo_sum, kernel_sum },
+							&BlockSums {
+								utxo_sum,
+								kernel_sum,
+							},
 						)?;
 					}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -647,7 +647,9 @@ impl Chain {
 
 			// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
 			if header.total_kernel_sum != kernel_sum {
-				return Err(ErrorKind::Other(format!("total_kernel_sum in header does not match")).into());
+				return Err(
+					ErrorKind::Other(format!("total_kernel_sum in header does not match")).into(),
+				);
 			}
 
 			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -645,6 +645,11 @@ impl Chain {
 			// Validate the extension, generating the utxo_sum and kernel_sum.
 			let (utxo_sum, kernel_sum) = extension.validate(&header, false, status)?;
 
+			{
+				// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
+				assert_eq!(header.total_kernel_sum, kernel_sum);
+			}
+
 			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 			extension.batch.save_block_sums(
 				&header.hash(),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1031,10 +1031,9 @@ fn setup_head(
 				extension.apply_block(&genesis)?;
 
 				// Save the block_sums to the db for use later.
-				extension.batch.save_block_sums(
-					&genesis.hash(),
-					&BlockSums::default(),
-				)?;
+				extension
+					.batch
+					.save_block_sums(&genesis.hash(), &BlockSums::default())?;
 
 				Ok(())
 			})?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -645,9 +645,9 @@ impl Chain {
 			// Validate the extension, generating the utxo_sum and kernel_sum.
 			let (utxo_sum, kernel_sum) = extension.validate(&header, false, status)?;
 
-			{
-				// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
-				assert_eq!(header.total_kernel_sum, kernel_sum);
+			// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
+			if header.total_kernel_sum != kernel_sum {
+				return Err(ErrorKind::Other(format!("total_kernel_sum in header does not match")).into());
 			}
 
 			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -520,7 +520,9 @@ fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Er
 		// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
 		let prev = ext.batch.get_block_header(&b.header.previous)?;
 		if prev.total_kernel_sum != block_sums.kernel_sum {
-			return Err(ErrorKind::Other(format!("total_kernel_sum in header does not match")).into());
+			return Err(
+				ErrorKind::Other(format!("total_kernel_sum in header does not match")).into(),
+			);
 		}
 	}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -516,6 +516,12 @@ fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Er
 	// Retrieve the block_sums for the previous block.
 	let block_sums = ext.batch.get_block_sums(&b.header.previous)?;
 
+	{
+		// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
+		let prev = ext.batch.get_block_header(&b.header.previous)?;
+		assert_eq!(prev.total_kernel_sum, block_sums.kernel_sum);
+	}
+
 	// Overage is based purely on the new block.
 	// Previous block_sums have taken all previous overage into account.
 	let overage = b.header.overage();

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -698,7 +698,13 @@ pub fn rewind_and_apply_fork(
 		let fb = store
 			.get_block(&h)
 			.map_err(|e| ErrorKind::StoreErr(e, format!("getting forked blocks")))?;
-		ext.apply_block(&fb)?;
+
+		// Re-verify coinbase maturity along this fork.
+		verify_coinbase_maturity(&fb, ext)?;
+		// Re-verify block_sums to set the block_sums up on this fork correctly.
+		verify_block_sums(&fb, ext)?;
+		// Re-apply the blocks.
+		apply_block_to_txhashset(&fb, ext)?;
 	}
 	Ok(())
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -513,7 +513,6 @@ fn verify_coinbase_maturity(block: &Block, ext: &mut txhashset::Extension) -> Re
 /// based on block_sums of previous block, accounting for the inputs|outputs|kernels
 /// of the new block.
 fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Error> {
-
 	// Retrieve the block_sums for the previous block.
 	let block_sums = ext.batch.get_block_sums(&b.header.previous)?;
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -495,8 +495,7 @@ fn validate_block(
 			&prev.total_kernel_offset,
 			&prev.total_kernel_sum,
 			verifier_cache,
-		)
-		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
+		).map_err(|e| ErrorKind::InvalidBlockProof(e))?;
 	Ok(())
 }
 
@@ -523,7 +522,10 @@ fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Er
 	// Save the latest block_sums for the latest block to the batch.
 	ext.batch.save_block_sums(
 		&b.header.hash(),
-		&BlockSums{ utxo_sum, kernel_sum }
+		&BlockSums {
+			utxo_sum,
+			kernel_sum,
+		},
 	)?;
 
 	Ok(())

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -519,7 +519,9 @@ fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Er
 	{
 		// Now that we have block_sums the total_kernel_sum on the block_header is redundant.
 		let prev = ext.batch.get_block_header(&b.header.previous)?;
-		assert_eq!(prev.total_kernel_sum, block_sums.kernel_sum);
+		if prev.total_kernel_sum != block_sums.kernel_sum {
+			return Err(ErrorKind::Other(format!("total_kernel_sum in header does not match")).into());
+		}
 	}
 
 	// Overage is based purely on the new block.

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -674,7 +674,9 @@ impl<'a> Extension<'a> {
 		// and we should have inserted to both in exactly the same pos.
 		{
 			if self.output_pmmr.unpruned_size() != self.rproof_pmmr.unpruned_size() {
-				return Err(ErrorKind::Other(format!("output vs rproof MMRs different sizes")).into());
+				return Err(
+					ErrorKind::Other(format!("output vs rproof MMRs different sizes")).into(),
+				);
 			}
 
 			if output_pos != rproof_pos {

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -872,7 +872,10 @@ impl<'a> Extension<'a> {
 	/// This is an expensive operation as we need to retrieve all the UTXOs and kernels
 	/// from the respective MMRs.
 	/// For a significantly faster way of validating full kernel sums see BlockSums.
-	pub fn validate_kernel_sums(&self, header: &BlockHeader) -> Result<((Commitment, Commitment)), Error> {
+	pub fn validate_kernel_sums(
+		&self,
+		header: &BlockHeader,
+	) -> Result<((Commitment, Commitment)), Error> {
 		let (utxo_sum, kernel_sum) =
 			self.verify_kernel_sums(header.total_overage(), header.total_kernel_offset())?;
 		Ok((utxo_sum, kernel_sum))

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -19,6 +19,7 @@ use core::core::{Block, BlockHeader};
 use core::pow::Difficulty;
 use core::ser;
 
+
 bitflags! {
 /// Options for block validation
 	pub struct Options: u32 {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -19,7 +19,6 @@ use core::core::{Block, BlockHeader};
 use core::pow::Difficulty;
 use core::ser;
 
-
 bitflags! {
 /// Options for block validation
 	pub struct Options: u32 {

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! BlockSums per-block running totals for utxo_sum and kernel_sum.
+//! Allows fast "full" verification of kernel sums at a given block height.
+
 use core::committed::Committed;
 use ser::{self, Readable, Reader, Writeable, Writer};
 use util::secp::pedersen::Commitment;

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -59,7 +59,10 @@ impl Default for BlockSums {
 	}
 }
 
-// WAT?
+/// WAT?
+/// It's a tuple but we can verify the "full" kernel sums on it.
+/// This means we can take a previous block_sums, apply a new block to it
+/// and verify the full kernel sums (full UTXO and kernel sets).
 impl<'a> Committed for (BlockSums, &'a Committed) {
 	fn inputs_committed(&self) -> Vec<Commitment> {
 		self.1.inputs_committed()

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -14,8 +14,8 @@
 
 use core::committed::Committed;
 use ser::{self, Readable, Reader, Writeable, Writer};
-use util::secp_static;
 use util::secp::pedersen::Commitment;
+use util::secp_static;
 
 /// The output_sum and kernel_sum for a given block.
 /// This is used to validate the next block being processed by applying

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -1,0 +1,76 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::committed::Committed;
+use ser::{self, Readable, Reader, Writeable, Writer};
+use util::secp_static;
+use util::secp::pedersen::Commitment;
+
+/// The output_sum and kernel_sum for a given block.
+/// This is used to validate the next block being processed by applying
+/// the inputs, outputs, kernels and kernel_offset from the new block
+/// and checking everything sums correctly.
+#[derive(Debug, Clone)]
+pub struct BlockSums {
+	/// The sum of the unspent outputs.
+	pub utxo_sum: Commitment,
+	/// The sum of all kernels.
+	pub kernel_sum: Commitment,
+}
+
+impl Writeable for BlockSums {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_fixed_bytes(&self.utxo_sum)?;
+		writer.write_fixed_bytes(&self.kernel_sum)?;
+		Ok(())
+	}
+}
+
+impl Readable for BlockSums {
+	fn read(reader: &mut Reader) -> Result<BlockSums, ser::Error> {
+		Ok(BlockSums {
+			utxo_sum: Commitment::read(reader)?,
+			kernel_sum: Commitment::read(reader)?,
+		})
+	}
+}
+
+impl Default for BlockSums {
+	fn default() -> BlockSums {
+		let zero_commit = secp_static::commit_to_zero_value();
+		BlockSums {
+			utxo_sum: zero_commit.clone(),
+			kernel_sum: zero_commit.clone(),
+		}
+	}
+}
+
+// WAT?
+impl<'a> Committed for (BlockSums, &'a Committed) {
+	fn inputs_committed(&self) -> Vec<Commitment> {
+		self.1.inputs_committed()
+	}
+
+	fn outputs_committed(&self) -> Vec<Commitment> {
+		let mut outputs = vec![self.0.utxo_sum];
+		outputs.extend(&self.1.outputs_committed());
+		outputs
+	}
+
+	fn kernels_committed(&self) -> Vec<Commitment> {
+		let mut kernels = vec![self.0.kernel_sum];
+		kernels.extend(&self.1.kernels_committed());
+		kernels
+	}
+}

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -15,6 +15,7 @@
 //! Core types
 
 pub mod block;
+pub mod block_sums;
 pub mod committed;
 pub mod compact_block;
 pub mod compact_transaction;
@@ -30,6 +31,7 @@ use consensus::GRIN_BASE;
 use util::secp::pedersen::Commitment;
 
 pub use self::block::*;
+pub use self::block_sums::*;
 pub use self::committed::Committed;
 pub use self::compact_block::*;
 pub use self::compact_transaction::*;


### PR DESCRIPTION
Related - #1554. 

This now allows us to verify the full UTXO set against the full kernel set _for every block_ without it being a prohibitively expensive operation.

* Re-introduce `BlockSums`
  * store these in db per block
  * maintains (utxo_sum, kernel_sum) per block
  * write block_sums to db on init if its missing for latest block
  * write block_sums to db on fast sync (for initial block)
  * write block_sums to db every time we successfully verify a new block in pipeline
* 🤯implemented `Committed` on a (BlockSum, Block) tuple
  * This lets us verify "full" kernel sums on a block given previous block_sums...
* Added additional `verify_block_sums` step in `pipe::process_block()` to wire this all up
 
We did this once before - https://github.com/mimblewimble/grin/pull/1043
But removed them when we added `total_kernel_sum` to the header.

This puts them back because we actually need the `utxo_sum` in addition to the `kernel_sum`.

TODO - 
- [x] fix tests where block_sums are not correctly initialized
- [x] test chain compaction
- [x] get rid of those asserts (maybe log a warning or something, not crash the network...)

