### PR TITLE
spit chain and peer lmdb envs

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -160,7 +160,7 @@ impl Server {
 		let db_env = Arc::new(store::new_env(config.db_root.clone()));
 		let shared_chain = Arc::new(chain::Chain::init(
 			config.db_root.clone(),
-			db_env.clone(),
+			db_env,
 			chain_adapter.clone(),
 			genesis.clone(),
 			pow::verify_size,
@@ -186,8 +186,9 @@ impl Server {
 			Err(_) => None,
 		};
 
+		let peer_db_env = Arc::new(store::new_named_env(config.db_root.clone(), "peer".into()));
 		let p2p_server = Arc::new(p2p::Server::new(
-			db_env,
+			peer_db_env,
 			config.p2p_config.capabilities,
 			config.p2p_config.clone(),
 			net_adapter.clone(),

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -54,10 +54,18 @@ pub fn option_to_not_found<T>(res: Result<Option<T>, Error>, field_name: &str) -
 	}
 }
 
-/// Create a new LMDB env under the provided directory to spawn various
-/// databases from.
+/// Create a new LMDB env under the provided directory.
+/// By default creates an environment named "lmdb".
+/// Be aware of transactional semantics in lmdb
+/// (transactions are per environment, not per database).
 pub fn new_env(path: String) -> lmdb::Environment {
-	let full_path = path + "/lmdb";
+	new_named_env(path, "lmdb".into())
+}
+
+/// TODO - We probably need more flexibility here, 500GB probably too big for peers...
+/// Create a new LMDB env under the provided directory with the provided name.
+pub fn new_named_env(path: String, name: String) -> lmdb::Environment {
+	let full_path = [path, name].join("/");
 	fs::create_dir_all(&full_path).unwrap();
 	unsafe {
 		let mut env_builder = lmdb::EnvBuilder::new().unwrap();


### PR DESCRIPTION
Resolves #1679.

Split our one lmdb env out into two separate envs - 

chain_data/lmdb (chain_store)
chain_data/peer (peer_store)

* separate files on disk
* separate transactions (which translates into batches in our code)

Pretty sure (but hard to verify) our deadlocks/contention is coming from interactions involving both the `peer_store` and `chain_store` lmdb databases.

For example - on startup we happen to see a broadcast from a peer that we do not yet believe to be connected. We interact with the `chain_store` to process the block. And we interact with the `peer_store` to store peer state etc.

