### PR TITLE
refactor: small cleanup of rand usage

### DIFF
--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -14,7 +14,7 @@
 
 //! Compact Blocks.
 
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, Rng};
 
 use consensus::VerifySortOrder;
 use core::block::{Block, BlockHeader, Error};
@@ -164,7 +164,7 @@ impl CompactBlock {
 impl From<Block> for CompactBlock {
 	fn from(block: Block) -> Self {
 		let header = block.header.clone();
-		let nonce = thread_rng().next_u64();
+		let nonce = thread_rng().gen();
 
 		let out_full = block
 			.outputs()

--- a/core/src/core/compact_transaction.rs
+++ b/core/src/core/compact_transaction.rs
@@ -14,7 +14,7 @@
 
 //! Compact Transactions.
 
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, Rng};
 
 use consensus::VerifySortOrder;
 use core::hash::{Hash, Hashed};
@@ -129,7 +129,7 @@ impl From<Transaction> for CompactTransaction {
 		let tx_hash = tx.hash();
 
 		// Generate a random nonce (short_ids specific to a particular peer connection).
-		let nonce = thread_rng().next_u64();
+		let nonce = thread_rng().gen();
 
 		let mut kern_ids = vec![];
 

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -16,8 +16,7 @@ use std::collections::VecDeque;
 use std::net::{SocketAddr, TcpStream};
 use std::sync::{Arc, RwLock};
 
-use rand::os::OsRng;
-use rand::RngCore;
+use rand::{thread_rng, Rng};
 
 use core::core::hash::Hash;
 use core::pow::Difficulty;
@@ -185,8 +184,7 @@ impl Handshake {
 
 	/// Generate a new random nonce and store it in our ring buffer
 	fn next_nonce(&self) -> u64 {
-		let mut rng = OsRng::new().unwrap();
-		let nonce = rng.next_u64();
+		let nonce = thread_rng().gen();
 
 		let mut nonces = self.nonces.write().unwrap();
 		nonces.push_back(nonce);

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use chrono::prelude::Utc;
-use rand::{self, Rng};
+use rand::{thread_rng, Rng};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
@@ -168,7 +168,7 @@ fn process_fresh_entries(
 ) -> Result<(), PoolError> {
 	let mut tx_pool = tx_pool.write().unwrap();
 
-	let mut rng = rand::thread_rng();
+	let mut rng = thread_rng();
 
 	let fresh_entries = &mut tx_pool
 		.stempool
@@ -201,7 +201,7 @@ fn process_expired_entries(
 	tx_pool: Arc<RwLock<TransactionPool>>,
 ) -> Result<(), PoolError> {
 	let now = Utc::now().timestamp();
-	let embargo_sec = dandelion_config.embargo_secs.unwrap() + rand::thread_rng().gen_range(0, 31);
+	let embargo_sec = dandelion_config.embargo_secs.unwrap() + thread_rng().gen_range(0, 31);
 	let cutoff = now - embargo_sec as i64;
 
 	let mut expired_entries = vec![];

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -16,7 +16,7 @@
 //! them into a block and returns it.
 
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
-use rand::{self, Rng};
+use rand::{thread_rng, Rng};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
@@ -137,8 +137,7 @@ fn build_block(
 		verifier_cache,
 	)?;
 
-	let mut rng = rand::OsRng::new().unwrap();
-	b.header.pow.nonce = rng.gen();
+	b.header.pow.nonce = thread_rng().gen();
 	b.header.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now_sec, 0), Utc);;
 
 	let b_difficulty = (b.header.total_difficulty() - head.total_difficulty()).to_num();

--- a/util/src/macros.rs
+++ b/util/src/macros.rs
@@ -145,13 +145,6 @@ macro_rules! impl_array_newtype {
                 }
             }
         }
-
-        impl ::rand::Rand for $thing {
-            #[inline]
-            fn rand<R: ::rand::Rng>(r: &mut R) -> $thing {
-                $thing(::rand::Rand::rand(r))
-            }
-        }
     }
 }
 


### PR DESCRIPTION
According to https://github.com/mimblewimble/rust-secp256k1-zkp/pull/29#issuecomment-423720319, a bit of cleanup of `rand` crate usage, using `Rng` instead of `RngCore`.

Please remember 2 points of `rand` crate usage in any new code:
- `Trait rand::Rng` **is the primary trait to use when generating random values.**
- **End users should normally use Rng** from the `rand crate`, which is automatically implemented for every type implementing `RngCore`.

Warmly remind for 2 most popular functions, but **usage changed** from `rand 0.4` to `rand 0.5`:
- Please use `gen()` instead of `next_u64()`
- Please use `fill()` instead of `fill_bytes()`

For detail usage, please refer to doc:  https://docs.rs/rand/0.5.0/rand/trait.Rng.html


btw, in this PR, I cleaned 3 building warning messages of `deprecated item 'rand::Rand::rand'`, in `impl_array_newtype`, just removed the rand impl function since it's not used.

