### PR TITLE
Add last_seen to peer info

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.5"
 serde = "1"
 serde_derive = "1"
 slog = { version = "~2.3", features = ["max_level_trace", "release_max_level_trace"] }
-chrono = "0.4.4"
+chrono = { version = "0.4.4", features = ["serde"] }
 
 grin_core = { path = "../core" }
 grin_store = { path = "../store" }

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -16,6 +16,7 @@ use std::collections::VecDeque;
 use std::net::{SocketAddr, TcpStream};
 use std::sync::{Arc, RwLock};
 
+use chrono::prelude::*;
 use rand::{thread_rng, Rng};
 
 use core::core::hash::Hash;
@@ -100,6 +101,7 @@ impl Handshake {
 			total_difficulty: shake.total_difficulty,
 			height: 0,
 			direction: Direction::Outbound,
+			last_seen: Utc::now(),
 		};
 
 		// If denied then we want to close the connection
@@ -156,6 +158,7 @@ impl Handshake {
 			total_difficulty: hand.total_difficulty,
 			height: 0,
 			direction: Direction::Inbound,
+			last_seen: Utc::now(),
 		};
 
 		// At this point we know the published ip and port of the peer

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, RwLock};
 
 use rand::{thread_rng, Rng};
 
-use chrono::prelude::Utc;
+use chrono::prelude::*;
 use core::core;
 use core::core::hash::{Hash, Hashed};
 use core::pow::Difficulty;
@@ -644,29 +644,11 @@ impl NetAdapter for Peers {
 	}
 
 	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
-		if diff != self.total_difficulty() || height != self.total_height() {
-			trace!(
-				LOGGER,
-				"ping/pong: {}: {} @ {} vs us: {} @ {}",
-				addr,
-				diff,
-				height,
-				self.total_difficulty(),
-				self.total_height()
-			);
-		}
-
 		if let Some(peer) = self.get_connected_peer(&addr) {
-			let (prev_diff, prev_height) = {
-				let peer = peer.read().unwrap();
-				(peer.info.total_difficulty, peer.info.height)
-			};
-
-			if diff != prev_diff || height != prev_height {
-				let mut peer = peer.write().unwrap();
-				peer.info.total_difficulty = diff;
-				peer.info.height = height;
-			}
+			let mut peer = peer.write().unwrap();
+			peer.info.total_difficulty = diff;
+			peer.info.height = height;
+			peer.info.last_seen = Utc::now();
 		}
 	}
 

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -18,6 +18,8 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::mpsc;
 
+use chrono::prelude::*;
+
 use core::core::hash::Hash;
 use core::pow::Difficulty;
 use core::{core, ser};
@@ -243,6 +245,7 @@ pub struct PeerInfo {
 	pub total_difficulty: Difficulty,
 	pub height: u64,
 	pub direction: Direction,
+	pub last_seen: DateTime<Utc>,
 }
 
 /// The full txhashset data along with indexes required for a consumer to

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -19,6 +19,8 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
+use chrono::prelude::*;
+
 use chain;
 use common::types::SyncStatus;
 use p2p;
@@ -144,6 +146,8 @@ pub struct PeerStats {
 	pub height: u64,
 	/// direction
 	pub direction: String,
+	/// Last time we saw a ping/pong from this peer.
+	pub last_seen: DateTime<Utc>,
 }
 
 impl StratumStats {
@@ -176,6 +180,7 @@ impl PeerStats {
 			total_difficulty: peer.info.total_difficulty.to_num(),
 			height: peer.info.height,
 			direction: direction.to_string(),
+			last_seen: peer.info.last_seen,
 		}
 	}
 }

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -18,6 +18,8 @@ use std::cmp::Ordering;
 
 use servers::{PeerStats, ServerStats};
 
+use chrono::prelude::*;
+
 use cursive::direction::Orientation;
 use cursive::traits::{Boxable, Identifiable};
 use cursive::view::View;
@@ -55,7 +57,12 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::Address => self.addr.clone(),
 			PeerColumn::State => self.state.clone(),
 			PeerColumn::TotalDifficulty => {
-				format!("{} D @ {} H", self.total_difficulty, self.height).to_string()
+				format!(
+					"{} D @ {} H ({}s)",
+					self.total_difficulty,
+					self.height,
+					(Utc::now() - self.last_seen).num_seconds(),
+				).to_string()
 			}
 			PeerColumn::Direction => self.direction.clone(),
 			PeerColumn::Version => self.version.to_string(),

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -56,14 +56,12 @@ impl TableViewItem<PeerColumn> for PeerStats {
 		match column {
 			PeerColumn::Address => self.addr.clone(),
 			PeerColumn::State => self.state.clone(),
-			PeerColumn::TotalDifficulty => {
-				format!(
-					"{} D @ {} H ({}s)",
-					self.total_difficulty,
-					self.height,
-					(Utc::now() - self.last_seen).num_seconds(),
-				).to_string()
-			}
+			PeerColumn::TotalDifficulty => format!(
+				"{} D @ {} H ({}s)",
+				self.total_difficulty,
+				self.height,
+				(Utc::now() - self.last_seen).num_seconds(),
+			).to_string(),
 			PeerColumn::Direction => self.direction.clone(),
 			PeerColumn::Version => self.version.to_string(),
 		}


### PR DESCRIPTION
Becoming more and more suspicious that our peer data gets stale locally.
I observed a "stuck" node that said it only had one "most work peer" but looking at the total_diff against each connected peer there were discrepencies - the data was stale.

This PR adds a `last_seen` to peer info.
We now update this on every ping/pong message.
Expose last_seen under the peer list in the tui.


