### PR TITLE
Add prev_root in BlockHeaderPrintable

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -491,6 +491,8 @@ pub struct BlockHeaderPrintable {
 	pub height: u64,
 	/// Hash of the block previous to this in the chain.
 	pub previous: String,
+	/// Root hash of the header MMR at the previous header.
+	pub prev_root: String,
 	/// rfc3339 timestamp at which the block was built.
 	pub timestamp: String,
 	/// Merklish root of all the commitments in the TxHashSet
@@ -520,6 +522,7 @@ impl BlockHeaderPrintable {
 			version: h.version,
 			height: h.height,
 			previous: util::to_hex(h.previous.to_vec()),
+			prev_root: util::to_hex(h.prev_root.to_vec()),
 			timestamp: h.timestamp.to_rfc3339(),
 			output_root: util::to_hex(h.output_root.to_vec()),
 			range_proof_root: util::to_hex(h.range_proof_root.to_vec()),

--- a/doc/api/node_api.md
+++ b/doc/api/node_api.md
@@ -40,9 +40,9 @@ Optionally return results as "compact blocks" by passing `?compact` query.
 
 * **URL**
 
-  /v1/blocks/hash
-  /v1/blocks/height
-  /v1/blocks/commit
+  * /v1/blocks/hash
+  * /v1/blocks/height
+  * /v1/blocks/commit
 
 * **Method:**
 
@@ -73,6 +73,7 @@ Optionally return results as "compact blocks" by passing `?compact` query.
     | - version             | number   | Version of the block                                                        |
     | - height              | number   | Height of this block since the genesis block (height 0)                     |
     | - previous            | string   | Hash of the block previous to this in the chain                             |
+    | - prev_root           | string   | Root hash of the header MMR at the previous header                          |
     | - timestamp           | string   | RFC3339 timestamp at which the block was built                              |
     | - output_root         | string   | Merklish root of all the commitments in the TxHashSet                       |
     | - range_proof_root    | string   | Merklish root of all range proofs in the TxHashSet                          |
@@ -126,9 +127,9 @@ Returns data about a block headers given either a hash or height or an output co
 
 * **URL**
 
-  /v1/headers/hash
-  /v1/headers/height
-  /v1/headers/commit
+  * /v1/headers/hash
+  * /v1/headers/height
+  * /v1/headers/commit
 
 * **Method:**
 
@@ -159,6 +160,7 @@ Returns data about a block headers given either a hash or height or an output co
     | - version             | number   | Version of the block                                                        |
     | - height              | number   | Height of this block since the genesis block (height 0)                     |
     | - previous            | string   | Hash of the block previous to this in the chain                             |
+    | - prev_root           | string   | Root hash of the header MMR at the previous header                          |
     | - timestamp           | string   | RFC3339 timestamp at which the block was built                              |
     | - output_root         | string   | Merklish root of all the commitments in the TxHashSet                       |
     | - range_proof_root    | string   | Merklish root of all range proofs in the TxHashSet                          |
@@ -327,9 +329,9 @@ Retrieves details about specifics outputs. Supports retrieval of multiple output
 
 * **URL**
 
-  /v1/chain/outputs/byids?id=x
-  /v1/chain/outputs/byids?id=x,y,z
-  /v1/chain/outputs/byids?id=x&id=y&id=z
+  * /v1/chain/outputs/byids?id=x
+  * /v1/chain/outputs/byids?id=x,y,z
+  * /v1/chain/outputs/byids?id=x&id=y&id=z
 
 * **Method:**
 
@@ -550,8 +552,8 @@ Retrieves the last n outputs inserted into the tree.
 
 * **URL**
 
-/v1/txhashset/lastoutputs (gets last 10)
-/v1/txhashset/lastoutputs?n=x
+  * /v1/txhashset/lastoutputs (gets last 10)
+  * /v1/txhashset/lastoutputs?n=x
 
 * **Method:**
 
@@ -600,8 +602,8 @@ Retrieves the last n rangeproofs inserted in to the tree.
 
 * **URL**
 
-/v1/txhashset/lastrangeproofs (gets last 10)
-/v1/txhashset/lastrangeproofs?n=x
+  * /v1/txhashset/lastrangeproofs (gets last 10)
+  * /v1/txhashset/lastrangeproofs?n=x
 
 * **Method:**
 
@@ -650,8 +652,8 @@ Retrieves the last n kernels inserted in to the tree.
 
 * **URL**
 
-/v1/txhashset/lastkernels (gets last 10)
-/v1/txhashset/lastkernels?n=x
+  * /v1/txhashset/lastkernels (gets last 10)
+  * /v1/txhashset/lastkernels?n=x
 
 * **Method:**
 

--- a/doc/api/wallet_owner_api.md
+++ b/doc/api/wallet_owner_api.md
@@ -21,9 +21,8 @@ Attempt to update and retrieve outputs.
 
 * **URL**
 
-  /v1/wallet/owner/retrieve_outputs
-  or
-  /v1/wallet/owner/retrieve_outputs?refresh&show_spent&tx_id=x&tx_id=y
+  * /v1/wallet/owner/retrieve_outputs
+  * /v1/wallet/owner/retrieve_outputs?refresh&show_spent&tx_id=x&tx_id=y
 
 * **Method:**
 
@@ -86,8 +85,8 @@ Attempt to update and retrieve outputs.
 
 * **URL**
 
-  /v1/wallet/owner/retrieve_summary_info
-  /v1/wallet/owner/retrieve_summary_info?refresh
+  * /v1/wallet/owner/retrieve_summary_info
+  * /v1/wallet/owner/retrieve_summary_info?refresh
 
 * **Method:**
 
@@ -190,9 +189,8 @@ Return whether the outputs were validated against a node and an array of TxLogEn
 
 * **URL**
 
-  /v1/wallet/owner/retrieve_txs
-  or
-  /v1/wallet/owner/retrieve_txs?refresh?id=x
+  */v1/wallet/owner/retrieve_txs
+  */v1/wallet/owner/retrieve_txs?refresh?id=x
 
 * **Method:**
 


### PR DESCRIPTION
Add `prev_root` in `BlockHeaderPrintable`.
Also small formatting in `doc/api`