### PR TITLE
maintain head and header_head on the chain, pass them wrapped in arcs to pipe

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -223,13 +223,11 @@ impl Chain {
 		let mut txhashset = self.txhashset.write().unwrap();
 		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 
-		let bhash = b.hash();
-
 		let add_to_hash_cache = || {
 			// only add to hash cache below if block is definitively accepted
 			// or rejected
 			let mut cache = self.block_hashes_cache.write().unwrap();
-			cache.insert(bhash, true);
+			cache.insert(b.hash(), true);
 		};
 
 		match pipe::process_block(&b, &mut ctx) {
@@ -828,11 +826,6 @@ impl Chain {
 			});
 		}
 		Ok((outputs.0, max_index, output_vec))
-	}
-
-	/// Total difficulty at the head of the chain
-	pub fn total_difficulty(&self) -> Difficulty {
-		self.head().unwrap().total_difficulty
 	}
 
 	/// Orphans pool size

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -242,14 +242,20 @@ impl Chain {
 
 		*head = tip.clone();
 
-		debug!(LOGGER, "chain: head updated to {} at {}", tip.last_block_h, tip.height);
+		debug!(
+			LOGGER,
+			"chain: head updated to {} at {}", tip.last_block_h, tip.height
+		);
 	}
 
 	fn update_header_head(&self, tip: &Tip) {
 		let mut header_head = self.header_head.write().unwrap();
 		*header_head = tip.clone();
 
-		debug!(LOGGER, "chain: header_head updated to {} at {}", tip.last_block_h, tip.height);
+		debug!(
+			LOGGER,
+			"chain: header_head updated to {} at {}", tip.last_block_h, tip.height
+		);
 	}
 
 	/// Attempt to add a new block to the chain. Returns the new chain tip if it
@@ -387,9 +393,7 @@ impl Chain {
 				batch.commit()?;
 				Ok(())
 			}
