### PR TITLE
Make check_api_secret_file private

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -107,7 +107,7 @@ fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 }
 
 /// Check that the api secret file exists and is valid
-pub fn check_api_secret_file() -> Result<(), ConfigError> {
+fn check_api_secret_file() -> Result<(), ConfigError> {
 	let grin_path = get_grin_path()?;
 	let mut api_secret_path = grin_path.clone();
 	api_secret_path.push(API_SECRET_FILE_NAME);

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -35,5 +35,5 @@ mod comments;
 pub mod config;
 pub mod types;
 
-pub use config::{check_api_secret_file, initial_setup_server, initial_setup_wallet};
+pub use config::{initial_setup_server, initial_setup_wallet};
 pub use types::{ConfigError, ConfigMembers, GlobalConfig, GlobalWalletConfig};


### PR DESCRIPTION
This does not appear to be used outside of the crate.