### PR TITLE
Remove RwLock around individual peer instances

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -27,7 +27,7 @@ use core::core::hash::{Hash, Hashed};
 use core::core::{OutputFeatures, OutputIdentifier, Transaction};
 use core::ser;
 use p2p;
-use p2p::types::ReasonForBan;
+use p2p::types::{PeerInfoDisplay, ReasonForBan};
 use pool;
 use regex::Regex;
 use rest::*;
@@ -405,13 +405,12 @@ pub struct PeersConnectedHandler {
 
 impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
-		panic!("cannot serialize peer infos right now");
-		// let mut peers = vec![];
-		// for p in &w(&self.peers).connected_peers() {
-		// 	let peer_info = p.info.clone();
-		// 	peers.push(peer_info);
-		// }
-		// json_response(&peers)
+		let mut peers: Vec<PeerInfoDisplay> = vec![];
+		for p in &w(&self.peers).connected_peers() {
+			let peer_info = p.info.clone();
+			peers.push(peer_info.into());
+		}
+		json_response(&peers)
 	}
 }
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -405,13 +405,13 @@ pub struct PeersConnectedHandler {
 
 impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
-		let mut peers = vec![];
-		for p in &w(&self.peers).connected_peers() {
-			let p = p.read().unwrap();
-			let peer_info = p.info.clone();
-			peers.push(peer_info);
-		}
-		json_response(&peers)
+		panic!("cannot serialize peer infos right now");
+		// let mut peers = vec![];
+		// for p in &w(&self.peers).connected_peers() {
+		// 	let peer_info = p.info.clone();
+		// 	peers.push(peer_info);
+		// }
+		// json_response(&peers)
 	}
 }
 

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -23,7 +23,7 @@ use core::core::hash::Hash;
 use core::pow::Difficulty;
 use msg::{read_message, write_message, Hand, Shake, SockAddr, Type, PROTOCOL_VERSION, USER_AGENT};
 use peer::Peer;
-use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo, PeerInfoStuff};
+use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo, LiveInfo};
 use util::LOGGER;
 
 const NONCES_CAP: usize = 100;
