### PR TITLE
test: double the speed of Travis-CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,10 @@ env:
 script:
   - if [[ "TEST_SUITE" != "none" ]]; then
         IFS='-' read -r -a array <<< "$TEST_SUITE";
-        for TEST_DIR in "${array[@]}" do
+        for TEST_DIR in "${array[@]}"
+        do
           echo "Start testing in folder $TEST_DIR...";
-          cd $TEST_DIR && cargo test --release;
+          cd $TEST_DIR && rm -rf target/tmp && cargo test --release;
           cd - > /dev/null;
           echo "Testing done for folder $TEST_DIR";
         done;

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ env:
   - TEST_SUITE=api-util-none
 
 script:
-  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${array[0]};
+  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[0]};
     if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
-  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${array[1]};
+  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[1]};
     if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,13 @@ env:
 
 script:
   - if [[ "TEST_SUITE" != "none" ]]; then
-        IFS='-' read -r -a array <<< "$TEST_SUITE"
-        for TEST_DIR in "${array[@]}"
-        do
-          echo "Start testing in folder $TEST_DIR..."
+        IFS='-' read -r -a array <<< "$TEST_SUITE";
+        for TEST_DIR in "${array[@]}" do
+          echo "Start testing in folder $TEST_DIR...";
           cd $TEST_DIR && cargo test --release;
           cd - > /dev/null;
-          echo "Testing done for folder $TEST_DIR"
-        done
+          echo "Testing done for folder $TEST_DIR";
+        done;
     fi
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
 script:
   - if [[ "TEST_SUITE" != "none" ]]; then
         IFS='-' read -r -a array <<< "$TEST_SUITE";
-        for TEST_DIR in "${array[@]}"
+        for TEST_DIR in "${array[@]}";
         do
           echo "Start testing in folder $TEST_DIR...";
           cd $TEST_DIR && rm -rf target/tmp && cargo test --release;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,21 +46,28 @@ env:
   - RUST_BACKTRACE="1"
   - RUST_FLAGS="-C debug-assertions"
   matrix:
-  - TEST_SUITE=servers-store
+  - TEST_SUITE=servers
   - TEST_SUITE=chain-core
   - TEST_SUITE=pool-p2p
   - TEST_SUITE=keychain-wallet
-  - TEST_SUITE=api-util-none
+  - TEST_SUITE=api-util-store
 
 script:
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[0]};
+    echo "start testing on folder $DIR...";
     if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[1]};
+    echo "start testing on folder $DIR...";
     if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
+  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[2]};
+    if [[ -n "$DIR" ]];  then
+      echo "start testing on folder $DIR...";
+      cd $DIR && cargo test --release; cd - > /dev/null;
+    fi;
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "api-util-none" ]]; then cargo build --release;        fi
-  - if [[ "TEST_SUITE" == "api-util-none" ]]; then ./.auto-release.sh;           fi
+  - if [[ "TEST_SUITE" == "servers" ]]; then cargo build --release;        fi
+  - if [[ "TEST_SUITE" == "servers" ]]; then ./.auto-release.sh;           fi
 
 deploy:
   provider: releases
@@ -72,6 +79,6 @@ deploy:
   on:
     repo: mimblewimble/grin
     tags: true
-    condition: $TEST_DIR = "api-util-none"
+    condition: $TEST_SUITE = "servers"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ sudo: required
 cache:
   cargo: true
   timeout: 240
+  directories:
+    - $HOME/.cargo
+    - $TRAVIS_BUILD_DIR/target
 
 before_cache:
-  - rm -rf target/tmp
+  - rm -rf $TRAVIS_BUILD_DIR/target/tmp
 
 rust:
   - stable
@@ -25,14 +28,15 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - libgit2-dev
+      - libncurses5-dev
+      - libncursesw5-dev
+      - zlib1g-dev
+      - libssl-dev
       - g++-5
       - cmake
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - cmake
-      - gcc
-      - binutils-dev
+      - clang
+      - pkg-config
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update       ; fi
@@ -46,24 +50,17 @@ env:
   - TEST_SUITE=chain-core
   - TEST_SUITE=pool-p2p
   - TEST_SUITE=keychain-wallet
-  - TEST_SUITE=config-api-util
-  - TEST_SUITE=none
+  - TEST_SUITE=api-util-none
 
 script:
-  - if [[ "TEST_SUITE" != "none" ]]; then
-        IFS='-' read -r -a array <<< "$TEST_SUITE";
-        for TEST_DIR in "${array[@]}";
-        do
-          echo "Start testing in folder $TEST_DIR...";
-          cd $TEST_DIR && rm -rf target/tmp && cargo test --release;
-          cd - > /dev/null;
-          echo "Testing done for folder $TEST_DIR";
-        done;
-    fi
+  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${array[0]};
+    if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
+  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${array[1]};
+    if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "none" ]]; then cargo build --release;                fi
-  - if [[ "TEST_SUITE" == "none" ]]; then ./.auto-release.sh;                   fi
+  - if [[ "TEST_SUITE" == "api-util-none" ]]; then cargo build --release;           fi
+  - if [[ "TEST_SUITE" == "api-util-none" ]]; then ./.auto-release.sh;              fi
 
 deploy:
   provider: releases