-			Err(e) => {
-				Err(e)
-			}
+			Err(e) => Err(e),
 		}
 	}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -676,7 +676,7 @@ impl Chain {
 		// Initial check based on relative heights of current head and header_head.
 		{
 			let head = self.head().unwrap();
-			let header_head = self.get_header_head().unwrap();
+			let header_head = self.header_head().unwrap();
 			if header_head.height - head.height < global::cut_through_horizon() as u64 {
 				return Err(ErrorKind::InvalidTxHashSet("not needed".to_owned()).into());
 			}
@@ -912,9 +912,14 @@ impl Chain {
 		Ok(())
 	}
 
-	/// Get the tip that's also the head of the chain
+	/// Tip (head) of the block chain.
 	pub fn head(&self) -> Result<Tip, Error> {
 		Ok(self.head.read().unwrap().clone())
+	}
+
+	/// Tip (head) of the header chain.
+	pub fn header_head(&self) -> Result<Tip, Error> {
+		Ok(self.header_head.read().unwrap().clone())
 	}
 
 	/// Block header for the chain head
@@ -998,13 +1003,6 @@ impl Chain {
 		self.store
 			.get_sync_head()
 			.map_err(|e| ErrorKind::StoreErr(e, "chain get sync head".to_owned()).into())
-	}
-
-	/// Get the tip of the header chain.
-	pub fn get_header_head(&self) -> Result<Tip, Error> {
-		self.store
-			.get_header_head()
-			.map_err(|e| ErrorKind::StoreErr(e, "chain get header head".to_owned()).into())
 	}
 
 	/// Builds an iterator on blocks starting from the current chain head and

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -206,11 +206,7 @@ impl Chain {
 
 	/// Processes a single block, then checks for orphans, processing
 	/// those as well if they're found
-	pub fn process_block(
-		&self,
-		b: Block,
-		opts: Options,
-	) -> Result<Option<Tip>, Error> {
+	pub fn process_block(&self, b: Block, opts: Options) -> Result<Option<Tip>, Error> {
 		let height = b.header.height;
 		let res = self.process_block_single(b, opts);
 		if res.is_ok() {
@@ -246,7 +242,7 @@ impl Chain {
 				self.adapter.block_accepted(&b, opts);
 
 				Ok(head)
-			},
+			}
 			Err(e) => {
 				match e.kind() {
 					ErrorKind::Orphan => {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -44,9 +44,9 @@ pub struct BlockContext {
 	/// The options
 	pub opts: Options,
 	/// The head
-	pub head: Tip,
+	pub head: Arc<RwLock<Tip>>,
 	/// The header head
-	pub header_head: Tip,
+	pub header_head: Arc<RwLock<Tip>>,
 	/// The POW verification function
 	pub pow_verifier: fn(&BlockHeader, u8) -> Result<(), pow::Error>,
 	/// MMR sum tree states
@@ -62,7 +62,8 @@ pub struct BlockContext {
 // Check if this block is the next block *immediately*
 // after our current chain head.
 fn is_next_block(header: &BlockHeader, ctx: &mut BlockContext) -> bool {
-	header.previous == ctx.head.last_block_h
+	let head = ctx.head.read().unwrap();
+	header.previous == head.last_block_h
 }
 
 /// Runs the block processing pipeline, including validation and finding a
@@ -106,13 +107,7 @@ pub fn process_block(
 	}
 
 	// Header specific processing.
-	{
-		handle_block_header(&b.header, ctx, batch)?;
-
-		// Update header_head (but only if this header increases our total known work).
-		// i.e. Only if this header is now the head of the current "most work" chain.
-		update_header_head(&b.header, ctx, batch)?;
-	}
+	handle_block_header(&b.header, ctx, batch)?;
 
 	// Check if are processing the "next" block relative to the current chain head.
 	if is_next_block(&b.header, ctx) {
@@ -180,7 +175,8 @@ pub fn process_block(
 
 		// If applying this block does not increase the work on the chain then
 		// we know we have not yet updated the chain to produce a new chain head.
-		if !block_has_more_work(&b.header, &ctx.head) {
+		let head = ctx.head.read().unwrap();
+		if !has_more_work(&b.header, &head) {
 			extension.force_rollback();
 		}
 
@@ -197,11 +193,15 @@ pub fn process_block(
 	// Add the newly accepted block and header to our index.
 	add_block(b, batch)?;
 
-	// Update the chain head in the index (if necessary)
-	let res = update_head(b, ctx, batch)?;
+	// Update the chain head (and header_head) if total work is increased.
+	let res = {
+		let _ = update_header_head(&b.header, ctx, batch)?;
+		let res = update_head(b, ctx, batch)?;
+		res
+	};
 
-	// Return the new chain tip if we added work, or
-	// None if this block has not added work.
+	// Return the new chain tip if we added work.
+	// Return None if this block has not added work.
 	Ok(res)
 }
 
@@ -211,7 +211,7 @@ pub fn sync_block_headers(
 	headers: &Vec<BlockHeader>,
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
-) -> Result<(), Error> {
+) -> Result<Option<Tip>, Error> {
 	if let Some(header) = headers.first() {
 		debug!(
 			LOGGER,
@@ -221,7 +221,7 @@ pub fn sync_block_headers(
 			header.height,
 		);
 	} else {
-		return Ok(());
+		return Ok(None);
 	}
 
 	let all_known = if let Some(last_header) = headers.last() {
@@ -242,15 +242,16 @@ pub fn sync_block_headers(
 	// progressing.
 	// We only need to do this once at the end of this batch of headers.
 	if let Some(header) = headers.last() {
-		// Update header_head (but only if this header increases our total known work).
-		// i.e. Only if this header is now the head of the current "most work" chain.
-		update_header_head(header, ctx, batch)?;
-
 		// Update sync_head regardless of total work.
 		update_sync_head(header, batch)?;
-	}
 
-	Ok(())
+		// Update header_head (but only if this header increases our total known work).
+		// i.e. Only if this header is now the head of the current "most work" chain.
+		let res = update_header_head(header, ctx, batch)?;
+		Ok(res)
+	} else {
+		Ok(None)
+	}
 }
 
 fn handle_block_header(
@@ -280,14 +281,16 @@ pub fn process_block_header(
 	); // keep this
 
 	check_header_known(bh.hash(), ctx)?;
-	validate_header(&bh, ctx, batch)
+	validate_header(&bh, ctx, batch)?;
+	Ok(())
 }
 
 /// Quick in-memory check to fast-reject any block header we've already handled
 /// recently. Keeps duplicates from the network in check.
 /// ctx here is specific to the header_head (tip of the header chain)
 fn check_header_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
-	if bh == ctx.header_head.last_block_h || bh == ctx.header_head.prev_block_h {
+	let header_head = ctx.head.read().unwrap();
+	if bh == header_head.last_block_h || bh == header_head.prev_block_h {
 		return Err(ErrorKind::Unfit("header already known".to_string()).into());
 	}
 	Ok(())
@@ -297,8 +300,9 @@ fn check_header_known(bh: Hash, ctx: &mut BlockContext) -> Result<(), Error> {
 /// Keeps duplicates from the network in check.
 /// Checks against the last_block_h and prev_block_h of the chain head.
 fn check_known_head(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
+	let head = ctx.head.read().unwrap();
 	let bh = header.hash();
-	if bh == ctx.head.last_block_h || bh == ctx.head.prev_block_h {
+	if bh == head.last_block_h || bh == head.prev_block_h {
 		return Err(ErrorKind::Unfit("already known in head".to_string()).into());
 	}
 	Ok(())
@@ -332,7 +336,8 @@ fn check_known_store(
 ) -> Result<(), Error> {
 	match batch.block_exists(&header.hash()) {
 		Ok(true) => {
-			if header.height < ctx.head.height.saturating_sub(50) {
+			let head = ctx.head.read().unwrap();
+			if header.height < head.height.saturating_sub(50) {
 				// TODO - we flag this as an "abusive peer" but only in the case
 				// where we have the full block in our store.
 				// So this is not a particularly exhaustive check.
@@ -384,7 +389,8 @@ fn check_known_mmr(
 	write_txhashset: &mut txhashset::TxHashSet,
 ) -> Result<(), Error> {
 	// No point checking the MMR if this block is not earlier in the chain.
-	if header.height > ctx.head.height {
+	let head = ctx.head.read().unwrap();
+	if header.height > head.height {
 		return Ok(());
 	}
 
@@ -638,31 +644,26 @@ fn update_head(
 ) -> Result<Option<Tip>, Error> {
 	// if we made a fork with more work than the head (which should also be true
 	// when extending the head), update it
-	if block_has_more_work(&b.header, &ctx.head) {
-		// update the block height index
+	let head = ctx.head.read().unwrap();
+	if has_more_work(&b.header, &head) {
+		// Update the block height index based on this new head.
 		batch
-			.setup_height(&b.header, &ctx.head)
+			.setup_height(&b.header, &head)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe setup height".to_owned()))?;
 
-		// in sync mode, only update the "body chain", otherwise update both the
-		// "header chain" and "body chain", updating the header chain in sync resets
-		// all additional "future" headers we've received
 		let tip = Tip::from_block(&b.header);
-		if ctx.opts.contains(Options::SYNC) {
-			batch
-				.save_body_head(&tip)
-				.map_err(|e| ErrorKind::StoreErr(e, "pipe save body".to_owned()))?;
-		} else {
-			batch
-				.save_head(&tip)
-				.map_err(|e| ErrorKind::StoreErr(e, "pipe save head".to_owned()))?;
-		}
+
+		batch
+			.save_body_head(&tip)
+			.map_err(|e| ErrorKind::StoreErr(e, "pipe save body".to_owned()))?;
+
 		debug!(
 			LOGGER,
-			"pipe: chain head {} @ {}",
-			b.hash(),
-			b.header.height
+			"pipe: head updated to {} at {}",
+			tip.last_block_h,
+			tip.height
 		);
+
 		Ok(Some(tip))
 	} else {
 		Ok(None)
@@ -670,9 +671,8 @@ fn update_head(
 }
 
 // Whether the provided block totals more work than the chain tip
-fn block_has_more_work(header: &BlockHeader, tip: &Tip) -> bool {
-	let block_tip = Tip::from_block(header);
-	block_tip.total_difficulty > tip.total_difficulty
+fn has_more_work(header: &BlockHeader, head: &Tip) -> bool {
+	header.total_difficulty() > head.total_difficulty
 }
 
 /// Update the sync head so we can keep syncing from where we left off.
@@ -691,13 +691,15 @@ fn update_header_head(
 	ctx: &mut BlockContext,
 	batch: &mut store::Batch,
 ) -> Result<Option<Tip>, Error> {
-	let tip = Tip::from_block(bh);
-	if tip.total_difficulty > ctx.header_head.total_difficulty {
+	let header_head = ctx.header_head.read().unwrap();
+	if has_more_work(&bh, &header_head) {
+		let tip = Tip::from_block(bh);
 		batch
 			.save_header_head(&tip)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
-		ctx.header_head = tip.clone();
-		debug!(LOGGER, "header head {} @ {}", bh.hash(), bh.height);
+
+		debug!(LOGGER, "pipe: header_head updated to {} at {}", tip.last_block_h, tip.height);
+
 		Ok(Some(tip))
 	} else {
 		Ok(None)

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -73,10 +73,7 @@ fn is_next_block(header: &BlockHeader, head: &Tip) -> bool {
 /// Runs the block processing pipeline, including validation and finding a
 /// place for the new block in the chain.
 /// Returns new head if chain head updated.
-pub fn process_block(
-	b: &Block,
-	ctx: &mut BlockContext,
-) -> Result<Option<Tip>, Error> {
+pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	// TODO should just take a promise for a block with a full header so we don't
 	// spend resources reading the full block when its header is invalid
 
@@ -247,10 +244,7 @@ pub fn sync_block_headers(
 	}
 }
 
-fn handle_block_header(
-	header: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+fn handle_block_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
 	validate_header(header, ctx)?;
 	add_block_header(header, ctx)?;
 	Ok(())
@@ -260,10 +254,7 @@ fn handle_block_header(
 /// We validate the header but we do not store it or update header head based
 /// on this. We will update these once we get the block back after requesting
 /// it.
-pub fn process_block_header(
-	bh: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+pub fn process_block_header(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
 	debug!(
 		LOGGER,
 		"pipe: process_block_header at {} [{}]",
@@ -320,10 +311,7 @@ fn check_known_orphans(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(
 }
 
 // Check if this block is in the store already.
-fn check_known_store(
-	header: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+fn check_known_store(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
 	match ctx.batch.block_exists(&header.hash()) {
 		Ok(true) => {
 			let head = ctx.batch.head()?;
@@ -372,10 +360,7 @@ fn check_prev_store(header: &BlockHeader, batch: &mut store::Batch) -> Result<()
 // First check the header matches via current height index.
 // Then peek directly into the MMRs at the appropriate pos.
 // We can avoid a full rewind in this case.
-fn check_known_mmr(
-	header: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+fn check_known_mmr(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
 	// No point checking the MMR if this block is not earlier in the chain.
 	let head = ctx.batch.head()?;
 	if header.height > head.height {
@@ -417,10 +402,7 @@ fn check_known_mmr(
 /// First level of block validation that only needs to act on the block header
 /// to make it as cheap as possible. The different validations are also
 /// arranged by order of cost to have as little DoS surface as possible.
-fn validate_header(
-	header: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
 	// check version, enforces scheduled hard fork
 	if !consensus::valid_header_version(header.height, header.version) {
 		error!(
@@ -527,10 +509,7 @@ fn validate_header(
 	Ok(())
 }
 
-fn validate_block(
-	block: &Block,
-	ctx: &mut BlockContext,
-) -> Result<(), Error> {
+fn validate_block(block: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
 	let prev = ctx.batch.get_block_header(&block.header.previous)?;
 	block
 		.validate(
@@ -623,10 +602,7 @@ fn add_block_header(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Erro
 /// Directly updates the head if we've just appended a new block to it or handle
 /// the situation where we've just added enough work to have a fork with more
 /// work than the head.
-fn update_head(
-	b: &Block,
-	ctx: &BlockContext,
-) -> Result<Option<Tip>, Error> {
+fn update_head(b: &Block, ctx: &BlockContext) -> Result<Option<Tip>, Error> {
 	// if we made a fork with more work than the head (which should also be true
 	// when extending the head), update it
 	let head = ctx.batch.head()?;
@@ -669,10 +645,7 @@ fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Er
 }
 
 /// Update the header head if this header has most work.
-fn update_header_head(
-	bh: &BlockHeader,
-	ctx: &mut BlockContext,
-) -> Result<Option<Tip>, Error> {
+fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	let header_head = ctx.batch.header_head()?;
 	if has_more_work(&bh, &header_head) {
 		let tip = Tip::from_block(bh);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -659,9 +659,7 @@ fn update_head(
 
 		debug!(
 			LOGGER,
-			"pipe: head updated to {} at {}",
-			tip.last_block_h,
-			tip.height
+			"pipe: head updated to {} at {}", tip.last_block_h, tip.height
 		);
 
 		Ok(Some(tip))
@@ -698,7 +696,10 @@ fn update_header_head(
 			.save_header_head(&tip)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
 
-		debug!(LOGGER, "pipe: header_head updated to {} at {}", tip.last_block_h, tip.height);
+		debug!(
+			LOGGER,
+			"pipe: header_head updated to {} at {}", tip.last_block_h, tip.height
+		);
 
 		Ok(Some(tip))
 	} else {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -67,11 +67,13 @@ impl ChainStore {
 		option_to_not_found(self.db.get_ser(&vec![HEAD_PREFIX]), "HEAD")
 	}
 
+	/// Header of the block at the head of the block chain (not the same thing as header_head).
 	pub fn head_header(&self) -> Result<BlockHeader, Error> {
 		self.get_block_header(&self.head()?.last_block_h)
 	}
 
-	pub fn get_header_head(&self) -> Result<Tip, Error> {
+	/// Head of the header chain (not the same thing as head_header).
+	pub fn header_head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), "HEADER_HEAD")
 	}
 
@@ -170,11 +172,13 @@ impl<'a> Batch<'a> {
 		option_to_not_found(self.db.get_ser(&vec![HEAD_PREFIX]), "HEAD")
 	}
 
+	/// Header of the block at the head of the block chain (not the same thing as header_head).
 	pub fn head_header(&self) -> Result<BlockHeader, Error> {
 		self.get_block_header(&self.head()?.last_block_h)
 	}
 
-	pub fn get_header_head(&self) -> Result<Tip, Error> {
+	/// Head of the header chain (not the same thing as head_header).
+	pub fn header_head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), "HEADER_HEAD")
 	}
 
@@ -207,7 +211,7 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn reset_sync_head(&self) -> Result<(), Error> {
-		let head = self.get_header_head()?;
+		let head = self.header_head()?;
 		self.save_sync_head(&head)
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -450,7 +450,7 @@ impl NetToChainAdapter {
 		let prev_hash = b.header.previous;
 		let bhash = b.hash();
 		match chain.process_block(b, self.chain_opts()) {
-			Ok((tip, _)) => {
+			Ok(tip) => {
 				self.validate_chain(bhash);
 				self.check_compact(tip);
 				true
@@ -523,13 +523,13 @@ impl NetToChainAdapter {
 		}
 	}
 
-	fn check_compact(&self, tip_res: Option<Tip>) {
+	fn check_compact(&self, tip: Option<Tip>) {
 		// no compaction during sync or if we're in historical mode
 		if self.archive_mode || self.sync_state.is_syncing() {
 			return;
 		}
 
-		if let Some(tip) = tip_res {
+		if let Some(tip) = tip {
 			// trigger compaction every 2000 blocks, uses a different thread to avoid
 			// blocking the caller thread (likely a peer)
 			if tip.height % 2000 == 0 {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -379,7 +379,7 @@ impl Server {
 
 	/// The head of the block header chain
 	pub fn header_head(&self) -> chain::Tip {
-		self.chain.get_header_head().unwrap()
+		self.chain.header_head().unwrap()
 	}
 
 	/// Returns a set of stats about this server. This and the ServerStats

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -522,7 +522,7 @@ fn needs_syncing(
 	peers: Arc<Peers>,
 	chain: Arc<chain::Chain>,
 ) -> (bool, u64) {
-	let local_diff = chain.total_difficulty();
+	let local_diff = chain.head().unwrap().total_difficulty;
 	let peer = peers.most_work_peer();
 	let is_syncing = sync_state.is_syncing();
 	let mut most_work_height = 0;

--- a/servers/src/grin/sync.rs
+++ b/servers/src/grin/sync.rs
@@ -148,7 +148,7 @@ pub fn run_sync(
 
 		// if syncing is needed
 		let head = chain.head().unwrap();
-		let header_head = chain.get_header_head().unwrap();
+		let header_head = chain.header_head().unwrap();
 
 		// run the header sync in every 10s at least
 		if si.header_sync_due(sync_state.as_ref(), &header_head) {
@@ -365,7 +365,7 @@ impl BodySyncInfo {
 fn body_sync(peers: Arc<Peers>, chain: Arc<chain::Chain>, body_sync_info: &mut BodySyncInfo) {
 	let horizon = global::cut_through_horizon() as u64;
 	let body_head: chain::Tip = chain.head().unwrap();
-	let header_head: chain::Tip = chain.get_header_head().unwrap();
+	let header_head: chain::Tip = chain.header_head().unwrap();
 	let sync_head: chain::Tip = chain.get_sync_head().unwrap();
 
 	body_sync_info.reset();
@@ -455,7 +455,7 @@ fn header_sync(
 	chain: Arc<chain::Chain>,
 	history_locators: &mut Vec<(u64, Hash)>,
 ) {
-	if let Ok(header_head) = chain.get_header_head() {
+	if let Ok(header_head) = chain.header_head() {
 		let difficulty = header_head.total_difficulty;
 
 		if let Some(peer) = peers.most_work_peer() {
@@ -596,7 +596,7 @@ fn get_locator(
 
 	// for security, clear history_locators[] in any case of header chain rollback,
 	// the easiest way is to check whether the sync head and the header head are identical.
-	if history_locators.len() > 0 && tip.hash() != chain.get_header_head()?.hash() {
+	if history_locators.len() > 0 && tip.hash() != chain.header_head()?.hash() {
 		history_locators.clear();
 	}
 

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -43,11 +43,25 @@ impl TUIStatusListener for TUIStatusView {
 						.child(TextView::new("0").with_id("connected_peers")),
 				).child(
 					LinearLayout::new(Orientation::Horizontal)
+						.child(TextView::new("------------------------")),
+				).child(
+					LinearLayout::new(Orientation::Horizontal)
+						.child(TextView::new("Header Chain Height: "))
+						.child(TextView::new("  ").with_id("basic_header_chain_height")),
+				).child(
+					LinearLayout::new(Orientation::Horizontal)
+						.child(TextView::new("Header Cumulative Difficulty: "))
+						.child(TextView::new("  ").with_id("basic_header_total_difficulty")),
+				).child(
+					LinearLayout::new(Orientation::Horizontal)
+						.child(TextView::new("------------------------")),
+				).child(
+					LinearLayout::new(Orientation::Horizontal)
 						.child(TextView::new("Chain Height: "))
 						.child(TextView::new("  ").with_id("chain_height")),
 				).child(
 					LinearLayout::new(Orientation::Horizontal)
-						.child(TextView::new("Total Difficulty: "))
+						.child(TextView::new("Cumulative Difficulty: "))
 						.child(TextView::new("  ").with_id("basic_total_difficulty")),
 				).child(
 					LinearLayout::new(Orientation::Horizontal)
@@ -177,6 +191,12 @@ impl TUIStatusListener for TUIStatusView {
 		});
 		c.call_on_id("basic_total_difficulty", |t: &mut TextView| {
 			t.set_content(stats.head.total_difficulty.to_string());
+		});
+		c.call_on_id("basic_header_chain_height", |t: &mut TextView| {
+			t.set_content(stats.header_head.height.to_string());
+		});
+		c.call_on_id("basic_header_total_difficulty", |t: &mut TextView| {
+			t.set_content(stats.header_head.total_difficulty.to_string());
 		});
 		/*c.call_on_id("basic_mining_config_status", |t: &mut TextView| {
 			t.set_content(basic_mining_config_status);


### PR DESCRIPTION
Refactor `chain` and `pipe` to make pipe aware of "current" chain head.
This allows one thread (say a peer processing a block) to be aware of another thread (say header sync) updating `header_head`.

We now only ever update `head` if we are sure the total work has increased.

And we only ever update `header_head` if total work has increased on the header chain.

This should prevent any situations during sync where we update to a older (less work) `head` or `header_head`.

* Maintain both `head` and `header_head` on chain (wrapped in arcs)
* Pass `chain.head` and `chain.header_head` into pipe in the ctx (wrapped in arcs)
* `sync_block_headers` now returns the updated `header_head` tip if we see more total work
* use a `RwLock` and not a `Mutex` around `head` so code is more explicit around when exactly we mutate the `head` (vs. just reading the current `head`)

