### PR TITLE
fix: panic at get_locator

### DIFF
--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -240,15 +240,16 @@ impl HeaderSync {
 			let shrink_index = self
 				.history_locators
 				.iter()
-				.position(|&r| r.0 > shrink_height)
-				.unwrap();
-			if shrink_index > 100 {
-				// shrink but avoid trivial shrinking
-				let mut shrunk = self.history_locators[shrink_index..].to_vec();
-				shrunk_size = shrink_index;
-				self.history_locators.clear();
-				self.history_locators.push((0, locator[locator.len() - 1]));
-				self.history_locators.append(&mut shrunk);
+				.position(|&r| r.0 > shrink_height);
+			if let Some(shrink_index) = shrink_index {
+				if shrink_index > 100 {
+					// shrink but avoid trivial shrinking
+					let mut shrunk = self.history_locators[shrink_index..].to_vec();
+					shrunk_size = shrink_index;
+					self.history_locators.clear();
+					self.history_locators.push((0, locator[locator.len() - 1]));
+					self.history_locators.append(&mut shrunk);
+				}
 			}
 			debug!(
 				LOGGER,


### PR DESCRIPTION
A small fix for a panic on an unwrap:
```
DEBG sync: locator heights : [1, 0]
DEBG sync: locator heights': [1, 0]
ERRO
thread 'sync' panicked at 'called `Option::unwrap()` on a `None` value': libcore/option.rs:345stack backtrace:
  ...
  10:        0x10f15dd9c - grin_servers::grin::sync::header_sync::HeaderSync::get_locator::h18a2786edac31dba
                        at servers/src/grin/sync/header_sync.rs:240
  11:        0x10f15c7b7 - grin_servers::grin::sync::header_sync::HeaderSync::request_headers::h84a2e0d074b8e530
                        at servers/src/grin/sync/header_sync.rs:136
  12:        0x10f15c682 - grin_servers::grin::sync::header_sync::HeaderSync::header_sync::h302ab76ec8ee0523
                        at servers/src/grin/sync/header_sync.rs:128
  13:        0x10f15c1af - grin_servers::grin::sync::header_sync::HeaderSync::check_run::h81d6e92585a3d2e1
                        at servers/src/grin/sync/header_sync.rs:83
  14:        0x10f15963e - grin_servers::grin::sync::syncer::sync_loop::h0da8c14686c255ea
                        at servers/src/grin/sync/syncer.rs:140
  15:        0x10f0fdeb6 - grin_servers::grin::sync::syncer::run_sync::{{closure}}::h29066a617013331c
                        at servers/src/grin/sync/syncer.rs:41
```