### PR TITLE
Allow TLS for Wallet APIs

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -797,6 +797,7 @@ pub fn start_rest_apis(
 	tx_pool: Weak<RwLock<pool::TransactionPool>>,
 	peers: Weak<p2p::Peers>,
 	api_secret: Option<String>,
+	tls_config: Option<TLSConfig>,
 ) -> bool {
 	let mut apis = ApiServer::new();
 	let mut router = build_router(chain, tx_pool, peers).expect("unable to build API router");
@@ -810,7 +811,7 @@ pub fn start_rest_apis(
 
 	info!(LOGGER, "Starting HTTP API server at {}.", addr);
 	let socket_addr: SocketAddr = addr.parse().expect("unable to parse socket address");
-	apis.start(socket_addr, router).is_ok()
+	apis.start(socket_addr, router, tls_config).is_ok()
 }
 
 pub fn build_router(

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -69,7 +69,7 @@ fn test_start_api() {
 	router.add_middleware(counter.clone());
 	let server_addr = "127.0.0.1:14434";
 	let addr: SocketAddr = server_addr.parse().expect("unable to parse server address");
-	assert!(server.start(addr, router).is_ok());
+	assert!(server.start(addr, router, None).is_ok());
 	let url = format!("http://{}/v1/", server_addr);
 	let index = api::client::get::<Vec<String>>(url.as_str(), None).unwrap();
 	assert_eq!(index.len(), 2);
@@ -94,7 +94,7 @@ fn test_start_api_tls() {
 	let router = build_router();
 	let server_addr = "127.0.0.1:14444";
 	let addr: SocketAddr = server_addr.parse().expect("unable to parse server address");
-	assert!(server.start_tls(addr, router, tls_conf).is_ok());
+	assert!(server.start(addr, router, Some(tls_conf)).is_ok());
 	let url = format!("https://{}/v1/", server_addr);
 	let index = api::client::get::<Vec<String>>(url.as_str(), None).unwrap();
 	assert_eq!(index.len(), 2);

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -310,6 +310,14 @@ fn comments() -> HashMap<String, String> {
 		"api_listen_port".to_string(),
 		"
 #port for wallet listener
+
+#path of TLS certificate file (PKCS#12 format is supported)
+#self-signed certificates are not supported, use https://github.com/FiloSottile/mkcert
+#to test on localhost
+#tls_certificate_file = \"\"
+#password of TLS certificate file (PKCS#12 format is supported)
+#tls_certificate_pass = \"\"
+
 ".to_string(),
 	);
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -263,6 +263,7 @@ impl Server {
 			Arc::downgrade(&tx_pool),
 			Arc::downgrade(&p2p_server.peers),
 			api_secret,
+			None,
 		);
 
 		info!(

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -280,6 +280,7 @@ impl LocalServerContainer {
 		wallet::controller::foreign_listener(
 			Box::new(wallet),
 			&self.wallet_config.api_listen_addr(),
+			None,
 		).unwrap_or_else(|e| {
 			panic!(
 				"Error creating wallet listener: {:?} Config: {:?}",

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -426,7 +426,7 @@ fn replicate_tx_fluff_failure() {
 	let client1 = HTTPWalletClient::new("http://127.0.0.1:23003", None);
 	let wallet1 = create_wallet("target/tmp/tx_fluff/wallet1", client1.clone());
 	let wallet1_handle = thread::spawn(move || {
-		controller::foreign_listener(wallet1, "127.0.0.1:33000")
+		controller::foreign_listener(wallet1, "127.0.0.1:33000", None)
 			.unwrap_or_else(|e| panic!("Error creating wallet1 listener: {:?}", e,));
 	});
 
@@ -434,7 +434,7 @@ fn replicate_tx_fluff_failure() {
 	let client2 = HTTPWalletClient::new("http://127.0.0.1:23001", None);
 	let wallet2 = create_wallet("target/tmp/tx_fluff/wallet2", client2.clone());
 	let wallet2_handle = thread::spawn(move || {
-		controller::foreign_listener(wallet2, "127.0.0.1:33001")
+		controller::foreign_listener(wallet2, "127.0.0.1:33001", None)
 			.unwrap_or_else(|e| panic!("Error creating wallet2 listener: {:?}", e,));
 	});
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -48,6 +48,10 @@ pub struct WalletConfig {
 	pub check_node_api_http_addr: String,
 	// The directory in which wallet files are stored
 	pub data_file_dir: String,
+	/// TLS ceritificate file
+	pub tls_certificate_file: Option<String>,
+	/// TLS ceritificate password
+	pub tls_certificate_pass: Option<String>,
 }
 
 impl Default for WalletConfig {
@@ -60,6 +64,8 @@ impl Default for WalletConfig {
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
 			data_file_dir: ".".to_string(),
+			tls_certificate_file: None,
+			tls_certificate_pass: None,
 		}
 	}
 }


### PR DESCRIPTION
This PR adds an optionalsupport of TLS for wallet APIs. Only PKCS12 format is supported, will address .pem support in the next PR and provide some documentation.
Address #1425