### PR TITLE
[WIP] txpool (tx validation) using block sums for full validation

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -450,28 +450,6 @@ impl Chain {
 		Ok(bh.height + 1)
 	}
 
-	/// Validate a vec of "raw" transactions against a known chain state
-	/// at the block with the specified block hash.
-	/// Specifying a "pre_tx" if we need to adjust the state, for example when
-	/// validating the txs in the stempool we adjust the state based on the
-	/// txpool.
-	pub fn validate_raw_txs(
-		&self,
-		txs: Vec<Transaction>,
-		pre_tx: Option<Transaction>,
-		block_hash: &Hash,
-	) -> Result<Vec<Transaction>, Error> {
-		// Get header so we can rewind chain state correctly.
-		let header = self.store.get_block_header(block_hash)?;
-
-		let mut txhashset = self.txhashset.write().unwrap();
-		txhashset::extending_readonly(&mut txhashset, |extension| {
-			extension.rewind(&header)?;
-			let valid_txs = extension.validate_raw_txs(txs, pre_tx)?;
-			Ok(valid_txs)
-		})
-	}
-
 	/// Verify we are not attempting to spend a coinbase output
 	/// that has not yet sufficiently matured.
 	pub fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), Error> {
@@ -874,6 +852,13 @@ impl Chain {
 		self.store
 			.get_block_header(h)
 			.map_err(|e| ErrorKind::StoreErr(e, "chain get header".to_owned()).into())
+	}
+
+	/// Get block_sums by header hash.
+	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
+		self.store
+			.get_block_sums(h)
+			.map_err(|e| ErrorKind::StoreErr(e, "chain get block_sums".to_owned()).into())
 	}
 
 	/// Gets the block header at the provided height

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -90,6 +90,14 @@ impl ChainStore {
 		self.db.exists(&to_key(BLOCK_PREFIX, &mut h.to_vec()))
 	}
 
