### PR TITLE
minor improvement on peer lock for ping/pong and banned check

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -656,8 +656,13 @@ impl NetAdapter for Peers {
 			);
 		}
 
-		if diff.to_num() > 0 {
-			if let Some(peer) = self.get_connected_peer(&addr) {
+		if let Some(peer) = self.get_connected_peer(&addr) {
+			let (prev_diff, prev_height) = {
+				let peer = peer.read().unwrap();
+				(peer.info.total_difficulty, peer.info.height)
+			};
+
+			if diff != prev_diff || height != prev_height {
 				let mut peer = peer.write().unwrap();
 				peer.info.total_difficulty = diff;
 				peer.info.height = height;
@@ -667,7 +672,7 @@ impl NetAdapter for Peers {
 
 	fn is_banned(&self, addr: SocketAddr) -> bool {
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let peer = peer.write().unwrap();
+			let peer = peer.read().unwrap();
 			peer.is_banned()
 		} else {
 			false


### PR DESCRIPTION
1. peer lock optimization for ping/pong
- We have ping/pong for each connected peers on every 10 seconds, that means for each peer, we will have 1 Ping + 1 Pong / 10s
- The new block rate is 60s. So, in every 12 function call of `peer_difficulty()`, normally we only have 1 update for `total_difficulty` and `height`.  (not the case of `sync` state).
- `RwLock` write lock is much more expensive than read lock.

So, let's give a bit of optimization on the peer lock, only call `write` lock when needed.

2. is_banned peer lock
- `is_banned()` function will be called as the 1st operation on every received message
- obviously the `is_banned()` function ONLY need a read lock on peer, instead of the expensive write lock.
