### PR TITLE
[DNM] replace std lib sync primitives with parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +872,7 @@ dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1zkp 0.7.1 (git+https://github.com/mimblewimble/rust-secp256k1-zkp?tag=grin_integration_23a)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1551,6 +1557,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,10 +1591,13 @@ name = "parking_lot_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1596,6 +1610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "phf"
@@ -2149,6 +2172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,6 +2699,7 @@ dependencies = [
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37847f133aae7acf82bb9577ccd8bda241df836787642654286e79679826a54b"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -2746,12 +2780,14 @@ dependencies = [
 "checksum openssl 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2e79eede055813a3ac52fb3915caf8e1c9da2dec1587871aec9f6f7b48508d"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.36 (registry+https://github.com/rust-lang/crates.io-index)" = "409d77eeb492a1aebd6eb322b2ee72ff7c7496b4434d98b3bf8be038755de65e"
+"checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
 "checksum phf_codegen 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "7d187f00cd98d5afbcd8898f6cf181743a449162aeb329dcd2f3849009e605ad"
 "checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
@@ -2818,6 +2854,7 @@ dependencies = [
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -14,7 +14,8 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Weak};
+use util::RwLock;
 
 use failure::ResultExt;
 use futures::future::ok;
@@ -407,7 +408,7 @@ impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
 		let mut peers = vec![];
 		for p in &w(&self.peers).connected_peers() {
-			let p = p.read().unwrap();
+			let p = p.read();
 			let peer_info = p.info.clone();
 			peers.push(peer_info);
 		}
@@ -697,7 +698,7 @@ struct PoolInfoHandler {
 impl Handler for PoolInfoHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
 		let pool_arc = w(&self.tx_pool);
-		let pool = pool_arc.read().unwrap();
+		let pool = pool_arc.read();
 
 		json_response(&PoolInfo {
 			pool_size: pool.total_size(),
@@ -755,7 +756,7 @@ impl PoolPushHandler {
 					);
 
 					//  Push to tx pool.
-					let mut tx_pool = pool_arc.write().unwrap();
+					let mut tx_pool = pool_arc.write();
 					let header = tx_pool.blockchain.chain_head().unwrap();
 					tx_pool
 						.add_to_pool(source, tx, !fluff, &header)

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -18,8 +18,9 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use util::RwLock;
 
 use lmdb;
 use lru_cache::LruCache;
@@ -75,7 +76,7 @@ impl OrphanBlockPool {
 	}
 
 	fn len(&self) -> usize {
-		let orphans = self.orphans.read().unwrap();
+		let orphans = self.orphans.read();
 		orphans.len()
 	}
 
@@ -84,8 +85,8 @@ impl OrphanBlockPool {
 	}
 
 	fn add(&self, orphan: Orphan) {
-		let mut orphans = self.orphans.write().unwrap();
-		let mut height_idx = self.height_idx.write().unwrap();
+		let mut orphans = self.orphans.write();
+		let mut height_idx = self.height_idx.write();
 		{
 			let height_hashes = height_idx
 				.entry(orphan.block.header.height)
@@ -125,15 +126,15 @@ impl OrphanBlockPool {
 	/// Get an orphan from the pool indexed by the hash of its parent, removing
 	/// it at the same time, preventing clone
 	fn remove_by_height(&self, height: &u64) -> Option<Vec<Orphan>> {
-		let mut orphans = self.orphans.write().unwrap();
-		let mut height_idx = self.height_idx.write().unwrap();
+		let mut orphans = self.orphans.write();
+		let mut height_idx = self.height_idx.write();
 		height_idx
 			.remove(height)
 			.map(|hs| hs.iter().filter_map(|h| orphans.remove(h)).collect())
 	}
 
 	pub fn contains(&self, hash: &Hash) -> bool {
-		let orphans = self.orphans.read().unwrap();
+		let orphans = self.orphans.read();
 		orphans.contains_key(hash)
 	}
 }
@@ -220,7 +221,7 @@ impl Chain {
 		let maybe_new_head: Result<Option<Tip>, Error>;
 		{
 			let batch = self.store.batch()?;
-			let mut txhashset = self.txhashset.write().unwrap();
+			let mut txhashset = self.txhashset.write();
 			let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 
 			maybe_new_head = pipe::process_block(&b, &mut ctx);
@@ -233,7 +234,7 @@ impl Chain {
 		let add_to_hash_cache = |hash: Hash| {
 			// only add to hash cache below if block is definitively accepted
 			// or rejected
-			let mut cache = self.block_hashes_cache.write().unwrap();
+			let mut cache = self.block_hashes_cache.write();
 			cache.insert(hash, true);
 		};
 
@@ -300,7 +301,7 @@ impl Chain {
 	/// Process a block header received during "header first" propagation.
 	pub fn process_block_header(&self, bh: &BlockHeader, opts: Options) -> Result<(), Error> {
 		let batch = self.store.batch()?;
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 		pipe::process_block_header(bh, &mut ctx)?;
 		ctx.batch.commit()?;
@@ -316,7 +317,7 @@ impl Chain {
 		opts: Options,
 	) -> Result<(), Error> {
 		let batch = self.store.batch()?;
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 
 		pipe::sync_block_headers(headers, &mut ctx)?;
@@ -417,7 +418,7 @@ impl Chain {
 	/// current chain state, specifically the current winning (valid, most
 	/// work) fork.
 	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<Hash, Error> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let res = txhashset.is_unspent(output_ref);
 		match res {
 			Err(e) => Err(e),
@@ -427,7 +428,7 @@ impl Chain {
 
 	/// Validate the tx against the current UTXO set.
 	pub fn validate_tx(&self, tx: &Transaction) -> Result<(), Error> {
-		let txhashset = self.txhashset.read().unwrap();
+		let txhashset = self.txhashset.read();
 		txhashset::utxo_view(&txhashset, |utxo| {
 			utxo.validate_tx(tx)?;
 			Ok(())
@@ -443,7 +444,7 @@ impl Chain {
 	/// that has not yet sufficiently matured.
 	pub fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), Error> {
 		let height = self.next_block_height()?;
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset::extending_readonly(&mut txhashset, |extension| {
 			extension.verify_coinbase_maturity(&tx.inputs(), height)?;
 			Ok(())
@@ -470,7 +471,7 @@ impl Chain {
 			return Ok(());
 		}
 
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 
 		// Now create an extension from the txhashset and validate against the
 		// latest block header. Rewind the extension to the specified header to
@@ -485,7 +486,7 @@ impl Chain {
 	/// Sets the txhashset roots on a brand new block by applying the block on
 	/// the current txhashset state.
 	pub fn set_txhashset_roots(&self, b: &mut Block, is_fork: bool) -> Result<(), Error> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let (roots, sizes) = txhashset::extending_readonly(&mut txhashset, |extension| {
 			if is_fork {
 				pipe::rewind_and_apply_fork(b, extension)?;
@@ -508,7 +509,7 @@ impl Chain {
 		output: &OutputIdentifier,
 		block_header: &BlockHeader,
 	) -> Result<MerkleProof, Error> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 
 		let merkle_proof = txhashset::extending_readonly(&mut txhashset, |extension| {
 			extension.rewind(&block_header)?;
@@ -521,13 +522,13 @@ impl Chain {
 	/// Return a merkle proof valid for the current output pmmr state at the
 	/// given pos
 	pub fn get_merkle_proof_for_pos(&self, commit: Commitment) -> Result<MerkleProof, String> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset.merkle_proof(commit)
 	}
 
 	/// Returns current txhashset roots
 	pub fn get_txhashset_roots(&self) -> (Hash, Hash, Hash) {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset.roots()
 	}
 
@@ -542,7 +543,7 @@ impl Chain {
 		// to rewind after receiving the txhashset zip.
 		let header = self.get_block_header(&h)?;
 		{
-			let mut txhashset = self.txhashset.write().unwrap();
+			let mut txhashset = self.txhashset.write();
 			txhashset::extending_readonly(&mut txhashset, |extension| {
 				extension.rewind(&header)?;
 				extension.snapshot()?;
@@ -667,7 +668,7 @@ impl Chain {
 
 		// Replace the chain txhashset with the newly built one.
 		{
-			let mut txhashset_ref = self.txhashset.write().unwrap();
+			let mut txhashset_ref = self.txhashset.write();
 			*txhashset_ref = txhashset;
 		}
 
@@ -722,7 +723,7 @@ impl Chain {
 		debug!(LOGGER, "Starting blockchain compaction.");
 		// Compact the txhashset via the extension.
 		{
-			let mut txhashset = self.txhashset.write().unwrap();
+			let mut txhashset = self.txhashset.write();
 			txhashset.compact()?;
 
 			// print out useful debug info after compaction
@@ -786,19 +787,19 @@ impl Chain {
 
 	/// returns the last n nodes inserted into the output sum tree
 	pub fn get_last_n_output(&self, distance: u64) -> Vec<(Hash, OutputIdentifier)> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset.last_n_output(distance)
 	}
 
 	/// as above, for rangeproofs
 	pub fn get_last_n_rangeproof(&self, distance: u64) -> Vec<(Hash, RangeProof)> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset.last_n_rangeproof(distance)
 	}
 
 	/// as above, for kernels
 	pub fn get_last_n_kernel(&self, distance: u64) -> Vec<(Hash, TxKernel)> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		txhashset.last_n_kernel(distance)
 	}
 
@@ -808,7 +809,7 @@ impl Chain {
 		start_index: u64,
 		max: u64,
 	) -> Result<(u64, u64, Vec<Output>), Error> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let max_index = txhashset.highest_output_insertion_index();
 		let outputs = txhashset.outputs_by_insertion_index(start_index, max);
 		let rangeproofs = txhashset.rangeproofs_by_insertion_index(start_index, max);
@@ -895,7 +896,7 @@ impl Chain {
 		&self,
 		output_ref: &OutputIdentifier,
 	) -> Result<BlockHeader, Error> {
-		let mut txhashset = self.txhashset.write().unwrap();
+		let mut txhashset = self.txhashset.write();
 		let (_, pos) = txhashset.is_unspent(output_ref)?;
 		let mut min = 1;
 		let mut max = {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -14,7 +14,8 @@
 
 //! Implementation of the chain block acceptance (or refusal) pipeline.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chrono::prelude::Utc;
 use chrono::Duration;
@@ -288,7 +289,7 @@ fn check_known_head(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), 
 /// Keeps duplicates from the network in check.
 /// Checks against the cache of recently processed block hashes.
 fn check_known_cache(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
-	let mut cache = ctx.block_hashes_cache.write().unwrap();
+	let mut cache = ctx.block_hashes_cache.write();
 	if cache.contains_key(&header.hash()) {
 		return Err(ErrorKind::Unfit("already known in cache".to_string()).into());
 	}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -14,7 +14,8 @@
 
 //! Implements storage primitives required by the chain
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use croaring::Bitmap;
 use lmdb;
@@ -102,7 +103,7 @@ impl ChainStore {
 
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		{
-			let mut header_cache = self.header_cache.write().unwrap();
+			let mut header_cache = self.header_cache.write();
 
 			// cache hit - return the value from the cache
 			if let Some(header) = header_cache.get_mut(h) {
@@ -119,7 +120,7 @@ impl ChainStore {
 		// cache miss - so adding to the cache for next time
 		if let Ok(header) = header {
 			{
-				let mut header_cache = self.header_cache.write().unwrap();
+				let mut header_cache = self.header_cache.write();
 				header_cache.insert(*h, header.clone());
 			}
 			Ok(header)
@@ -415,7 +416,7 @@ impl<'a> Batch<'a> {
 		self.save_block_input_bitmap(&block.hash(), &bitmap)?;
 
 		// Finally cache it locally for use later.
-		let mut cache = self.store.block_input_bitmap_cache.write().unwrap();
+		let mut cache = self.store.block_input_bitmap_cache.write();
 		cache.insert(block.hash(), bitmap.serialize());
 
 		Ok(bitmap)
@@ -423,7 +424,7 @@ impl<'a> Batch<'a> {
 
 	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
 		{
-			let mut cache = self.store.block_input_bitmap_cache.write().unwrap();
+			let mut cache = self.store.block_input_bitmap_cache.write();
 
 			// cache hit - return the value from the cache
 			if let Some(bytes) = cache.get_mut(bh) {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -15,7 +15,6 @@
 //! Implements storage primitives required by the chain
 
 use std::sync::Arc;
-use util::Mutex;
 use util::RwLock;
 
 use croaring::Bitmap;
@@ -47,7 +46,6 @@ const BLOCK_SUMS_PREFIX: u8 = 'M' as u8;
 /// All chain-related database operations
 pub struct ChainStore {
 	db: store::Store,
-	mutex: Mutex<u64>, // add for debug purpose. todo: please delete it
 	header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
 	block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
 }
@@ -58,7 +56,6 @@ impl ChainStore {
 		let db = store::Store::open(db_env, STORE_SUBPATH);
 		Ok(ChainStore {
 			db,
-			mutex: Mutex::new(0),
 			header_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
 			block_input_bitmap_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
 		})
@@ -156,11 +153,6 @@ impl ChainStore {
 
 	/// Builds a new batch to be used with this store.
 	pub fn batch(&self) -> Result<Batch, Error> {
-		//+ add for debug purpose. todo: please delete it
-		let mut locked = self.mutex.lock();
-		*locked += 1;
-		//-
-
 		Ok(Batch {
 			store: self,
 			db: self.db.batch()?,

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -24,7 +24,8 @@ extern crate rand;
 
 use chrono::Duration;
 use std::fs;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chain::types::NoopAdapter;
 use chain::Chain;

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -23,7 +23,8 @@ extern crate rand;
 
 use chrono::Duration;
 use std::fs;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chain::types::NoopAdapter;
 use chain::Chain;

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -23,7 +23,8 @@ extern crate rand;
 
 use chrono::Duration;
 use std::fs;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chain::types::NoopAdapter;
 use chain::ErrorKind;

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -18,6 +18,7 @@ extern crate grin_chain as chain;
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_store as store;
+extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 extern crate rand;
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -20,7 +20,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::iter::FromIterator;
 use std::mem;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use consensus::{self, reward, REWARD};
 use core::committed::{self, Committed};

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -510,7 +510,7 @@ impl Block {
 		let total_kernel_sum = {
 			let zero_commit = secp_static::commit_to_zero_value();
 			let secp = static_secp_instance();
-			let secp = secp.lock().unwrap();
+			let secp = secp.lock();
 			let mut excesses = map_vec!(agg_tx.kernels(), |x| x.excess());
 			excesses.push(prev.total_kernel_sum);
 			excesses.retain(|x| *x != zero_commit);
@@ -684,7 +684,7 @@ impl Block {
 
 		{
 			let secp = static_secp_instance();
-			let secp = secp.lock().unwrap();
+			let secp = secp.lock();
 			let over_commit = secp.commit_value(reward(self.total_fees()))?;
 
 			let out_adjust_sum = secp.commit_sum(

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -66,7 +66,7 @@ pub trait Committed {
 		// commit to zero built from the offset
 		let kernel_sum_plus_offset = {
 			let secp = static_secp_instance();
-			let secp = secp.lock().unwrap();
+			let secp = secp.lock();
 			let mut commits = vec![kernel_sum];
 			if *offset != BlindingFactor::zero() {
 				let key = offset.secret_key(&secp)?;
@@ -90,7 +90,7 @@ pub trait Committed {
 		if overage != 0 {
 			let over_commit = {
 				let secp = static_secp_instance();
-				let secp = secp.lock().unwrap();
+				let secp = secp.lock();
 				let overage_abs = overage.checked_abs().ok_or_else(|| Error::InvalidValue)? as u64;
 				secp.commit_value(overage_abs).unwrap()
 			};
@@ -144,7 +144,7 @@ pub fn sum_commits(
 	positive.retain(|x| *x != zero_commit);
 	negative.retain(|x| *x != zero_commit);
 	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
+	let secp = secp.lock();
 	Ok(secp.commit_sum(positive, negative)?)
 }
 
@@ -156,7 +156,7 @@ pub fn sum_kernel_offsets(
 	negative: Vec<BlindingFactor>,
 ) -> Result<BlindingFactor, Error> {
 	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
+	let secp = secp.lock();
 	let positive = to_secrets(positive, &secp);
 	let negative = to_secrets(negative, &secp);
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -17,8 +17,9 @@
 use std::cmp::max;
 use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::{error, fmt};
+use util::RwLock;
 
 use consensus::{self, VerifySortOrder};
 use core::hash::Hashed;
@@ -544,7 +545,7 @@ impl TransactionBody {
 
 		// Find all the outputs that have not had their rangeproofs verified.
 		let outputs = {
-			let mut verifier = verifier.write().unwrap();
+			let mut verifier = verifier.write();
 			verifier.filter_rangeproof_unverified(&self.outputs)
 		};
 
@@ -561,7 +562,7 @@ impl TransactionBody {
 
 		// Find all the kernels that have not yet been verified.
 		let kernels = {
-			let mut verifier = verifier.write().unwrap();
+			let mut verifier = verifier.write();
 			verifier.filter_kernel_sig_unverified(&self.kernels)
 		};
 
@@ -574,7 +575,7 @@ impl TransactionBody {
 
 		// Cache the successful verification results for the new outputs and kernels.
 		{
-			let mut verifier = verifier.write().unwrap();
+			let mut verifier = verifier.write();
 			verifier.add_rangeproof_verified(outputs);
 			verifier.add_kernel_sig_verified(kernels);
 		}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -198,7 +198,7 @@ impl TxKernel {
 	pub fn verify(&self) -> Result<(), secp::Error> {
 		let msg = Message::from_slice(&kernel_sig_msg(self.fee, self.lock_height))?;
 		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
+		let secp = secp.lock();
 		let sig = &self.excess_sig;
 		// Verify aggsig directly in libsecp
 		let pubkey = &self.excess.to_pubkey(&secp)?;
@@ -903,7 +903,7 @@ pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transact
 	// now compute the total kernel offset
 	let total_kernel_offset = {
 		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
+		let secp = secp.lock();
 		let mut positive_key = vec![mk_tx.offset]
 			.into_iter()
 			.filter(|x| *x != BlindingFactor::zero())
@@ -1084,7 +1084,7 @@ impl Output {
 	/// Validates the range proof using the commitment
 	pub fn verify_proof(&self) -> Result<(), secp::Error> {
 		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
+		let secp = secp.lock();
 		match secp.verify_bullet_proof(self.commit, self.proof, None) {
 			Ok(_) => Ok(()),
 			Err(e) => Err(e),
@@ -1097,7 +1097,7 @@ impl Output {
 		proofs: &Vec<RangeProof>,
 	) -> Result<(), secp::Error> {
 		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
+		let secp = secp.lock();
 		match secp.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None) {
 			Ok(_) => Ok(()),
 			Err(e) => Err(e),

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -27,7 +27,7 @@ use pow::{self, CuckooContext, Difficulty, EdgeType, PoWContext};
 /// code wherever mining is needed. This should allow for
 /// different sets of parameters for different purposes,
 /// e.g. CI, User testing, production values
-use std::sync::RwLock;
+use util::RwLock;
 
 /// Define these here, as they should be developer-set, not really tweakable
 /// by users
@@ -114,7 +114,7 @@ lazy_static!{
 
 /// Set the mining mode
 pub fn set_mining_mode(mode: ChainTypes) {
-	let mut param_ref = CHAIN_TYPE.write().unwrap();
+	let mut param_ref = CHAIN_TYPE.write();
 	*param_ref = mode;
 }
 
@@ -138,7 +138,7 @@ where
 
 /// The minimum acceptable sizeshift
 pub fn min_sizeshift() -> u8 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_MIN_SIZESHIFT,
 		ChainTypes::UserTesting => USER_TESTING_MIN_SIZESHIFT,
@@ -151,7 +151,7 @@ pub fn min_sizeshift() -> u8 {
 /// while the min_sizeshift can be changed on a soft fork, changing
 /// ref_sizeshift is a hard fork.
 pub fn ref_sizeshift() -> u8 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_MIN_SIZESHIFT,
 		ChainTypes::UserTesting => USER_TESTING_MIN_SIZESHIFT,
@@ -162,7 +162,7 @@ pub fn ref_sizeshift() -> u8 {
 
 /// The proofsize
 pub fn proofsize() -> usize {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_PROOF_SIZE,
 		ChainTypes::UserTesting => USER_TESTING_PROOF_SIZE,
@@ -172,7 +172,7 @@ pub fn proofsize() -> usize {
 
 /// Coinbase maturity for coinbases to be spent at given height
 pub fn coinbase_maturity(height: u64) -> u64 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_COINBASE_MATURITY,
 		ChainTypes::UserTesting => USER_TESTING_COINBASE_MATURITY,
@@ -186,7 +186,7 @@ pub fn coinbase_maturity(height: u64) -> u64 {
 
 /// Initial mining difficulty
 pub fn initial_block_difficulty() -> u64 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => TESTING_INITIAL_DIFFICULTY,
 		ChainTypes::UserTesting => TESTING_INITIAL_DIFFICULTY,
@@ -199,7 +199,7 @@ pub fn initial_block_difficulty() -> u64 {
 
 /// Horizon at which we can cut-through and do full local pruning
 pub fn cut_through_horizon() -> u32 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		ChainTypes::AutomatedTesting => TESTING_CUT_THROUGH_HORIZON,
 		ChainTypes::UserTesting => TESTING_CUT_THROUGH_HORIZON,
@@ -209,19 +209,19 @@ pub fn cut_through_horizon() -> u32 {
 
 /// Are we in automated testing mode?
 pub fn is_automated_testing_mode() -> bool {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	ChainTypes::AutomatedTesting == *param_ref
 }
 
 /// Are we in user testing mode?
 pub fn is_user_testing_mode() -> bool {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	ChainTypes::UserTesting == *param_ref
 }
 
 /// Are we in production mode (a live public network)?
 pub fn is_production_mode() -> bool {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	ChainTypes::Testnet1 == *param_ref
 		|| ChainTypes::Testnet2 == *param_ref
 		|| ChainTypes::Testnet3 == *param_ref
@@ -233,7 +233,7 @@ pub fn is_production_mode() -> bool {
 /// as the genesis block POW solution turns out to be the same for every new
 /// block chain at the moment
 pub fn get_genesis_nonce() -> u64 {
-	let param_ref = CHAIN_TYPE.read().unwrap();
+	let param_ref = CHAIN_TYPE.read();
 	match *param_ref {
 		// won't make a difference
 		ChainTypes::AutomatedTesting => 0,

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -18,8 +18,9 @@ extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Instant;
+use util::RwLock;
 
 pub mod common;
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -18,7 +18,8 @@ extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 pub mod common;
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -351,7 +351,7 @@ fn blind_tx() {
 	let Output { proof, .. } = btx.outputs()[0];
 
 	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
+	let secp = secp.lock();
 	let info = secp.range_proof_info(proof);
 
 	assert!(info.min == 0);

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -18,7 +18,8 @@ extern crate grin_keychain as keychain;
 extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 pub mod common;
 
@@ -48,20 +49,20 @@ fn test_verifier_cache_rangeproofs() {
 
 	// Check our output is not verified according to the cache.
 	{
-		let mut cache = cache.write().unwrap();
+		let mut cache = cache.write();
 		let unverified = cache.filter_rangeproof_unverified(&vec![out]);
 		assert_eq!(unverified, vec![out]);
 	}
 
 	// Add our output to the cache.
 	{
-		let mut cache = cache.write().unwrap();
+		let mut cache = cache.write();
 		cache.add_rangeproof_verified(vec![out]);
 	}
 
 	// Check it shows as verified according to the cache.
 	{
-		let mut cache = cache.write().unwrap();
+		let mut cache = cache.write();
 		let unverified = cache.filter_rangeproof_unverified(&vec![out]);
 		assert_eq!(unverified, vec![]);
 	}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -17,7 +17,8 @@
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use blake2;
 
@@ -166,7 +167,7 @@ impl ExtKeychain {
 		// then check the derivation cache to see if we have previously derived this key
 		// if so use the derivation from the cache to derive the key
 		{
-			let cache = self.key_derivation_cache.read().unwrap();
+			let cache = self.key_derivation_cache.read();
 			if let Some(derivation) = cache.get(key_id) {
 				trace!(
 					LOGGER,
@@ -183,7 +184,7 @@ impl ExtKeychain {
 		// TODO - remove hard limit (within reason)
 		// TODO - do we benefit here if we track our max known n_child?
 		{
-			let mut cache = self.key_derivation_cache.write().unwrap();
+			let mut cache = self.key_derivation_cache.write();
 			for i in 1..100_000 {
 				let child_key = self.extkey.derive(&self.secp, i)?;
 				// let child_key_id = extkey.identifier(&self.secp)?;

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -189,7 +189,7 @@ impl Add for BlindingFactor {
 	//
 	fn add(self, other: BlindingFactor) -> Self::Output {
 		let secp = static_secp_instance();
-		let secp = secp.lock().unwrap();
+		let secp = secp.lock();
 		let keys = vec![self, other]
 			.into_iter()
 			.filter(|x| *x != BlindingFactor::zero())

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -23,8 +23,9 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc};
 use std::{cmp, thread, time};
+use util::Mutex;
 
 use core::ser;
 use msg::{read_body, read_exact, read_header, write_all, write_to_buf, MsgHeader, Type};

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -14,7 +14,8 @@
 
 use std::collections::VecDeque;
 use std::net::{SocketAddr, TcpStream};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use rand::{thread_rng, Rng};
 
@@ -141,7 +142,7 @@ impl Handshake {
 			});
 		} else {
 			// check the nonce to see if we are trying to connect to ourselves
-			let nonces = self.nonces.read().unwrap();
+			let nonces = self.nonces.read();
 			if nonces.contains(&hand.nonce) {
 				return Err(Error::PeerWithSelf);
 			}
@@ -186,7 +187,7 @@ impl Handshake {
 	fn next_nonce(&self) -> u64 {
 		let nonce = thread_rng().gen();
 
-		let mut nonces = self.nonces.write().unwrap();
+		let mut nonces = self.nonces.write();
 		nonces.push_back(nonce);
 		if nonces.len() >= NONCES_CAP {
 			nonces.pop_front();

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -14,7 +14,8 @@
 
 use std::fs::File;
 use std::net::{SocketAddr, TcpStream};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use conn;
 use core::core;
@@ -136,12 +137,12 @@ impl Peer {
 
 	/// Whether this peer has been banned.
 	pub fn is_banned(&self) -> bool {
-		State::Banned == *self.state.read().unwrap()
+		State::Banned == *self.state.read()
 	}
 
 	/// Set this peer status to banned
 	pub fn set_banned(&self) {
-		*self.state.write().unwrap() = State::Banned;
+		*self.state.write() = State::Banned;
 	}
 
 	/// Send a ping to the remote peer, providing our local difficulty and
@@ -326,7 +327,7 @@ impl Peer {
 	}
 
 	fn check_connection(&self) -> bool {
-		let mut state = self.state.write().unwrap();
+		let mut state = self.state.write();
 		match self.connection.as_ref().unwrap().error_channel.try_recv() {
 			Ok(Error::Serialization(e)) => {
 				if State::Banned != *state {
@@ -367,14 +368,14 @@ impl TrackingAdapter {
 	}
 
 	fn has(&self, hash: Hash) -> bool {
-		let known = self.known.read().unwrap();
+		let known = self.known.read();
 		// may become too slow, an ordered set (by timestamp for eviction) may
 		// end up being a better choice
 		known.contains(&hash)
 	}
 
 	fn push(&self, hash: Hash) {
-		let mut known = self.known.write().unwrap();
+		let mut known = self.known.write();
 		if known.len() > MAX_TRACK_SIZE {
 			known.truncate(MAX_TRACK_SIZE);
 		}

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -330,7 +330,7 @@ impl Peer {
 		match self.connection.as_ref().unwrap().error_channel.try_recv() {
 			Ok(Error::Serialization(e)) => {
 				let need_stop = {
-					let mut state = self.state.write().unwrap();
+					let mut state = self.state.write();
 					if State::Banned != *state {
 						*state = State::Disconnected;
 						true
@@ -349,7 +349,7 @@ impl Peer {
 			}
 			Ok(e) => {
 				let need_stop = {
-					let mut state = self.state.write().unwrap();
+					let mut state = self.state.write();
 					if State::Disconnected != *state {
 						*state = State::Disconnected;
 						true
@@ -364,7 +364,7 @@ impl Peer {
 				false
 			}
 			Err(_) => {
-				let state = self.state.read().unwrap();
+				let state = self.state.read();
 				State::Connected == *state
 			}
 		}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -15,9 +15,10 @@
 use std::fs::File;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use std::{io, thread};
+use util::RwLock;
 
 use lmdb;
 
@@ -187,7 +188,7 @@ impl Server {
 					self.peers.clone(),
 				)?));
 				{
-					let mut peer = peer.write().unwrap();
+					let mut peer = peer.write();
 					peer.start(stream);
 				}
 				self.peers.add_connected(peer.clone())?;
@@ -219,7 +220,7 @@ impl Server {
 			self.peers.clone(),
 		)?));
 		{
-			let mut peer = peer.write().unwrap();
+			let mut peer = peer.write();
 			peer.start(stream);
 		}
 		self.peers.add_connected(peer)?;

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -90,7 +90,7 @@ fn peer_handshake() {
 	thread::sleep(time::Duration::from_secs(1));
 
 	let server_peer = server.peers.get_connected_peer(&my_addr).unwrap();
-	let server_peer = server_peer.read().unwrap();
+	let server_peer = server_peer.read();
 	assert_eq!(server_peer.info.total_difficulty, Difficulty::one());
 	assert!(server.peers.peer_count() > 0);
 }

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -16,7 +16,8 @@
 //! Used for both the txpool and stempool layers in the pool.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use core::consensus;
 use core::core::hash::{Hash, Hashed};

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -17,7 +17,8 @@
 //! resulting tx pool can be added to the current chain state to produce a
 //! valid chain state.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chrono::prelude::Utc;
 

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -25,7 +25,8 @@ extern crate rand;
 
 pub mod common;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use core::core::verifier_cache::LruVerifierCache;
 use core::core::{Block, BlockHeader, Transaction};
@@ -81,7 +82,7 @@ fn test_transaction_pool_block_building() {
 	let child_tx_2 = test_transaction(&keychain, vec![38], vec![32]);
 
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 
 		// Add the three root txs to the pool.
 		write_pool
@@ -106,7 +107,7 @@ fn test_transaction_pool_block_building() {
 	}
 
 	let txs = {
-		let read_pool = pool.read().unwrap();
+		let read_pool = pool.read();
 		read_pool.prepare_mineable_transactions().unwrap()
 	};
 	// children should have been aggregated into parents
@@ -124,7 +125,7 @@ fn test_transaction_pool_block_building() {
 	// Now reconcile the transaction pool with the new block
 	// and check the resulting contents of the pool are what we expect.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		write_pool.reconcile_block(&block).unwrap();
 
 		assert_eq!(write_pool.total_size(), 0);

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -25,7 +25,8 @@ extern crate rand;
 
 pub mod common;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use core::core::{Block, BlockHeader};
 
@@ -127,7 +128,7 @@ fn test_transaction_pool_block_reconciliation() {
 	// First we add the above transactions to the pool.
 	// All should be accepted.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		assert_eq!(write_pool.total_size(), 0);
 
 		for tx in &txs_to_add {
@@ -165,13 +166,13 @@ fn test_transaction_pool_block_reconciliation() {
 
 	// Check the pool still contains everything we expect at this point.
 	{
-		let write_pool = pool.write().unwrap();
+		let write_pool = pool.write();
 		assert_eq!(write_pool.total_size(), txs_to_add.len());
 	}
 
 	// And reconcile the pool with this latest block.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		write_pool.reconcile_block(&block).unwrap();
 
 		assert_eq!(write_pool.total_size(), 4);

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -25,7 +25,8 @@ extern crate rand;
 
 pub mod common;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use common::*;
 use core::core::hash::Hash;
@@ -83,7 +84,7 @@ fn test_coinbase_maturity() {
 	let pool = RwLock::new(test_setup(chain, verifier_cache));
 
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		let tx = test_transaction(&keychain, vec![50], vec![49]);
 		match write_pool.add_to_pool(test_source(), tx.clone(), true, &BlockHeader::default()) {
 			Err(PoolError::ImmatureCoinbase) => {}

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -28,7 +28,8 @@ extern crate rand;
 
 use std::collections::HashSet;
 use std::fs;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use core::core::hash::{Hash, Hashed};
 use core::core::verifier_cache::VerifierCache;
@@ -98,7 +99,7 @@ impl ChainAdapter {
 		batch.commit().unwrap();
 
 		{
-			let mut utxo = self.utxo.write().unwrap();
+			let mut utxo = self.utxo.write();
 			for x in block.inputs() {
 				utxo.remove(&x.commitment());
 			}
@@ -129,7 +130,7 @@ impl BlockChain for ChainAdapter {
 	}
 
 	fn validate_tx(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		let utxo = self.utxo.read().unwrap();
+		let utxo = self.utxo.read();
 
 		for x in tx.outputs() {
 			if utxo.contains(&x.commitment()) {

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -25,7 +25,8 @@ extern crate rand;
 
 pub mod common;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use common::*;
 use core::core::verifier_cache::LruVerifierCache;
@@ -72,7 +73,7 @@ fn test_the_transaction_pool() {
 
 	// Add this tx to the pool (stem=false, direct to txpool).
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		write_pool
 			.add_to_pool(test_source(), initial_tx, false, &header)
 			.unwrap();
@@ -86,7 +87,7 @@ fn test_the_transaction_pool() {
 
 	// Take a write lock and add a couple of tx entries to the pool.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 
 		// Check we have a single initial tx in the pool.
 		assert_eq!(write_pool.total_size(), 1);
@@ -110,7 +111,7 @@ fn test_the_transaction_pool() {
 	// This will fail during tx aggregation due to duplicate outputs and duplicate
 	// kernels.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		assert!(
 			write_pool
 				.add_to_pool(test_source(), tx1.clone(), true, &header)
@@ -122,7 +123,7 @@ fn test_the_transaction_pool() {
 	// tx).
 	{
 		let tx1a = test_transaction(&keychain, vec![500, 600], vec![499, 599]);
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		assert!(
 			write_pool
 				.add_to_pool(test_source(), tx1a, true, &header)
@@ -133,7 +134,7 @@ fn test_the_transaction_pool() {
 	// Test adding a tx attempting to spend a non-existent output.
 	{
 		let bad_tx = test_transaction(&keychain, vec![10_001], vec![10_000]);
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		assert!(
 			write_pool
 				.add_to_pool(test_source(), bad_tx, true, &header)
@@ -147,7 +148,7 @@ fn test_the_transaction_pool() {
 	// to be immediately stolen via a "replay" tx.
 	{
 		let tx = test_transaction(&keychain, vec![900], vec![498]);
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		assert!(
 			write_pool
 				.add_to_pool(test_source(), tx, true, &header)
@@ -157,7 +158,7 @@ fn test_the_transaction_pool() {
 
 	// Confirm the tx pool correctly identifies an invalid tx (already spent).
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		let tx3 = test_transaction(&keychain, vec![500], vec![497]);
 		assert!(
 			write_pool
@@ -171,7 +172,7 @@ fn test_the_transaction_pool() {
 	// Check we can take some entries from the stempool and "fluff" them into the
 	// txpool. This also exercises multi-kernel txs.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 		let agg_tx = write_pool
 			.stempool
 			.aggregate_transaction()
@@ -189,7 +190,7 @@ fn test_the_transaction_pool() {
 	// We will do this be adding a new tx to the pool
 	// that is a superset of a tx already in the pool.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 
 		let tx4 = test_transaction(&keychain, vec![800], vec![799]);
 		// tx1 and tx2 are already in the txpool (in aggregated form)
@@ -210,7 +211,7 @@ fn test_the_transaction_pool() {
 	// Check we cannot "double spend" an output spent in a previous block.
 	// We use the initial coinbase output here for convenience.
 	{
-		let mut write_pool = pool.write().unwrap();
+		let mut write_pool = pool.write();
 
 		let double_spend_tx =
 			{ test_transaction_spending_coinbase(&keychain, &header, vec![1000]) };

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -34,3 +34,6 @@ grin_wallet = { path = "../wallet" }
 [dev-dependencies]
 blake2-rfc = "0.2"
 grin_config = { path = "../config" }
+
+[features]
+deadlock_detection = []

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -16,8 +16,9 @@
 //! to collect information about server status
 
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::SystemTime;
+use util::RwLock;
 
 use chain;
 use common::types::SyncStatus;

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -14,7 +14,8 @@
 
 //! Server types
 use std::convert::From;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use api;
 use chain;
@@ -292,12 +293,12 @@ impl SyncState {
 	/// Whether the current state matches any active syncing operation.
 	/// Note: This includes our "initial" state.
 	pub fn is_syncing(&self) -> bool {
-		*self.current.read().unwrap() != SyncStatus::NoSync
+		*self.current.read() != SyncStatus::NoSync
 	}
 
 	/// Current syncing status
 	pub fn status(&self) -> SyncStatus {
-		*self.current.read().unwrap()
+		*self.current.read()
 	}
 
 	/// Update the syncing status
@@ -306,7 +307,7 @@ impl SyncState {
 			return;
 		}
 
-		let mut status = self.current.write().unwrap();
+		let mut status = self.current.write();
 
 		debug!(
 			LOGGER,
@@ -318,7 +319,7 @@ impl SyncState {
 
 	/// Communicate sync error
 	pub fn set_sync_error(&self, error: Error) {
-		*self.sync_error.write().unwrap() = Some(error);
+		*self.sync_error.write() = Some(error);
 	}
 
 	/// Get sync error
@@ -328,7 +329,7 @@ impl SyncState {
 
 	/// Clear sync error
 	pub fn clear_sync_error(&self) {
-		*self.sync_error.write().unwrap() = None;
+		*self.sync_error.write() = None;
 	}
 }
 
@@ -338,7 +339,7 @@ impl chain::TxHashsetWriteStatus for SyncState {
 	}
 
 	fn on_validation(&self, vkernels: u64, vkernel_total: u64, vrproofs: u64, vrproof_total: u64) {
-		let mut status = self.current.write().unwrap();
+		let mut status = self.current.write();
 		match *status {
 			SyncStatus::TxHashsetValidation {
 				kernels,

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -15,9 +15,10 @@
 use chrono::prelude::Utc;
 use rand::{thread_rng, Rng};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use util::RwLock;
 
 use core::core::hash::Hashed;
 use core::core::transaction;
@@ -88,7 +89,7 @@ fn process_stem_phase(
 	tx_pool: Arc<RwLock<TransactionPool>>,
 	verifier_cache: Arc<RwLock<VerifierCache>>,
 ) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write().unwrap();
+	let mut tx_pool = tx_pool.write();
 
 	let header = tx_pool.blockchain.chain_head()?;
 
@@ -135,7 +136,7 @@ fn process_fluff_phase(
 	tx_pool: Arc<RwLock<TransactionPool>>,
 	verifier_cache: Arc<RwLock<VerifierCache>>,
 ) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write().unwrap();
+	let mut tx_pool = tx_pool.write();
 
 	let header = tx_pool.blockchain.chain_head()?;
 
@@ -174,7 +175,7 @@ fn process_fresh_entries(
 	dandelion_config: DandelionConfig,
 	tx_pool: Arc<RwLock<TransactionPool>>,
 ) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write().unwrap();
+	let mut tx_pool = tx_pool.write();
 
 	let mut rng = thread_rng();
 
@@ -214,7 +215,7 @@ fn process_expired_entries(
 
 	let mut expired_entries = vec![];
 	{
-		let tx_pool = tx_pool.read().unwrap();
+		let tx_pool = tx_pool.read();
 		for entry in tx_pool
 			.stempool
 			.entries
@@ -238,7 +239,7 @@ fn process_expired_entries(
 		);
 
 		{
-			let mut tx_pool = tx_pool.write().unwrap();
+			let mut tx_pool = tx_pool.write();
 			let header = tx_pool.blockchain.chain_head()?;
 
 			for entry in expired_entries {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -149,7 +149,7 @@ fn monitor_peers(
 	// ask them for their list of peers
 	let mut connected_peers: Vec<SocketAddr> = vec![];
 	for p in peers.connected_peers() {
-		if let Ok(p) = p.try_read() {
+		if let Some(p) = p.try_read() {
 			debug!(
 				LOGGER,
 				"monitor_peers: {}:{} ask {} for more peers", config.host, config.port, p.info.addr,
@@ -276,7 +276,7 @@ fn listen_for_addrs(
 				for _ in 0..3 {
 					match p2p_c.connect(&addr) {
 						Ok(p) => {
-							if let Ok(p) = p.try_read() {
+							if let Some(p) = p.try_read() {
 								let _ = p.send_peer_request(capab);
 							}
 							let _ = peers_c.update_state(addr, p2p::State::Healthy);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -18,8 +18,9 @@
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::{thread, time};
+use util::RwLock;
 
 use api;
 use chain;
@@ -80,7 +81,7 @@ impl Server {
 			if let Some(s) = enable_stratum_server {
 				if s {
 					{
-						let mut stratum_stats = serv.state_info.stratum_stats.write().unwrap();
+						let mut stratum_stats = serv.state_info.stratum_stats.write();
 						stratum_stats.is_enabled = true;
 					}
 					serv.start_stratum_server(c.clone());
@@ -386,7 +387,7 @@ impl Server {
 	/// other
 	/// consumers
 	pub fn get_server_stats(&self) -> Result<ServerStats, Error> {
-		let stratum_stats = self.state_info.stratum_stats.read().unwrap().clone();
+		let stratum_stats = self.state_info.stratum_stats.read().clone();
 		let awaiting_peers = self.state_info.awaiting_peers.load(Ordering::Relaxed);
 
 		// Fill out stats on our current difficulty calculation
@@ -444,7 +445,7 @@ impl Server {
 			.connected_peers()
 			.into_iter()
 			.map(|p| {
-				let p = p.read().unwrap();
+				let p = p.read();
 				PeerStats::from_peer(&p)
 			}).collect();
 		Ok(ServerStats {

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -159,7 +159,7 @@ impl BodySync {
 					self.peers.more_work_peer()
 				};
 				if let Some(peer) = peer {
-					if let Ok(peer) = peer.try_read() {
+					if let Some(peer) = peer.try_read() {
 						if let Err(e) = peer.send_block_request(*hash) {
 							debug!(LOGGER, "Skipped request to {}: {:?}", peer.info.addr, e);
 						} else {

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -124,7 +124,7 @@ impl HeaderSync {
 			let difficulty = header_head.total_difficulty;
 
 			if let Some(peer) = self.peers.most_work_peer() {
-				if let Ok(p) = peer.try_read() {
+				if let Some(p) = peer.try_read() {
 					let peer_difficulty = p.info.total_difficulty.clone();
 					if peer_difficulty > difficulty {
 						self.request_headers(&p);

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -14,7 +14,8 @@
 
 use chrono::prelude::{DateTime, Utc};
 use chrono::Duration;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chain;
 use common::types::{Error, SyncState, SyncStatus};
@@ -76,7 +77,7 @@ impl StateSync {
 		// check sync error
 		{
 			let clone = self.sync_state.sync_error();
-			if let Some(ref sync_error) = *clone.read().unwrap() {
+			if let Some(ref sync_error) = *clone.read() {
 				error!(
 					LOGGER,
 					"fast_sync: error = {:?}. restart fast sync", sync_error
@@ -88,7 +89,7 @@ impl StateSync {
 
 		// check peer connection status of this sync
 		if let Some(ref peer) = self.fast_sync_peer {
-			if let Ok(p) = peer.try_read() {
+			if let Some(p) = peer.try_read() {
 				if !p.is_connected() && SyncStatus::TxHashsetDownload == self.sync_state.status() {
 					sync_need_restart = true;
 					info!(
@@ -135,7 +136,7 @@ impl StateSync {
 		let horizon = global::cut_through_horizon() as u64;
 
 		if let Some(peer) = self.peers.most_work_peer() {
-			if let Ok(p) = peer.try_read() {
+			if let Some(p) = peer.try_read() {
 				// ask for txhashset at 90% of horizon, this still leaves time for download
 				// and validation to happen and stay within horizon
 				let mut txhashset_head = self

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -159,7 +159,7 @@ fn needs_syncing(
 	// difficulty than us
 	if is_syncing {
 		if let Some(peer) = peer {
-			if let Ok(peer) = peer.try_read() {
+			if let Some(peer) = peer.try_read() {
 				most_work_height = peer.info.height;
 
 				if peer.info.total_difficulty <= local_diff {
@@ -182,7 +182,7 @@ fn needs_syncing(
 		}
 	} else {
 		if let Some(peer) = peer {
-			if let Ok(peer) = peer.try_read() {
+			if let Some(peer) = peer.try_read() {
 				most_work_height = peer.info.height;
 
 				// sum the last 5 difficulties to give us the threshold

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -17,9 +17,10 @@
 
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use rand::{thread_rng, Rng};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use util::RwLock;
 
 use chain;
 use common::types::Error;
@@ -112,7 +113,6 @@ fn build_block(
 	// TODO - we have a lot of unwrap() going on in this fn...
 	let txs = tx_pool
 		.read()
-		.unwrap()
 		.prepare_mineable_transactions()
 		.unwrap();
 

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -21,9 +21,10 @@ use serde_json::Value;
 use std::error::Error;
 use std::io::{BufRead, ErrorKind, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use std::{cmp, thread};
+use util::Mutex;
 use util::RwLock;
 
 use chain;
@@ -122,7 +123,7 @@ fn accept_workers(
 					.set_nonblocking(true)
 					.expect("set_nonblocking call failed");
 				let mut worker = Worker::new(worker_id.to_string(), BufStream::new(stream));
-				workers.lock().unwrap().push(worker);
+				workers.lock().push(worker);
 				// stats for this worker (worker stat objects are added and updated but never
 				// removed)
 				let mut worker_stats = WorkerStats::default();
@@ -285,7 +286,7 @@ impl StratumServer {
 
 	// Handle an RPC request message from the worker(s)
 	fn handle_rpc_requests(&mut self, stratum_stats: &mut Arc<RwLock<StratumStats>>) {
-		let mut workers_l = self.workers.lock().unwrap();
+		let mut workers_l = self.workers.lock();
 		for num in 0..workers_l.len() {
 			match workers_l[num].read_message() {
 				Some(the_message) => {
@@ -580,7 +581,7 @@ impl StratumServer {
 	// Purge dead/sick workers - remove all workers marked in error state
 	fn clean_workers(&mut self, stratum_stats: &mut Arc<RwLock<StratumStats>>) -> usize {
 		let mut start = 0;
-		let mut workers_l = self.workers.lock().unwrap();
+		let mut workers_l = self.workers.lock();
 		loop {
 			for num in start..workers_l.len() {
 				if workers_l[num].error == true {
@@ -637,7 +638,7 @@ impl StratumServer {
 		// Push the new block to all connected clients
 		// NOTE: We do not give a unique nonce (should we?) so miners need
 		//       to choose one for themselves
-		let mut workers_l = self.workers.lock().unwrap();
+		let mut workers_l = self.workers.lock();
 		for num in 0..workers_l.len() {
 			workers_l[num].write_message(job_request_json.clone());
 		}

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -21,9 +21,10 @@ use serde_json::Value;
 use std::error::Error;
 use std::io::{BufRead, ErrorKind, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use std::{cmp, thread};
+use util::RwLock;
 
 use chain;
 use common::stats::{StratumStats, WorkerStats};
@@ -128,7 +129,7 @@ fn accept_workers(
 				worker_stats.is_connected = true;
 				worker_stats.id = worker_id.to_string();
 				worker_stats.pow_difficulty = 1; // XXX TODO
-				let mut stratum_stats = stratum_stats.write().unwrap();
+				let mut stratum_stats = stratum_stats.write();
 				stratum_stats.worker_stats.push(worker_stats);
 				worker_id = worker_id + 1;
 			}
@@ -305,7 +306,7 @@ impl StratumServer {
 						}
 					};
 
-					let mut stratum_stats = stratum_stats.write().unwrap();
+					let mut stratum_stats = stratum_stats.write();
 					let worker_stats_id = stratum_stats
 						.worker_stats
 						.iter()
@@ -590,7 +591,7 @@ impl StratumServer {
 						workers_l[num].id;
 	                                );
 					// Update worker stats
-					let mut stratum_stats = stratum_stats.write().unwrap();
+					let mut stratum_stats = stratum_stats.write();
 					let worker_stats_id = stratum_stats
 						.worker_stats
 						.iter()
@@ -604,7 +605,7 @@ impl StratumServer {
 				start = num + 1;
 			}
 			if start >= workers_l.len() {
-				let mut stratum_stats = stratum_stats.write().unwrap();
+				let mut stratum_stats = stratum_stats.write();
 				stratum_stats.num_workers = workers_l.len();
 				return stratum_stats.num_workers;
 			}
@@ -688,7 +689,7 @@ impl StratumServer {
 
 		// We have started
 		{
-			let mut stratum_stats = stratum_stats.write().unwrap();
+			let mut stratum_stats = stratum_stats.write();
 			stratum_stats.is_running = true;
 			stratum_stats.cuckoo_size = cuckoo_size as u16;
 		}
@@ -750,7 +751,7 @@ impl StratumServer {
 				deadline = Utc::now().timestamp() + attempt_time_per_block as i64;
 
 				{
-					let mut stratum_stats = stratum_stats.write().unwrap();
+					let mut stratum_stats = stratum_stats.write();
 					stratum_stats.block_height = new_block.header.height;
 					stratum_stats.network_difficulty = self.current_difficulty;
 				}

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -19,7 +19,8 @@
 
 use chrono::prelude::Utc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use chain;
 use common::types::StratumServerConfig;

--- a/servers/tests/api.rs
+++ b/servers/tests/api.rs
@@ -26,8 +26,9 @@ extern crate grin_wallet as wallet;
 
 mod framework;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{thread, time};
+use util::Mutex;
 
 use core::global::{self, ChainTypes};
 
@@ -52,7 +53,7 @@ fn simple_server_wallet() {
 	));
 
 	let _ = thread::spawn(move || {
-		let mut w = coinbase_wallet.lock().unwrap();
+		let mut w = coinbase_wallet.lock();
 		w.run_wallet(0);
 	});
 

--- a/servers/tests/dandelion.rs
+++ b/servers/tests/dandelion.rs
@@ -27,8 +27,9 @@ extern crate grin_wallet as wallet;
 mod framework;
 
 use framework::{LocalServerContainer, LocalServerContainerConfig};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{thread, time};
+use util::Mutex;
 
 use util::LOGGER;
 
@@ -56,12 +57,12 @@ fn test_dandelion_timeout() {
 	let coinbase_wallet = Arc::new(Mutex::new(
 		LocalServerContainer::new(coinbase_config).unwrap(),
 	));
-	let coinbase_wallet_config = { coinbase_wallet.lock().unwrap().wallet_config.clone() };
+	let coinbase_wallet_config = { coinbase_wallet.lock().wallet_config.clone() };
 
 	let coinbase_seed = LocalServerContainer::get_wallet_seed(&coinbase_wallet_config);
 
 	let _ = thread::spawn(move || {
-		let mut w = coinbase_wallet.lock().unwrap();
+		let mut w = coinbase_wallet.lock();
 		w.run_wallet(0);
 	});
 
@@ -71,12 +72,12 @@ fn test_dandelion_timeout() {
 	recp_config.wallet_port = 20002;
 	let target_wallet = Arc::new(Mutex::new(LocalServerContainer::new(recp_config).unwrap()));
 	let target_wallet_cloned = target_wallet.clone();
-	let recp_wallet_config = { target_wallet.lock().unwrap().wallet_config.clone() };
+	let recp_wallet_config = { target_wallet.lock().wallet_config.clone() };
 
 	let recp_seed = LocalServerContainer::get_wallet_seed(&recp_wallet_config);
 	//Start up a second wallet, to receive
 	let _ = thread::spawn(move || {
-		let mut w = target_wallet_cloned.lock().unwrap();
+		let mut w = target_wallet_cloned.lock();
 		w.run_wallet(0);
 	});
 

--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -25,8 +25,9 @@ extern crate blake2_rfc as blake2;
 
 use std::default::Default;
 use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{fs, thread, time};
+use util::Mutex;
 
 use wallet::{FileWallet, HTTPWalletClient, WalletConfig};
 
@@ -530,7 +531,7 @@ impl LocalServerContainerPool {
 					thread::sleep(time::Duration::from_millis(2000));
 				}
 				let server_ref = s.run_server(run_length);
-				return_container_ref.lock().unwrap().push(server_ref);
+				return_container_ref.lock().push(server_ref);
 			});
 			// Not a big fan of sleeping hack here, but there appears to be a
 			// concurrency issue when creating files in rocksdb that causes
@@ -573,7 +574,7 @@ impl LocalServerContainerPool {
 }
 
 pub fn stop_all_servers(servers: Arc<Mutex<Vec<servers::Server>>>) {
-	let locked_servs = servers.lock().unwrap();
+	let locked_servs = servers.lock();
 	for s in locked_servs.deref() {
 		s.stop();
 	}

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -24,8 +24,9 @@ extern crate grin_wallet as wallet;
 mod framework;
 
 use std::default::Default;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{thread, time};
+use util::Mutex;
 
 use core::core::hash::Hashed;
 use core::global::{self, ChainTypes};

--- a/servers/tests/wallet.rs
+++ b/servers/tests/wallet.rs
@@ -27,8 +27,9 @@ extern crate grin_wallet as wallet;
 mod framework;
 
 use framework::{LocalServerContainer, LocalServerContainerConfig};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{thread, time};
+use util::Mutex;
 
 use util::LOGGER;
 
@@ -55,11 +56,11 @@ fn basic_wallet_transactions() {
 	let coinbase_wallet = Arc::new(Mutex::new(
 		LocalServerContainer::new(coinbase_config).unwrap(),
 	));
-	let coinbase_wallet_config = { coinbase_wallet.lock().unwrap().wallet_config.clone() };
+	let coinbase_wallet_config = { coinbase_wallet.lock().wallet_config.clone() };
 
 	let coinbase_seed = LocalServerContainer::get_wallet_seed(&coinbase_wallet_config);
 	let _ = thread::spawn(move || {
-		let mut w = coinbase_wallet.lock().unwrap();
+		let mut w = coinbase_wallet.lock();
 		w.run_wallet(0);
 	});
 
@@ -69,11 +70,11 @@ fn basic_wallet_transactions() {
 	recp_config.wallet_port = 20002;
 	let target_wallet = Arc::new(Mutex::new(LocalServerContainer::new(recp_config).unwrap()));
 	let target_wallet_cloned = target_wallet.clone();
-	let recp_wallet_config = { target_wallet.lock().unwrap().wallet_config.clone() };
+	let recp_wallet_config = { target_wallet.lock().wallet_config.clone() };
 	let recp_seed = LocalServerContainer::get_wallet_seed(&recp_wallet_config);
 	//Start up a second wallet, to receive
 	let _ = thread::spawn(move || {
-		let mut w = target_wallet_cloned.lock().unwrap();
+		let mut w = target_wallet_cloned.lock();
 		w.run_wallet(0);
 	});
 

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -18,9 +18,10 @@ use std::io::Read;
 use std::path::PathBuf;
 /// Wallet commands processing
 use std::process::exit;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use util::Mutex;
 
 use clap::ArgMatches;
 

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -17,6 +17,7 @@
 use std::fs;
 use std::marker;
 use std::sync::Arc;
+use util::Mutex;
 
 use lmdb_zero as lmdb;
 use lmdb_zero::traits::CreateCursor;
@@ -79,6 +80,7 @@ pub fn new_env(path: String) -> lmdb::Environment {
 pub struct Store {
 	env: Arc<lmdb::Environment>,
 	db: Arc<lmdb::Database<'static>>,
+	mutex: Mutex<u64>, // add for debug purpose. todo: please delete it
 }
 
 impl Store {
@@ -92,7 +94,11 @@ impl Store {
 				&lmdb::DatabaseOptions::new(lmdb::db::CREATE),
 			).unwrap(),
 		);
-		Store { env, db }
+		Store {
+			env,
+			db,
+			mutex: Mutex::new(0),
+		}
 	}
 
 	/// Gets a value from the db, provided its key
@@ -153,6 +159,11 @@ impl Store {
 
 	/// Builds a new batch to be used with this store.
 	pub fn batch(&self) -> Result<Batch, Error> {
+		//+ add for debug purpose. todo: please delete it
+		let mut locked = self.mutex.lock();
+		*locked += 1;
+		//-
+
 		let txn = lmdb::WriteTransaction::new(self.env.clone())?;
 		Ok(Batch {
 			store: self,

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -18,6 +18,7 @@ slog-term = "~2.4"
 slog-async = "~2.3"
 walkdir = "2"
 zip = "0.4"
+parking_lot = {version = "0.6", features = ["deadlock_detection"]}
 
 [dependencies.secp256k1zkp]
 git = "https://github.com/mimblewimble/rust-secp256k1-zkp"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -41,6 +41,7 @@ extern crate zip as zip_rs;
 // Re-export so only has to be included once
 extern crate parking_lot;
 pub use parking_lot::deadlock;
+pub use parking_lot::Mutex;
 pub use parking_lot::RwLock;
 
 // Re-export so only has to be included once

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -40,6 +40,7 @@ extern crate walkdir;
 extern crate zip as zip_rs;
 // Re-export so only has to be included once
 extern crate parking_lot;
+pub use parking_lot::deadlock;
 pub use parking_lot::RwLock;
 
 // Re-export so only has to be included once

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -38,6 +38,9 @@ extern crate serde;
 extern crate serde_derive;
 extern crate walkdir;
 extern crate zip as zip_rs;
+// Re-export so only has to be included once
+extern crate parking_lot;
+pub use parking_lot::RwLock;
 
 // Re-export so only has to be included once
 pub extern crate secp256k1zkp as secp_;

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -17,7 +17,7 @@ use slog_async;
 use slog_term;
 use std::fs::OpenOptions;
 use std::ops::Deref;
-use std::sync::Mutex;
+use Mutex;
 
 use backtrace::Backtrace;
 use std::{panic, thread};
@@ -46,12 +46,12 @@ lazy_static! {
 
 	/// And a static reference to the logger itself, accessible from all crates
 	pub static ref LOGGER: Logger = {
-		let was_init = WAS_INIT.lock().unwrap().clone();
-		let config = LOGGING_CONFIG.lock().unwrap();
+		let was_init = WAS_INIT.lock().clone();
+		let config = LOGGING_CONFIG.lock();
 		let slog_level_stdout = convert_log_level(&config.stdout_log_level);
 		let slog_level_file = convert_log_level(&config.file_log_level);
 		if config.tui_running.is_some() && config.tui_running.unwrap() {
-			let mut tui_running_ref = TUI_RUNNING.lock().unwrap();
+			let mut tui_running_ref = TUI_RUNNING.lock();
 			*tui_running_ref = true;
 		}
 
@@ -91,10 +91,10 @@ lazy_static! {
 /// Initialize the logger with the given configuration
 pub fn init_logger(config: Option<LoggingConfig>) {
 	if let Some(c) = config {
-		let mut config_ref = LOGGING_CONFIG.lock().unwrap();
+		let mut config_ref = LOGGING_CONFIG.lock();
 		*config_ref = c.clone();
 		// Logger configuration successfully injected into LOGGING_CONFIG...
-		let mut was_init_ref = WAS_INIT.lock().unwrap();
+		let mut was_init_ref = WAS_INIT.lock();
 		*was_init_ref = true;
 		// .. allow logging, having ensured that paths etc are immutable
 	}
@@ -103,14 +103,14 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 
 /// Initializes the logger for unit and integration tests
 pub fn init_test_logger() {
-	let mut was_init_ref = WAS_INIT.lock().unwrap();
+	let mut was_init_ref = WAS_INIT.lock();
 	if *was_init_ref.deref() {
 		return;
 	}
 	let mut logger = LoggingConfig::default();
 	logger.log_to_file = false;
 	logger.stdout_log_level = LogLevel::Debug;
-	let mut config_ref = LOGGING_CONFIG.lock().unwrap();
+	let mut config_ref = LOGGING_CONFIG.lock();
 	*config_ref = logger;
 	*was_init_ref = true;
 }
@@ -149,7 +149,7 @@ fn send_panic_to_log() {
 			),
 		}
 		//also print to stderr
-		let tui_running = TUI_RUNNING.lock().unwrap().clone();
+		let tui_running = TUI_RUNNING.lock().clone();
 		if !tui_running {
 			eprintln!(
 				"Thread '{}' panicked with message:\n\"{}\"\nSee grin.log for further details.",

--- a/util/src/secp_static.rs
+++ b/util/src/secp_static.rs
@@ -17,7 +17,8 @@
 
 use rand::thread_rng;
 use secp_ as secp;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use Mutex;
 
 lazy_static! {
 	/// Static reference to secp instance
@@ -28,7 +29,7 @@ lazy_static! {
 /// Returns the static instance, but calls randomize on it as well
 /// (Recommended to avoid side channel attacks
 pub fn static_secp_instance() -> Arc<Mutex<secp::Secp256k1>> {
-	let mut secp_inst = SECP256K1.lock().unwrap();
+	let mut secp_inst = SECP256K1.lock();
 	secp_inst.randomize(&mut thread_rng());
 	SECP256K1.clone()
 }
@@ -36,6 +37,6 @@ pub fn static_secp_instance() -> Arc<Mutex<secp::Secp256k1>> {
 /// Convenient way to generate a commitment to zero.
 pub fn commit_to_zero_value() -> secp::pedersen::Commitment {
 	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
+	let secp = secp.lock();
 	secp.commit_value(0).unwrap()
 }

--- a/wallet/src/libtx/build.rs
+++ b/wallet/src/libtx/build.rs
@@ -253,7 +253,8 @@ where
 // Just a simple test, most exhaustive tests in the core mod.rs.
 #[cfg(test)]
 mod test {
-	use std::sync::{Arc, RwLock};
+	use std::sync::Arc;
+	use util::RwLock;
 
 	use super::*;
 	use core::core::verifier_cache::{LruVerifierCache, VerifierCache};

--- a/wallet/src/libtx/reward.rs
+++ b/wallet/src/libtx/reward.rs
@@ -47,7 +47,7 @@ where
 	};
 
 	let secp = static_secp_instance();
-	let secp = secp.lock().unwrap();
+	let secp = secp.lock();
 	let over_commit = secp.commit_value(reward(fees))?;
 	let out_commit = output.commitment();
 	let excess = secp.commit_sum(vec![out_commit], vec![over_commit])?;

--- a/wallet/src/libtx/slate.rs
+++ b/wallet/src/libtx/slate.rs
@@ -16,7 +16,8 @@
 //! around during an interactive wallet exchange
 
 use rand::thread_rng;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 use uuid::Uuid;
 
 use core::core::committed::Committed;

--- a/wallet/src/libwallet/controller.rs
+++ b/wallet/src/libwallet/controller.rs
@@ -33,9 +33,10 @@ use serde_json;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use url::form_urlencoded;
 use util::secp::pedersen;
+use util::Mutex;
 use util::{to_base64, LOGGER};
 
 /// Instantiate wallet Owner API for a single-use (command line) call

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -14,7 +14,8 @@
 
 //! Transaction building functions
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use util::RwLock;
 
 use core::core::verifier_cache::LruVerifierCache;
 use core::core::Transaction;

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -22,7 +22,8 @@ extern crate grin_wallet as wallet;
 extern crate serde_json;
 
 use chrono::Duration;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use util::Mutex;
 
 use chain::Chain;
 use core::core::{OutputFeatures, OutputIdentifier, Transaction};

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -20,9 +20,10 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+use util::RwLock;
 
 use common::api;
 use common::serde_json;

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -20,9 +20,10 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use util::Mutex;
 use util::RwLock;
 
 use common::api;
@@ -307,7 +308,7 @@ impl LocalWalletClient {
 
 	/// get an instance of the send queue for other senders
 	pub fn get_send_instance(&self) -> Sender<WalletProxyMessage> {
-		self.tx.lock().unwrap().clone()
+		self.tx.lock().clone()
 	}
 }
 
@@ -339,11 +340,11 @@ impl WalletClient for LocalWalletClient {
 			body: serde_json::to_string(slate).unwrap(),
 		};
 		{
-			let p = self.proxy_tx.lock().unwrap();
+			let p = self.proxy_tx.lock();
 			p.send(m)
 				.context(libwallet::ErrorKind::ClientCallback("Send TX Slate"))?;
 		}
-		let r = self.rx.lock().unwrap();
+		let r = self.rx.lock();
 		let m = r.recv().unwrap();
 		trace!(LOGGER, "Received send_tx_slate response: {:?}", m.clone());
 		Ok(
@@ -363,11 +364,11 @@ impl WalletClient for LocalWalletClient {
 			body: serde_json::to_string(tx).unwrap(),
 		};
 		{
-			let p = self.proxy_tx.lock().unwrap();
+			let p = self.proxy_tx.lock();
 			p.send(m)
 				.context(libwallet::ErrorKind::ClientCallback("post_tx send"))?;
 		}
-		let r = self.rx.lock().unwrap();
+		let r = self.rx.lock();
 		let m = r.recv().unwrap();
 		trace!(LOGGER, "Received post_tx response: {:?}", m.clone());
 		Ok(())
@@ -382,12 +383,12 @@ impl WalletClient for LocalWalletClient {
 			body: "".to_owned(),
 		};
 		{
-			let p = self.proxy_tx.lock().unwrap();
+			let p = self.proxy_tx.lock();
 			p.send(m).context(libwallet::ErrorKind::ClientCallback(
 				"Get chain height send",
 			))?;
 		}
-		let r = self.rx.lock().unwrap();
+		let r = self.rx.lock();
 		let m = r.recv().unwrap();
 		trace!(
 			LOGGER,
@@ -418,12 +419,12 @@ impl WalletClient for LocalWalletClient {
 			body: query_str,
 		};
 		{
-			let p = self.proxy_tx.lock().unwrap();
+			let p = self.proxy_tx.lock();
 			p.send(m).context(libwallet::ErrorKind::ClientCallback(
 				"Get outputs from node send",
 			))?;
 		}
-		let r = self.rx.lock().unwrap();
+		let r = self.rx.lock();
 		let m = r.recv().unwrap();
 		let outputs: Vec<api::Output> = serde_json::from_str(&m.body).unwrap();
 		let mut api_outputs: HashMap<pedersen::Commitment, (String, u64)> = HashMap::new();
@@ -457,13 +458,13 @@ impl WalletClient for LocalWalletClient {
 			body: query_str,
 		};
 		{
-			let p = self.proxy_tx.lock().unwrap();
+			let p = self.proxy_tx.lock();
 			p.send(m).context(libwallet::ErrorKind::ClientCallback(
 				"Get outputs from node by PMMR index send",
 			))?;
 		}
 
-		let r = self.rx.lock().unwrap();
+		let r = self.rx.lock();
 		let m = r.recv().unwrap();
 		let o: api::OutputListing = serde_json::from_str(&m.body).unwrap();
 


### PR DESCRIPTION
parking_lot: https://crates.io/crates/parking_lot
- provides implementations of Mutex, RwLock, Condvar and Once
- **smaller, faster and more flexible** than those in the Rust standard library
- **a experimental deadlock detector** that works for Mutex, RwLock and ReentrantMutex

[copy from https://crates.io/crates/parking_lot]:
When tested on x86_64 Linux, `parking_lot::Mutex` was found to be **1.5x faster** than std::sync::Mutex when uncontended, and **up to 5x faster** when contended from multiple threads. The numbers for `RwLock` vary depending on the number of reader and writer threads, but are almost **always faster** than the standard library `RwLock`, and even **up to 50x faster in some cases**.

- [x] replace all `RwLock` with `parking_lot::RwLock`
- [x] replace all `Mutex` with `parking_lot::Mutex`
- [x] add deadlock detector

To be discussed, to be reviewed, and to be tested.
 

