### PR TITLE
small speed optimization for header sync

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -186,7 +186,7 @@ impl MessageHandler for Protocol {
 					let headers: Headers = headers_streaming_body(
 						conn,
 						msg.header.msg_len,
-						8,
+						32,
 						&mut total_read,
 						&mut reserved,
 						header_size,


### PR DESCRIPTION
near 35% speed up for header sync.

Before this PR: 
- 463s for 132145 headers,  or 285.4 headers/s

After this PR: 
- 340s for 132866 headers, or 390.7 headers/s

Root Cause:
- After a nice performance optimization in https://github.com/mimblewimble/grin/pull/1629 by @antiochp , we only call one `batch.commit` for one `headers_received()` function call. So, the function `headers_received()` is much faster than before.
- Currently we split 511 headers into 8-headers batch for one `headers_received()` function call. Since this function is much faster now, we can change this `8` to a bigger number.
- I tested 16 and 32, and 64.  The best number for now is `32`.


