### PR TITLE
Use secp crate directly without extra use statement

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -40,8 +40,7 @@ extern crate walkdir;
 extern crate zip as zip_rs;
 
 // Re-export so only has to be included once
-pub extern crate secp256k1zkp as secp_;
-pub use secp_ as secp;
+pub extern crate secp256k1zkp as secp;
 
 // Logging related
 pub mod logger;

--- a/util/src/secp_static.rs
+++ b/util/src/secp_static.rs
@@ -16,7 +16,7 @@
 //! initialization overhead
 
 use rand::thread_rng;
-use secp_ as secp;
+use secp;
 use std::sync::{Arc, Mutex};
 
 lazy_static! {


### PR DESCRIPTION
I noticed this extra use statement, but it doesn't appear to be necessary.