### PR TITLE
small improvement on the capabilities config comments

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -210,8 +210,9 @@ fn comments() -> HashMap<String, String> {
 
 	retval.insert(
 		"[server.p2p_config.capabilities]".to_string(),
-		"#7 = Bit flags for FULL_NODE, this structure needs to be changed
-#internally to make it more configurable
+		"# 7 = Bit flags for FULL_NODE
+# 6 = Bit flags for FAST_SYNC_NODE
+#This structure needs to be changed internally, to make it more configurable
 ".to_string(),
 	);
 


### PR DESCRIPTION
> John Tromp @tromp 16:23
it says Bit flags for FULL_NODE and then bits = 6
#7 = Bit flags for FULL_NODE, this structure needs to be changed
#internally to make it more configurable
[server.p2p_config.capabilities]
bits = 6
---

> Gary Yu @garyyu 16:24
it says 7= … FULL_NODE. Confused?
---

> John Tromp @tromp 16:25
6 is for FAST_SYNC_NODE
oh i see why im confused
the 7 is not separate from #
---

> John Tromp @tromp 16:27
i read it as a garbled # bit flags for FULL_NODE
---

> Gary Yu @garyyu 16:28
Ok, will give a minor change on this comment.

