### PR TITLE
fix: binary auto release feature broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
     fi;
 
 before_deploy:
-  - if [[ "TEST_SUITE" == "pool-p2p" ]]; then
+  - if [[ "$TEST_SUITE" == "pool-p2p" ]]; then
       cargo clean && cargo build --release && ./.auto-release.sh;
     fi
 


### PR DESCRIPTION
Auto binary release & auto change log generation feature broken, because of a mistake on the script.

Not easy to test this feature on my own repo now, since the token and repo name is different.

Have to merge and test on mimblewimble/grin repo.