@@ -98,7 +98,7 @@ impl Handshake {
 			user_agent: shake.user_agent,
 			addr: peer_addr,
 			version: shake.version,
-			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff {
+			live_info: Arc::new(RwLock::new(LiveInfo {
 				total_difficulty: shake.total_difficulty,
 				height: 0,
 			})),
@@ -157,7 +157,7 @@ impl Handshake {
 			user_agent: hand.user_agent,
 			addr: extract_ip(&hand.sender_addr.0, &conn),
 			version: hand.version,
-			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff {
+			live_info: Arc::new(RwLock::new(LiveInfo {
 				total_difficulty: hand.total_difficulty,
 				height: 0,
 			})),

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -101,9 +101,9 @@ impl Handshake {
 			live_info: Arc::new(RwLock::new(PeerLiveInfo {
 				total_difficulty: shake.total_difficulty,
 				height: 0,
+				last_seen: Utc::now(),
 			})),
 			direction: Direction::Outbound,
-			last_seen: Utc::now(),
 		};
 
 		// If denied then we want to close the connection
@@ -160,9 +160,9 @@ impl Handshake {
 			live_info: Arc::new(RwLock::new(PeerLiveInfo {
 				total_difficulty: hand.total_difficulty,
 				height: 0,
+				last_seen: Utc::now(),
 			})),
 			direction: Direction::Inbound,
-			last_seen: Utc::now(),
 		};
 
 		// At this point we know the published ip and port of the peer

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -98,7 +98,7 @@ impl Handshake {
 			user_agent: shake.user_agent,
 			addr: peer_addr,
 			version: shake.version,
-			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff{
+			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff {
 				total_difficulty: shake.total_difficulty,
 				height: 0,
 			})),

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -23,7 +23,7 @@ use core::core::hash::Hash;
 use core::pow::Difficulty;
 use msg::{read_message, write_message, Hand, Shake, SockAddr, Type, PROTOCOL_VERSION, USER_AGENT};
 use peer::Peer;
-use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo, LiveInfo};
+use types::{Capabilities, Direction, Error, LiveInfo, P2PConfig, PeerInfo};
 use util::LOGGER;
 
 const NONCES_CAP: usize = 100;

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -23,7 +23,7 @@ use core::core::hash::Hash;
 use core::pow::Difficulty;
 use msg::{read_message, write_message, Hand, Shake, SockAddr, Type, PROTOCOL_VERSION, USER_AGENT};
 use peer::Peer;
-use types::{Capabilities, Direction, Error, LiveInfo, P2PConfig, PeerInfo};
+use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo, PeerLiveInfo};
 use util::LOGGER;
 
 const NONCES_CAP: usize = 100;
@@ -98,7 +98,7 @@ impl Handshake {
 			user_agent: shake.user_agent,
 			addr: peer_addr,
 			version: shake.version,
-			live_info: Arc::new(RwLock::new(LiveInfo {
+			live_info: Arc::new(RwLock::new(PeerLiveInfo {
 				total_difficulty: shake.total_difficulty,
 				height: 0,
 			})),
@@ -157,7 +157,7 @@ impl Handshake {
 			user_agent: hand.user_agent,
 			addr: extract_ip(&hand.sender_addr.0, &conn),
 			version: hand.version,
-			live_info: Arc::new(RwLock::new(LiveInfo {
+			live_info: Arc::new(RwLock::new(PeerLiveInfo {
 				total_difficulty: hand.total_difficulty,
 				height: 0,
 			})),

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -23,7 +23,7 @@ use core::core::hash::Hash;
 use core::pow::Difficulty;
 use msg::{read_message, write_message, Hand, Shake, SockAddr, Type, PROTOCOL_VERSION, USER_AGENT};
 use peer::Peer;
-use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo};
+use types::{Capabilities, Direction, Error, P2PConfig, PeerInfo, PeerInfoStuff};
 use util::LOGGER;
 
 const NONCES_CAP: usize = 100;
@@ -98,8 +98,10 @@ impl Handshake {
 			user_agent: shake.user_agent,
 			addr: peer_addr,
 			version: shake.version,
-			total_difficulty: shake.total_difficulty,
-			height: 0,
+			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff{
+				total_difficulty: shake.total_difficulty,
+				height: 0,
+			})),
 			direction: Direction::Outbound,
 			last_seen: Utc::now(),
 		};
@@ -113,7 +115,7 @@ impl Handshake {
 		debug!(
 			LOGGER,
 			"Connected! Cumulative {} offered from {:?} {:?} {:?}",
-			peer_info.total_difficulty.to_num(),
+			shake.total_difficulty.to_num(),
 			peer_info.addr,
 			peer_info.user_agent,
 			peer_info.capabilities
@@ -155,8 +157,10 @@ impl Handshake {
 			user_agent: hand.user_agent,
 			addr: extract_ip(&hand.sender_addr.0, &conn),
 			version: hand.version,
-			total_difficulty: hand.total_difficulty,
-			height: 0,
+			peer_info_stuff: Arc::new(RwLock::new(PeerInfoStuff {
+				total_difficulty: hand.total_difficulty,
+				height: 0,
+			})),
 			direction: Direction::Inbound,
 			last_seen: Utc::now(),
 		};

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -182,7 +182,10 @@ impl Peer {
 	pub fn send_block(&self, b: &core::Block) -> Result<bool, Error> {
 		if !self.tracking_adapter.has(b.hash()) {
 			trace!(LOGGER, "Send block {} to {}", b.hash(), self.info.addr);
-			self.connection.as_ref().unwrap().send(b, msg::Type::Block)?;
+			self.connection
+				.as_ref()
+				.unwrap()
+				.send(b, msg::Type::Block)?;
 			Ok(true)
 		} else {
 			debug!(

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -56,11 +56,11 @@ unsafe impl Send for Peer {}
 
 impl Peer {
 	// Only accept and connect can be externally used to build a peer
-	fn new(info: PeerInfo, na: Arc<NetAdapter>) -> Peer {
+	fn new(info: PeerInfo, adapter: Arc<NetAdapter>) -> Peer {
 		Peer {
-			info: info,
+			info,
 			state: Arc::new(RwLock::new(State::Connected)),
-			tracking_adapter: TrackingAdapter::new(na),
+			tracking_adapter: TrackingAdapter::new(adapter),
 			connection: None,
 		}
 	}
@@ -70,10 +70,10 @@ impl Peer {
 		capab: Capabilities,
 		total_difficulty: Difficulty,
 		hs: &Handshake,
-		na: Arc<NetAdapter>,
+		adapter: Arc<NetAdapter>,
 	) -> Result<Peer, Error> {
 		let info = hs.accept(capab, total_difficulty, conn)?;
-		Ok(Peer::new(info, na))
+		Ok(Peer::new(info, adapter))
 	}
 
 	pub fn connect(

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -179,10 +179,11 @@ impl Peer {
 
 	/// Sends the provided block to the remote peer. The request may be dropped
 	/// if the remote peer is known to already have the block.
-	pub fn send_block(&self, b: &core::Block) -> Result<(), Error> {
+	pub fn send_block(&self, b: &core::Block) -> Result<bool, Error> {
 		if !self.tracking_adapter.has(b.hash()) {
 			trace!(LOGGER, "Send block {} to {}", b.hash(), self.info.addr);
-			self.connection.as_ref().unwrap().send(b, msg::Type::Block)
+			self.connection.as_ref().unwrap().send(b, msg::Type::Block)?;
+			Ok(true)
 		} else {
 			debug!(
 				LOGGER,
@@ -190,11 +191,11 @@ impl Peer {
 				b.hash(),
 				self.info.addr,
 			);
-			Ok(())
+			Ok(false)
 		}
 	}
 
-	pub fn send_compact_block(&self, b: &core::CompactBlock) -> Result<(), Error> {
+	pub fn send_compact_block(&self, b: &core::CompactBlock) -> Result<bool, Error> {
 		if !self.tracking_adapter.has(b.hash()) {
 			trace!(
 				LOGGER,
@@ -205,7 +206,8 @@ impl Peer {
 			self.connection
 				.as_ref()
 				.unwrap()
-				.send(b, msg::Type::CompactBlock)
+				.send(b, msg::Type::CompactBlock)?;
+			Ok(true)
 		} else {
 			debug!(
 				LOGGER,
@@ -213,37 +215,39 @@ impl Peer {
 				b.hash(),
 				self.info.addr,
 			);
-			Ok(())
+			Ok(false)
 		}
 	}
 
-	pub fn send_header(&self, bh: &core::BlockHeader) -> Result<(), Error> {
+	pub fn send_header(&self, bh: &core::BlockHeader) -> Result<bool, Error> {
 		if !self.tracking_adapter.has(bh.hash()) {
 			debug!(LOGGER, "Send header {} to {}", bh.hash(), self.info.addr);
 			self.connection
 				.as_ref()
 				.unwrap()
-				.send(bh, msg::Type::Header)
+				.send(bh, msg::Type::Header)?;
+			Ok(true)
 		} else {
-			trace!(
+			debug!(
 				LOGGER,
 				"Suppress header send {} to {} (already seen)",
 				bh.hash(),
 				self.info.addr,
 			);
-			Ok(())
+			Ok(false)
 		}
 	}
 
 	/// Sends the provided transaction to the remote peer. The request may be
 	/// dropped if the remote peer is known to already have the transaction.
-	pub fn send_transaction(&self, tx: &core::Transaction) -> Result<(), Error> {
+	pub fn send_transaction(&self, tx: &core::Transaction) -> Result<bool, Error> {
 		if !self.tracking_adapter.has(tx.hash()) {
 			debug!(LOGGER, "Send tx {} to {}", tx.hash(), self.info.addr);
 			self.connection
 				.as_ref()
 				.unwrap()
-				.send(tx, msg::Type::Transaction)
+				.send(tx, msg::Type::Transaction)?;
+			Ok(true)
 		} else {
 			debug!(
 				LOGGER,
@@ -251,7 +255,7 @@ impl Peer {
 				tx.hash(),
 				self.info.addr
 			);
-			Ok(())
+			Ok(false)
 		}
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -270,17 +270,17 @@ impl Peers {
 
 	fn broadcast<F>(&self, obj_name: &str, num_peers: u32, inner: F) -> u32
 	where
-		F: Fn(&Peer) -> Result<(), Error>,
+		F: Fn(&Peer) -> Result<bool, Error>,
 	{
 		let mut count = 0;
 
 		// Iterate over our connected peers.
 		// Try our best to send to at most num_peers peers.
 		for p in self.connected_peers().iter() {
-			if let Err(e) = inner(&p) {
-				debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e);
-			} else {
-				count += 1;
+			match inner(&p) {
+				Ok(true) => count += 1,
+				Ok(false) => (),
+				Err(e) => debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e),
 			}
 
 			if count >= num_peers {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -95,8 +95,7 @@ impl Peers {
 					.insert(Utc::now().timestamp(), peer.clone());
 				debug!(
 					LOGGER,
-					"Successfully updated Dandelion relay to: {}",
-					peer.info.addr
+					"Successfully updated Dandelion relay to: {}", peer.info.addr
 				);
 			}
 			None => debug!(LOGGER, "Could not update dandelion relay"),
@@ -423,16 +422,10 @@ impl Peers {
 		// build a list of peers to be cleaned up
 		for peer in self.peers.read().unwrap().values() {
 			if peer.is_banned() {
-				debug!(
-					LOGGER,
-					"clean_peers {:?}, peer banned", peer.info.addr
-				);
+				debug!(LOGGER, "clean_peers {:?}, peer banned", peer.info.addr);
 				rm.push(peer.clone());
 			} else if !peer.is_connected() {
-				debug!(
-					LOGGER,
-					"clean_peers {:?}, not connected", peer.info.addr
-				);
+				debug!(LOGGER, "clean_peers {:?}, not connected", peer.info.addr);
 				rm.push(peer.clone());
 			}
 		}

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -612,10 +612,7 @@ impl NetAdapter for Peers {
 
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let mut live_info = peer.info.live_info.write().unwrap();
-			live_info.total_difficulty = diff;
-			live_info.height = height;
-			live_info.last_seen = Utc::now();
+			peer.info.update(height, diff);
 		}
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -35,8 +35,8 @@ use types::{
 pub struct Peers {
 	pub adapter: Arc<ChainAdapter>,
 	store: PeerStore,
-	peers: RwLock<HashMap<SocketAddr, Arc<RwLock<Peer>>>>,
-	dandelion_relay: RwLock<HashMap<i64, Arc<RwLock<Peer>>>>,
+	peers: RwLock<HashMap<SocketAddr, Arc<Peer>>>,
+	dandelion_relay: RwLock<HashMap<i64, Arc<Peer>>>,
 	config: P2PConfig,
 }
 
@@ -56,20 +56,19 @@ impl Peers {
 
 	/// Adds the peer to our internal peer mapping. Note that the peer is still
 	/// returned so the server can run it.
-	pub fn add_connected(&self, peer: Arc<RwLock<Peer>>) -> Result<(), Error> {
+	pub fn add_connected(&self, peer: Arc<Peer>) -> Result<(), Error> {
 		let peer_data: PeerData;
 		let addr: SocketAddr;
 		{
-			let p = peer.read().unwrap();
 			peer_data = PeerData {
-				addr: p.info.addr,
-				capabilities: p.info.capabilities,
-				user_agent: p.info.user_agent.clone(),
+				addr: peer.info.addr,
+				capabilities: peer.info.capabilities,
+				user_agent: peer.info.user_agent.clone(),
 				flags: State::Healthy,
 				last_banned: 0,
 				ban_reason: ReasonForBan::None,
 			};
-			addr = p.info.addr.clone();
+			addr = peer.info.addr.clone();
 		}
 		debug!(LOGGER, "Saving newly connected peer {}.", addr);
 		self.save_peer(&peer_data)?;
@@ -97,7 +96,7 @@ impl Peers {
 				debug!(
 					LOGGER,
 					"Successfully updated Dandelion relay to: {}",
-					peer.read().unwrap().info.addr
+					peer.info.addr
 				);
 			}
 			None => debug!(LOGGER, "Could not update dandelion relay"),
@@ -105,7 +104,7 @@ impl Peers {
 	}
 
 	// Get the dandelion relay
-	pub fn get_dandelion_relay(&self) -> HashMap<i64, Arc<RwLock<Peer>>> {
+	pub fn get_dandelion_relay(&self) -> HashMap<i64, Arc<Peer>> {
 		self.dandelion_relay.read().unwrap().clone()
 	}
 
@@ -114,32 +113,30 @@ impl Peers {
 	}
 
 	/// Get vec of peers we are currently connected to.
-	pub fn connected_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
+	pub fn connected_peers(&self) -> Vec<Arc<Peer>> {
 		let mut res = self
 			.peers
 			.read()
 			.unwrap()
 			.values()
-			.filter(|p| p.read().unwrap().is_connected())
+			.filter(|p| p.is_connected())
 			.cloned()
 			.collect::<Vec<_>>();
 		thread_rng().shuffle(&mut res);
 		res
 	}
 
-	pub fn outgoing_connected_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
+	pub fn outgoing_connected_peers(&self) -> Vec<Arc<Peer>> {
 		let peers = self.connected_peers();
 		let res = peers
 			.into_iter()
-			.filter(|x| match x.try_read() {
-				Ok(peer) => peer.info.direction == Direction::Outbound,
-				Err(_) => false,
-			}).collect::<Vec<_>>();
+			.filter(|x| x.info.direction == Direction::Outbound)
+			.collect::<Vec<_>>();
 		res
 	}
 
 	/// Get a peer we're connected to by address.
-	pub fn get_connected_peer(&self, addr: &SocketAddr) -> Option<Arc<RwLock<Peer>>> {
+	pub fn get_connected_peer(&self, addr: &SocketAddr) -> Option<Arc<Peer>> {
 		self.peers.read().unwrap().get(addr).map(|p| p.clone())
 	}
 
@@ -149,13 +146,13 @@ impl Peers {
 			.read()
 			.unwrap()
 			.values()
-			.filter(|p| p.read().unwrap().is_connected())
+			.filter(|x| x.is_connected())
 			.count() as u32
 	}
 
 	// Return vec of connected peers that currently advertise more work
 	// (total_difficulty) than we do.
-	pub fn more_work_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
+	pub fn more_work_peers(&self) -> Vec<Arc<Peer>> {
 		let peers = self.connected_peers();
 		if peers.len() == 0 {
 			return vec![];
@@ -165,10 +162,8 @@ impl Peers {
 
 		let mut max_peers = peers
 			.into_iter()
-			.filter(|x| match x.try_read() {
-				Ok(peer) => peer.info.total_difficulty > total_difficulty,
-				Err(_) => false,
-			}).collect::<Vec<_>>();
+			.filter(|x| x.info.total_difficulty() > total_difficulty)
+			.collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
 		max_peers
@@ -176,7 +171,7 @@ impl Peers {
 
 	// Return vec of connected peers that currently advertise more work
 	// (total_difficulty) than we do and are also full archival nodes.
-	pub fn more_work_archival_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
+	pub fn more_work_archival_peers(&self) -> Vec<Arc<Peer>> {
 		let peers = self.connected_peers();
 		if peers.len() == 0 {
 			return vec![];
@@ -186,12 +181,9 @@ impl Peers {
 
 		let mut max_peers = peers
 			.into_iter()
-			.filter(|x| match x.try_read() {
-				Ok(peer) => {
-					peer.info.total_difficulty > total_difficulty
-						&& peer.info.capabilities.contains(Capabilities::FULL_HIST)
-				}
-				Err(_) => false,
+			.filter(|x| {
+				x.info.total_difficulty() > total_difficulty
+					&& x.info.capabilities.contains(Capabilities::FULL_HIST)
 			}).collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
@@ -199,18 +191,18 @@ impl Peers {
 	}
 
 	/// Returns single random peer with more work than us.
-	pub fn more_work_peer(&self) -> Option<Arc<RwLock<Peer>>> {
+	pub fn more_work_peer(&self) -> Option<Arc<Peer>> {
 		self.more_work_peers().pop()
 	}
 
 	/// Returns single random archival peer with more work than us.
-	pub fn more_work_archival_peer(&self) -> Option<Arc<RwLock<Peer>>> {
+	pub fn more_work_archival_peer(&self) -> Option<Arc<Peer>> {
 		self.more_work_archival_peers().pop()
 	}
 
 	/// Return vec of connected peers that currently have the most worked
 	/// branch, showing the highest total difficulty.
-	pub fn most_work_peers(&self) -> Vec<Arc<RwLock<Peer>>> {
+	pub fn most_work_peers(&self) -> Vec<Arc<Peer>> {
 		let peers = self.connected_peers();
 		if peers.len() == 0 {
 			return vec![];
@@ -218,18 +210,14 @@ impl Peers {
 
 		let max_total_difficulty = peers
 			.iter()
-			.map(|x| match x.try_read() {
-				Ok(peer) => peer.info.total_difficulty.clone(),
-				Err(_) => Difficulty::zero(),
-			}).max()
+			.map(|x| x.info.total_difficulty())
+			.max()
 			.unwrap();
 
 		let mut max_peers = peers
 			.into_iter()
-			.filter(|x| match x.try_read() {
-				Ok(peer) => peer.info.total_difficulty == max_total_difficulty,
-				Err(_) => false,
-			}).collect::<Vec<_>>();
+			.filter(|x| x.info.total_difficulty() == max_total_difficulty)
+			.collect::<Vec<_>>();
 
 		thread_rng().shuffle(&mut max_peers);
 		max_peers
@@ -237,7 +225,7 @@ impl Peers {
 
 	/// Returns single random peer with the most worked branch, showing the
 	/// highest total difficulty.
-	pub fn most_work_peer(&self) -> Option<Arc<RwLock<Peer>>> {
+	pub fn most_work_peer(&self) -> Option<Arc<Peer>> {
 		self.most_work_peers().pop()
 	}
 
@@ -259,7 +247,6 @@ impl Peers {
 		if let Some(peer) = self.get_connected_peer(peer_addr) {
 			debug!(LOGGER, "Banning peer {}", peer_addr);
 			// setting peer status will get it removed at the next clean_peer
-			let peer = peer.write().unwrap();
 			peer.send_ban_reason(ban_reason);
 			peer.set_banned();
 			peer.stop();
@@ -292,17 +279,12 @@ impl Peers {
 		// Iterate over our connected peers.
 		// Try our best to send to at most num_peers peers.
 		for p in peers.iter() {
-			match p.try_read() {
-				Ok(p) => {
-					if p.is_connected() {
-						if let Err(e) = f(&p) {
-							debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e);
-						} else {
-							count += 1;
-						}
-					}
+			if p.is_connected() {
+				if let Err(e) = f(&p) {
+					debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e);
+				} else {
+					count += 1;
 				}
-				Err(_) => (),
 			}
 
 			if count >= num_peers {
@@ -361,7 +343,6 @@ impl Peers {
 			return Err(Error::NoDandelionRelay);
 		}
 		for relay in dandelion_relay.values() {
-			let relay = relay.read().unwrap();
 			if relay.is_connected() {
 				if let Err(e) = relay.send_stem_transaction(tx) {
 					debug!(
@@ -395,7 +376,6 @@ impl Peers {
 	pub fn check_all(&self, total_difficulty: Difficulty, height: u64) {
 		let peers_map = self.peers.read().unwrap();
 		for p in peers_map.values() {
-			let p = p.read().unwrap();
 			if p.is_connected() {
 				let _ = p.send_ping(total_difficulty, height);
 			}
@@ -442,17 +422,16 @@ impl Peers {
 
 		// build a list of peers to be cleaned up
 		for peer in self.peers.read().unwrap().values() {
-			let peer_inner = peer.read().unwrap();
-			if peer_inner.is_banned() {
+			if peer.is_banned() {
 				debug!(
 					LOGGER,
-					"clean_peers {:?}, peer banned", peer_inner.info.addr
+					"clean_peers {:?}, peer banned", peer.info.addr
 				);
 				rm.push(peer.clone());
-			} else if !peer_inner.is_connected() {
+			} else if !peer.is_connected() {
 				debug!(
 					LOGGER,
-					"clean_peers {:?}, not connected", peer_inner.info.addr
+					"clean_peers {:?}, not connected", peer.info.addr
 				);
 				rm.push(peer.clone());
 			}
@@ -462,7 +441,6 @@ impl Peers {
 		{
 			let mut peers = self.peers.write().unwrap();
 			for p in rm {
-				let p = p.read().unwrap();
 				peers.remove(&p.info.addr);
 			}
 		}
@@ -478,14 +456,11 @@ impl Peers {
 		};
 
 		// map peers to addrs in a block to bound how long we keep the read lock for
-		let addrs = {
-			self.connected_peers()
-				.iter()
-				.map(|x| {
-					let p = x.read().unwrap();
-					p.info.addr.clone()
-				}).collect::<Vec<_>>()
-		};
+		let addrs = self
+			.connected_peers()
+			.iter()
+			.map(|x| x.info.addr.clone())
+			.collect::<Vec<_>>();
 
 		// now remove them taking a short-lived write lock each time
 		// maybe better to take write lock once and remove them all?
@@ -498,7 +473,6 @@ impl Peers {
 	pub fn stop(&self) {
 		let mut peers = self.peers.write().unwrap();
 		for (_, peer) in peers.drain() {
-			let peer = peer.read().unwrap();
 			peer.stop();
 		}
 	}
@@ -645,16 +619,15 @@ impl NetAdapter for Peers {
 
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let mut peer = peer.write().unwrap();
-			peer.info.total_difficulty = diff;
-			peer.info.height = height;
-			peer.info.last_seen = Utc::now();
+			let mut info = peer.peer_info.write().unwrap();
+			info.total_difficulty = diff;
+			info.height = height;
+			info.last_seen = Utc::now();
 		}
 	}
 
 	fn is_banned(&self, addr: SocketAddr) -> bool {
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let peer = peer.read().unwrap();
 			peer.is_banned()
 		} else {
 			false

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -612,10 +612,10 @@ impl NetAdapter for Peers {
 
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let mut info = peer.peer_info.write().unwrap();
-			info.total_difficulty = diff;
-			info.height = height;
-			info.last_seen = Utc::now();
+			let mut live_info = peer.info.live_info.write().unwrap();
+			live_info.total_difficulty = diff;
+			live_info.height = height;
+			live_info.last_seen = Utc::now();
 		}
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -268,22 +268,19 @@ impl Peers {
 		};
 	}
 
-	fn broadcast<F>(&self, obj_name: &str, num_peers: u32, f: F) -> u32
+	fn broadcast<F>(&self, obj_name: &str, num_peers: u32, inner: F) -> u32
 	where
 		F: Fn(&Peer) -> Result<(), Error>,
 	{
-		let peers = self.connected_peers();
 		let mut count = 0;
 
 		// Iterate over our connected peers.
 		// Try our best to send to at most num_peers peers.
-		for p in peers.iter() {
-			if p.is_connected() {
-				if let Err(e) = f(&p) {
-					debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e);
-				} else {
-					count += 1;
-				}
+		for p in self.connected_peers().iter() {
+			if let Err(e) = inner(&p) {
+				debug!(LOGGER, "Error sending {} to peer: {:?}", obj_name, e);
+			} else {
+				count += 1;
 			}
 
 			if count >= num_peers {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -240,6 +240,7 @@ enum_from_primitive! {
 pub struct PeerLiveInfo {
 	pub total_difficulty: Difficulty,
 	pub height: u64,
+	pub last_seen: DateTime<Utc>,
 }
 
 /// General information about a connected peer that's useful to other modules.

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -237,7 +237,7 @@ enum_from_primitive! {
 }
 
 #[derive(Clone, Debug)]
-pub struct PeerInfoStuff {
+pub struct LiveInfo {
 	pub total_difficulty: Difficulty,
 	pub height: u64,
 }
@@ -252,16 +252,16 @@ pub struct PeerInfo {
 	// pub total_difficulty: RwLock<Difficulty>,
 	// pub height: RwLock<u64>,
 	pub direction: Direction,
-	pub peer_info_stuff: Arc<RwLock<PeerInfoStuff>>,
+	pub live_info: Arc<RwLock<LiveInfo>>,
 }
 
 impl PeerInfo {
 	pub fn total_difficulty(&self) -> Difficulty {
-		self.peer_info_stuff.read().unwrap().total_difficulty
+		self.live_info.read().unwrap().total_difficulty
 	}
 
 	pub fn height(&self) -> u64 {
-		self.peer_info_stuff.read().unwrap().height
+		self.live_info.read().unwrap().height
 	}
 
 	pub fn last_seen(&self) -> DateTime<Utc> {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -17,6 +17,7 @@ use std::fs::File;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::mpsc;
+use std::sync::{Arc, RwLock};
 
 use chrono::prelude::*;
 
@@ -235,17 +236,37 @@ enum_from_primitive! {
 	}
 }
 
+#[derive(Clone, Debug)]
+pub struct PeerInfoStuff {
+	pub total_difficulty: Difficulty,
+	pub height: u64,
+}
+
 /// General information about a connected peer that's useful to other modules.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct PeerInfo {
 	pub capabilities: Capabilities,
 	pub user_agent: String,
 	pub version: u32,
 	pub addr: SocketAddr,
-	pub total_difficulty: Difficulty,
-	pub height: u64,
+	// pub total_difficulty: RwLock<Difficulty>,
+	// pub height: RwLock<u64>,
 	pub direction: Direction,
-	pub last_seen: DateTime<Utc>,
+	pub peer_info_stuff: Arc<RwLock<PeerInfoStuff>>,
+}
+
+impl PeerInfo {
+	pub fn total_difficulty(&self) -> Difficulty {
+		self.peer_info_stuff.read().unwrap().total_difficulty
+	}
+
+	pub fn height(&self) -> u64 {
+		self.peer_info_stuff.read().unwrap().height
+	}
+
+	pub fn last_seen(&self) -> DateTime<Utc> {
+		self.peer_info_stuff.read().unwrap().last_seen
+	}
 }
 
 /// The full txhashset data along with indexes required for a consumer to

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -90,7 +90,6 @@ fn peer_handshake() {
 	thread::sleep(time::Duration::from_secs(1));
 
 	let server_peer = server.peers.get_connected_peer(&my_addr).unwrap();
-	let server_peer = server_peer.read().unwrap();
-	assert_eq!(server_peer.info.total_difficulty, Difficulty::one());
+	assert_eq!(server_peer.info.total_difficulty(), Difficulty::one());
 	assert!(server.peers.peer_count() > 0);
 }

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -575,13 +575,8 @@ impl NetToChainAdapter {
 				match  wo(&self.peers).get_connected_peer(addr) {
 					None => debug!(LOGGER, "send_block_request_to_peer: can't send request to peer {:?}, not connected", addr),
 					Some(peer) => {
-						match peer.read() {
-							Err(e) => debug!(LOGGER, "send_block_request_to_peer: can't send request to peer {:?}, read fails: {:?}", addr, e),
-							Ok(p) => {
-								if let Err(e) =  f(&p, h) {
-									error!(LOGGER, "send_block_request_to_peer: failed: {:?}", e)
-								}
-							}
+						if let Err(e) =  f(&peer, h) {
+							error!(LOGGER, "send_block_request_to_peer: failed: {:?}", e)
 						}
 					}
 				}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -571,18 +571,26 @@ impl NetToChainAdapter {
 		F: Fn(&p2p::Peer, Hash) -> Result<(), p2p::Error>,
 	{
 		match w(&self.chain).block_exists(h) {
-			Ok(false) => {
-				match  wo(&self.peers).get_connected_peer(addr) {
-					None => debug!(LOGGER, "send_block_request_to_peer: can't send request to peer {:?}, not connected", addr),
-					Some(peer) => {
-						if let Err(e) =  f(&peer, h) {
-							error!(LOGGER, "send_block_request_to_peer: failed: {:?}", e)
-						}
+			Ok(false) => match wo(&self.peers).get_connected_peer(addr) {
+				None => debug!(
+					LOGGER,
+					"send_block_request_to_peer: can't send request to peer {:?}, not connected",
+					addr
+				),
+				Some(peer) => {
+					if let Err(e) = f(&peer, h) {
+						error!(LOGGER, "send_block_request_to_peer: failed: {:?}", e)
 					}
 				}
-			}
-			Ok(true) => debug!(LOGGER, "send_block_request_to_peer: block {} already known", h),
-			Err(e) => error!(LOGGER, "send_block_request_to_peer: failed to check block exists: {:?}", e)
+			},
+			Ok(true) => debug!(
+				LOGGER,
+				"send_block_request_to_peer: block {} already known", h
+			),
+			Err(e) => error!(
+				LOGGER,
+				"send_block_request_to_peer: failed to check block exists: {:?}", e
+			),
 		}
 	}
 

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -180,7 +180,7 @@ impl PeerStats {
 			total_difficulty: peer.info.total_difficulty().to_num(),
 			height: peer.info.height(),
 			direction: direction.to_string(),
-			last_seen: peer.info.last_seen,
+			last_seen: peer.info.last_seen(),
 		}
 	}
 }

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -177,8 +177,8 @@ impl PeerStats {
 			state: state.to_string(),
 			addr: addr,
 			version: peer.info.version,
-			total_difficulty: peer.info.total_difficulty.to_num(),
-			height: peer.info.height,
+			total_difficulty: peer.info.total_difficulty().to_num(),
+			height: peer.info.height(),
 			direction: direction.to_string(),
 			last_seen: peer.info.last_seen,
 		}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -159,16 +159,12 @@ fn monitor_peers(
 	// ask them for their list of peers
 	let mut connected_peers: Vec<SocketAddr> = vec![];
 	for p in peers.connected_peers() {
-		if let Ok(p) = p.try_read() {
-			debug!(
-				LOGGER,
-				"monitor_peers: {}:{} ask {} for more peers", config.host, config.port, p.info.addr,
-			);
-			let _ = p.send_peer_request(capabilities);
-			connected_peers.push(p.info.addr)
-		} else {
-			warn!(LOGGER, "monitor_peers: failed to get read lock on peer");
-		}
+		debug!(
+			LOGGER,
+			"monitor_peers: {}:{} ask {} for more peers", config.host, config.port, p.info.addr,
+		);
+		let _ = p.send_peer_request(capabilities);
+		connected_peers.push(p.info.addr)
 	}
 
 	// Attempt to connect to preferred peers if there is some
@@ -286,9 +282,7 @@ fn listen_for_addrs(
 				for _ in 0..3 {
 					match p2p_c.connect(&addr) {
 						Ok(p) => {
-							if let Ok(p) = p.try_read() {
-								let _ = p.send_peer_request(capab);
-							}
+							let _ = p.send_peer_request(capab);
 							let _ = peers_c.update_state(addr, p2p::State::Healthy);
 							break;
 						}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -320,8 +320,7 @@ pub fn dns_seeds() -> Box<Fn() -> Vec<SocketAddr> + Send> {
 						.map(|mut addr| {
 							addr.set_port(13414);
 							addr
-						})
-						.filter(|addr| !temp_addresses.contains(addr))
+						}).filter(|addr| !temp_addresses.contains(addr))
 						.collect()),
 				),
 				Err(e) => debug!(

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -442,7 +442,8 @@ impl Server {
 			.peers
 			.connected_peers()
 			.into_iter()
-			.map(|p| PeerStats::from_peer(&p)).collect();
+			.map(|p| PeerStats::from_peer(&p))
+			.collect();
 		Ok(ServerStats {
 			peer_count: self.peer_count(),
 			head: self.head(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -442,10 +442,7 @@ impl Server {
 			.peers
 			.connected_peers()
 			.into_iter()
-			.map(|p| {
-				let p = p.read().unwrap();
-				PeerStats::from_peer(&p)
-			}).collect();
+			.map(|p| PeerStats::from_peer(&p)).collect();
 		Ok(ServerStats {
 			peer_count: self.peer_count(),
 			head: self.head(),

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -159,12 +159,10 @@ impl BodySync {
 					self.peers.more_work_peer()
 				};
 				if let Some(peer) = peer {
-					if let Ok(peer) = peer.try_read() {
-						if let Err(e) = peer.send_block_request(*hash) {
-							debug!(LOGGER, "Skipped request to {}: {:?}", peer.info.addr, e);
-						} else {
-							self.body_sync_hashes.push(hash.clone());
-						}
+					if let Err(e) = peer.send_block_request(*hash) {
+						debug!(LOGGER, "Skipped request to {}: {:?}", peer.info.addr, e);
+					} else {
+						self.body_sync_hashes.push(hash.clone());
 					}
 				}
 			}

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -124,11 +124,8 @@ impl HeaderSync {
 			let difficulty = header_head.total_difficulty;
 
 			if let Some(peer) = self.peers.most_work_peer() {
-				if let Ok(p) = peer.try_read() {
-					let peer_difficulty = p.info.total_difficulty.clone();
-					if peer_difficulty > difficulty {
-						self.request_headers(&p);
-					}
+				if peer.info.total_difficulty() > difficulty {
+					self.request_headers(&peer);
 				}
 			}
 		}

--- a/servers/tests/api.rs
+++ b/servers/tests/api.rs
@@ -460,12 +460,13 @@ pub fn get_peer(
 pub fn get_connected_peers(
 	base_addr: &String,
 	api_server_port: u16,
-) -> Result<Vec<p2p::PeerInfo>, Error> {
+) -> Result<Vec<p2p::types::PeerInfoDisplay>, Error> {
 	let url = format!(
 		"http://{}:{}/v1/peers/connected",
 		base_addr, api_server_port
 	);
-	api::client::get::<Vec<p2p::PeerInfo>>(url.as_str(), None).map_err(|e| Error::API(e))
+	api::client::get::<Vec<p2p::types::PeerInfoDisplay>>(url.as_str(), None)
+		.map_err(|e| Error::API(e))
 }
 
 pub fn get_all_peers(

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -127,7 +127,7 @@ fn simulate_seeding() {
 		"http://{}:{}/v1/peers/connected",
 		&server_config.base_addr, 30020
 	);
-	let peers_all = api::client::get::<Vec<p2p::PeerInfo>>(url.as_str(), None);
+	let peers_all = api::client::get::<Vec<p2p::types::PeerInfoDisplay>>(url.as_str(), None);
 	assert!(peers_all.is_ok());
 	assert_eq!(peers_all.unwrap().len(), 4);
 

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -123,25 +123,29 @@ pub fn list_connected_peers(config: &ServerConfig, api_secret: Option<String>) {
 	let mut e = term::stdout().unwrap();
 	let url = format!("http://{}/v1/peers/connected", config.api_http_addr);
 	let peers_info: Result<Vec<p2p::PeerInfo>, api::Error>;
-	peers_info = api::client::get::<Vec<p2p::PeerInfo>>(url.as_str(), api_secret);
 
-	match peers_info.map_err(|e| Error::API(e)) {
-		Ok(connected_peers) => {
-			let mut index = 0;
-			for connected_peer in connected_peers {
-				writeln!(e, "Peer {}:", index).unwrap();
-				writeln!(e, "Capabilities: {:?}", connected_peer.capabilities).unwrap();
-				writeln!(e, "User agent: {}", connected_peer.user_agent).unwrap();
-				writeln!(e, "Version: {}", connected_peer.version).unwrap();
-				writeln!(e, "Peer address: {}", connected_peer.addr).unwrap();
-				writeln!(e, "Total difficulty: {}", connected_peer.total_difficulty).unwrap();
-				writeln!(e, "Direction: {:?}", connected_peer.direction).unwrap();
-				println!();
-				index = index + 1;
-			}
-		}
-		Err(_) => writeln!(e, "Failed to get connected peers").unwrap(),
-	};
+	panic!("peer info not serializable");
+
+	// peers_info = api::client::get::<Vec<p2p::PeerInfo>>(url.as_str(), api_secret);
+	//
+	// match peers_info.map_err(|e| Error::API(e)) {
+	// 	Ok(connected_peers) => {
+	// 		let mut index = 0;
+	// 		for connected_peer in connected_peers {
+	// 			writeln!(e, "Peer {}:", index).unwrap();
+	// 			writeln!(e, "Capabilities: {:?}", connected_peer.capabilities).unwrap();
+	// 			writeln!(e, "User agent: {}", connected_peer.user_agent).unwrap();
+	// 			writeln!(e, "Version: {}", connected_peer.version).unwrap();
+	// 			writeln!(e, "Peer address: {}", connected_peer.addr).unwrap();
+	// 			writeln!(e, "Total difficulty: {}", connected_peer.total_difficulty()).unwrap();
+	// 			writeln!(e, "Direction: {:?}", connected_peer.direction).unwrap();
+	// 			println!();
+	// 			index = index + 1;
+	// 		}
+	// 	}
+	// 	Err(_) => writeln!(e, "Failed to get connected peers").unwrap(),
+	// };
+
 	e.reset().unwrap();
 }
 

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -122,29 +122,28 @@ pub fn unban_peer(config: &ServerConfig, peer_addr: &SocketAddr, api_secret: Opt
 pub fn list_connected_peers(config: &ServerConfig, api_secret: Option<String>) {
 	let mut e = term::stdout().unwrap();
 	let url = format!("http://{}/v1/peers/connected", config.api_http_addr);
-	let peers_info: Result<Vec<p2p::PeerInfo>, api::Error>;
+	// let peers_info: Result<Vec<p2p::PeerInfoDisplay>, api::Error>;
 
-	panic!("peer info not serializable");
+	let peers_info = api::client::get::<Vec<p2p::types::PeerInfoDisplay>>(url.as_str(), api_secret);
 
-	// peers_info = api::client::get::<Vec<p2p::PeerInfo>>(url.as_str(), api_secret);
-	//
-	// match peers_info.map_err(|e| Error::API(e)) {
-	// 	Ok(connected_peers) => {
-	// 		let mut index = 0;
-	// 		for connected_peer in connected_peers {
-	// 			writeln!(e, "Peer {}:", index).unwrap();
-	// 			writeln!(e, "Capabilities: {:?}", connected_peer.capabilities).unwrap();
-	// 			writeln!(e, "User agent: {}", connected_peer.user_agent).unwrap();
-	// 			writeln!(e, "Version: {}", connected_peer.version).unwrap();
-	// 			writeln!(e, "Peer address: {}", connected_peer.addr).unwrap();
-	// 			writeln!(e, "Total difficulty: {}", connected_peer.total_difficulty()).unwrap();
-	// 			writeln!(e, "Direction: {:?}", connected_peer.direction).unwrap();
-	// 			println!();
-	// 			index = index + 1;
-	// 		}
-	// 	}
-	// 	Err(_) => writeln!(e, "Failed to get connected peers").unwrap(),
-	// };
+	match peers_info.map_err(|e| Error::API(e)) {
+		Ok(connected_peers) => {
+			let mut index = 0;
+			for connected_peer in connected_peers {
+				writeln!(e, "Peer {}:", index).unwrap();
+				writeln!(e, "Capabilities: {:?}", connected_peer.capabilities).unwrap();
+				writeln!(e, "User agent: {}", connected_peer.user_agent).unwrap();
+				writeln!(e, "Version: {}", connected_peer.version).unwrap();
+				writeln!(e, "Peer address: {}", connected_peer.addr).unwrap();
+				writeln!(e, "Height: {}", connected_peer.height).unwrap();
+				writeln!(e, "Total difficulty: {}", connected_peer.total_difficulty).unwrap();
+				writeln!(e, "Direction: {:?}", connected_peer.direction).unwrap();
+				println!();
+				index = index + 1;
+			}
+		}
+		Err(_) => writeln!(e, "Failed to get connected peers").unwrap(),
+	};
 
 	e.reset().unwrap();
 }


### PR DESCRIPTION
Peers are basically immutable.

The only things that ever get mutated are - 
* `state` (already wrapped as a separate `Arc<RwLock<State>>`)
* `height` & `total_difficulty` (this PR wraps these in a `Arc<RwLock<PeerLiveInfo>>`)

Everything else is immutable and we can use an `Arc<Peer>` instead of an `Arc<RwLock<Peer>>`.

This PR makes the writeable parts of a `Peer` more explicit.
We can now read from the vec of `peers` and interact with a `peer` instance without needing to take a read lock (or write lock) on it.

TODO - 
- [x] serialization and things that depend on PeerInfo being serializable
- [x] wrap the `height` and `total_difficulty` updates in a fn on `PeerInfo`
- [x] naming - `LiveInfo` does not really work (`PeerLiveInfo` for lack of anything any better)

This should get rid of much of the lock contention around peer instances. 

We can now simply treat them as immutable except for a couple of very limited interactions - 

* height and total_difficulty updates from ping/pong
* state changes (banning etc.)

Everything else just needs to deal with an immutable `Arc<Peer>`.