### PR TITLE
optimization of peer state write lock

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -347,11 +347,16 @@ impl Peer {
 				false
 			}
 			Ok(e) => {
-				if State::Disconnected != *state {
-					{
-						let mut state = self.state.write().unwrap();
+				let need_stop = {
+					let mut state = self.state.write().unwrap();
+					if State::Disconnected != *state {
 						*state = State::Disconnected;
+						true
+					} else {
+						false
 					}
+				};
+				if need_stop {
 					debug!(LOGGER, "Client {} connection lost: {:?}", self.info.addr, e);
 					self.stop();
 				}


### PR DESCRIPTION

- Peer `check_connection()` function is being heavily called on peer status checking everywhere.
- Peer state is a slow changing element
- Currently we have the expensive RwLock `write` lock for each `check_connection()` call, it's better to optimize it as `read` lock and only call `write` lock when needed.

