### PR TITLE
cleanup mine_block difficulty_iterator usage

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -395,14 +395,13 @@ impl Server {
 		// code clean. This may be handy for testing but not really needed
 		// for release
 		let diff_stats = {
-			let diff_iter = self.chain.difficulty_iter();
-
 			let last_blocks: Vec<Result<(u64, Difficulty), consensus::TargetError>> =
-				global::difficulty_data_to_vector(diff_iter)
+				global::difficulty_data_to_vector(self.chain.difficulty_iter())
 					.into_iter()
 					.skip(consensus::MEDIAN_TIME_WINDOW as usize)
 					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
+
 
 			let mut last_time = last_blocks[0].clone().unwrap().0;
 			let tip_height = self.chain.head().unwrap().height as i64;

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -402,7 +402,6 @@ impl Server {
 					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
 
-
 			let mut last_time = last_blocks[0].clone().unwrap().0;
 			let tip_height = self.chain.head().unwrap().height as i64;
 			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -104,9 +104,9 @@ fn build_block(
 		now_sec = head_sec + 1;
 	}
 
-	// get the difficulty our block should be at
-	let diff_iter = chain.difficulty_iter();
-	let difficulty = consensus::next_difficulty(diff_iter).unwrap();
+	// Determine the difficulty our block should be at.
+	// Note: do not keep the difficulty_iter in scope (it has an active batch).
+	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
 
 	// extract current transaction from the pool
 	// TODO - we have a lot of unwrap() going on in this fn...


### PR DESCRIPTION
Identified a couple of places where we kept a `difficulty_iterator` around in scope.
These have an active `batch` so care needs to be taken.

I think we need to revisit the `difficulty_iterator` and see if there is a more robust way of doing the diff calcs without needing to maintain an active db batch like this.

But - these _may_ be involved in the lock contention/deadlocking we've been seeing.

