### PR TITLE
fix: to avoid dead lock, always put txhashset.write before store.batch

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -219,8 +219,8 @@ impl Chain {
 	fn process_block_single(&self, b: Block, opts: Options) -> Result<Option<Tip>, Error> {
 		let maybe_new_head: Result<Option<Tip>, Error>;
 		{
-			let batch = self.store.batch()?;
 			let mut txhashset = self.txhashset.write().unwrap();
+			let batch = self.store.batch()?;
 			let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 
 			maybe_new_head = pipe::process_block(&b, &mut ctx);
@@ -299,8 +299,8 @@ impl Chain {
 
 	/// Process a block header received during "header first" propagation.
 	pub fn process_block_header(&self, bh: &BlockHeader, opts: Options) -> Result<(), Error> {
-		let batch = self.store.batch()?;
 		let mut txhashset = self.txhashset.write().unwrap();
+		let batch = self.store.batch()?;
 		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 		pipe::process_block_header(bh, &mut ctx)?;
 		ctx.batch.commit()?;
@@ -315,8 +315,8 @@ impl Chain {
 		headers: &Vec<BlockHeader>,
 		opts: Options,
 	) -> Result<(), Error> {
-		let batch = self.store.batch()?;
 		let mut txhashset = self.txhashset.write().unwrap();
+		let batch = self.store.batch()?;
 		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
 
 		pipe::sync_block_headers(headers, &mut ctx)?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -666,17 +666,6 @@ impl Chain {
 
 		status.on_save();
 
-		// Replace the chain txhashset with the newly built one.
-		{
-			let mut txhashset_ref = self.txhashset.write().unwrap();
-			*txhashset_ref = txhashset;
-		}
-
-		debug!(
-			LOGGER,
-			"chain: txhashset_write: replaced our txhashset with the new one"
-		);
-
 		// Save the new head to the db and rebuild the header by height index.
 		{
 			let tip = Tip::from_block(&header);
@@ -691,6 +680,17 @@ impl Chain {
 		debug!(
 			LOGGER,
 			"chain: txhashset_write: finished committing the batch (head etc.)"
+		);
+
+		// Replace the chain txhashset with the newly built one.
+		{
+			let mut txhashset_ref = self.txhashset.write().unwrap();
+			*txhashset_ref = txhashset;
+		}
+
+		debug!(
+			LOGGER,
+			"chain: txhashset_write: replaced our txhashset with the new one"
 		);
 
 		// Check for any orphan blocks and process them based on the new chain state.


### PR DESCRIPTION
Fix for https://github.com/mimblewimble/grin/issues/1698

And we have to always remember in the future that `txhashset.write()` must always before `store.batch()`.

Perhaps somebody has better fix solution for this?  wrap a dedication function? or define a macro?