+	pub fn get_block_sums(&self, bh: &Hash) -> Result<BlockSums, Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut bh.to_vec())),
+			&format!("Block sums for block: {}", bh),
+		)
+	}
+
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		{
 			let mut header_cache = self.header_cache.write().unwrap();

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -29,9 +29,7 @@ use core::core::committed::Committed;
 use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::pmmr::{self, PMMR};
-use core::core::{
-	Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel,
-};
+use core::core::{Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel};
 use core::global;
 use core::ser::{PMMRIndexHashable, PMMRable};
 

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -30,7 +30,7 @@ use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::pmmr::{self, PMMR};
 use core::core::{
-	Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel,
+	Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel,
 };
 use core::global;
 use core::ser::{PMMRIndexHashable, PMMRable};
@@ -437,115 +437,6 @@ impl<'a> Extension<'a> {
 			rollback: false,
 			batch,
 		}
-	}
-
-	// Rewind the MMR backend to undo applying a raw tx to the txhashset extension.
-	// This is used during txpool validation to undo an invalid tx.
-	fn rewind_raw_tx(
-		&mut self,
-		output_pos: u64,
-		kernel_pos: u64,
-		rewind_rm_pos: &Bitmap,
-	) -> Result<(), Error> {
-		self.rewind_to_pos(output_pos, kernel_pos, rewind_rm_pos)?;
-		Ok(())
-	}
-
-	/// Apply a "raw" transaction to the txhashset.
-	/// We will never commit a txhashset extension that includes raw txs.
-	/// But we can use this when validating txs in the tx pool.
-	/// If we can add a tx to the tx pool and then successfully add the
-	/// aggregated tx from the tx pool to the current chain state (via a
-	/// txhashset extension) then we know the tx pool is valid (including the
-	/// new tx).
-	pub fn apply_raw_tx(&mut self, tx: &Transaction) -> Result<(), Error> {
-		// This should *never* be called on a writeable extension...
-		assert!(
-			self.rollback,
-			"applied raw_tx to writeable txhashset extension"
-		);
-
-		// Checkpoint the MMR positions before we apply the new tx,
-		// anything goes wrong we will rewind to these positions.
-		let output_pos = self.output_pmmr.unpruned_size();
-		let kernel_pos = self.kernel_pmmr.unpruned_size();
-
-		// Build bitmap of output pos spent (as inputs) by this tx for rewind.
-		let rewind_rm_pos = tx
-			.inputs()
-			.iter()
-			.filter_map(|x| self.batch.get_output_pos(&x.commitment()).ok())
-			.map(|x| x as u32)
-			.collect();
-
-		for ref output in tx.outputs() {
-			match self.apply_output(output) {
-				Ok(pos) => {
-					self.batch.save_output_pos(&output.commitment(), pos)?;
-				}
-				Err(e) => {
-					self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
-					return Err(e);
-				}
-			}
-		}
-
-		for ref input in tx.inputs() {
-			if let Err(e) = self.apply_input(input) {
-				self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
-				return Err(e);
-			}
-		}
-
-		for ref kernel in tx.kernels() {
-			if let Err(e) = self.apply_kernel(kernel) {
-				self.rewind_raw_tx(output_pos, kernel_pos, &rewind_rm_pos)?;
-				return Err(e);
-			}
-		}
-
-		Ok(())
-	}
-
-	/// Validate a vector of "raw" transactions against the current chain state.
-	/// We support rewind on a "dirty" txhashset - so we can apply each tx in
-	/// turn, rewinding if any particular tx is not valid and continuing
-	/// through the vec of txs provided. This allows us to efficiently apply
-	/// all the txs, filtering out those that are not valid and returning the
-	/// final vec of txs that were successfully validated against the txhashset.
-	///
-	/// Note: We also pass in a "pre_tx". This tx is applied to and validated
-	/// before we start applying the vec of txs. We use this when validating
-	/// txs in the stempool as we need to account for txs in the txpool as
-	/// well (new_tx + stempool + txpool + txhashset). So we aggregate the
-	/// contents of the txpool into a single aggregated tx and pass it in here
-	/// as the "pre_tx" so we apply it to the txhashset before we start
-	/// validating the stempool txs.
-	/// This is optional and we pass in None when validating the txpool txs
-	/// themselves.
-	///
-	pub fn validate_raw_txs(
-		&mut self,
-		txs: Vec<Transaction>,
-		pre_tx: Option<Transaction>,
-	) -> Result<Vec<Transaction>, Error> {
-		let mut valid_txs = vec![];
-
-		// First apply the "pre_tx" to account for any state that need adding to
-		// the chain state before we can validate our vec of txs.
-		// This is the aggregate tx from the txpool if we are validating the stempool.
-		if let Some(tx) = pre_tx {
-			self.apply_raw_tx(&tx)?;
-		}
-
-		// Now validate each tx, rewinding any tx (and only that tx)
-		// if it fails to validate successfully.
-		for tx in txs {
-			if self.apply_raw_tx(&tx).is_ok() {
-				valid_txs.push(tx);
-			}
-		}
-		Ok(valid_txs)
 	}
 
 	/// Verify we are not attempting to spend any coinbase outputs

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -404,7 +404,7 @@ impl TransactionBody {
 	}
 
 	/// Total fee for a TransactionBody is the sum of fees of all kernels.
