### PR TITLE
Introduce a constant for peer send channel capacity

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -141,6 +141,8 @@ impl<'a> Response<'a> {
 	}
 }
 
+pub const SEND_CHANNEL_CAP: usize = 10;
+
 // TODO count sent and received
 pub struct Tracker {
 	/// Bytes we've sent.
@@ -173,7 +175,7 @@ pub fn listen<H>(stream: TcpStream, handler: H) -> Tracker
 where
 	H: MessageHandler,
 {
-	let (send_tx, send_rx) = mpsc::sync_channel(10);
+	let (send_tx, send_rx) = mpsc::sync_channel(SEND_CHANNEL_CAP);
 	let (close_tx, close_rx) = mpsc::channel();
 	let (error_tx, error_rx) = mpsc::channel();
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -50,6 +50,7 @@ mod serv;
 mod store;
 pub mod types;
 
+pub use conn::SEND_CHANNEL_CAP;
 pub use peer::Peer;
 pub use peers::Peers;
 pub use serv::{DummyAdapter, Server};

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -133,7 +133,7 @@ impl BodySync {
 		};
 
 		let block_count = cmp::min(
-			cmp::min(100, peers.len() * 10),
+			cmp::min(100, peers.len() * p2p::SEND_CHANNEL_CAP),
 			chain::MAX_ORPHAN_SIZE.saturating_sub(self.chain.orphans_len()) + 1,
 		);
 


### PR DESCRIPTION
We implicitly use it also in body_sync, so it's hard to keep it in sync.