### PR TITLE
Fix small txhashset download timeouts

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -268,7 +268,7 @@ impl MessageHandler for Protocol {
 					let mut tmp_zip = BufWriter::new(File::create(file)?);
 					let total_size = sm_arch.bytes as usize;
 					let mut downloaded_size: usize = 0;
-					let mut request_size = 48_000;
+					let mut request_size = cmp::min(48_000, sm_arch.bytes) as usize;
 					while request_size > 0 {
 						downloaded_size += msg.copy_attachment(request_size, &mut tmp_zip)?;
 						request_size = cmp::min(48_000, total_size - downloaded_size);


### PR DESCRIPTION
Initial chunk size is too large for small txhashsets, resulting in a timeout in `read_exact`.