### PR TITLE
Bump Docker builder image to rust:1.29.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multistage docker build, requires docker 17.05
 
 # builder stage
-FROM rust:1.26 as builder
+FROM rust:1.29.0 as builder
 
 RUN set -ex && \
     apt-get update && \


### PR DESCRIPTION
Fixes grin_p2p build error:

    error[E0658]: use of unstable library feature 'duration_from_micros' (see
    issue #44400)
       --> p2p/src/msg.rs:120:19
        |
    120 |     let sleep_time = time::Duration::from_micros(10);
        |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^