### PR TITLE
Skip sigs txhashset validation

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -524,7 +524,6 @@ pub struct ChainValidationHandler {
 
 impl Handler for ChainValidationHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
-		// TODO - read skip_rproofs from query params
 		match w(&self.chain).validate(true) {
 			Ok(_) => response(StatusCode::OK, ""),
 			Err(e) => response(

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -462,7 +462,7 @@ impl Chain {
 	}
 
 	/// Validate the current chain state.
-	pub fn validate(&self, skip_rproofs: bool) -> Result<(), Error> {
+	pub fn validate(&self, fast_validation: bool) -> Result<(), Error> {
 		let header = self.store.head_header()?;
 
 		// Lets just treat an "empty" node that just got started up as valid.
@@ -477,7 +477,7 @@ impl Chain {
 		// ensure the view is consistent.
 		txhashset::extending_readonly(&mut txhashset, |extension| {
 			extension.rewind(&header)?;
-			extension.validate(skip_rproofs, &NoStatus)?;
+			extension.validate(fast_validation, &NoStatus)?;
 			Ok(())
 		})
 	}
@@ -636,6 +636,7 @@ impl Chain {
 			extension.rewind(&header)?;
 
 			// Validate the extension, generating the utxo_sum and kernel_sum.
+			// Full validation, including rangeproofs and kernel signature verification.
 			let (utxo_sum, kernel_sum) = extension.validate(false, status)?;
 
 			// Now that we have block_sums the total_kernel_sum on the block_header is redundant.


### PR DESCRIPTION
The *only* time we need to do a "full" (expensive) chain validation is after receiving a txhashset.zip from a peer during fast sync.

When we run compaction we do not need to re-verify kernel signatures or rangeproofs (as we are not adding any new data).

We were already skipping rangeproof verification during compaction.

Skipping kernel signature verification shrinks chain compaction down to approx 3s - 

```
time curl -X POST 127.0.0.1:13413/v1/chain/compact
curl -X POST 127.0.0.1:13413/v1/chain/compact  0.01s user 0.01s system 0% cpu 3.192 total
```

And "fast validation" on its own takes 2.5s - 

```
time curl 127.0.0.1:13413/v1/chain/validate 
curl 127.0.0.1:13413/v1/chain/validate  0.01s user 0.01s system 0% cpu 2.528 total
```

