### PR TITLE
revert travis-ci speed optimization for cache problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 os:
   - linux
-#  - osx
+  - osx
 
 dist: trusty
 sudo: required
@@ -13,12 +13,9 @@ sudo: required
 cache:
   cargo: true
   timeout: 240
-  directories:
-    - $HOME/.cargo
-    - $TRAVIS_BUILD_DIR/target
 
 before_cache:
-  - rm -rf $TRAVIS_BUILD_DIR/target/tmp
+  - rm -rf target/tmp
 
 rust:
   - stable
@@ -45,33 +42,25 @@ env:
   - RUST_BACKTRACE="1"
   - RUST_FLAGS="-C debug-assertions"
   matrix:
-  - TEST_SUITE=servers
-  - TEST_SUITE=chain-core
-  - TEST_SUITE=pool-p2p
-  - TEST_SUITE=keychain-wallet
-  - TEST_SUITE=api-util-store
+  - RUST_TEST_THREADS=1 TEST_DIR=servers
+  - TEST_DIR=store
+  - TEST_DIR=chain
+  - TEST_DIR=pool
+  - TEST_DIR=wallet
+  - TEST_DIR=p2p
+  - TEST_DIR=api
+  - TEST_DIR=keychain
+  - TEST_DIR=core
+  - TEST_DIR=util
+  - TEST_DIR=config
+  - TEST_DIR=none
 
 script:
-  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[0]};
-    echo "start testing on folder $DIR...";
-    if [[ -n "$DIR" ]];  then cd $DIR && cargo test --release; cd - > /dev/null; fi;
-  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[1]};
-    if [[ -n "$DIR" ]];  then
-      echo "start testing on folder $DIR...";
-      cd $DIR && cargo test --release; cd - > /dev/null;
-    fi;
-  - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[2]};
-    if [[ -n "$DIR" ]];  then
-      echo "start testing on folder $DIR...";
-      cd $DIR && cargo test --release; cd - > /dev/null;
-    fi;
+  - if [[ "$TEST_DIR" == "none" ]]; then cargo build --release;                fi
+  - if [[ "$TEST_DIR" != "none" ]]; then cd $TEST_DIR && cargo test --release; fi
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "pool-p2p" ]]; then
-      cargo clean;
-      cargo build --release;
-      ./.auto-release.sh;
-    fi
+  - if [[ "$TEST_DIR" == "none" ]]; then ./.auto-release.sh;                   fi
 
 deploy:
   provider: releases
@@ -83,6 +72,6 @@ deploy:
   on:
     repo: mimblewimble/grin
     tags: true
-    condition: $TEST_SUITE = "pool-p2p"
+    condition: $TEST_DIR = "none"
 
 


### PR DESCRIPTION
As found in https://github.com/mimblewimble/grin/issues/1675, the current Travis-CI seems have a major problem on the cache, even the building error PR can pass the Travis-CI test.

I have to revert the speed optimization of #1647 for the moment, and will investigate the cache problem later.

Sorry for this!  It's also an unexpected surprise for me:(