### PR TITLE
rework to only pass a single block_context to pipeline

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -178,6 +178,10 @@ impl<'a> Batch<'a> {
 		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), "HEADER_HEAD")
 	}
 
+	pub fn get_sync_head(&self) -> Result<Tip, Error> {
+		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]), "SYNC_HEAD")
+	}
+
 	pub fn save_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![HEAD_PREFIX], t)?;
 		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)


### PR DESCRIPTION
* We only need to pass a single block_context (containing the various heads) to the processing pipeline.
* Simplifies block_header processing.
* Makes block processing a bit more flexible (we have access to all heads now).

