### PR TITLE
Fix shift by 1 block in TUI

### DIFF
--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -14,7 +14,7 @@
 
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
 /// proof of work within a block header.
-use std::cmp::{min,max};
+use std::cmp::{max, min};
 use std::ops::{Add, Div, Mul, Sub};
 use std::{fmt, iter};
 
@@ -36,11 +36,7 @@ where
 	T: EdgeType,
 {
 	/// Create new instance of context with appropriate parameters
-	fn new(
-		edge_bits: u8,
-		proof_size: usize,
-		max_sols: u32,
-	) -> Result<Box<Self>, Error>;
+	fn new(edge_bits: u8, proof_size: usize, max_sols: u32) -> Result<Box<Self>, Error>;
 	/// Sets the header along with an optional nonce at the end
 	/// solve: whether to set up structures for a solve (true) or just validate (false)
 	fn set_header_nonce(
@@ -78,11 +74,6 @@ impl Difficulty {
 	pub fn from_num(num: u64) -> Difficulty {
 		// can't have difficulty lower than 1
 		Difficulty { num: max(num, 1) }
-	}
-
-	/// Compute difficulty scaling factor for graph defined by 2 * 2^edge_bits * edge_bits bits
-	pub fn scale(edge_bits: u8) -> u64 {
-		(2 << (edge_bits - global::base_edge_bits()) as u64) * (edge_bits as u64)
 	}
 
 	/// Computes the difficulty from a hash. Divides the maximum target by the
@@ -408,10 +399,7 @@ impl Readable for Proof {
 			}
 			nonces.push(nonce);
 		}
-		Ok(Proof {
-			edge_bits,
-			nonces,
-		})
+		Ok(Proof { edge_bits, nonces })
 	}
 }
 

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
-use core::pow::Difficulty;
+use core::consensus::graph_weight;
 
 use chrono::prelude::*;
 
@@ -159,8 +159,7 @@ pub struct PeerStats {
 impl StratumStats {
 	/// Calculate network hashrate
 	pub fn network_hashrate(&self) -> f64 {
-		42.0 * (self.network_difficulty as f64 / Difficulty::scale(self.edge_bits as u8) as f64)
-			/ 60.0
+		42.0 * (self.network_difficulty as f64 / graph_weight(self.edge_bits as u8) as f64) / 60.0
 	}
 }
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -406,7 +406,7 @@ impl Server {
 			let mut last_time = last_blocks[0].timestamp;
 			let tip_height = self.chain.head().unwrap().height as i64;
 			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
-
+			warn!(LOGGER, "Earliest block height{:?}", earliest_block_height);
 			let mut i = 1;
 
 			let diff_entries: Vec<DiffBlock> = last_blocks
@@ -414,7 +414,9 @@ impl Server {
 				.skip(1)
 				.map(|n| {
 					let dur = n.timestamp - last_time;
-					let height = earliest_block_height + i + 1;
+					let height = earliest_block_height + i;
+					warn!(LOGGER, "Height {:?}", height);
+					warn!(LOGGER, "{:?}", n);
 					i += 1;
 					last_time = n.timestamp;
 					DiffBlock {


### PR DESCRIPTION
Fix shift by 1 block in TUI.
Also remove unused function `scale` and use `graph_weight` introduce in #1774.