### PR TITLE
fix: avoid a confusing log when fastsync start

### DIFF
--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -123,6 +123,19 @@ impl StateSync {
 					}
 					Err(e) => self.sync_state.set_sync_error(Error::P2P(e)),
 				}
+
+				// to avoid the confusing log,
+				// update the final HeaderSync state mainly for 'current_height'
+				{
+					let status = self.sync_state.status();
+					if let SyncStatus::HeaderSync { .. } = status {
+						self.sync_state.update(SyncStatus::HeaderSync {
+							current_height: header_head.height,
+							highest_height,
+						});
+					}
+				}
+
 				self.sync_state.update(SyncStatus::TxHashsetDownload);
 			}
 		}


### PR DESCRIPTION
Header head already updated to highest height, but the `sync_state` log say current_height is on a previous height:
```
Oct 11 11:21:05.444 DEBG fast_sync: before txhashset request, header head: 133001 / 1a9f24a4, txhashset_head: 130408 / 004d0278
Oct 11 11:21:05.445 DEBG sync_state: sync_status: HeaderSync { current_height: 132765, highest_height: 133001 } -> TxHashsetDownload
```
Here in this example, it says `current_height: 132765` but actually it should be `133001`.

I'm confused and thought something must be wrong there but it just a wrong log message. So, better to correct this wrong message and avoid any future confusing.
