### PR TITLE
chain difficulty_iter don't need a WriteTransaction batch

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -943,8 +943,8 @@ impl Chain {
 	/// difficulty calculation (timestamp and previous difficulties).
 	pub fn difficulty_iter(&self) -> store::DifficultyIter {
 		let head = self.head().unwrap();
-		let batch = self.store.batch().unwrap();
-		store::DifficultyIter::from(head.last_block_h, batch)
+		let store = self.store.clone();
+		store::DifficultyIter::from(head.last_block_h, store)
 	}
 
 	/// Check whether we have a block without reading it

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -434,7 +434,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		// the _network_ difficulty of the previous block
 		// (during testnet1 we use _block_ difficulty here)
 		let child_batch = ctx.batch.child()?;
-		let diff_iter = store::DifficultyIter::from(header.previous, child_batch);
+		let diff_iter = store::DifficultyIter::from_batch(header.previous, child_batch);
 		let network_difficulty = consensus::next_difficulty(diff_iter)
 			.context(ErrorKind::Other("network difficulty".to_owned()))?;
 		if target_difficulty != network_difficulty.clone() {


### PR DESCRIPTION
- A little bit optimization for chain store batch usage. the chain::difficulty_iter() is a typical `ReadTransaction` and batch for `WriteTransaction` is not necessary.  And `read` is not blocking, so it's much better for performance improvement.

- This PR can fix https://github.com/mimblewimble/grin/issues/1616, to avoid cause TUI freeze.
- And it's the base of https://github.com/mimblewimble/grin/issues/1702.