### PR TITLE
Secondary PoW scaling factor dampening, cleanup

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -264,7 +264,7 @@ where
 	T: IntoIterator<Item = HeaderInfo>,
 {
 	// Convert iterator to vector, so we can append to it if necessary
-	let needed_block_count = DIFFICULTY_ADJUST_WINDOW as usize;
+	let needed_block_count = DIFFICULTY_ADJUST_WINDOW as usize + 1;
 	let mut last_n: Vec<HeaderInfo> = cursor.into_iter().take(needed_block_count).collect();
 
 	// Sort blocks from earliest to latest (to keep conceptually easier)

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -19,8 +19,7 @@
 use consensus::HeaderInfo;
 use consensus::{
 	BASE_EDGE_BITS, BLOCK_TIME_SEC, COINBASE_MATURITY, CUT_THROUGH_HORIZON,
-	DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY, MEDIAN_TIME_WINDOW, PROOFSIZE,
-	SECOND_POW_EDGE_BITS,
+	DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY, PROOFSIZE, SECOND_POW_EDGE_BITS,
 };
 use pow::{self, CuckatooContext, EdgeType, PoWContext};
 /// An enum collecting sets of parameters used throughout the
@@ -265,7 +264,7 @@ where
 	T: IntoIterator<Item = HeaderInfo>,
 {
 	// Convert iterator to vector, so we can append to it if necessary
-	let needed_block_count = (MEDIAN_TIME_WINDOW + DIFFICULTY_ADJUST_WINDOW) as usize;
+	let needed_block_count = DIFFICULTY_ADJUST_WINDOW as usize;
 	let mut last_n: Vec<HeaderInfo> = cursor.into_iter().take(needed_block_count).collect();
 
 	// Sort blocks from earliest to latest (to keep conceptually easier)

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -493,19 +493,19 @@ fn secondary_pow_scale() {
 	let window = DIFFICULTY_ADJUST_WINDOW;
 	let mut hi = HeaderInfo::from_diff_scaling(Difficulty::from_num(10), 100);
 
-	// all primary, factor should be multiplied by 4 (max adjustment) so it
-	// becomes easier to find a high difficulty block
+	// all primary, factor should increase so it becomes easier to find a high
+	// difficulty block
 	assert_eq!(
 		secondary_pow_scaling(1, &(0..window).map(|_| hi.clone()).collect()),
-		200
+		148
 	);
-	// all secondary on 90%, factor should lose 10%
+	// all secondary on 90%, factor should go down a bit
 	hi.is_secondary = true;
 	assert_eq!(
 		secondary_pow_scaling(1, &(0..window).map(|_| hi.clone()).collect()),
-		90
+		96
 	);
-	// all secondary on 1%, should be divided by 4 (max adjustment)
+	// all secondary on 1%, factor should go down to bound (divide by 2)
 	assert_eq!(
 		secondary_pow_scaling(890_000, &(0..window).map(|_| hi.clone()).collect()),
 		50
@@ -529,7 +529,7 @@ fn secondary_pow_scale() {
 		),
 		100
 	);
-	// 95% secondary, should come down
+	// 95% secondary, should come down based on 100 median
 	assert_eq!(
 		secondary_pow_scaling(
 			1,
@@ -538,9 +538,9 @@ fn secondary_pow_scale() {
 				.chain((0..(window * 95 / 100)).map(|_| hi.clone()))
 				.collect()
 		),
-		94
+		98
 	);
-	// 40% secondary, should come up
+	// 40% secondary, should come up based on 50 median
 	assert_eq!(
 		secondary_pow_scaling(
 			1,
@@ -549,7 +549,7 @@ fn secondary_pow_scale() {
 				.chain((0..(window * 4 / 10)).map(|_| hi.clone()))
 				.collect()
 		),
-		100
+		61
 	);
 }
 

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -385,17 +385,17 @@ fn next_target_adjustment() {
 	let diff_one = Difficulty::one();
 	assert_eq!(
 		next_difficulty(1, vec![HeaderInfo::from_ts_diff(cur_time, diff_one)]),
-		HeaderInfo::from_diff_scaling(Difficulty::one(), 2),
+		HeaderInfo::from_diff_scaling(Difficulty::one(), 1),
 	);
 	assert_eq!(
 		next_difficulty(1, vec![HeaderInfo::new(cur_time, diff_one, 10, true)]),
-		HeaderInfo::from_diff_scaling(Difficulty::one(), 2),
+		HeaderInfo::from_diff_scaling(Difficulty::one(), 1),
 	);
 
 	let mut hi = HeaderInfo::from_diff_scaling(diff_one, 1);
 	assert_eq!(
 		next_difficulty(1, repeat(60, hi.clone(), DIFFICULTY_ADJUST_WINDOW, None)),
-		HeaderInfo::from_diff_scaling(Difficulty::one(), 2),
+		HeaderInfo::from_diff_scaling(Difficulty::one(), 1),
 	);
 	hi.is_secondary = true;
 	assert_eq!(
@@ -405,7 +405,7 @@ fn next_target_adjustment() {
 	hi.secondary_scaling = 100;
 	assert_eq!(
 		next_difficulty(1, repeat(60, hi.clone(), DIFFICULTY_ADJUST_WINDOW, None)),
-		HeaderInfo::from_diff_scaling(Difficulty::one(), 90),
+		HeaderInfo::from_diff_scaling(Difficulty::one(), 96),
 	);
 
 	// Check we don't get stuck on difficulty 1
@@ -416,11 +416,11 @@ fn next_target_adjustment() {
 	);
 
 	// just enough data, right interval, should stay constant
-	let just_enough = DIFFICULTY_ADJUST_WINDOW;
+	let just_enough = DIFFICULTY_ADJUST_WINDOW + 1;
 	hi.difficulty = Difficulty::from_num(1000);
 	assert_eq!(
 		next_difficulty(1, repeat(60, hi.clone(), just_enough, None)).difficulty,
-		Difficulty::from_num(1005)
+		Difficulty::from_num(1000)
 	);
 
 	// checking averaging works
@@ -436,28 +436,28 @@ fn next_target_adjustment() {
 	s2.append(&mut s1);
 	assert_eq!(
 		next_difficulty(1, s2).difficulty,
-		Difficulty::from_num(1005)
+		Difficulty::from_num(1000)
 	);
 
 	// too slow, diff goes down
 	hi.difficulty = Difficulty::from_num(1000);
 	assert_eq!(
 		next_difficulty(1, repeat(90, hi.clone(), just_enough, None)).difficulty,
-		Difficulty::from_num(863)
+		Difficulty::from_num(857)
 	);
 	assert_eq!(
 		next_difficulty(1, repeat(120, hi.clone(), just_enough, None)).difficulty,
-		Difficulty::from_num(756)
+		Difficulty::from_num(750)
 	);
 
 	// too fast, diff goes up
 	assert_eq!(
 		next_difficulty(1, repeat(55, hi.clone(), just_enough, None)).difficulty,
-		Difficulty::from_num(1034)
+		Difficulty::from_num(1028)
 	);
 	assert_eq!(
 		next_difficulty(1, repeat(45, hi.clone(), just_enough, None)).difficulty,
-		Difficulty::from_num(1095)
+		Difficulty::from_num(1090)
 	);
 
 	// hitting lower time bound, should always get the same result below

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -400,7 +400,6 @@ impl Server {
 			let last_blocks: Vec<consensus::HeaderInfo> =
 				global::difficulty_data_to_vector(self.chain.difficulty_iter())
 					.into_iter()
-					.skip(consensus::MEDIAN_TIME_WINDOW as usize)
 					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
 


### PR DESCRIPTION
Dampen by the same amount as difficulty. Also remove median time window in difficulty calculation as it's unnecessary with strictly increasing block times.