### PR TITLE
The Header MMR (One MMR To Rule Them All)

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -97,9 +97,9 @@ impl TxHashSet {
 	pub fn from_head(head: Arc<chain::Chain>) -> TxHashSet {
 		let roots = head.get_txhashset_roots();
 		TxHashSet {
-			output_root_hash: roots.0.to_hex(),
-			range_proof_root_hash: roots.1.to_hex(),
-			kernel_root_hash: roots.2.to_hex(),
+			output_root_hash: roots.output_root.to_hex(),
+			range_proof_root_hash: roots.rproof_root.to_hex(),
+			kernel_root_hash: roots.kernel_root.to_hex(),
 		}
 	}
 }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -35,7 +35,7 @@ use grin_store::Error::NotFoundErr;
 use pipe;
 use store;
 use txhashset;
-use types::{ChainAdapter, NoStatus, Options, Tip, TxHashsetWriteStatus};
+use types::{ChainAdapter, NoStatus, Options, Tip, TxHashSetRoots, TxHashsetWriteStatus};
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::LOGGER;
 
@@ -530,7 +530,7 @@ impl Chain {
 	}
 
 	/// Returns current txhashset roots
-	pub fn get_txhashset_roots(&self) -> (Hash, Hash, Hash) {
+	pub fn get_txhashset_roots(&self) -> TxHashSetRoots {
 		let mut txhashset = self.txhashset.write().unwrap();
 		txhashset.roots()
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -598,7 +598,10 @@ impl Chain {
 		Ok(())
 	}
 
-	// TODO - think about how to optimize this.
+	/// Rebuild the sync MMR based on current header_head.
+	/// We rebuild the sync MMR when first entering sync mode so ensure we
+	/// have an MMR we can safely rewind based on the headers received from a peer.
+	/// TODO - think about how to optimize this.
 	pub fn rebuild_sync_mmr(&self, head: &Tip) -> Result<(), Error> {
 		let mut txhashset = self.txhashset.write().unwrap();
 		let mut batch = self.store.batch()?;
@@ -610,7 +613,11 @@ impl Chain {
 		Ok(())
 	}
 
-	// TODO - think about how to optimize this.
+	/// Rebuild the header MMR based on current header_head.
+	/// We rebuild the header MMR after receiving a txhashset from a peer.
+	/// The txhashset contains output, rangeproof and kernel MMRs but we construct
+	/// the header MMR locally based on headers from our db.
+	/// TODO - think about how to optimize this.
 	fn rebuild_header_mmr(
 		&self,
 		head: &Tip,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -54,19 +54,13 @@ const KERNEL_SUBDIR: &'static str = "kernel";
 
 const TXHASHSET_ZIP: &'static str = "txhashset_snapshot.zip";
 
-struct DBPMMRHandle<T>
-where
-	T: PMMRable,
-{
-	backend: DBPMMRBackend<T>,
+struct DBPMMRHandle {
+	backend: DBPMMRBackend,
 	last_pos: u64,
 }
 
-impl<T> DBPMMRHandle<T>
-where
-	T: PMMRable + ::std::fmt::Debug,
-{
-	fn new(root_dir: &str, sub_dir: &str, file_name: &str) -> Result<DBPMMRHandle<T>, Error> {
+impl DBPMMRHandle {
+	fn new(root_dir: &str, sub_dir: &str, file_name: &str) -> Result<DBPMMRHandle, Error> {
 		let path = Path::new(root_dir).join(sub_dir).join(file_name);
 		fs::create_dir_all(path.clone())?;
 		let backend = DBPMMRBackend::new(path.to_str().unwrap().to_string())?;
@@ -118,7 +112,7 @@ pub struct TxHashSet {
 	/// readonly_extension.
 	/// It can also be rewound and applied separately via a header_extension.
 	/// Note: the header MMR is backed by the database maintains just the hash file.
-	header_pmmr_h: DBPMMRHandle<BlockHeader>,
+	header_pmmr_h: DBPMMRHandle,
 
 	/// Header MMR to support exploratory sync_head.
 	/// The header_head and sync_head chains can diverge so we need to maintain
@@ -127,7 +121,7 @@ pub struct TxHashSet {
 	/// Note: this is rewound and applied separately to the other MMRs
 	/// via a "sync_extension".
 	/// Note: the sync MMR is backed by the database and maintains just the hash file.
-	sync_pmmr_h: DBPMMRHandle<BlockHeader>,
+	sync_pmmr_h: DBPMMRHandle,
 
 	output_pmmr_h: PMMRHandle<OutputIdentifier>,
 	rproof_pmmr_h: PMMRHandle<RangeProof>,
@@ -616,7 +610,7 @@ where
 pub struct HeaderExtension<'a> {
 	header: BlockHeader,
 
-	pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend<BlockHeader>>,
+	pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend>,
 
 	/// Rollback flag.
 	rollback: bool,
@@ -629,7 +623,7 @@ pub struct HeaderExtension<'a> {
 
 impl<'a> HeaderExtension<'a> {
 	fn new(
-		pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend<BlockHeader>>,
+		pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend>,
 		batch: &'a Batch,
 		header: BlockHeader,
 	) -> HeaderExtension<'a> {
@@ -733,7 +727,7 @@ impl<'a> HeaderExtension<'a> {
 pub struct Extension<'a> {
 	header: BlockHeader,
 
-	header_pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend<BlockHeader>>,
+	header_pmmr: DBPMMR<'a, BlockHeader, DBPMMRBackend>,
 	output_pmmr: PMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
 	rproof_pmmr: PMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 	kernel_pmmr: PMMR<'a, TxKernel, PMMRBackend<TxKernel>>,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -664,11 +664,7 @@ impl<'a> HeaderExtension<'a> {
 
 	// TODO - think about how to optimize this.
 	// Requires *all* header hashes to be iterated over in ascending order.
-	pub fn rebuild(
-		&mut self,
-		head: &Tip,
-		genesis: &BlockHeader,
-	) -> Result<(), Error> {
+	pub fn rebuild(&mut self, head: &Tip, genesis: &BlockHeader) -> Result<(), Error> {
 		debug!(
 			LOGGER,
 			"About to rebuild header extension from {:?} to {:?}.",

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -139,7 +139,11 @@ impl TxHashSet {
 		header: Option<&BlockHeader>,
 	) -> Result<TxHashSet, Error> {
 		Ok(TxHashSet {
-			header_pmmr_h: HashOnlyMMRHandle::new(&root_dir, HEADERHASHSET_SUBDIR, HEADER_HEAD_SUBDIR)?,
+			header_pmmr_h: HashOnlyMMRHandle::new(
+				&root_dir,
+				HEADERHASHSET_SUBDIR,
+				HEADER_HEAD_SUBDIR,
+			)?,
 			sync_pmmr_h: HashOnlyMMRHandle::new(&root_dir, HEADERHASHSET_SUBDIR, SYNC_HEAD_SUBDIR)?,
 			output_pmmr_h: PMMRHandle::new(
 				&root_dir,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -636,13 +636,26 @@ impl<'a> HeaderExtension<'a> {
 		Ok(())
 	}
 
-	pub fn rewind(&mut self, height: u64) -> Result<(), Error> {
-		debug!(LOGGER, "Rewind header extension to height {}", height,);
+	pub fn rewind(&mut self, header: &BlockHeader) -> Result<(), Error> {
+		debug!(
+			LOGGER,
+			"Rewind header extension to {} at {}",
+			header.hash(),
+			header.height
+		);
 
-		let header_pos = pmmr::insertion_to_pmmr_index(height);
+		let header_pos = pmmr::insertion_to_pmmr_index(header.height + 1);
 		self.pmmr
 			.rewind(header_pos)
 			.map_err(&ErrorKind::TxHashSetErr)?;
+
+		Ok(())
+	}
+
+	pub fn clear(&mut self) -> Result<(), Error> {
+		debug!(LOGGER, "Clear header extension.");
+
+		self.pmmr.rewind(0).map_err(&ErrorKind::TxHashSetErr)?;
 
 		Ok(())
 	}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1109,7 +1109,7 @@ impl<'a> Extension<'a> {
 		}
 	}
 
-	/// Validate the provided header by comparing its "prev_root" to the 
+	/// Validate the provided header by comparing its "prev_root" to the
 	/// root of the current header MMR.
 	///
 	/// TODO - Implement this once we commit to prev_root in block headers.

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -34,9 +34,11 @@ bitflags! {
 }
 
 /// A helper to hold the roots of the txhashset in order to keep them
-/// readable
+/// readable.
 #[derive(Debug)]
 pub struct TxHashSetRoots {
+	/// Header root
+	pub header_root: Hash,
 	/// Output root
 	pub output_root: Hash,
 	/// Range Proof root

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -34,7 +34,7 @@ use core::{
 use global;
 use keychain::{self, BlindingFactor};
 use pow::{Difficulty, Proof, ProofOfWork};
-use ser::{self, Readable, Reader, Writeable, Writer};
+use ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
 use util::{secp, secp_static, static_secp_instance, LOGGER};
 
 /// Errors thrown by Block validation
@@ -193,6 +193,14 @@ impl Default for BlockHeader {
 			kernel_mmr_size: 0,
 			pow: ProofOfWork::default(),
 		}
+	}
+}
+
+/// Block header hashes are maintained in the header MMR
+/// but we store the data itself in the db.
+impl PMMRable for BlockHeader {
+	fn len() -> usize {
+		0
 	}
 }
 

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -53,11 +53,13 @@ impl fmt::Display for Hash {
 }
 
 impl Hash {
+	pub const SIZE: usize = 32;
+
 	/// Builds a Hash from a byte vector. If the vector is too short, it will be
 	/// completed by zeroes. If it's too long, it will be truncated.
 	pub fn from_vec(v: &[u8]) -> Hash {
-		let mut h = [0; 32];
-		let copy_size = min(v.len(), 32);
+		let mut h = [0; Hash::SIZE];
+		let copy_size = min(v.len(), Hash::SIZE);
 		h[..copy_size].copy_from_slice(&v[..copy_size]);
 		Hash(h)
 	}

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -19,7 +19,7 @@ use core::BlockHeader;
 use ser::PMMRable;
 
 pub trait HashOnlyBackend {
-	fn append(&mut self, position: u64, data: Vec<Hash>) -> Result<(), String>;
+	fn append(&mut self, data: Vec<Hash>) -> Result<(), String>;
 
 	fn rewind(&mut self, position: u64) -> Result<(), String>;
 
@@ -38,7 +38,7 @@ where
 	/// associated data element to flatfile storage (for leaf nodes only). The
 	/// position of the first element of the Vec in the MMR is provided to
 	/// help the implementation.
-	fn append(&mut self, position: u64, data: &T, hashes: Vec<Hash>) -> Result<(), String>;
+	fn append(&mut self, data: T, hashes: Vec<Hash>) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -18,10 +18,7 @@ use core::hash::Hash;
 use core::BlockHeader;
 use ser::PMMRable;
 
-pub trait DBBackend<T>
-where
-	T: PMMRable,
-{
+pub trait DBBackend {
 	fn append(&mut self, position: u64, data: Vec<Hash>) -> Result<(), String>;
 
 	fn rewind(&mut self, position: u64) -> Result<(), String>;

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -38,7 +38,7 @@ where
 	/// associated data element to flatfile storage (for leaf nodes only). The
 	/// position of the first element of the Vec in the MMR is provided to
 	/// help the implementation.
-	fn append(&mut self, position: u64, data: Vec<(Hash, Option<T>)>) -> Result<(), String>;
+	fn append(&mut self, position: u64, data: &T, hashes: Vec<Hash>) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -18,6 +18,17 @@ use core::hash::Hash;
 use core::BlockHeader;
 use ser::PMMRable;
 
+pub trait DBBackend<T>
+where
+	T: PMMRable,
+{
+	fn append(&mut self, position: u64, data: Vec<Hash>) -> Result<(), String>;
+
+	fn rewind(&mut self, position: u64) -> Result<(), String>;
+
+	fn get_hash(&self, position: u64) -> Option<Hash>;
+}
+
 /// Storage backend for the MMR, just needs to be indexed by order of insertion.
 /// The PMMR itself does not need the Backend to be accurate on the existence
 /// of an element (i.e. remove could be a no-op) but layers above can

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -18,7 +18,7 @@ use core::hash::Hash;
 use core::BlockHeader;
 use ser::PMMRable;
 
-pub trait DBBackend {
+pub trait HashOnlyBackend {
 	fn append(&mut self, position: u64, data: Vec<Hash>) -> Result<(), String>;
 
 	fn rewind(&mut self, position: u64) -> Result<(), String>;

--- a/core/src/core/pmmr/db_pmmr.rs
+++ b/core/src/core/pmmr/db_pmmr.rs
@@ -17,14 +17,14 @@
 use std::marker;
 
 use core::hash::Hash;
-use core::pmmr::{bintree_postorder_height, is_leaf, peak_map_height, peaks, DBBackend};
+use core::pmmr::{bintree_postorder_height, is_leaf, peak_map_height, peaks, HashOnlyBackend};
 use ser::{PMMRIndexHashable, PMMRable};
 
 /// Database backed MMR.
 pub struct DBPMMR<'a, T, B>
 where
 	T: PMMRable,
-	B: 'a + DBBackend,
+	B: 'a + HashOnlyBackend,
 {
 	/// The last position in the PMMR
 	last_pos: u64,
@@ -37,7 +37,7 @@ where
 impl<'a, T, B> DBPMMR<'a, T, B>
 where
 	T: PMMRable + ::std::fmt::Debug,
-	B: 'a + DBBackend,
+	B: 'a + HashOnlyBackend,
 {
 	/// Build a new db backed MMR.
 	pub fn new(backend: &'a mut B) -> DBPMMR<T, B> {

--- a/core/src/core/pmmr/db_pmmr.rs
+++ b/core/src/core/pmmr/db_pmmr.rs
@@ -121,7 +121,7 @@ where
 		}
 
 		// append all the new nodes and update the MMR index
-		self.backend.append(elmt_pos, to_append)?;
+		self.backend.append(to_append)?;
 		self.last_pos = pos;
 		Ok(elmt_pos)
 	}

--- a/core/src/core/pmmr/db_pmmr.rs
+++ b/core/src/core/pmmr/db_pmmr.rs
@@ -24,7 +24,7 @@ use ser::{PMMRIndexHashable, PMMRable};
 pub struct DBPMMR<'a, T, B>
 where
 	T: PMMRable,
-	B: 'a + DBBackend<T>,
+	B: 'a + DBBackend,
 {
 	/// The last position in the PMMR
 	last_pos: u64,
@@ -37,7 +37,7 @@ where
 impl<'a, T, B> DBPMMR<'a, T, B>
 where
 	T: PMMRable + ::std::fmt::Debug,
-	B: 'a + DBBackend<T>,
+	B: 'a + DBBackend,
 {
 	/// Build a new db backed MMR.
 	pub fn new(backend: &'a mut B) -> DBPMMR<T, B> {

--- a/core/src/core/pmmr/db_pmmr.rs
+++ b/core/src/core/pmmr/db_pmmr.rs
@@ -1,0 +1,173 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database backed MMR.
+
+use std::marker;
+
+use core::hash::Hash;
+use core::pmmr::{bintree_postorder_height, is_leaf, peak_map_height, peaks, DBBackend};
+use ser::{PMMRIndexHashable, PMMRable};
+
+/// Database backed MMR.
+pub struct DBPMMR<'a, T, B>
+where
+	T: PMMRable,
+	B: 'a + DBBackend<T>,
+{
+	/// The last position in the PMMR
+	last_pos: u64,
+	/// The backend for this readonly PMMR
+	backend: &'a mut B,
+	// only needed to parameterise Backend
+	_marker: marker::PhantomData<T>,
+}
+
+impl<'a, T, B> DBPMMR<'a, T, B>
+where
+	T: PMMRable + ::std::fmt::Debug,
+	B: 'a + DBBackend<T>,
+{
+	/// Build a new db backed MMR.
+	pub fn new(backend: &'a mut B) -> DBPMMR<T, B> {
+		DBPMMR {
+			last_pos: 0,
+			backend: backend,
+			_marker: marker::PhantomData,
+		}
+	}
+
+	/// Build a new db backed MMR initialized to
+	/// last_pos with the provided db backend.
+	pub fn at(backend: &'a mut B, last_pos: u64) -> DBPMMR<T, B> {
+		DBPMMR {
+			last_pos: last_pos,
+			backend: backend,
+			_marker: marker::PhantomData,
+		}
+	}
+
+	pub fn unpruned_size(&self) -> u64 {
+		self.last_pos
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.last_pos == 0
+	}
+
+	pub fn rewind(&mut self, position: u64) -> Result<(), String> {
+		// Identify which actual position we should rewind to as the provided
+		// position is a leaf. We traverse the MMR to include any parent(s) that
+		// need to be included for the MMR to be valid.
+		let mut pos = position;
+		while bintree_postorder_height(pos + 1) > 0 {
+			pos += 1;
+		}
+		self.backend.rewind(pos)?;
+		self.last_pos = pos;
+		Ok(())
+	}
+
+	/// Get the hash element at provided position in the MMR.
+	pub fn get_hash(&self, pos: u64) -> Option<Hash> {
+		if pos > self.last_pos {
+			// If we are beyond the rhs of the MMR return None.
+			None
+		} else if is_leaf(pos) {
+			// If we are a leaf then get data from the backend.
+			self.backend.get_hash(pos)
+		} else {
+			// If we are not a leaf then return None as only leaves have data.
+			None
+		}
+	}
+
+	/// Push a new element into the MMR. Computes new related peaks at
+	/// the same time if applicable.
+	pub fn push(&mut self, elmt: T) -> Result<u64, String> {
+		let elmt_pos = self.last_pos + 1;
+		let mut current_hash = elmt.hash_with_index(elmt_pos - 1);
+
+		let mut to_append = vec![current_hash];
+		let mut pos = elmt_pos;
+
+		let (peak_map, height) = peak_map_height(pos - 1);
+		if height != 0 {
+			return Err(format!("bad mmr size {}", pos - 1));
+		}
+		// hash with all immediately preceding peaks, as indicated by peak map
+		let mut peak = 1;
+		while (peak_map & peak) != 0 {
+			let left_sibling = pos + 1 - 2 * peak;
+			let left_hash = self
+				.backend
+				.get_hash(left_sibling)
+				.ok_or("missing left sibling in tree, should not have been pruned")?;
+			peak *= 2;
+			pos += 1;
+			current_hash = (left_hash, current_hash).hash_with_index(pos - 1);
+			to_append.push(current_hash);
+		}
+
+		// append all the new nodes and update the MMR index
+		self.backend.append(elmt_pos, to_append)?;
+		self.last_pos = pos;
+		Ok(elmt_pos)
+	}
+
+	pub fn peaks(&self) -> Vec<Hash> {
+		let peaks_pos = peaks(self.last_pos);
+		peaks_pos
+			.into_iter()
+			.filter_map(|pi| self.backend.get_hash(pi))
+			.collect()
+	}
+
+	pub fn root(&self) -> Hash {
+		let mut res = None;
+		for peak in self.peaks().iter().rev() {
+			res = match res {
+				None => Some(*peak),
+				Some(rhash) => Some((*peak, rhash).hash_with_index(self.unpruned_size())),
+			}
+		}
+		res.expect("no root, invalid tree")
+	}
+
+	pub fn validate(&self) -> Result<(), String> {
+		// iterate on all parent nodes
+		for n in 1..(self.last_pos + 1) {
+			let height = bintree_postorder_height(n);
+			if height > 0 {
+				if let Some(hash) = self.get_hash(n) {
+					let left_pos = n - (1 << height);
+					let right_pos = n - 1;
+					if let Some(left_child_hs) = self.get_hash(left_pos) {
+						if let Some(right_child_hs) = self.get_hash(right_pos) {
+							// hash the two child nodes together with parent_pos and compare
+							if (left_child_hs, right_child_hs).hash_with_index(n - 1) != hash {
+								return Err(format!(
+									"Invalid MMR, hash of parent at {} does \
+									 not match children.",
+									n
+								));
+							}
+						}
+					}
+				}
+			}
+		}
+		Ok(())
+	}
+}

--- a/core/src/core/pmmr/mod.rs
+++ b/core/src/core/pmmr/mod.rs
@@ -37,11 +37,13 @@
 //! either be a simple Vec or a database.
 
 mod backend;
+mod db_pmmr;
 mod pmmr;
 mod readonly_pmmr;
 mod rewindable_pmmr;
 
 pub use self::backend::*;
+pub use self::db_pmmr::*;
 pub use self::pmmr::*;
 pub use self::readonly_pmmr::*;
 pub use self::rewindable_pmmr::*;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -463,6 +463,9 @@ pub fn n_leaves(size: u64) -> u64 {
 
 /// Returns the pmmr index of the nth inserted element
 pub fn insertion_to_pmmr_index(mut sz: u64) -> u64 {
+	if sz == 0 {
+		return 0;
+	}
 	// 1 based pmmrs
 	sz -= 1;
 	2 * sz - sz.count_ones() as u64 + 1

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -195,7 +195,7 @@ where
 		}
 
 		// append all the new nodes and update the MMR index
-		self.backend.append(elmt_pos, &elmt, to_append)?;
+		self.backend.append(elmt, to_append)?;
 		self.last_pos = pos;
 		Ok(elmt_pos)
 	}

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -173,7 +173,7 @@ where
 		let elmt_pos = self.last_pos + 1;
 		let mut current_hash = elmt.hash_with_index(elmt_pos - 1);
 
-		let mut to_append = vec![(current_hash, Some(elmt))];
+		let mut to_append = vec![current_hash];
 		let mut pos = elmt_pos;
 
 		let (peak_map, height) = peak_map_height(pos - 1);
@@ -191,11 +191,11 @@ where
 			peak *= 2;
 			pos += 1;
 			current_hash = (left_hash, current_hash).hash_with_index(pos - 1);
-			to_append.push((current_hash, None));
+			to_append.push(current_hash);
 		}
 
 		// append all the new nodes and update the MMR index
-		self.backend.append(elmt_pos, to_append)?;
+		self.backend.append(elmt_pos, &elmt, to_append)?;
 		self.last_pos = pos;
 		Ok(elmt_pos)
 	}

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -19,7 +19,7 @@ use std::marker;
 
 use core::hash::Hash;
 use core::pmmr::{bintree_postorder_height, is_leaf, peaks, Backend};
-use ser::{PMMRable, PMMRIndexHashable};
+use ser::{PMMRIndexHashable, PMMRable};
 
 /// Rewindable (but still readonly) view of a PMMR.
 pub struct RewindablePMMR<'a, T, B>

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -438,7 +438,7 @@ fn pmmr_prune() {
 	}
 
 	// First check the initial numbers of elements.
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 0);
 
 	// pruning a leaf with no parent should do nothing
@@ -447,7 +447,7 @@ fn pmmr_prune() {
 		pmmr.prune(16).unwrap();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 1);
 
 	// pruning leaves with no shared parent just removes 1 element
@@ -456,7 +456,7 @@ fn pmmr_prune() {
 		pmmr.prune(2).unwrap();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 2);
 
 	{
@@ -464,7 +464,7 @@ fn pmmr_prune() {
 		pmmr.prune(4).unwrap();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 3);
 
 	// pruning a non-leaf node has no effect
@@ -473,7 +473,7 @@ fn pmmr_prune() {
 		pmmr.prune(3).unwrap_err();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 3);
 
 	// TODO - no longer true (leaves only now) - pruning sibling removes subtree
@@ -482,7 +482,7 @@ fn pmmr_prune() {
 		pmmr.prune(5).unwrap();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 4);
 
 	// TODO - no longer true (leaves only now) - pruning all leaves under level >1
@@ -492,7 +492,7 @@ fn pmmr_prune() {
 		pmmr.prune(1).unwrap();
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 5);
 
 	// pruning everything should only leave us with a single peak
@@ -503,7 +503,7 @@ fn pmmr_prune() {
 		}
 		assert_eq!(orig_root, pmmr.root());
 	}
-	assert_eq!(ba.elems.len(), 16);
+	assert_eq!(ba.hashes.len(), 16);
 	assert_eq!(ba.remove_list.len(), 9);
 }
 

--- a/core/tests/vec_backend/mod.rs
+++ b/core/tests/vec_backend/mod.rs
@@ -98,7 +98,7 @@ where
 
 	fn get_data_from_file(&self, position: u64) -> Option<T> {
 		let idx = pmmr::n_leaves(position);
-		let data = &self.data[(idx-1) as usize];
+		let data = &self.data[(idx - 1) as usize];
 		Some(data.clone())
 	}
 

--- a/core/tests/vec_backend/mod.rs
+++ b/core/tests/vec_backend/mod.rs
@@ -17,7 +17,7 @@ extern crate croaring;
 use croaring::Bitmap;
 
 use core::core::hash::Hash;
-use core::core::pmmr::Backend;
+use core::core::pmmr::{self, Backend};
 use core::core::BlockHeader;
 use core::ser;
 use core::ser::{PMMRable, Readable, Reader, Writeable, Writer};
@@ -59,7 +59,8 @@ where
 	T: PMMRable,
 {
 	/// Backend elements
-	pub elems: Vec<Option<(Hash, Option<T>)>>,
+	pub data: Vec<T>,
+	pub hashes: Vec<Hash>,
 	/// Positions of removed elements
 	pub remove_list: Vec<u64>,
 }
@@ -68,8 +69,9 @@ impl<T> Backend<T> for VecBackend<T>
 where
 	T: PMMRable,
 {
-	fn append(&mut self, _position: u64, data: Vec<(Hash, Option<T>)>) -> Result<(), String> {
-		self.elems.append(&mut map_vec!(data, |d| Some(d.clone())));
+	fn append(&mut self, data: T, hashes: Vec<Hash>) -> Result<(), String> {
+		self.data.push(data);
+		self.hashes.append(&mut hashes.clone());
 		Ok(())
 	}
 
@@ -77,11 +79,7 @@ where
 		if self.remove_list.contains(&position) {
 			None
 		} else {
-			if let Some(ref elem) = self.elems[(position - 1) as usize] {
-				Some(elem.0)
-			} else {
-				None
-			}
+			self.get_from_file(position)
 		}
 	}
 
@@ -89,28 +87,19 @@ where
 		if self.remove_list.contains(&position) {
 			None
 		} else {
-			if let Some(ref elem) = self.elems[(position - 1) as usize] {
-				elem.1.clone()
-			} else {
-				None
-			}
+			self.get_data_from_file(position)
 		}
 	}
 
 	fn get_from_file(&self, position: u64) -> Option<Hash> {
-		if let Some(ref x) = self.elems[(position - 1) as usize] {
-			Some(x.0)
-		} else {
-			None
-		}
+		let hash = &self.hashes[(position - 1) as usize];
+		Some(hash.clone())
 	}
 
 	fn get_data_from_file(&self, position: u64) -> Option<T> {
-		if let Some(ref x) = self.elems[(position - 1) as usize] {
-			x.1.clone()
-		} else {
-			None
-		}
+		let idx = pmmr::n_leaves(position);
+		let data = &self.data[(idx-1) as usize];
+		Some(data.clone())
 	}
 
 	fn remove(&mut self, position: u64) -> Result<(), String> {
@@ -119,7 +108,9 @@ where
 	}
 
 	fn rewind(&mut self, position: u64, _rewind_rm_pos: &Bitmap) -> Result<(), String> {
-		self.elems = self.elems[0..(position as usize) + 1].to_vec();
+		let idx = pmmr::n_leaves(position);
+		self.data = self.data[0..(idx as usize) + 1].to_vec();
+		self.hashes = self.hashes[0..(position as usize) + 1].to_vec();
 		Ok(())
 	}
 
@@ -141,20 +132,9 @@ where
 	/// Instantiates a new VecBackend<T>
 	pub fn new() -> VecBackend<T> {
 		VecBackend {
-			elems: vec![],
+			data: vec![],
+			hashes: vec![],
 			remove_list: vec![],
 		}
 	}
-
-	// /// Current number of elements in the underlying Vec.
-	// pub fn used_size(&self) -> usize {
-	// 	let mut usz = self.elems.len();
-	// 	for (idx, _) in self.elems.iter().enumerate() {
-	// 		let idx = idx as u64;
-	// 		if self.remove_list.contains(&idx) {
-	// 			usz -= 1;
-	// 		}
-	// 	}
-	// 	usz
-	// }
 }

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -72,11 +72,7 @@ impl HeaderSync {
 				self.chain.reset_sync_head(&header_head).unwrap();
 
 				// Rebuild the sync MMR to match our updates sync_head.
-				let header = self
-					.chain
-					.get_block_header(&header_head.last_block_h)
-					.unwrap();
-				self.chain.rebuild_sync_mmr(&header).unwrap();
+				self.chain.rebuild_sync_mmr(&header_head).unwrap();
 
 				self.history_locators.clear();
 				true

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -67,7 +67,17 @@ impl HeaderSync {
 					header_head.hash(),
 					header_head.height,
 				);
+
+				// Reset sync_head to the same as current header_head.
 				self.chain.reset_sync_head(&header_head).unwrap();
+
+				// Rebuild the sync MMR to match our updates sync_head.
+				let header = self
+					.chain
+					.get_block_header(&header_head.last_block_h)
+					.unwrap();
+				self.chain.rebuild_sync_mmr(&header).unwrap();
+
 				self.history_locators.clear();
 				true
 			}

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -50,31 +50,6 @@ use byteorder::{BigEndian, WriteBytesExt};
 
 pub use lmdb::*;
 
-/// An iterator thad produces Readable instances back. Wraps the lower level
-/// DBIterator and deserializes the returned values.
-// pub struct SerIterator<T>
-// where
-// 	T: ser::Readable,
-// {
-// 	iter: DBIterator,
-// 	_marker: marker::PhantomData<T>,
-// }
-//
-// impl<T> Iterator for SerIterator<T>
-// where
-// 	T: ser::Readable,
-// {
-// 	type Item = T;
-//
-// 	fn next(&mut self) -> Option<T> {
-// 		let next = self.iter.next();
-// 		next.and_then(|r| {
-// 			let (_, v) = r;
-// 			ser::deserialize(&mut &v[..]).ok()
-// 		})
-// 	}
-// }
-
 /// Build a db key from a prefix and a byte vector identifier.
 pub fn to_key(prefix: u8, k: &mut Vec<u8>) -> Vec<u8> {
 	let mut res = Vec::with_capacity(k.len() + 2);

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -69,17 +69,14 @@ where
 {
 	/// Append the provided Hashes to the backend storage.
 	#[allow(unused_variables)]
-	fn append(&mut self, position: u64, data: Vec<(Hash, Option<T>)>) -> Result<(), String> {
-		for d in data {
-			self.hash_file.append(&mut ser::ser_vec(&d.0).unwrap());
-			if let Some(elem) = d.1 {
-				self.data_file.append(&mut ser::ser_vec(&elem).unwrap());
-
-				if self.prunable {
-					// Add the new position to our leaf_set.
-					self.leaf_set.add(position);
-				}
-			}
+	fn append(&mut self, position: u64, data: &T, hashes: Vec<Hash>) -> Result<(), String> {
+		if self.prunable {
+			// Add the new position to our leaf_set.
+			self.leaf_set.add(position);
+		}
+		self.data_file.append(&mut ser::ser_vec(data).unwrap());
+		for ref h in hashes {
+			self.hash_file.append(&mut ser::ser_vec(h).unwrap());
 		}
 		Ok(())
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -18,7 +18,7 @@ use std::{fs, io, marker};
 use croaring::Bitmap;
 
 use core::core::hash::{Hash, Hashed};
-use core::core::pmmr::{self, family, Backend, DBBackend};
+use core::core::pmmr::{self, family, Backend, HashOnlyBackend};
 use core::core::BlockHeader;
 use core::ser::{self, PMMRable};
 use leaf_set::LeafSet;
@@ -451,12 +451,12 @@ where
 	}
 }
 
-pub struct DBPMMRBackend {
+pub struct HashOnlyMMRBackend {
 	data_dir: String,
 	hash_file: HashFile,
 }
 
-impl DBBackend for DBPMMRBackend {
+impl HashOnlyBackend for HashOnlyMMRBackend {
 	fn append(&mut self, position: u64, hashes: Vec<Hash>) -> Result<(), String> {
 		for ref h in hashes {
 			self.hash_file.append(h);
@@ -474,12 +474,12 @@ impl DBBackend for DBPMMRBackend {
 	}
 }
 
-impl DBPMMRBackend {
+impl HashOnlyMMRBackend {
 	/// Instantiates a new PMMR backend.
 	/// Use the provided dir to store its files.
-	pub fn new(data_dir: String) -> io::Result<DBPMMRBackend> {
+	pub fn new(data_dir: String) -> io::Result<HashOnlyMMRBackend> {
 		let hash_file = HashFile::open(format!("{}/{}", data_dir, PMMR_HASH_FILE))?;
-		Ok(DBPMMRBackend {
+		Ok(HashOnlyMMRBackend {
 			data_dir,
 			hash_file,
 		})

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -484,9 +484,7 @@ impl HashOnlyMMRBackend {
 	/// Use the provided dir to store its files.
 	pub fn new(data_dir: String) -> io::Result<HashOnlyMMRBackend> {
 		let hash_file = HashFile::open(format!("{}/{}", data_dir, PMMR_HASH_FILE))?;
-		Ok(HashOnlyMMRBackend {
-			hash_file,
-		})
+		Ok(HashOnlyMMRBackend { hash_file })
 	}
 
 	/// The unpruned size of this MMR backend.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -67,26 +67,17 @@ impl<T> Backend<T> for PMMRBackend<T>
 where
 	T: PMMRable + ::std::fmt::Debug,
 {
-	/// Append the provided Hashes to the backend storage.
+	/// Append the provided data and hashes to the backend storage.
+	/// Add the new leaf pos to our leaf_set if this is a prunable MMR.
 	#[allow(unused_variables)]
 	fn append(&mut self, data: T, hashes: Vec<Hash>) -> Result<(), String> {
 		if self.prunable {
-			// Add the new position to our leaf_set.
-			// TODO - how to get position here???
-			// TODO - can we determine it from result of append below?
-
-			// What to do here?
-			// We need to work back from unsynced file size to pos
-			// accounting for prune offset
-
 			let record_len = Hash::SIZE as u64;
 			let shift = self.prune_list.get_total_shift();
 			let position = (self.hash_file.size_unsync() / record_len) + shift + 1;
 			self.leaf_set.add(position);
 		}
-
 		self.data_file.append(&mut ser::ser_vec(&data).unwrap());
-
 		for ref h in hashes {
 			self.hash_file.append(&mut ser::ser_vec(h).unwrap());
 		}

--- a/store/src/rm_log.rs
+++ b/store/src/rm_log.rs
@@ -134,8 +134,7 @@ impl RemoveLog {
 						None
 					}
 				},
-			)
-			.collect()
+			).collect()
 	}
 }
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -25,10 +25,66 @@ use libc::{ftruncate as ftruncate64, off_t as off64_t};
 #[cfg(any(target_os = "linux"))]
 use libc::{ftruncate64, off64_t};
 
+use core::core::hash::Hash;
 use core::ser;
+use util::LOGGER;
 
 /// A no-op function for doing nothing with some pruned data.
 pub fn prune_noop(_pruned_data: &[u8]) {}
+
+pub struct HashFile {
+	file: AppendOnlyFile,
+}
+
+impl HashFile {
+	pub fn open(path: String) -> io::Result<HashFile> {
+		let file = AppendOnlyFile::open(path)?;
+		Ok(HashFile { file })
+	}
+
+	// TODO - error handling, get rid of unwrap()
+	pub fn append(&mut self, hash: &Hash) -> io::Result<()> {
+		self.file.append(&mut ser::ser_vec(hash).unwrap());
+		Ok(())
+	}
+
+	pub fn read(&self, position: u64) -> Option<Hash> {
+		// Read PMMR
+		// The MMR starts at 1, our binary backend starts at 0
+		let pos = position - 1;
+
+		// Must be on disk, doing a read at the correct position
+		let file_offset = (pos as usize) * Hash::SIZE;
+		let data = self.file.read(file_offset, Hash::SIZE);
+		match ser::deserialize(&mut &data[..]) {
+			Ok(h) => Some(h),
+			Err(e) => {
+				error!(
+					LOGGER,
+					"Corrupted storage, could not read an entry from hash file: {:?}", e
+				);
+				return None;
+			}
+		}
+	}
+
+	pub fn rewind(&mut self, position: u64) -> io::Result<()> {
+		self.file.rewind(position * Hash::SIZE as u64);
+		Ok(())
+	}
+
+	pub fn flush(&mut self) -> io::Result<()> {
+		self.file.flush()
+	}
+
+	pub fn discard(&mut self) {
+		self.file.discard()
+	}
+
+	pub fn size(&self) -> io::Result<u64> {
+		self.file.size()
+	}
+}
 
 /// Wrapper for a file that can be read at any position (random read) but for
 /// which writes are append only. Reads are backed by a memory map (mmap(2)),

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -302,6 +302,10 @@ impl AppendOnlyFile {
 		fs::metadata(&self.path).map(|md| md.len())
 	}
 
+	pub fn size_unsync(&self) -> u64 {
+		(self.buffer_start + self.buffer.len()) as u64
+	}
+
 	/// Path of the underlying file
 	pub fn path(&self) -> String {
 		self.path.clone()

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -32,22 +32,25 @@ use util::LOGGER;
 /// A no-op function for doing nothing with some pruned data.
 pub fn prune_noop(_pruned_data: &[u8]) {}
 
+/// Hash file (MMR) wrapper around an append only file.
 pub struct HashFile {
 	file: AppendOnlyFile,
 }
 
 impl HashFile {
+	/// Open (or create) a hash file at the provided path on disk.
 	pub fn open(path: String) -> io::Result<HashFile> {
 		let file = AppendOnlyFile::open(path)?;
 		Ok(HashFile { file })
 	}
 
-	// TODO - error handling, get rid of unwrap()
+	/// TODO - Error handling, get rid of unwrap()
 	pub fn append(&mut self, hash: &Hash) -> io::Result<()> {
 		self.file.append(&mut ser::ser_vec(hash).unwrap());
 		Ok(())
 	}
 
+	/// Read a hash from the hash file by position.
 	pub fn read(&self, position: u64) -> Option<Hash> {
 		// Read PMMR
 		// The MMR starts at 1, our binary backend starts at 0
@@ -68,19 +71,23 @@ impl HashFile {
 		}
 	}
 
+	/// Rewind the backend file to the specified position.
 	pub fn rewind(&mut self, position: u64) -> io::Result<()> {
 		self.file.rewind(position * Hash::SIZE as u64);
 		Ok(())
 	}
 
+	/// Flush unsynced changes to the hash file to disk.
 	pub fn flush(&mut self) -> io::Result<()> {
 		self.file.flush()
 	}
 
+	/// Discard any unsynced changes to the hash file.
 	pub fn discard(&mut self) {
 		self.file.discard()
 	}
 
+	/// Size of the hash file in bytes.
 	pub fn size(&self) -> io::Result<u64> {
 		self.file.size()
 	}
@@ -302,6 +309,7 @@ impl AppendOnlyFile {
 		fs::metadata(&self.path).map(|md| md.len())
 	}
 
+	/// Current size of the (unsynced) file in bytes.
 	pub fn size_unsync(&self) -> u64 {
 		(self.buffer_start + self.buffer.len()) as u64
 	}

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -44,16 +44,18 @@ impl HashFile {
 		Ok(HashFile { file })
 	}
 
-	/// TODO - Error handling, get rid of unwrap()
+	/// Append a hash to this hash file.
+	/// Will not be written to disk until flush() is subsequently called.
+	/// Alternatively discard() may be called to discard any pending changes.
 	pub fn append(&mut self, hash: &Hash) -> io::Result<()> {
-		self.file.append(&mut ser::ser_vec(hash).unwrap());
+		let mut bytes = ser::ser_vec(hash).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+		self.file.append(&mut bytes);
 		Ok(())
 	}
 
 	/// Read a hash from the hash file by position.
 	pub fn read(&self, position: u64) -> Option<Hash> {
-		// Read PMMR
-		// The MMR starts at 1, our binary backend starts at 0
+		// The MMR starts at 1, our binary backend starts at 0.
 		let pos = position - 1;
 
 		// Must be on disk, doing a read at the correct position


### PR DESCRIPTION
* Add support for a db backed MMR (hash file, data maintained in db).
* Add additional MMRs to `txhashset`
  * header MMR (headers based on `header_head`)
  * sync MMR (headers based on `sync_head`)
* `txhashset::extending` now extends header MMR (in addition to output, rangeproof, kernel)
* `txhashset::readonly_extending` extends header MMR (in addition to output, rangeproof, kernel)
* `txhashset::header_extending` extends header MMR _in isolation_ (for header validation, where we do not yet have full blocks)
* `txhashset::sync_extending` extends  sync MMR only (for handling batches of headers during sync)
* after receiving output, rangeproof, kernel MMRs from peer via `txhashset.zip` receiving node now re-builds header MMR based on headers in db prior to validating the reconstructed txhashset
* on entering sync state we rebuild the sync MMR based on current `header_head` - this allows us to safely rewind and reapply headers as necessary based on current most work chain

None of this is consensus breaking, we just add the MMRs in this PR.
Consensus breaking changes will come in a separate PR.

----

TODO (this PR) - 
- [x] Cleanup code.
- [x] Cleanup comment/doc warnings.
- [x] More testing.
- [x] ~Optimize `rebuild_header_mmr()` and `rebuild_sync_mmr()` or are they acceptable for now?~
- [x] ~skip `rewind()` on "next header" for `header_extending` and `sync_extending`.~
- [x] Header MMR tracks `header_head` - confirm this is ok if/when `head` and `header_head` differ. 
  - [x] "Catch up" on same chain if nodes falls behind.
  - [x] Short forks where two blocks get mined simultaneously.
- [x] Support migrating an existing node
  - [x] Create/backfill header MMRs as necessary on `chain::init()`

----

TODO (potentially separate PR) - 
* This adds a header MMR but we __do not__ commit to the MMR root yet in block headers -
  * Replace `header.previous` with `header.prev_root`.
  * DB indices to allow us to find previous header easily?
  * Validate `prev_root` prior when validating blocks _and_ headers.
  * What would be involved in hard-forking this in later?

----

Optimizations/Improvements to think about - 
* Skip `rewind()` on "next header" during header extension (we can live without this initially).
* "Rebuild" sync MMR from header MMR by simply copying the files themselves (no need to actually rebuild the MMR from the hashes) 
* Can we extend the header MMR during header validation then simply reuse the updated header MMR when applying full blocks? (Right now we rewind and reapply a couple of times, first the validate header, then to validate and apply the block).