### PR TITLE
Fix concurrency issue around peer add and start. Fixes #1585

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -60,7 +60,7 @@ impl Peers {
 		let peer_data: PeerData;
 		let addr: SocketAddr;
 		{
-			let p = peer.write().unwrap();
+			let p = peer.read().unwrap();
 			peer_data = PeerData {
 				addr: p.info.addr,
 				capabilities: p.info.capabilities,

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -56,25 +56,29 @@ impl Peers {
 
 	/// Adds the peer to our internal peer mapping. Note that the peer is still
 	/// returned so the server can run it.
-	pub fn add_connected(&self, p: Peer) -> Result<Arc<RwLock<Peer>>, Error> {
-		debug!(LOGGER, "Saving newly connected peer {}.", p.info.addr);
-		let peer_data = PeerData {
-			addr: p.info.addr,
-			capabilities: p.info.capabilities,
-			user_agent: p.info.user_agent.clone(),
-			flags: State::Healthy,
-			last_banned: 0,
-			ban_reason: ReasonForBan::None,
-		};
+	pub fn add_connected(&self, peer: Arc<RwLock<Peer>>) -> Result<(), Error> {
+		let peer_data: PeerData;
+		let addr: SocketAddr;
+		{
+			let p = peer.write().unwrap();
+			peer_data = PeerData {
+				addr: p.info.addr,
+				capabilities: p.info.capabilities,
+				user_agent: p.info.user_agent.clone(),
+				flags: State::Healthy,
+				last_banned: 0,
+				ban_reason: ReasonForBan::None,
+			};
+			addr = p.info.addr.clone();
+		}
+		debug!(LOGGER, "Saving newly connected peer {}.", addr);
 		self.save_peer(&peer_data)?;
 
-		let addr = p.info.addr.clone();
-		let apeer = Arc::new(RwLock::new(p));
 		{
 			let mut peers = self.peers.write().unwrap();
-			peers.insert(addr, apeer.clone());
+			peers.insert(addr, peer.clone());
 		}
-		Ok(apeer)
+		Ok(())
 	}
 
 	// Update the dandelion relay


### PR DESCRIPTION
We used to add the peer to the peers list _and then_ start it and set its connection. This leads to peers getting picked up for other tasks (like sync) even though they're not yet fully ready.