### PR TITLE
[DNM] do not maintain head in ctx (go back to db via batch for this)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -357,12 +357,8 @@ impl Chain {
 	}
 
 	fn new_ctx(&self, opts: Options, batch: &mut Batch) -> Result<pipe::BlockContext, Error> {
-		let head = batch.head()?;
-		let header_head = batch.get_header_head()?;
 		Ok(pipe::BlockContext {
 			opts,
-			head,
-			header_head,
 			pow_verifier: self.pow_verifier,
 			block_hashes_cache: self.block_hashes_cache.clone(),
 			txhashset: self.txhashset.clone(),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -34,7 +34,6 @@ use error::{Error, ErrorKind};
 use grin_store::Error::NotFoundErr;
 use pipe;
 use store;
-use store::Batch;
 use txhashset;
 use types::{ChainAdapter, NoStatus, Options, Tip, TxHashsetWriteStatus};
 use util::secp::pedersen::{Commitment, RangeProof};
@@ -237,7 +236,7 @@ impl Chain {
 	) -> Result<(Option<Tip>, Option<Block>), Error> {
 		let mut batch = self.store.batch()?;
 		let bhash = b.hash();
-		let mut ctx = self.new_ctx(opts, &mut batch)?;
+		let mut ctx = self.new_ctx(opts)?;
 
 		let res = pipe::process_block(&b, &mut ctx, &mut batch, self.verifier_cache.clone());
 
@@ -336,7 +335,7 @@ impl Chain {
 	/// Process a block header received during "header first" propagation.
 	pub fn process_block_header(&self, bh: &BlockHeader, opts: Options) -> Result<(), Error> {
 		let mut batch = self.store.batch()?;
-		let mut ctx = self.new_ctx(opts, &mut batch)?;
+		let mut ctx = self.new_ctx(opts)?;
 		pipe::process_block_header(bh, &mut ctx, &mut batch)?;
 		batch.commit()?;
 		Ok(())
@@ -350,13 +349,13 @@ impl Chain {
 		opts: Options,
 	) -> Result<(), Error> {
 		let mut batch = self.store.batch()?;
-		let mut ctx = self.new_ctx(opts, &mut batch)?;
+		let mut ctx = self.new_ctx(opts)?;
 		pipe::sync_block_headers(headers, &mut ctx, &mut batch)?;
 		batch.commit()?;
 		Ok(())
 	}
 
-	fn new_ctx(&self, opts: Options, batch: &mut Batch) -> Result<pipe::BlockContext, Error> {
+	fn new_ctx(&self, opts: Options) -> Result<pipe::BlockContext, Error> {
 		Ok(pipe::BlockContext {
 			opts,
 			pow_verifier: self.pow_verifier,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -59,8 +59,8 @@ pub struct BlockContext {
 
 // Check if this block is the next block *immediately*
 // after our current chain head.
-fn is_next_block(header: &BlockHeader, ctx: &mut BlockContext) -> bool {
-	header.previous == ctx.head.last_block_h
+fn is_next_block(header: &BlockHeader, head: &Tip) -> bool {
+	header.previous == head.last_block_h
 }
 
 /// Runs the block processing pipeline, including validation and finding a
@@ -95,7 +95,7 @@ pub fn process_block(
 	// Fast in-memory checks to avoid re-processing a block we recently processed.
 	{
 		// Check if we have recently processed this block (via ctx chain head).
-		check_known_head(&b.header, ctx)?;
+		check_known_head(&b.header, batch)?;
 
 		// Check if we have recently processed this block (via block_hashes_cache).
 		check_known_cache(&b.header, ctx)?;
@@ -110,11 +110,12 @@ pub fn process_block(
 
 		// Update header_head (but only if this header increases our total known work).
 		// i.e. Only if this header is now the head of the current "most work" chain.
-		update_header_head(&b.header, ctx, batch)?;
+		update_header_head(&b.header, batch)?;
 	}
 
 	// Check if are processing the "next" block relative to the current chain head.
-	if is_next_block(&b.header, ctx) {
+	let head = batch.head()?;
+	if is_next_block(&b.header, &head) {
 		// If this is the "next" block then either -
 		//   * common case where we process blocks sequentially.
 		//   * special case where this is the first fast sync full block
@@ -123,14 +124,14 @@ pub fn process_block(
 		// Check we have *this* block in the store.
 		// Stop if we have processed this block previously (it is in the store).
 		// This is more expensive than the earlier check_known() as we hit the store.
-		check_known_store(&b.header, ctx, batch)?;
+		check_known_store(&b.header, batch)?;
 
 		// Check existing MMR (via rewind) to see if this block is known to us already.
 		// This should catch old blocks before we check to see if they appear to be
 		// orphaned due to compacting/pruning on a fast-sync node.
 		// This is more expensive than check_known_store() as we rewind the txhashset.
 		// But we only incur the cost of the rewind if this is an earlier block on the same chain.
-		check_known_mmr(&b.header, ctx, batch, &mut txhashset)?;
+		check_known_mmr(&b.header, batch, &mut txhashset)?;
 
 		// At this point it looks like this is a new block that we have not yet processed.
 		// Check we have the *previous* block in the store.
@@ -148,7 +149,13 @@ pub fn process_block(
 		// First we rewind the txhashset extension if necessary
 		// to put it into a consistent state for validating the block.
 		// We can skip this step if the previous header is the latest header we saw.
-		if is_next_block(&b.header, ctx) {
+
+		//
+		// TODO - Is this safe to do? Can we just go look in the db via the batch?
+		//
+		let head = extension.batch.head()?;
+
+		if is_next_block(&b.header, &head) {
 			// No need to rewind if we are processing the next block.
 		} else {
 			// Rewind the re-apply blocks on the forked chain to
@@ -179,7 +186,7 @@ pub fn process_block(
 
 		// If applying this block does not increase the work on the chain then
 		// we know we have not yet updated the chain to produce a new chain head.
-		if !block_has_more_work(&b.header, &ctx.head) {
+		if b.header.total_difficulty() <= head.total_difficulty {
 			extension.force_rollback();
 		}
 
@@ -243,7 +250,7 @@ pub fn sync_block_headers(
 	if let Some(header) = headers.last() {
 		// Update header_head (but only if this header increases our total known work).
 		// i.e. Only if this header is now the head of the current "most work" chain.
-		update_header_head(header, ctx, batch)?;
+		update_header_head(header, batch)?;
 
 		// Update sync_head regardless of total work.
 		update_sync_head(header, batch)?;
@@ -278,15 +285,16 @@ pub fn process_block_header(
 		bh.hash()
 	); // keep this
 
-	check_header_known(bh.hash(), ctx)?;
+	check_header_known(bh.hash(), batch)?;
 	validate_header(&bh, ctx, batch)
 }
 
 /// Quick in-memory check to fast-reject any block header we've already handled
 /// recently. Keeps duplicates from the network in check.
 /// ctx here is specific to the header_head (tip of the header chain)
-fn check_header_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
-	if bh == ctx.header_head.last_block_h || bh == ctx.header_head.prev_block_h {
+fn check_header_known(bh: Hash, batch: &mut store::Batch) -> Result<(), Error> {
+	let header_head = batch.get_header_head()?;
+	if bh == header_head.last_block_h || bh == header_head.prev_block_h {
 		return Err(ErrorKind::Unfit("header already known".to_string()).into());
 	}
 	Ok(())
@@ -295,9 +303,10 @@ fn check_header_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
 /// Quick in-memory check to fast-reject any block handled recently.
 /// Keeps duplicates from the network in check.
 /// Checks against the last_block_h and prev_block_h of the chain head.
-fn check_known_head(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
+fn check_known_head(header: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
 	let bh = header.hash();
-	if bh == ctx.head.last_block_h || bh == ctx.head.prev_block_h {
+	let head = batch.head()?;
+	if bh == head.last_block_h || bh == head.prev_block_h {
 		return Err(ErrorKind::Unfit("already known in head".to_string()).into());
 	}
 	Ok(())
@@ -326,12 +335,12 @@ fn check_known_orphans(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(
 // Check if this block is in the store already.
 fn check_known_store(
 	header: &BlockHeader,
-	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<(), Error> {
 	match batch.block_exists(&header.hash()) {
 		Ok(true) => {
-			if header.height < ctx.head.height.saturating_sub(50) {
+			let head = batch.head()?;
+			if header.height < head.height.saturating_sub(50) {
 				// TODO - we flag this as an "abusive peer" but only in the case
 				// where we have the full block in our store.
 				// So this is not a particularly exhaustive check.
@@ -378,13 +387,15 @@ fn check_prev_store(header: &BlockHeader, batch: &mut store::Batch) -> Result<()
 // We can avoid a full rewind in this case.
 fn check_known_mmr(
 	header: &BlockHeader,
-	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 	write_txhashset: &mut txhashset::TxHashSet,
 ) -> Result<(), Error> {
 	// No point checking the MMR if this block is not earlier in the chain.
-	if header.height > ctx.head.height {
-		return Ok(());
+	{
+		let head = batch.head()?;
+		if header.height > head.height {
+			return Ok(());
+		}
 	}
 
 	// Use "header by height" index to look at current most work chain.
@@ -635,18 +646,19 @@ fn update_head(
 	ctx: &BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<Option<Tip>, Error> {
-	// if we made a fork with more work than the head (which should also be true
-	// when extending the head), update it
-	if block_has_more_work(&b.header, &ctx.head) {
+	// If we made a fork with more work than the head (which should also be true
+	// when extending the head), update it.
+	let current_head = batch.head()?;
+	if b.header.total_difficulty() >  current_head.total_difficulty {
 		// update the block height index
+		let tip = Tip::from_block(&b.header);
 		batch
-			.setup_height(&b.header, &ctx.head)
+			.setup_height(&b.header, &tip)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe setup height".to_owned()))?;
 
 		// in sync mode, only update the "body chain", otherwise update both the
 		// "header chain" and "body chain", updating the header chain in sync resets
 		// all additional "future" headers we've received
-		let tip = Tip::from_block(&b.header);
 		if ctx.opts.contains(Options::SYNC) {
 			batch
 				.save_body_head(&tip)
@@ -668,12 +680,6 @@ fn update_head(
 	}
 }
 
-// Whether the provided block totals more work than the chain tip
-fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
-	let block_tip = Tip::from_block(header);
-	block_tip.total_difficulty > tip.total_difficulty
-}
-
 /// Update the sync head so we can keep syncing from where we left off.
 fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
 	let tip = Tip::from_block(bh);
@@ -687,16 +693,20 @@ fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Er
 /// Update the header head if this header has most work.
 fn update_header_head(
 	bh: &BlockHeader,
-	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<Option<Tip>, Error> {
-	let tip = Tip::from_block(bh);
-	if tip.total_difficulty > ctx.header_head.total_difficulty {
+
+	// Get current header_head from the db (via the batch)
+	// and compare the new header to this.
+	let header_head = batch.get_header_head()?;
+	if bh.total_difficulty() > header_head.total_difficulty {
+		let tip = Tip::from_block(&bh);
 		batch
 			.save_header_head(&tip)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
-		ctx.header_head = tip.clone();
+
 		debug!(LOGGER, "header head {} @ {}", bh.hash(), bh.height);
+
 		Ok(Some(tip))
 	} else {
 		Ok(None)

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -333,10 +333,7 @@ fn check_known_orphans(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(
 }
 
 // Check if this block is in the store already.
-fn check_known_store(
-	header: &BlockHeader,
-	batch: &mut store::Batch,
-) -> Result<(), Error> {
+fn check_known_store(header: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
 	match batch.block_exists(&header.hash()) {
 		Ok(true) => {
 			let head = batch.head()?;
@@ -649,7 +646,7 @@ fn update_head(
 	// If we made a fork with more work than the head (which should also be true
 	// when extending the head), update it.
 	let current_head = batch.head()?;
-	if b.header.total_difficulty() >  current_head.total_difficulty {
+	if b.header.total_difficulty() > current_head.total_difficulty {
 		// update the block height index
 		let tip = Tip::from_block(&b.header);
 		batch
@@ -691,11 +688,7 @@ fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Er
 }
 
 /// Update the header head if this header has most work.
-fn update_header_head(
-	bh: &BlockHeader,
-	batch: &mut store::Batch,
-) -> Result<Option<Tip>, Error> {
-
+fn update_header_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<Option<Tip>, Error> {
 	// Get current header_head from the db (via the batch)
 	// and compare the new header to this.
 	let header_head = batch.get_header_head()?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -43,10 +43,10 @@ use failure::ResultExt;
 pub struct BlockContext {
 	/// The options
 	pub opts: Options,
-	/// The head
-	pub head: Tip,
-	/// The header head
-	pub header_head: Tip,
+	// /// The head
+	// pub head: Tip,
+	// /// The header head
+	// pub header_head: Tip,
 	/// The POW verification function
 	pub pow_verifier: fn(&BlockHeader, u8) -> Result<(), pow::Error>,
 	/// MMR sum tree states


### PR DESCRIPTION
[Do not merge without discussion]

I think this eliminates a source of potentially stale data during block and header processing.
Need to do more testing to be confident this actually works as expected.

But like this we go look in the db (accessible via the batch) and we do not keep a potentially stale `head` or `header_head` in the ctx passed into `process_block()`.
So we should be less likely to process a block in one thread and in a separate thread go sync block headers because we got out of date and revert the `header_head` to some previous (and now incorrect) value.

