### PR TITLE
fix: seed thread panicked on a try_read unwrap

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -97,7 +97,7 @@ impl Peers {
 				debug!(
 					LOGGER,
 					"Successfully updated Dandelion relay to: {}",
-					peer.try_read().unwrap().info.addr
+					peer.read().unwrap().info.addr
 				);
 			}
 			None => debug!(LOGGER, "Could not update dandelion relay"),


### PR DESCRIPTION

See a panic, root cause is a `try_read().unwrap()` which is not supposed to be used like that. 
```
thread 'seed' panicked at 'called `Result::unwrap()` on an `Err` value: "WouldBlock"': libcore/result.rs:945stack backtrace:
   0:        0x101bb5bd4 - backtrace::backtrace::trace::h82eb823bdd666e6f
                        at /Users/garyyu/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/backtrace/mod.rs:42
   1:        0x101bb0b1c - backtrace::capture::Backtrace::new_unresolved::h1572ddbcdcb8a4c9
                        at /Users/garyyu/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/capture.rs:88
   2:        0x101bb0a7e - backtrace::capture::Backtrace::new::hd858d1b781edfd7f
                        at /Users/garyyu/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.9/src/capture.rs:63
   3:        0x101a93149 - grin_util::logger::send_panic_to_log::{{closure}}::h50fa16f612f571fd
                        at util/src/logger.rs:121
   4:        0x102054b28 - std::panicking::rust_panic_with_hook::h28749c6c929f49fc
                        at libstd/panicking.rs:479
   5:        0x10205467c - std::panicking::continue_panic_fmt::h2b83096170ce8c01
                        at libstd/panicking.rs:390
   6:        0x102054568 - _rust_begin_unwind
                        at libstd/panicking.rs:325
   7:        0x102097461 - core::panicking::panic_fmt::h014200104cad7730
                        at libcore/panicking.rs:77
   8:        0x1016026de - core::result::unwrap_failed::hf7481e216cae22b4
                        at /Users/travis/build/rust-lang/rust/src/libcore/macros.rs:26
   9:        0x1015fc0e3 - <core::result::Result<T, E>>::unwrap::hed121df8336ea79a
                        at /Users/travis/build/rust-lang/rust/src/libcore/result.rs:782
  10:        0x10168d348 - grin_p2p::peers::Peers::update_dandelion_relay::hc2139204626495c8
                        at p2p/src/peers.rs:101
  11:        0x100f92126 - grin_servers::grin::seed::update_dandelion_relay::h2564a37aba8e4129
                        at servers/src/grin/seed.rs:208
  12:        0x100eebf0a - grin_servers::grin::seed::connect_and_monitor::{{closure}}::he4c4d25d2bb5e9e2
                        at servers/src/grin/seed.rs:82
```