### PR TITLE
test: avoid infinite waiting on basic_stratum_server test

### DIFF
--- a/servers/tests/stratum.rs
+++ b/servers/tests/stratum.rs
@@ -32,8 +32,8 @@ use serde_json::Value;
 use std::io::prelude::{BufRead, Write};
 use std::net::TcpStream;
 
-use std::{thread, time};
 use std::process;
+use std::{thread, time};
 
 use core::global::{self, ChainTypes};
 use util::LOGGER;


### PR DESCRIPTION
Sometimes we can see the one hour timeout on Travis-CI test for case `basic_stratum_server`.

Here is an improvement on this test on 2 aspects:
1. Add log to indicate where the test arrived
2. Add 10 seconds timeout for this test, since it's suppose to be completed in 3 seconds.

Then after this PR merged, if any failure case found in Travis-CI on this test, we can take a look what's the problem exactly, instead of just restarting the test.
