### PR TITLE
fix: remove unused DiffStats from get_server_stats

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -102,7 +102,7 @@ pub struct StratumStats {
 }
 
 /// Stats on the last WINDOW blocks and the difficulty calculation
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DiffStats {
 	/// latest height
 	pub height: u64,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -395,49 +395,49 @@ impl Server {
 		// code clean. This may be handy for testing but not really needed
 		// for release
 		let diff_stats = DiffStats::default();
-//		let diff_stats = {
-//			let diff_iter = self.chain.difficulty_iter();
-//
-//			let last_blocks: Vec<Result<(u64, Difficulty), consensus::TargetError>> =
-//				global::difficulty_data_to_vector(diff_iter)
-//					.into_iter()
-//					.skip(consensus::MEDIAN_TIME_WINDOW as usize)
-//					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
-//					.collect();
-//
-//			let mut last_time = last_blocks[0].clone().unwrap().0;
-//			let tip_height = self.chain.head().unwrap().height as i64;
-//			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
-//
-//			let mut i = 1;
-//
-//			let diff_entries: Vec<DiffBlock> = last_blocks
-//				.iter()
-//				.skip(1)
-//				.map(|n| {
-//					let (time, diff) = n.clone().unwrap();
-//					let dur = time - last_time;
-//					let height = earliest_block_height + i + 1;
-//					i += 1;
-//					last_time = time;
-//					DiffBlock {
-//						block_number: height,
-//						difficulty: diff.to_num(),
-//						time: time,
-//						duration: dur,
-//					}
-//				}).collect();
-//
-//			let block_time_sum = diff_entries.iter().fold(0, |sum, t| sum + t.duration);
-//			let block_diff_sum = diff_entries.iter().fold(0, |sum, d| sum + d.difficulty);
-//			DiffStats {
-//				height: tip_height as u64,
-//				last_blocks: diff_entries,
-//				average_block_time: block_time_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),
-//				average_difficulty: block_diff_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),
-//				window_size: consensus::DIFFICULTY_ADJUST_WINDOW,
-//			}
-//		};
+		//		let diff_stats = {
+		//			let diff_iter = self.chain.difficulty_iter();
+		//
+		//			let last_blocks: Vec<Result<(u64, Difficulty), consensus::TargetError>> =
+		//				global::difficulty_data_to_vector(diff_iter)
+		//					.into_iter()
+		//					.skip(consensus::MEDIAN_TIME_WINDOW as usize)
+		//					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
+		//					.collect();
+		//
+		//			let mut last_time = last_blocks[0].clone().unwrap().0;
+		//			let tip_height = self.chain.head().unwrap().height as i64;
+		//			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
+		//
+		//			let mut i = 1;
+		//
+		//			let diff_entries: Vec<DiffBlock> = last_blocks
+		//				.iter()
+		//				.skip(1)
+		//				.map(|n| {
+		//					let (time, diff) = n.clone().unwrap();
+		//					let dur = time - last_time;
+		//					let height = earliest_block_height + i + 1;
+		//					i += 1;
+		//					last_time = time;
+		//					DiffBlock {
+		//						block_number: height,
+		//						difficulty: diff.to_num(),
+		//						time: time,
+		//						duration: dur,
+		//					}
+		//				}).collect();
+		//
+		//			let block_time_sum = diff_entries.iter().fold(0, |sum, t| sum + t.duration);
+		//			let block_diff_sum = diff_entries.iter().fold(0, |sum, d| sum + d.difficulty);
+		//			DiffStats {
+		//				height: tip_height as u64,
+		//				last_blocks: diff_entries,
+		//				average_block_time: block_time_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),
+		//				average_difficulty: block_diff_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),
+		//				window_size: consensus::DIFFICULTY_ADJUST_WINDOW,
+		//			}
+		//		};
 
 		let peer_stats = self
 			.p2p


### PR DESCRIPTION
Improvement for https://github.com/mimblewimble/grin/issues/1616.

TUI thread periodically call `get_server_stats` which call `difficulty_iter`, and there's a `store.batch` lock in `difficulty_iter`, which cause the TUI may wait a long time before successfully get the lock, looks like a frozen TUI.



