### PR TITLE
fix: in case of all known, update header_head and sync_head

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -356,6 +356,31 @@ impl Chain {
 		Ok(())
 	}
 
+	/// Update sync head
+	/// This is only used for Independent HeaderSync
+	pub fn update_sync_head(&self, bh: &BlockHeader) -> Result<(), Error> {
+		let mut batch = self.store.batch()?;
+		let res = pipe::update_sync_head(bh, &mut batch);
+
+		if res.is_ok() {
+			batch.commit()?;
+		}
+		res
+	}
+
+	/// Update header head
+	/// This is only used for Independent HeaderSync
+	pub fn update_header_head(&self, bh: &BlockHeader, opts: Options) -> Result<Option<Tip>, Error> {
+		let mut batch = self.store.batch()?;
+		let mut sync_ctx = self.new_ctx(opts, &mut batch)?;
+		let res = pipe::update_header_head(bh, &mut sync_ctx, &mut batch);
+
+		if res.is_ok() {
+			batch.commit()?;
+		}
+		res
+	}
+
 	fn new_ctx(&self, opts: Options, batch: &mut Batch) -> Result<pipe::BlockContext, Error> {
 		let head = batch.head()?;
 		let header_head = batch.get_header_head()?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -370,7 +370,11 @@ impl Chain {
 
 	/// Update header head
 	/// This is only used for Independent HeaderSync
-	pub fn update_header_head(&self, bh: &BlockHeader, opts: Options) -> Result<Option<Tip>, Error> {
+	pub fn update_header_head(
+		&self,
+		bh: &BlockHeader,
+		opts: Options,
+	) -> Result<Option<Tip>, Error> {
 		let mut batch = self.store.batch()?;
 		let mut sync_ctx = self.new_ctx(opts, &mut batch)?;
 		let res = pipe::update_header_head(bh, &mut sync_ctx, &mut batch);

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -356,35 +356,6 @@ impl Chain {
 		Ok(())
 	}
 
-	/// Update sync head
-	/// This is only used for Independent HeaderSync
-	pub fn update_sync_head(&self, bh: &BlockHeader) -> Result<(), Error> {
-		let mut batch = self.store.batch()?;
-		let res = pipe::update_sync_head(bh, &mut batch);
-
-		if res.is_ok() {
-			batch.commit()?;
-		}
-		res
-	}
-
-	/// Update header head
-	/// This is only used for Independent HeaderSync
-	pub fn update_header_head(
-		&self,
-		bh: &BlockHeader,
-		opts: Options,
-	) -> Result<Option<Tip>, Error> {
-		let mut batch = self.store.batch()?;
-		let mut sync_ctx = self.new_ctx(opts, &mut batch)?;
-		let res = pipe::update_header_head(bh, &mut sync_ctx, &mut batch);
-
-		if res.is_ok() {
-			batch.commit()?;
-		}
-		res
-	}
-
 	fn new_ctx(&self, opts: Options, batch: &mut Batch) -> Result<pipe::BlockContext, Error> {
 		let head = batch.head()?;
 		let header_head = batch.get_header_head()?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -655,7 +655,7 @@ fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
 }
 
 /// Update the sync head so we can keep syncing from where we left off.
-fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
+pub fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
 	let tip = Tip::from_block(bh);
 	batch
 		.save_sync_head(&tip)
@@ -664,7 +664,8 @@ fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Er
 	Ok(())
 }
 
-fn update_header_head(
+/// Update the header head so we can keep syncing from where we left off.
+pub fn update_header_head(
 	bh: &BlockHeader,
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -205,15 +205,12 @@ pub fn sync_block_headers(
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<(), Error> {
-
 	let bhs_last = headers.last().unwrap().clone();
 	let last_h = bhs_last.hash();
 	if let Ok(_) = batch.get_block_header(&last_h) {
 		info!(
 			LOGGER,
-			"All known, ignoring. Update sync_head to {} at {}",
-			last_h,
-			bhs_last.height,
+			"All known, ignoring. Update sync_head to {} at {}", last_h, bhs_last.height,
 		);
 
 		let res = update_sync_head(&bhs_last, batch);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -673,7 +673,7 @@ fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
 }
 
 /// Update the sync head so we can keep syncing from where we left off.
-pub fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
+fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
 	let tip = Tip::from_block(bh);
 	batch
 		.save_sync_head(&tip)
@@ -683,7 +683,7 @@ pub fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<()
 }
 
 /// Update the header head so we can keep syncing from where we left off.
-pub fn update_header_head(
+fn update_header_head(
 	bh: &BlockHeader,
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -205,6 +205,27 @@ pub fn sync_block_headers(
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<(), Error> {
+
+	let bhs_last = headers.last().unwrap().clone();
+	let last_h = bhs_last.hash();
+	if let Ok(_) = batch.get_block_header(&last_h) {
+		info!(
+			LOGGER,
+			"All known, ignoring. Update sync_head to {} at {}",
+			last_h,
+			bhs_last.height,
+		);
+
+		let res = update_sync_head(&bhs_last, batch);
+		if let &Err(ref e) = &res {
+			error!(
+				LOGGER,
+				"Block header {} update_sync_head fail: {:?}", last_h, e
+			);
+		}
+		return Ok(());
+	}
+
 	if let Some(header) = headers.first() {
 		debug!(
 			LOGGER,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -272,9 +272,11 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				return true;
 			}
 
-			info!(LOGGER, "All known, ignoring. Update header_head and sync_head to {} at {}",
-				  last_h,
-				  bhs_last.height,
+			info!(
+				LOGGER,
+				"All known, ignoring. Update header_head and sync_head to {} at {}",
+				last_h,
+				bhs_last.height,
 			);
 
 			// Update header_head and sync_head to the last header of this Headers package
@@ -282,18 +284,14 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			if let &Err(ref e) = &res {
 				error!(
 					LOGGER,
-					"Block header {} update_header_head fail: {:?}",
-					last_h,
-					e
+					"Block header {} update_header_head fail: {:?}", last_h, e
 				);
 			}
 			let res = w(&self.chain).update_sync_head(&bhs_last);
 			if let &Err(ref e) = &res {
 				error!(
 					LOGGER,
-					"Block header {} update_sync_head fail: {:?}",
-					last_h,
-					e
+					"Block header {} update_sync_head fail: {:?}", last_h, e
 				);
 			}
 			return true;

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -263,40 +263,6 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			return false;
 		}
 
-		// headers will just set us backward if even the last is unknown
-		let bhs_last = bhs.last().unwrap().clone();
-		let last_h = bhs_last.hash();
-		if let Ok(_) = w(&self.chain).get_block_header(&last_h) {
-			if bhs.len() < p2p::MAX_BLOCK_HEADERS as usize - 1 {
-				info!(LOGGER, "All known, ignoring");
-				return true;
-			}
-
-			info!(
-				LOGGER,
-				"All known, ignoring. Update header_head and sync_head to {} at {}",
-				last_h,
-				bhs_last.height,
-			);
-
-			// Update header_head and sync_head to the last header of this Headers package
-			let res = w(&self.chain).update_header_head(&bhs_last, self.chain_opts());
-			if let &Err(ref e) = &res {
-				error!(
-					LOGGER,
-					"Block header {} update_header_head fail: {:?}", last_h, e
-				);
-			}
-			let res = w(&self.chain).update_sync_head(&bhs_last);
-			if let &Err(ref e) = &res {
-				error!(
-					LOGGER,
-					"Block header {} update_sync_head fail: {:?}", last_h, e
-				);
-			}
-			return true;
-		}
-
 		// try to add headers to our header chain
 		let res = w(&self.chain).sync_block_headers(&bhs, self.chain_opts());
 		if let &Err(ref e) = &res {


### PR DESCRIPTION
This is a work-around for #1612 , but it make sense to have this improvement fixing:

in case of all known for Headers received, update sync_head to the last header.