### PR TITLE
docs: fix broken links on doc/table_of_contents.md

### DIFF
--- a/doc/table_of_contents.md
+++ b/doc/table_of_contents.md
@@ -21,7 +21,7 @@
 
 ## Build and use
 
-- [api](api/api/md) - Explaining the different APIs in Grin and how to use them
+- [api](api/api.md) - Explaining the different APIs in Grin and how to use them
 - [build](build.md) - Explaining how to build and run the Grin binaries
 - [release](release_instruction.md) - Instructions of making a release
 - [usage](usage.md) - Explaining how to use grin in Testnet3

--- a/doc/table_of_contents.md
+++ b/doc/table_of_contents.md
@@ -17,7 +17,7 @@
 - [merkle_proof graph](merkle_proof/merkle_proof.png) - Example merkle proof with pruning applied
 - [pruning](pruning.md) - Technical explanation of pruning
 - [stratum](stratum.md) - Technical explanation of Grin Stratum RPC protocol
-- [transaction UML](transaction/aggregating transaction without lock_height) - UML of an interactive transaction
+- [transaction UML](wallet/transaction/basic-transaction-wf.png) - UML of an interactive transaction (aggregating transaction without `lock_height`)
 
 ## Build and use
 


### PR DESCRIPTION
fix broken link: slightly slighted api.md (doc/api/api.md)

also, this doesn't make sense ([L20](https://github.com/mimblewimble/grin/blame/bcaecdeba712549adadef9a385f6d6aec5472ca0/doc/table_of_contents.md#L20-L24)):
`[transaction UML](transaction/aggregating transaction without lock_height)`?
what should this be pointing to?