### PR TITLE
Replace RefCell with RwLock in OneTime (and cleanup Weak usage)

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -791,9 +791,9 @@ impl Handler for PoolPushHandler {
 /// except during tests).
 pub fn start_rest_apis(
 	addr: String,
-	chain: Weak<chain::Chain>,
-	tx_pool: Weak<RwLock<pool::TransactionPool>>,
-	peers: Weak<p2p::Peers>,
+	chain: Arc<chain::Chain>,
+	tx_pool: Arc<RwLock<pool::TransactionPool>>,
+	peers: Arc<p2p::Peers>,
 	api_secret: Option<String>,
 	tls_config: Option<TLSConfig>,
 ) -> bool {
@@ -813,9 +813,9 @@ pub fn start_rest_apis(
 }
 
 pub fn build_router(
-	chain: Weak<chain::Chain>,
-	tx_pool: Weak<RwLock<pool::TransactionPool>>,
-	peers: Weak<p2p::Peers>,
+	chain: Arc<chain::Chain>,
+	tx_pool: Arc<RwLock<pool::TransactionPool>>,
+	peers: Arc<p2p::Peers>,
 ) -> Result<Router, RouterError> {
 	let route_list = vec![
 		"get blocks".to_string(),
@@ -840,45 +840,45 @@ pub fn build_router(
 	let index_handler = IndexHandler { list: route_list };
 
 	let output_handler = OutputHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 
 	let block_handler = BlockHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let header_handler = HeaderHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let chain_tip_handler = ChainHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let chain_compact_handler = ChainCompactHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let chain_validation_handler = ChainValidationHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let status_handler = StatusHandler {
-		chain: chain.clone(),
-		peers: peers.clone(),
+		chain: Arc::downgrade(&chain),
+		peers: Arc::downgrade(&peers),
 	};
 	let txhashset_handler = TxHashSetHandler {
-		chain: chain.clone(),
+		chain: Arc::downgrade(&chain),
 	};
 	let pool_info_handler = PoolInfoHandler {
-		tx_pool: tx_pool.clone(),
+		tx_pool: Arc::downgrade(&tx_pool),
 	};
 	let pool_push_handler = PoolPushHandler {
-		tx_pool: tx_pool.clone(),
+		tx_pool: Arc::downgrade(&tx_pool),
 	};
 	let peers_all_handler = PeersAllHandler {
-		peers: peers.clone(),
+		peers: Arc::downgrade(&peers),
 	};
 	let peers_connected_handler = PeersConnectedHandler {
-		peers: peers.clone(),
+		peers: Arc::downgrade(&peers),
 	};
 	let peer_handler = PeerHandler {
-		peers: peers.clone(),
+		peers: Arc::downgrade(&peers),
 	};
 
 	let mut router = Router::new();

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -61,6 +61,10 @@ impl TransactionPool {
 		}
 	}
 
+	pub fn chain_head(&self) -> Result<BlockHeader, PoolError> {
+		self.blockchain.chain_head()
+	}
+
 	fn add_to_stempool(&mut self, entry: PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
 		// Add tx to stempool (passing in all txs from txpool to validate against).
 		self.stempool

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -40,7 +40,7 @@ use util::{OneTime, LOGGER};
 pub struct NetToChainAdapter {
 	sync_state: Arc<SyncState>,
 	archive_mode: bool,
-	chain: Arc<chain::Chain>,
+	chain: Weak<chain::Chain>,
 	tx_pool: Arc<RwLock<pool::TransactionPool>>,
 	verifier_cache: Arc<RwLock<VerifierCache>>,
 	peers: OneTime<Weak<p2p::Peers>>,
@@ -49,11 +49,11 @@ pub struct NetToChainAdapter {
 
 impl p2p::ChainAdapter for NetToChainAdapter {
 	fn total_difficulty(&self) -> Difficulty {
-		self.chain.head().unwrap().total_difficulty
+		self.chain().head().unwrap().total_difficulty
 	}
 
 	fn total_height(&self) -> u64 {
-		self.chain.head().unwrap().height
+		self.chain().head().unwrap().height
 	}
 
 	fn transaction_received(&self, tx: core::Transaction, stem: bool) {
@@ -68,7 +68,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		};
 
 		let tx_hash = tx.hash();
-		let header = self.chain.head_header().unwrap();
+		let header = self.chain().head_header().unwrap();
 
 		debug!(
 			LOGGER,
@@ -129,7 +129,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		} else {
 			// check at least the header is valid before hydrating
 			if let Err(e) = self
-				.chain
+				.chain()
 				.process_block_header(&cb.header, self.chain_opts())
 			{
 				debug!(LOGGER, "Invalid compact block header {}: {}", cb_hash, e);
@@ -161,7 +161,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				}
 			};
 
-			if let Ok(prev) = self.chain.get_block_header(&cb.header.previous) {
+			if let Ok(prev) = self.chain().get_block_header(&cb.header.previous) {
 				if block
 					.validate(
 						&prev.total_kernel_offset,
@@ -206,7 +206,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 		// pushing the new block header through the header chain pipeline
 		// we will go ask for the block if this is a new header
-		let res = self.chain.process_block_header(&bh, self.chain_opts());
+		let res = self.chain().process_block_header(&bh, self.chain_opts());
 
 		if let &Err(ref e) = &res {
 			debug!(
@@ -220,7 +220,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 					LOGGER,
 					"header_received: {} is a bad header, resetting header head", bhash
 				);
-				let _ = self.chain.reset_head();
+				let _ = self.chain().reset_head();
 				return false;
 			} else {
 				// we got an error when trying to process the block header
@@ -250,7 +250,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		}
 
 		// try to add headers to our header chain
-		let res = self.chain.sync_block_headers(&bhs, self.chain_opts());
+		let res = self.chain().sync_block_headers(&bhs, self.chain_opts());
 		if let &Err(ref e) = &res {
 			debug!(LOGGER, "Block headers refused by chain: {:?}", e);
 
@@ -275,7 +275,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		let hh = header.height;
 		let mut headers = vec![];
 		for h in (hh + 1)..(hh + (p2p::MAX_BLOCK_HEADERS as u64)) {
-			let header = self.chain.get_header_by_height(h);
+			let header = self.chain().get_header_by_height(h);
 			match header {
 				Ok(head) => headers.push(head),
 				Err(e) => match e.kind() {
@@ -299,7 +299,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 	/// Gets a full block by its hash.
 	fn get_block(&self, h: Hash) -> Option<core::Block> {
-		let b = self.chain.get_block(&h);
+		let b = self.chain().get_block(&h);
 		match b {
 			Ok(b) => Some(b),
 			_ => None,
@@ -310,7 +310,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 	/// the required indexes for a consumer to rewind to a consistent state
 	/// at the provided block hash.
 	fn txhashset_read(&self, h: Hash) -> Option<p2p::TxHashSetRead> {
-		match self.chain.txhashset_read(h.clone()) {
+		match self.chain().txhashset_read(h.clone()) {
 			Ok((out_index, kernel_index, read)) => Some(p2p::TxHashSetRead {
 				output_index: out_index,
 				kernel_index: kernel_index,
@@ -341,7 +341,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		}
 
 		if let Err(e) = self
-			.chain
+			.chain()
 			.txhashset_write(h, txhashset_data, self.sync_state.as_ref())
 		{
 			error!(LOGGER, "Failed to save txhashset archive: {}", e);
@@ -360,7 +360,7 @@ impl NetToChainAdapter {
 	pub fn new(
 		sync_state: Arc<SyncState>,
 		archive_mode: bool,
-		chain_ref: Arc<chain::Chain>,
+		chain: Arc<chain::Chain>,
 		tx_pool: Arc<RwLock<pool::TransactionPool>>,
 		verifier_cache: Arc<RwLock<VerifierCache>>,
 		config: ServerConfig,
@@ -368,7 +368,7 @@ impl NetToChainAdapter {
 		NetToChainAdapter {
 			sync_state,
 			archive_mode,
-			chain: chain_ref,
+			chain: Arc::downgrade(&chain),
 			tx_pool,
 			verifier_cache,
 			peers: OneTime::new(),
@@ -389,6 +389,12 @@ impl NetToChainAdapter {
 			.expect("Failed to upgrade weak ref to our peers.")
 	}
 
+	fn chain(&self) -> Arc<chain::Chain> {
+		self.chain
+			.upgrade()
+			.expect("Failed to upgrade weak ref to our chain.")
+	}
+
 	// recursively go back through the locator vector and stop when we find
 	// a header that we recognize this will be a header shared in common
 	// between us and the peer
@@ -397,12 +403,12 @@ impl NetToChainAdapter {
 			return None;
 		}
 
-		let known = self.chain.get_block_header(&locator[0]);
+		let known = self.chain().get_block_header(&locator[0]);
 
 		match known {
 			Ok(header) => {
 				// even if we know the block, it may not be on our winning chain
-				let known_winning = self.chain.get_header_by_height(header.height);
+				let known_winning = self.chain().get_header_by_height(header.height);
 				if let Ok(known_winning) = known_winning {
 					if known_winning.hash() != header.hash() {
 						self.find_common_header(locator[1..].to_vec())
@@ -429,7 +435,7 @@ impl NetToChainAdapter {
 	// remembering to reset the head if we have a bad block
 	fn process_block(&self, b: core::Block, addr: SocketAddr) -> bool {
 		if !self.archive_mode {
-			let head = self.chain.head().unwrap();
+			let head = self.chain().head().unwrap();
 			// we have a fast sync'd node and are sent a block older than our horizon,
 			// only sync can do something with that
 			if b.header.height < head
@@ -442,7 +448,7 @@ impl NetToChainAdapter {
 
 		let prev_hash = b.header.previous;
 		let bhash = b.hash();
-		match self.chain.process_block(b, self.chain_opts()) {
+		match self.chain().process_block(b, self.chain_opts()) {
 			Ok(tip) => {
 				self.validate_chain(bhash);
 				self.check_compact(tip);
@@ -453,7 +459,7 @@ impl NetToChainAdapter {
 					LOGGER,
 					"adapter: process_block: {} is a bad block, resetting head", bhash
 				);
-				let _ = self.chain.reset_head();
+				let _ = self.chain().reset_head();
 
 				// we potentially changed the state of the system here
 				// so check everything is still ok
@@ -465,7 +471,7 @@ impl NetToChainAdapter {
 				match e.kind() {
 					chain::ErrorKind::Orphan => {
 						// make sure we did not miss the parent block
-						if !self.chain.is_orphan(&prev_hash) && !self.sync_state.is_syncing() {
+						if !self.chain().is_orphan(&prev_hash) && !self.sync_state.is_syncing() {
 							debug!(LOGGER, "adapter: process_block: received an orphan block, checking the parent: {:}", prev_hash);
 							self.request_block_by_hash(prev_hash, &addr)
 						}
@@ -491,7 +497,7 @@ impl NetToChainAdapter {
 		// We are out of consensus at this point and want to track the problem
 		// down as soon as possible.
 		// Skip this if we are currently syncing (too slow).
-		if self.chain.head().unwrap().height > 0
+		if self.chain().head().unwrap().height > 0
 			&& !self.sync_state.is_syncing()
 			&& self.config.chain_validation_mode == ChainValidationMode::EveryBlock
 		{
@@ -502,7 +508,7 @@ impl NetToChainAdapter {
 				"adapter: process_block: ***** validating full chain state at {}", bhash,
 			);
 
-			self.chain
+			self.chain()
 				.validate(true)
 				.expect("chain validation failed, hard stop");
 
@@ -524,7 +530,7 @@ impl NetToChainAdapter {
 			// trigger compaction every 2000 blocks, uses a different thread to avoid
 			// blocking the caller thread (likely a peer)
 			if tip.height % 2000 == 0 {
-				let chain = self.chain.clone();
+				let chain = self.chain().clone();
 				let _ = thread::Builder::new()
 					.name("compactor".to_string())
 					.spawn(move || {
@@ -561,7 +567,7 @@ impl NetToChainAdapter {
 	where
 		F: Fn(&p2p::Peer, Hash) -> Result<(), p2p::Error>,
 	{
-		match self.chain.block_exists(h) {
+		match self.chain().block_exists(h) {
 			Ok(false) => match self.peers().get_connected_peer(addr) {
 				None => debug!(
 					LOGGER,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -34,7 +34,6 @@ use pool;
 use store;
 use util::{OneTime, LOGGER};
 
-
 /// Implementation of the NetAdapter for the . Gets notified when new
 /// blocks and transactions are received and forwards to the chain and pool
 /// implementations.
@@ -658,14 +657,14 @@ pub struct PoolToNetAdapter {
 
 impl pool::PoolAdapter for PoolToNetAdapter {
 	fn stem_tx_accepted(&self, tx: &core::Transaction) -> Result<(), pool::PoolError> {
-		self.peers.borrow()
+		self.peers
+			.borrow()
 			.broadcast_stem_transaction(tx)
 			.map_err(|_| pool::PoolError::DandelionError)?;
 		Ok(())
 	}
 	fn tx_accepted(&self, tx: &core::Transaction) {
-		self.peers.borrow()
-			.broadcast_transaction(tx);
+		self.peers.borrow().broadcast_transaction(tx);
 	}
 }
 
@@ -707,37 +706,43 @@ impl PoolToChainAdapter {
 
 impl pool::BlockChain for PoolToChainAdapter {
 	fn chain_head(&self) -> Result<BlockHeader, pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.head_header()
 			.map_err(|_| pool::PoolError::Other(format!("failed to get head_header")))
 	}
 
 	fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.get_block_header(hash)
 			.map_err(|_| pool::PoolError::Other(format!("failed to get block_header")))
 	}
 
 	fn get_block_sums(&self, hash: &Hash) -> Result<BlockSums, pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.get_block_sums(hash)
 			.map_err(|_| pool::PoolError::Other(format!("failed to get block_sums")))
 	}
 
 	fn validate_tx(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.validate_tx(tx)
 			.map_err(|_| pool::PoolError::Other(format!("failed to validate tx")))
 	}
 
 	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.verify_coinbase_maturity(tx)
 			.map_err(|_| pool::PoolError::ImmatureCoinbase)
 	}
 
 	fn verify_tx_lock_height(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		self.chain.borrow()
+		self.chain
+			.borrow()
 			.verify_tx_lock_height(tx)
 			.map_err(|_| pool::PoolError::ImmatureTransaction)
 	}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -656,7 +656,10 @@ impl ChainToPoolAndNetAdapter {
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
-		self.peers.borrow().upgrade().expect("Failed to upgrade weak ref to our peers.")
+		self.peers
+			.borrow()
+			.upgrade()
+			.expect("Failed to upgrade weak ref to our peers.")
 	}
 }
 

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -53,8 +53,6 @@ pub fn monitor_transactions(
 				let patience_secs = dandelion_config.patience_secs.unwrap();
 				thread::sleep(Duration::from_secs(patience_secs));
 
-				let tx_pool = tx_pool.clone();
-
 				// Step 1: find all "ToStem" entries in stempool from last run.
 				// Aggregate them up to give a single (valid) aggregated tx and propagate it
 				// to the next Dandelion relay along the stem.
@@ -90,7 +88,7 @@ fn process_stem_phase(
 ) -> Result<(), PoolError> {
 	let mut tx_pool = tx_pool.write().unwrap();
 
-	let header = tx_pool.blockchain.chain_head()?;
+	let header = tx_pool.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
 	let stem_txs = tx_pool
@@ -137,7 +135,7 @@ fn process_fluff_phase(
 ) -> Result<(), PoolError> {
 	let mut tx_pool = tx_pool.write().unwrap();
 
-	let header = tx_pool.blockchain.chain_head()?;
+	let header = tx_pool.chain_head()?;
 
 	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
 	let stem_txs = tx_pool
@@ -239,7 +237,7 @@ fn process_expired_entries(
 
 		{
 			let mut tx_pool = tx_pool.write().unwrap();
-			let header = tx_pool.blockchain.chain_head()?;
+			let header = tx_pool.chain_head()?;
 
 			for entry in expired_entries {
 				let src = TxSource {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -258,9 +258,9 @@ impl Server {
 		let api_secret = get_first_line(config.api_secret_path.clone());
 		api::start_rest_apis(
 			config.api_http_addr.clone(),
-			Arc::downgrade(&shared_chain),
-			Arc::downgrade(&tx_pool),
-			Arc::downgrade(&p2p_server.peers),
+			shared_chain.clone(),
+			tx_pool.clone(),
+			p2p_server.peers.clone(),
 			api_secret,
 			None,
 		);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -168,14 +168,14 @@ impl Server {
 			archive_mode,
 		)?);
 
-		pool_adapter.set_chain(Arc::downgrade(&shared_chain));
+		pool_adapter.set_chain(shared_chain.clone());
 
 		let awaiting_peers = Arc::new(AtomicBool::new(false));
 
 		let net_adapter = Arc::new(NetToChainAdapter::new(
 			sync_state.clone(),
 			archive_mode,
-			Arc::downgrade(&shared_chain),
+			shared_chain.clone(),
 			tx_pool.clone(),
 			verifier_cache.clone(),
 			config.clone(),
@@ -197,9 +197,9 @@ impl Server {
 			archive_mode,
 			block_1_hash,
 		)?);
-		chain_adapter.init(Arc::downgrade(&p2p_server.peers));
-		pool_net_adapter.init(Arc::downgrade(&p2p_server.peers));
-		net_adapter.init(Arc::downgrade(&p2p_server.peers));
+		chain_adapter.init(p2p_server.peers.clone());
+		pool_net_adapter.init(p2p_server.peers.clone());
+		net_adapter.init(p2p_server.peers.clone());
 
 		if config.p2p_config.seeding_type.clone() != p2p::Seeding::Programmatic {
 			let seeder = match config.p2p_config.seeding_type.clone() {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -58,9 +58,9 @@ pub mod macros;
 
 // other utils
 use byteorder::{BigEndian, ByteOrder};
-use std::sync::{Arc, RwLock};
 #[allow(unused_imports)]
 use std::ops::Deref;
+use std::sync::{Arc, RwLock};
 
 mod hex;
 pub use hex::*;
@@ -82,11 +82,13 @@ pub struct OneTime<T> {
 
 impl<T> OneTime<T>
 where
-	T: Clone
+	T: Clone,
 {
 	/// Builds a new uninitialized OneTime.
 	pub fn new() -> OneTime<T> {
-		OneTime { inner: Arc::new(RwLock::new(None)) }
+		OneTime {
+			inner: Arc::new(RwLock::new(None)),
+		}
 	}
 
 	/// Initializes the OneTime, should only be called once after construction.
@@ -101,7 +103,9 @@ where
 	/// Will panic (via expect) if called before initialization.
 	pub fn borrow(&self) -> T {
 		let inner = self.inner.read().unwrap();
-		inner.clone().expect("Cannot borrow one_time before initialization.")
+		inner
+			.clone()
+			.expect("Cannot borrow one_time before initialization.")
 	}
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -58,7 +58,7 @@ pub mod macros;
 
 // other utils
 use byteorder::{BigEndian, ByteOrder};
-use std::cell::{Ref, RefCell};
+use std::sync::{Arc, RwLock};
 #[allow(unused_imports)]
 use std::ops::Deref;
 
@@ -70,44 +70,38 @@ pub mod file;
 /// Compress and decompress zip bz2 archives
 pub mod zip;
 
-/// Encapsulation of a RefCell<Option<T>> for one-time initialization after
-/// construction. This implementation will purposefully fail hard if not used
-/// properly, for example if it's not initialized before being first used
+/// Encapsulation of a RwLock<Option<T>> for one-time initialization.
+/// This implementation will purposefully fail hard if not used
+/// properly, for example if not initialized before being first used
 /// (borrowed).
 #[derive(Clone)]
 pub struct OneTime<T> {
-	/// inner
-	inner: RefCell<Option<T>>,
+	/// The inner value.
+	inner: Arc<RwLock<Option<T>>>,
 }
 
-unsafe impl<T> Sync for OneTime<T> {}
-unsafe impl<T> Send for OneTime<T> {}
-
-impl<T> OneTime<T> {
+impl<T> OneTime<T>
+where
+	T: Clone
+{
 	/// Builds a new uninitialized OneTime.
 	pub fn new() -> OneTime<T> {
-		OneTime {
-			inner: RefCell::new(None),
-		}
+		OneTime { inner: Arc::new(RwLock::new(None)) }
 	}
 
 	/// Initializes the OneTime, should only be called once after construction.
+	/// Will panic (via assert) if called more than once.
 	pub fn init(&self, value: T) {
-		let mut inner_mut = self.inner.borrow_mut();
-		*inner_mut = Some(value);
-	}
-
-	/// Whether the OneTime has been initialized
-	pub fn is_initialized(&self) -> bool {
-		match self.inner.try_borrow() {
-			Ok(inner) => inner.is_some(),
-			Err(_) => false,
-		}
+		let mut inner = self.inner.write().unwrap();
+		assert!(inner.is_none());
+		*inner = Some(value);
 	}
 
 	/// Borrows the OneTime, should only be called after initialization.
-	pub fn borrow(&self) -> Ref<T> {
-		Ref::map(self.inner.borrow(), |o| o.as_ref().unwrap())
+	/// Will panic (via expect) if called before initialization.
+	pub fn borrow(&self) -> T {
+		let inner = self.inner.read().unwrap();
+		inner.clone().expect("Cannot borrow one_time before initialization.")
 	}
 }
 


### PR DESCRIPTION
This builds and runs... why do we need the complexity of weak refs?
