### PR TITLE
kick stuck peer out of connected peers

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -69,6 +69,10 @@ pub const TESTNET2_INITIAL_DIFFICULTY: u64 = 1000;
 /// a 30x Cuckoo adjustment factor
 pub const TESTNET3_INITIAL_DIFFICULTY: u64 = 30000;
 
+/// If a peer's last updated difficulty is 2 hours ago and its difficulty's lower than ours,
+/// we're sure this peer is a stuck node, and we will kick out such kind of stuck peers.
+pub const STUCK_PEER_KICK_TIME: i64 = 2 * 3600 * 1000;
+
 /// Types of chain a server can run with, dictates the genesis block and
 /// and mining parameters used.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -102,6 +102,7 @@ impl Handshake {
 				total_difficulty: shake.total_difficulty,
 				height: 0,
 				last_seen: Utc::now(),
+				stuck_detector: Utc::now(),
 			})),
 			direction: Direction::Outbound,
 		};
@@ -161,6 +162,7 @@ impl Handshake {
 				total_difficulty: hand.total_difficulty,
 				height: 0,
 				last_seen: Utc::now(),
+				stuck_detector: Utc::now(),
 			})),
 			direction: Direction::Inbound,
 		};

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -18,9 +18,9 @@ use std::sync::{Arc, RwLock};
 
 use chrono::prelude::{DateTime, Utc};
 use conn;
-use core::{core, global};
 use core::core::hash::{Hash, Hashed};
 use core::pow::Difficulty;
+use core::{core, global};
 use handshake::Handshake;
 use msg::{self, BanReason, GetPeerAddrs, Locator, Ping, TxHashSetRequest};
 use protocol::Protocol;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -140,6 +140,18 @@ impl Peer {
 		State::Banned == *self.state.read().unwrap()
 	}
 
+	/// Whether this peer is stuck on sync.
+	pub fn is_stuck(&self) -> bool {
+		let peer_live_info = self.info.live_info.read().unwrap();
+		let now = Utc::now().timestamp_millis();
+		// if last updated difficulty is 30 minutes ago, we're sure this peer is a stuck node.
+		if now > peer_live_info.stuck_detector.timestamp_millis() + 30 * 60 * 1000 {
+			true
+		} else {
+			false
+		}
+	}
+
 	/// Set this peer status to banned
 	pub fn set_banned(&self) {
 		*self.state.write().unwrap() = State::Banned;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 
 use chrono::prelude::{DateTime, Utc};
 use conn;
-use core::core;
+use core::{core, global};
 use core::core::hash::{Hash, Hashed};
 use core::pow::Difficulty;
 use handshake::Handshake;
@@ -141,14 +141,14 @@ impl Peer {
 	}
 
 	/// Whether this peer is stuck on sync.
-	pub fn is_stuck(&self) -> bool {
+	pub fn is_stuck(&self) -> (bool, Difficulty) {
 		let peer_live_info = self.info.live_info.read().unwrap();
 		let now = Utc::now().timestamp_millis();
-		// if last updated difficulty is 30 minutes ago, we're sure this peer is a stuck node.
-		if now > peer_live_info.stuck_detector.timestamp_millis() + 30 * 60 * 1000 {
-			true
+		// if last updated difficulty is 2 hours ago, we're sure this peer is a stuck node.
+		if now > peer_live_info.stuck_detector.timestamp_millis() + global::STUCK_PEER_KICK_TIME {
+			(true, peer_live_info.total_difficulty)
 		} else {
-			false
+			(false, peer_live_info.total_difficulty)
 		}
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -424,6 +424,11 @@ impl Peers {
 			} else if !peer.is_connected() {
 				debug!(LOGGER, "clean_peers {:?}, not connected", peer.info.addr);
 				rm.push(peer.clone());
+			} else if peer.is_stuck() {
+				debug!(LOGGER, "clean_peers {:?}, stuck peer", peer.info.addr);
+				peer.stop();
+				let _ = self.update_state(peer.info.addr, State::Defunct);
+				rm.push(peer.clone());
 			}
 		}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -424,11 +424,14 @@ impl Peers {
 			} else if !peer.is_connected() {
 				debug!(LOGGER, "clean_peers {:?}, not connected", peer.info.addr);
 				rm.push(peer.clone());
-			} else if peer.is_stuck() {
-				debug!(LOGGER, "clean_peers {:?}, stuck peer", peer.info.addr);
-				peer.stop();
-				let _ = self.update_state(peer.info.addr, State::Defunct);
-				rm.push(peer.clone());
+			} else {
+				let (stuck, diff) = peer.is_stuck();
+				if stuck && diff < self.adapter.total_difficulty() {
+					debug!(LOGGER, "clean_peers {:?}, stuck peer", peer.info.addr);
+					peer.stop();
+					let _ = self.update_state(peer.info.addr, State::Defunct);
+					rm.push(peer.clone());
+				}
 			}
 		}
 

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -241,6 +241,7 @@ pub struct PeerLiveInfo {
 	pub total_difficulty: Difficulty,
 	pub height: u64,
 	pub last_seen: DateTime<Utc>,
+	pub stuck_detector: DateTime<Utc>,
 }
 
 /// General information about a connected peer that's useful to other modules.
@@ -274,6 +275,9 @@ impl PeerInfo {
 	/// Takes a write lock on the live_info.
 	pub fn update(&self, height: u64, total_difficulty: Difficulty) {
 		let mut live_info = self.live_info.write().unwrap();
+		if total_difficulty != live_info.total_difficulty {
+			live_info.stuck_detector = Utc::now();
+		}
 		live_info.height = height;
 		live_info.total_difficulty = total_difficulty;
 		live_info.last_seen = Utc::now()


### PR DESCRIPTION
https://github.com/mimblewimble/grin/issues/1692#issuecomment-429590729

A small improvement:  kick out those stuck peers in half an hour, and mark it as `Defunc` state.

![2peers](https://user-images.githubusercontent.com/1852227/46911894-d4fc0700-cf9a-11e8-8773-52e06d2eb198.jpg)
