### PR TITLE
Commit to prev_root in block headers

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -486,23 +486,37 @@ impl Chain {
 	/// the current txhashset state.
 	pub fn set_txhashset_roots(&self, b: &mut Block, is_fork: bool) -> Result<(), Error> {
 		let mut txhashset = self.txhashset.write().unwrap();
-		let (roots, sizes) = txhashset::extending_readonly(&mut txhashset, |extension| {
-			if is_fork {
-				pipe::rewind_and_apply_fork(b, extension)?;
-			}
-			extension.apply_block(b)?;
-			Ok((extension.roots(), extension.sizes()))
-		})?;
+		let (prev_root, roots, sizes) =
+			txhashset::extending_readonly(&mut txhashset, |extension| {
+				if is_fork {
+					pipe::rewind_and_apply_fork(b, extension)?;
+				}
 
-		// Carefully destructure these correctly...
-		// TODO - Maybe sizes should be a struct to add some type safety here...
-		let (_, output_mmr_size, _, kernel_mmr_size) = sizes;
+				// Retrieve the header root before we apply the new block
+				let prev_root = extension.header_root();
 
+				// Apply the latest block to the chain state via the extension.
+				extension.apply_block(b)?;
+
+				Ok((prev_root, extension.roots(), extension.sizes()))
+			})?;
+
+		// Set the prev_root on the header.
+		b.header.prev_root = prev_root;
+
+		// Set the output, rangeproof and kernel MMR roots.
 		b.header.output_root = roots.output_root;
 		b.header.range_proof_root = roots.rproof_root;
 		b.header.kernel_root = roots.kernel_root;
-		b.header.output_mmr_size = output_mmr_size;
-		b.header.kernel_mmr_size = kernel_mmr_size;
+
+		// Set the output and kernel MMR sizes.
+		{
+			// Carefully destructure these correctly...
+			let (_, output_mmr_size, _, kernel_mmr_size) = sizes;
+			b.header.output_mmr_size = output_mmr_size;
+			b.header.kernel_mmr_size = kernel_mmr_size;
+		}
+
 		Ok(())
 	}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -218,6 +218,7 @@ pub fn sync_block_headers(
 			extension.rewind(&prev_header)?;
 
 			for header in headers {
+				extension.validate_root(header)?;
 				extension.apply_header(header)?;
 			}
 
@@ -500,6 +501,7 @@ fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Er
 /// Fully validate the block by applying it to the txhashset extension.
 /// Check both the txhashset roots and sizes are correct after applying the block.
 fn apply_block_to_txhashset(block: &Block, ext: &mut txhashset::Extension) -> Result<(), Error> {
+	ext.validate_header_root(&block.header)?;
 	ext.apply_block(block)?;
 	ext.validate_roots()?;
 	ext.validate_sizes()?;

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -257,7 +257,7 @@ fn empty_block_serialized_size() {
 	let b = new_block(vec![], &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 1_223;
+	let target_len = 1_284;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -270,7 +270,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 2_805;
+	let target_len = 2_866;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -283,7 +283,7 @@ fn empty_compact_block_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_231;
+	let target_len = 1_292;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -297,7 +297,7 @@ fn compact_block_single_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_237;
+	let target_len = 1_298;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -316,7 +316,7 @@ fn block_10_tx_serialized_size() {
 	let b = new_block(txs.iter().collect(), &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 17_043;
+	let target_len = 17_104;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -335,7 +335,7 @@ fn compact_block_10_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_291;
+	let target_len = 1_352;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -428,4 +428,27 @@ fn serialize_deserialize_compact_block() {
 
 	assert_eq!(cb1.header, cb2.header);
 	assert_eq!(cb1.kern_ids(), cb2.kern_ids());
+}
+
+#[test]
+fn empty_block_v2_switch() {
+	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let mut prev = BlockHeader::default();
+	prev.height = consensus::HEADER_V2_HARD_FORK - 1;
+	let key_id = keychain.derive_key_id(1).unwrap();
+	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let mut vec = Vec::new();
+	ser::serialize(&mut vec, &b).expect("serialization failed");
+	let target_len = 1_292;
+	assert_eq!(b.header.version, 2);
+	assert_eq!(vec.len(), target_len);
+
+	// another try right before v2
+	prev.height = consensus::HEADER_V2_HARD_FORK - 2;
+	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let mut vec = Vec::new();
+	ser::serialize(&mut vec, &b).expect("serialization failed");
+	let target_len = 1_284;
+	assert_eq!(b.header.version, 1);
+	assert_eq!(vec.len(), target_len);
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -257,7 +257,7 @@ fn empty_block_serialized_size() {
 	let b = new_block(vec![], &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 1_284;
+	let target_len = 1_255;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -270,7 +270,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 2_866;
+	let target_len = 2_837;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -283,7 +283,7 @@ fn empty_compact_block_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_292;
+	let target_len = 1_263;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -297,7 +297,7 @@ fn compact_block_single_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_298;
+	let target_len = 1_269;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -316,7 +316,7 @@ fn block_10_tx_serialized_size() {
 	let b = new_block(txs.iter().collect(), &keychain, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 17_104;
+	let target_len = 17_075;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -335,7 +335,7 @@ fn compact_block_10_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_352;
+	let target_len = 1_323;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -428,27 +428,4 @@ fn serialize_deserialize_compact_block() {
 
 	assert_eq!(cb1.header, cb2.header);
 	assert_eq!(cb1.kern_ids(), cb2.kern_ids());
-}
-
-#[test]
-fn empty_block_v2_switch() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
-	let mut prev = BlockHeader::default();
-	prev.height = consensus::HEADER_V2_HARD_FORK - 1;
-	let key_id = keychain.derive_key_id(1).unwrap();
-	let b = new_block(vec![], &keychain, &prev, &key_id);
-	let mut vec = Vec::new();
-	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 1_292;
-	assert_eq!(b.header.version, 2);
-	assert_eq!(vec.len(), target_len);
-
-	// another try right before v2
-	prev.height = consensus::HEADER_V2_HARD_FORK - 2;
-	let b = new_block(vec![], &keychain, &prev, &key_id);
-	let mut vec = Vec::new();
-	ser::serialize(&mut vec, &b).expect("serialization failed");
-	let target_len = 1_284;
-	assert_eq!(b.header.version, 1);
-	assert_eq!(vec.len(), target_len);
 }

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -95,9 +95,9 @@ fn build_block(
 	key_id: Option<Identifier>,
 	wallet_listener_url: Option<String>,
 ) -> Result<(core::Block, BlockFees), Error> {
-	// prepare the block header timestamp
 	let head = chain.head_header()?;
 
+	// prepare the block header timestamp
 	let mut now_sec = Utc::now().timestamp();
 	let head_sec = head.timestamp.timestamp();
 	if now_sec <= head_sec {


### PR DESCRIPTION
This takes the earlier work around maintaining the "header MMR" and adds the `prev_root` itself to the block header. 
Each header now commits to the root of the header MMR of all previous headers.
And when validating blocks/headers we can check the `prev_root` of the header does indeed match the root of the header MMR.

* commit to `prev_root` in block headers
* set `prev_root` on new header in `set_txhashset_roots()`
* validate `prev_root` during block and header processing
* reordered block header fields slightly - 
  * moved `timestamp` to before `previous` (to go with `height` and other non-hash values)

TODO - 
- [x] more testing
- [x] we need a clean t4 branch before attempting to merge in