@@ -75,6 +72,6 @@ deploy:
   on:
     repo: mimblewimble/grin
     tags: true
-    condition: $TEST_DIR = "none"
+    condition: $TEST_DIR = "api-util-none"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,14 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - libgit2-dev
-      - libncurses5-dev
-      - libncursesw5-dev
-      - zlib1g-dev
-      - libssl-dev
       - g++-5
       - cmake
-      - clang
-      - pkg-config
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update       ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,13 @@ env:
 
 script:
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[0]};
-    if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
+    if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[1]};
-    if [[ -nz "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
+    if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "api-util-none" ]]; then cargo build --release;           fi
-  - if [[ "TEST_SUITE" == "api-util-none" ]]; then ./.auto-release.sh;              fi
+  - if [[ "TEST_SUITE" == "api-util-none" ]]; then cargo build --release;        fi
+  - if [[ "TEST_SUITE" == "api-util-none" ]]; then ./.auto-release.sh;           fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 os:
   - linux
-  - osx
+#  - osx
 
 dist: trusty
 sudo: required
@@ -42,25 +42,28 @@ env:
   - RUST_BACKTRACE="1"
   - RUST_FLAGS="-C debug-assertions"
   matrix:
-  - RUST_TEST_THREADS=1 TEST_DIR=servers
-  - TEST_DIR=store
-  - TEST_DIR=chain
-  - TEST_DIR=pool
-  - TEST_DIR=wallet
-  - TEST_DIR=p2p
-  - TEST_DIR=api
-  - TEST_DIR=keychain
-  - TEST_DIR=core
-  - TEST_DIR=util
-  - TEST_DIR=config
-  - TEST_DIR=none
+  - TEST_SUITE=servers-store
+  - TEST_SUITE=chain-core
+  - TEST_SUITE=pool-p2p
+  - TEST_SUITE=keychain-wallet
+  - TEST_SUITE=config-api-util
+  - TEST_SUITE=none
 
 script:
-  - if [[ "$TEST_DIR" == "none" ]]; then cargo build --release;                fi
-  - if [[ "$TEST_DIR" != "none" ]]; then cd $TEST_DIR && cargo test --release; fi
+  - if [[ "TEST_SUITE" != "none" ]]; then
+        IFS='-' read -r -a array <<< "$TEST_SUITE"
+        for TEST_DIR in "${array[@]}"
+        do
+          echo "Start testing in folder $TEST_DIR..."
+          cd $TEST_DIR && cargo test --release;
+          cd - > /dev/null;
+          echo "Testing done for folder $TEST_DIR"
+        done
+    fi
 
 before_deploy:
-  - if [[ "$TEST_DIR" == "none" ]]; then ./.auto-release.sh;                   fi
+  - if [[ "TEST_SUITE" == "none" ]]; then cargo build --release;                fi
+  - if [[ "TEST_SUITE" == "none" ]]; then ./.auto-release.sh;                   fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,10 @@ script:
     echo "start testing on folder $DIR...";
     if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[1]};
-    echo "start testing on folder $DIR...";
-    if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
+    if [[ -n "$DIR" ]];  then
+      echo "start testing on folder $DIR...";
+      cd $DIR && cargo test --release; cd - > /dev/null;
+    fi;
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[2]};
     if [[ -n "$DIR" ]];  then
       echo "start testing on folder $DIR...";
@@ -66,8 +68,11 @@ script:
     fi;
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "servers" ]]; then cargo build --release;        fi
-  - if [[ "TEST_SUITE" == "servers" ]]; then ./.auto-release.sh;           fi
+  - if [[ "TEST_SUITE" == "pool-p2p" ]]; then
+      cargo clean;
+      cargo build --release;
+      ./.auto-release.sh;
+    fi
 
 deploy:
   provider: releases
@@ -79,6 +84,6 @@ deploy:
   on:
     repo: mimblewimble/grin
     tags: true
-    condition: $TEST_SUITE = "servers"
+    condition: $TEST_SUITE = "pool-p2p"
 
 


### PR DESCRIPTION
As part of work for https://github.com/mimblewimble/grin/issues/1635

The baseline of a single platform (Linux) Travis-CI on Grin is 22 minutes (see detail in #1635). This optimization will give us 10 minutes.

**Note**:  the speed depends on the cargo cache, both `22` minutes and `10` minutes above are talking about the performance with a well cache.  If a cache missed, the Travis-CI test time will increase greatly, so please note this and don't surprise if sometimes you got 19 minutes for example 😄 

The following optimization is applied to get this nice 10 minutes.
- Remove `config` test suite because there's no any tests in this folder
- Combine our 10 test folders into 5 test suites, since Travis-CI allow us (free account) at most run 5 parallel test suites.