-	pub fn fee(&self) -> u64 {
+	fn fee(&self) -> u64 {
 		self.kernels
 			.iter()
 			.fold(0, |acc, ref x| acc.saturating_add(x.fee))
@@ -748,7 +748,8 @@ impl Transaction {
 		self.body.fee()
 	}
 
-	fn overage(&self) -> i64 {
+	/// Total overage across all kernels.
+	pub fn overage(&self) -> i64 {
 		self.body.overage()
 	}
 

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -14,22 +14,22 @@
 
 use rand::thread_rng;
 use std::cmp::min;
+use std::ops::Add;
 /// Keychain trait and its main supporting types. The Identifier is a
 /// semi-opaque structure (just bytes) to track keys within the Keychain.
 /// BlindingFactor is a useful wrapper around a private key to help with
 /// commitment generation.
 use std::{error, fmt};
-use std::ops::Add;
 
 use blake2::blake2b::blake2b;
 use serde::{de, ser};
 
 use util;
-use util::static_secp_instance;
 use util::secp::constants::SECRET_KEY_SIZE;
 use util::secp::key::{PublicKey, SecretKey};
 use util::secp::pedersen::Commitment;
 use util::secp::{self, Message, Secp256k1, Signature};
+use util::static_secp_instance;
 
 // Size of an identifier in bytes
 pub const IDENTIFIER_SIZE: usize = 10;

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -175,8 +175,7 @@ impl Pool {
 	}
 
 	pub fn get_transactions_in_state(&self, state: PoolEntryState) -> Vec<Transaction> {
-		self
-			.entries
+		self.entries
 			.iter()
 			.filter(|x| x.state == state)
 			.map(|x| x.tx.clone())
@@ -244,7 +243,11 @@ impl Pool {
 		Ok(())
 	}
 
-	fn validate_raw_tx(&self, tx: &Transaction, header: &BlockHeader) -> Result<BlockSums, PoolError> {
+	fn validate_raw_tx(
+		&self,
+		tx: &Transaction,
+		header: &BlockHeader,
+	) -> Result<BlockSums, PoolError> {
 		let block_sums = self.blockchain.get_block_sums(&header.hash())?;
 		let new_sums = self.apply_tx_to_block_sums(&block_sums, tx, header)?;
 		Ok(new_sums)
@@ -285,7 +288,10 @@ impl Pool {
 		let (utxo_sum, kernel_sum) =
 			(block_sums.clone(), tx as &Committed).verify_kernel_sums(overage, offset)?;
 
-		Ok(BlockSums { utxo_sum, kernel_sum })
+		Ok(BlockSums {
+			utxo_sum,
+			kernel_sum,
+		})
 	}
 
 	pub fn reconcile(

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -191,7 +191,7 @@ impl TransactionPool {
 
 	/// Returns a vector of transactions from the txpool so we can build a
 	/// block from them.
-	pub fn prepare_mineable_transactions(&self) -> Vec<Transaction> {
+	pub fn prepare_mineable_transactions(&self) -> Result<Vec<Transaction>, PoolError> {
 		self.txpool.prepare_mineable_transactions()
 	}
 }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -18,9 +18,11 @@
 use chrono::prelude::{DateTime, Utc};
 
 use core::consensus;
+use core::core::committed;
 use core::core::hash::Hash;
 use core::core::transaction::{self, Transaction};
-use core::core::BlockHeader;
+use core::core::{BlockHeader, BlockSums};
+use keychain;
 
 /// Dandelion relay timer
 const DANDELION_RELAY_SECS: u64 = 600;
@@ -161,6 +163,10 @@ pub struct TxSource {
 pub enum PoolError {
 	/// An invalid pool entry caused by underlying tx validation error
 	InvalidTx(transaction::Error),
+	/// Underlying keychain error.
+	Keychain(keychain::Error),
+	/// Underlying "committed" error.
+	Committed(committed::Error),
 	/// Attempt to add a transaction to the pool with lock_height
 	/// greater than height of current block
 	ImmatureTransaction,
@@ -186,17 +192,20 @@ impl From<transaction::Error> for PoolError {
 	}
 }
 
+impl From<keychain::Error> for PoolError {
+	fn from(e: keychain::Error) -> PoolError {
+		PoolError::Keychain(e)
+	}
+}
+
+impl From<committed::Error> for PoolError {
+	fn from(e: committed::Error) -> PoolError {
+		PoolError::Committed(e)
+	}
+}
+
 /// Interface that the pool requires from a blockchain implementation.
 pub trait BlockChain: Sync + Send {
-	/// Validate a vec of txs against known chain state at specific block
-	/// after applying the pre_tx to the chain state.
-	fn validate_raw_txs(
-		&self,
-		txs: Vec<transaction::Transaction>,
-		pre_tx: Option<transaction::Transaction>,
-		block_hash: &Hash,
-	) -> Result<Vec<transaction::Transaction>, PoolError>;
-
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.
 	fn verify_coinbase_maturity(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;
@@ -206,6 +215,9 @@ pub trait BlockChain: Sync + Send {
 	fn verify_tx_lock_height(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;
 
 	fn chain_head(&self) -> Result<BlockHeader, PoolError>;
+
+	fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, PoolError>;
+	fn get_block_sums(&self, hash: &Hash) -> Result<BlockSums, PoolError>;
 }
 
 /// Bridge between the transaction pool and the rest of the system. Handles

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -129,7 +129,7 @@ fn test_transaction_pool_block_building() {
 
 	let txs = {
 		let read_pool = pool.read().unwrap();
-		read_pool.prepare_mineable_transactions()
+		read_pool.prepare_mineable_transactions().unwrap()
 	};
 	// children should have been aggregated into parents
 	assert_eq!(txs.len(), 3);

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, RwLock};
 use common::{test_setup, test_source, test_transaction};
 use core::core::hash::Hash;
 use core::core::verifier_cache::LruVerifierCache;
-use core::core::{BlockHeader, Transaction};
+use core::core::{BlockHeader, BlockSums, Transaction};
 use keychain::{ExtKeychain, Keychain};
 use pool::types::{BlockChain, PoolError};
 
@@ -48,12 +48,11 @@ impl BlockChain for CoinbaseMaturityErrorChainAdapter {
 		unimplemented!();
 	}
 
-	fn validate_raw_txs(
-		&self,
-		_txs: Vec<Transaction>,
-		_pre_tx: Option<Transaction>,
-		_block_hash: &Hash,
-	) -> Result<Vec<Transaction>, PoolError> {
+	fn get_block_header(&self, _hash: &Hash) -> Result<BlockHeader, PoolError> {
+		unimplemented!();
+	}
+
+	fn get_block_sums(&self, _hash: &Hash) -> Result<BlockSums, PoolError> {
 		unimplemented!();
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -27,7 +27,7 @@ use common::types::{self, ChainValidationMode, ServerConfig, SyncState, SyncStat
 use core::core::hash::{Hash, Hashed};
 use core::core::transaction::Transaction;
 use core::core::verifier_cache::VerifierCache;
-use core::core::{BlockHeader, CompactBlock};
+use core::core::{BlockHeader, BlockSums, CompactBlock};
 use core::pow::Difficulty;
 use core::{core, global};
 use p2p;
@@ -732,25 +732,18 @@ impl PoolToChainAdapter {
 
 impl pool::BlockChain for PoolToChainAdapter {
 	fn chain_head(&self) -> Result<BlockHeader, pool::PoolError> {
-		wo(&self.chain).head_header().map_err(|e| {
-			pool::PoolError::Other(format!(
-				"Chain adapter failed to retrieve chain head: {:?}",
-				e
-			))
-		})
+		wo(&self.chain).head_header()
+			.map_err(|_| pool::PoolError::Other(format!("failed to get head_header")))
 	}
 
-	fn validate_raw_txs(
-		&self,
-		txs: Vec<Transaction>,
-		pre_tx: Option<Transaction>,
-		block_hash: &Hash,
-	) -> Result<(Vec<Transaction>), pool::PoolError> {
-		wo(&self.chain)
-			.validate_raw_txs(txs, pre_tx, block_hash)
-			.map_err(|e| {
-				pool::PoolError::Other(format!("Chain adapter failed to validate_raw_txs: {:?}", e))
-			})
+	fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, pool::PoolError> {
+		wo(&self.chain).get_block_header(hash)
+			.map_err(|_| pool::PoolError::Other(format!("failed to get block_header")))
+	}
+
+	fn get_block_sums(&self, hash: &Hash) -> Result<BlockSums, pool::PoolError> {
+		wo(&self.chain).get_block_sums(hash)
+			.map_err(|_| pool::PoolError::Other(format!("failed to get block_sums")))
 	}
 
 	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), pool::PoolError> {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -732,17 +732,20 @@ impl PoolToChainAdapter {
 
 impl pool::BlockChain for PoolToChainAdapter {
 	fn chain_head(&self) -> Result<BlockHeader, pool::PoolError> {
-		wo(&self.chain).head_header()
+		wo(&self.chain)
+			.head_header()
 			.map_err(|_| pool::PoolError::Other(format!("failed to get head_header")))
 	}
 
 	fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, pool::PoolError> {
-		wo(&self.chain).get_block_header(hash)
+		wo(&self.chain)
+			.get_block_header(hash)
 			.map_err(|_| pool::PoolError::Other(format!("failed to get block_header")))
 	}
 
 	fn get_block_sums(&self, hash: &Hash) -> Result<BlockSums, pool::PoolError> {
-		wo(&self.chain).get_block_sums(hash)
+		wo(&self.chain)
+			.get_block_sums(hash)
 			.map_err(|_| pool::PoolError::Other(format!("failed to get block_sums")))
 	}
 

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -93,12 +93,10 @@ fn process_stem_phase(
 	let header = tx_pool.blockchain.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
-	let stem_txs = tx_pool.stempool.select_valid_transactions(
-		PoolEntryState::ToStem,
-		PoolEntryState::Stemmed,
-		txpool_tx,
-		&header.hash(),
-	)?;
+	let stem_txs = tx_pool.stempool.get_transactions_in_state(PoolEntryState::ToStem);
+	let stem_txs = tx_pool.stempool
+		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
+	tx_pool.stempool.transition_to_state(&stem_txs, PoolEntryState::Stemmed);
 
 	if stem_txs.len() > 0 {
 		debug!(
@@ -136,12 +134,10 @@ fn process_fluff_phase(
 	let header = tx_pool.blockchain.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
-	let stem_txs = tx_pool.stempool.select_valid_transactions(
-		PoolEntryState::ToFluff,
-		PoolEntryState::Fluffed,
-		txpool_tx,
-		&header.hash(),
-	)?;
+	let stem_txs = tx_pool.stempool.get_transactions_in_state(PoolEntryState::ToFluff);
+	let stem_txs = tx_pool.stempool
+		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
+	tx_pool.stempool.transition_to_state(&stem_txs, PoolEntryState::Fluffed);
 
 	if stem_txs.len() > 0 {
 		debug!(

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -93,10 +93,15 @@ fn process_stem_phase(
 	let header = tx_pool.blockchain.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
-	let stem_txs = tx_pool.stempool.get_transactions_in_state(PoolEntryState::ToStem);
-	let stem_txs = tx_pool.stempool
+	let stem_txs = tx_pool
+		.stempool
+		.get_transactions_in_state(PoolEntryState::ToStem);
+	let stem_txs = tx_pool
+		.stempool
 		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool.stempool.transition_to_state(&stem_txs, PoolEntryState::Stemmed);
+	tx_pool
+		.stempool
+		.transition_to_state(&stem_txs, PoolEntryState::Stemmed);
 
 	if stem_txs.len() > 0 {
 		debug!(
@@ -134,10 +139,15 @@ fn process_fluff_phase(
 	let header = tx_pool.blockchain.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
-	let stem_txs = tx_pool.stempool.get_transactions_in_state(PoolEntryState::ToFluff);
-	let stem_txs = tx_pool.stempool
+	let stem_txs = tx_pool
+		.stempool
+		.get_transactions_in_state(PoolEntryState::ToFluff);
+	let stem_txs = tx_pool
+		.stempool
 		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool.stempool.transition_to_state(&stem_txs, PoolEntryState::Fluffed);
+	tx_pool
+		.stempool
+		.transition_to_state(&stem_txs, PoolEntryState::Fluffed);
 
 	if stem_txs.len() > 0 {
 		debug!(

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -109,7 +109,8 @@ fn build_block(
 	let difficulty = consensus::next_difficulty(diff_iter).unwrap();
 
 	// extract current transaction from the pool
-	let txs = tx_pool.read().unwrap().prepare_mineable_transactions();
+	// TODO - we have a lot of unwrap() going on in this fn...
+	let txs = tx_pool.read().unwrap().prepare_mineable_transactions().unwrap();
 
 	// build the coinbase and the block itself
 	let fees = txs.iter().map(|tx| tx.fee()).sum();

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -110,7 +110,11 @@ fn build_block(
 
 	// extract current transaction from the pool
 	// TODO - we have a lot of unwrap() going on in this fn...
-	let txs = tx_pool.read().unwrap().prepare_mineable_transactions().unwrap();
+	let txs = tx_pool
+		.read()
+		.unwrap()
+		.prepare_mineable_transactions()
+		.unwrap();
 
 	// build the coinbase and the block itself
 	let fees = txs.iter().map(|tx| tx.fee()).sum();


### PR DESCRIPTION
Given a `BlockSums` and a new transaction, we can validate the transaction is valid in relation to the full chain state (doesn't double-spend, doesn't spend non-existent output etc.)

```
(block_sums, &tx).verify_kernel_sums()
```

Note this also works for aggregate transactions.
So we can easily (and quickly) validate the stempool against the txpool and chain state etc.

Still a WIP as we need to rework some of the tests.
But the main changes to txpool should be done.

This also simplifies the dependencies on txpool as well, we don't need to interact with a txhashset to do tx validation any more. We just need to be able to pull headers and their associated block_sums from the db.


