### PR TITLE
feat: remove expired peers from the storage

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -69,11 +69,11 @@ pub const TESTNET3_INITIAL_DIFFICULTY: u64 = 30000;
 /// we're sure this peer is a stuck node, and we will kick out such kind of stuck peers.
 pub const STUCK_PEER_KICK_TIME: i64 = 2 * 3600 * 1000;
 
-/// If a peer's last seen time is 2 weeks ago we will kick out such kind of 'dead' peers.
+/// If a peer's last seen time is 2 weeks ago we will forget such kind of defunct peers.
 const PEER_EXPIRATION_DAYS: i64 = 7 * 2;
 
-/// Constant that expresses dead peer timeout in milliseconds to be used in checks.
-pub const PEER_EXPIRATION_REMOVE_TIME: i64 = PEER_EXPIRATION_DAYS * 24 * 3600 * 1000;
+/// Constant that expresses defunct peer timeout in seconds to be used in checks.
+pub const PEER_EXPIRATION_REMOVE_TIME: i64 = PEER_EXPIRATION_DAYS * 24 * 3600;
 
 /// Testnet 4 initial block difficulty
 /// 1_000 times natural scale factor for cuckatoo29

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -69,6 +69,12 @@ pub const TESTNET3_INITIAL_DIFFICULTY: u64 = 30000;
 /// we're sure this peer is a stuck node, and we will kick out such kind of stuck peers.
 pub const STUCK_PEER_KICK_TIME: i64 = 2 * 3600 * 1000;
 
+/// If a peer's last seen time is 2 weeks ago we will kick out such kind of 'dead' peers.
+const PEER_EXPIRATION_DAYS: i64 = 7 * 2;
+
+/// Constant that expresses dead peer timeout in milliseconds to be used in checks.
+pub const PEER_EXPIRATION_REMOVE_TIME: i64 = PEER_EXPIRATION_DAYS * 24 * 3600 * 1000;
+
 /// Testnet 4 initial block difficulty
 /// 1_000 times natural scale factor for cuckatoo29
 pub const TESTNET4_INITIAL_DIFFICULTY: u64 = 1_000 * (2 << (29 - 24)) * 29;

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -492,6 +492,10 @@ impl Peers {
 		// Delete peers from the current list of peers
 		let mut peers = self.peers.write().unwrap();
 		for peer in peers_to_remove {
+			if let Some(peer) = peers.get(&peer.addr) {
+				peer.stop();
+			}
+
 			peers.remove(&peer.addr);
 
 			debug!(LOGGER, "remove_expired peer {:?} removed", &peer.addr)

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -473,7 +473,7 @@ impl Peers {
 		self.connected_peers().len() >= self.config.peer_min_preferred_count() as usize
 	}
 
-	/// Removes those peers that are seemed to be expired
+	/// Removes those peers that seem to have expired
 	pub fn remove_expired(&self) {
 		let now = Utc::now();
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -482,9 +482,16 @@ impl Peers {
 		let _ = self.store.delete_peers(|peer| {
 			let diff = now - Utc.timestamp(peer.last_connected, 0);
 
-			if 	peer.flags == State::Defunct && diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME) {
-				warn!("removing peer {:?}: last connected {} days {} hours {} minutes ago.", peer.addr,
-					  diff.num_days(), diff.num_hours(), diff.num_minutes());
+			if peer.flags == State::Defunct
+				&& diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME)
+			{
+				warn!(
+					"removing peer {:?}: last connected {} days {} hours {} minutes ago.",
+					peer.addr,
+					diff.num_days(),
+					diff.num_hours(),
+					diff.num_minutes()
+				);
 
 				peers_to_remove.push(peer.clone());
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -476,29 +476,25 @@ impl Peers {
 	/// Removes those peers that are seemed to be expired
 	pub fn remove_expired(&self) {
 		let now = Utc::now();
-		let mut peers_to_remove = vec![];
 
 		// Delete defunct peers from storage
 		let _ = self.store.delete_peers(|peer| {
 			let diff = now - Utc.timestamp(peer.last_connected, 0);
 
-			if peer.flags == State::Defunct
-				&& diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME)
-			{
-				warn!(
+			let should_remove = peer.flags == State::Defunct
+				&& diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME);
+
+			if should_remove {
+				debug!(
 					"removing peer {:?}: last connected {} days {} hours {} minutes ago.",
 					peer.addr,
 					diff.num_days(),
 					diff.num_hours(),
 					diff.num_minutes()
 				);
-
-				peers_to_remove.push(peer.clone());
-
-				true
-			} else {
-				false
 			}
+
+			should_remove
 		});
 	}
 }

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -22,8 +22,8 @@ use rand::{thread_rng, Rng};
 
 use chrono::prelude::*;
 use core::core;
-use core::global;
 use core::core::hash::{Hash, Hashed};
+use core::global;
 use core::pow::Difficulty;
 
 use peer::Peer;
@@ -490,8 +490,7 @@ impl Peers {
 		});
 
 		// Delete peers from the current list of peers
-		let mut peers = self.peers.write()
-			.unwrap();
+		let mut peers = self.peers.write().unwrap();
 		for peer in peers_to_remove {
 			peers.remove(&peer.addr);
 
@@ -632,7 +631,7 @@ impl NetAdapter for Peers {
 				flags: State::Healthy,
 				last_banned: 0,
 				ban_reason: ReasonForBan::None,
-				last_connected: Utc::now().timestamp()
+				last_connected: Utc::now().timestamp(),
 			};
 			if let Err(e) = self.save_peer(&peer) {
 				error!("Could not save received peer address: {:?}", e);

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -178,9 +178,9 @@ impl PeerStore {
 	}
 
 	/// Deletes peers from the storage that are satisfies some condition `predicate`
-	pub fn delete_peers<F>(&self, mut predicate: F) -> Result<(), Error>
+	pub fn delete_peers<F>(&self, predicate: F) -> Result<(), Error>
 	where
-		F: FnMut(&PeerData) -> bool,
+		F: Fn(&PeerData) -> bool,
 	{
 		let mut to_remove = vec![];
 

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -57,6 +57,8 @@ pub struct PeerData {
 	pub last_banned: i64,
 	/// The reason for the ban
 	pub ban_reason: ReasonForBan,
+	/// Time when we last connected to this peer.
+	pub last_connected: i64,
 }
 
 impl Writeable for PeerData {
@@ -68,7 +70,8 @@ impl Writeable for PeerData {
 			[write_bytes, &self.user_agent],
 			[write_u8, self.flags as u8],
 			[write_i64, self.last_banned],
-			[write_i32, self.ban_reason as i32]
+			[write_i32, self.ban_reason as i32],
+			[write_i64, self.last_connected]
 		);
 		Ok(())
 	}
@@ -77,12 +80,13 @@ impl Writeable for PeerData {
 impl Readable for PeerData {
 	fn read(reader: &mut Reader) -> Result<PeerData, ser::Error> {
 		let addr = SockAddr::read(reader)?;
-		let (capab, ua, fl, lb, br) =
-			ser_multiread!(reader, read_u32, read_vec, read_u8, read_i64, read_i32);
+		let (capab, ua, fl, lb, br, lc) =
+			ser_multiread!(reader, read_u32, read_vec, read_u8, read_i64, read_i32, read_i64);
 		let user_agent = String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData)?;
 		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
 		let last_banned = lb;
 		let ban_reason = ReasonForBan::from_i32(br).ok_or(ser::Error::CorruptedData)?;
+		let last_connected = lc;
 		match State::from_u8(fl) {
 			Some(flags) => Ok(PeerData {
 				addr: addr.0,
@@ -91,6 +95,7 @@ impl Readable for PeerData {
 				flags: flags,
 				last_banned: last_banned,
 				ban_reason: ban_reason,
+				last_connected
 			}),
 			None => Err(ser::Error::CorruptedData),
 		}
@@ -170,6 +175,31 @@ impl PeerStore {
 
 		batch.put_ser(&peer_key(peer.addr)[..], &peer)?;
 		batch.commit()
+	}
+
+	/// Deletes peers from the storage that are satisfies some condition `predicate`
+	pub fn delete_peers<F>(&self, mut predicate: F) -> Result<(), Error>
+	where F: FnMut(&PeerData) -> bool {
+		let mut to_remove = vec![];
+
+		for x in self.all_peers() {
+			if predicate(&x) {
+				to_remove.push(x)
+			}
+		}
+
+		// Delete peers in single batch
+		if !to_remove.is_empty() {
+			let batch = self.db.batch()?;
+
+			for peer in to_remove {
+				batch.delete(&peer_key(peer.addr)[..])?;
+			}
+
+			batch.commit()?;
+		}
+
+		Ok(())
 	}
 }
 

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -95,7 +95,7 @@ impl Readable for PeerData {
 				flags: flags,
 				last_banned: last_banned,
 				ban_reason: ban_reason,
-				last_connected
+				last_connected,
 			}),
 			None => Err(ser::Error::CorruptedData),
 		}
@@ -179,7 +179,9 @@ impl PeerStore {
 
 	/// Deletes peers from the storage that are satisfies some condition `predicate`
 	pub fn delete_peers<F>(&self, mut predicate: F) -> Result<(), Error>
-	where F: FnMut(&PeerData) -> bool {
+	where
+		F: FnMut(&PeerData) -> bool,
+	{
 		let mut to_remove = vec![];
 
 		for x in self.all_peers() {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -86,7 +86,7 @@ impl Readable for PeerData {
 		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
 		let last_banned = lb;
 		let ban_reason = ReasonForBan::from_i32(br).ok_or(ser::Error::CorruptedData)?;
-		let last_connected = lc;
+
 		match State::from_u8(fl) {
 			Some(flags) => Ok(PeerData {
 				addr: addr.0,
@@ -95,7 +95,7 @@ impl Readable for PeerData {
 				flags: flags,
 				last_banned: last_banned,
 				ban_reason: ban_reason,
-				last_connected,
+				last_connected: lc,
 			}),
 			None => Err(ser::Error::CorruptedData),
 		}

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -177,7 +177,7 @@ impl PeerStore {
 		batch.commit()
 	}
 
-	/// Deletes peers from the storage that are satisfies some condition `predicate`
+	/// Deletes peers from the storage that satisfy some condition `predicate`
 	pub fn delete_peers<F>(&self, predicate: F) -> Result<(), Error>
 	where
 		F: Fn(&PeerData) -> bool,

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -66,6 +66,9 @@ pub fn connect_and_monitor(
 				// make several attempts to get peers as quick as possible
 				// with exponential backoff
 				if Utc::now() - prev > Duration::seconds(cmp::min(20, 1 << start_attempt)) {
+					// Remove peers that are seemed to be expired
+					peers.remove_expired();
+
 					// try to connect to any address sent to the channel
 					listen_for_addrs(peers.clone(), p2p_server.clone(), capabilities, &rx);
 
@@ -110,9 +113,6 @@ fn monitor_peers(
 	let mut healthy_count = 0;
 	let mut banned_count = 0;
 	let mut defuncts = vec![];
-
-	// Remove peers that are seemed to be expired
-	peers.remove_expired();
 
 	for x in peers.all_peers() {
 		match x.flags {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -110,6 +110,10 @@ fn monitor_peers(
 	let mut healthy_count = 0;
 	let mut banned_count = 0;
 	let mut defuncts = vec![];
+
+	// Remove peers that are seemed to be expired
+	peers.remove_expired();
+
 	for x in peers.all_peers() {
 		match x.flags {
 			p2p::State::Banned => {


### PR DESCRIPTION
# Description

This pull-request makes Grin able to remove expired peers by the time they were last connected to.

Intended to close #1645.

## Changes made

1. Added `last_connected` field to the `PeerData` structure. This field indicates last moment when the successful connection with the peer occurred
2. Added function `delete_peers` to `PeerStore`. This function creates a batch for deletion of peers which are satisfying some predicate
3. Added function `remove_expired` to `Peers`. This function removes those peers which are seemed to be expired from the storage and peers list
4. Added call to the `remove_expired` from `seed.rs`'s `monitor_peers()`

## Open questions

There're some questions for the Grin people (maintainers probably) who are more familiar with codebase than I and have more insight into some subtle consequences of choices made during implementation of this feature:

- [x] Where/when to check for expired peers and remove them (for now it's done in `monitor_peers()`)?
- [x] Where/when to update peer's `last_connected` value to the current one?
- [x] It is necessary to also remove expired peers from list of peers list besides removing them from the storage?
- [x] If for some reason there're huge bunch of peers to remove, wouldn't removing them in single `batch` consume unacceptable amount of RAM? On the other hand, wouldn't removing peers one-by-one via `delete_peer` harm overall performance in this case?

# How Has This Been Tested?

1. Selected a small test value of 2 minutes of peer expiration timeout
2. Launched Grin and observed that it has collected list of peers, most of which were unavailable for various reasons and marked as defunct
3. After timeout of 2 minutes has been expired, removal of those peers has been observed in log
4. `monitor_peers` reported in log about some number of healthy peers and *zero* defunct peers which were deleted due to timeout

*Testing and feedback is highly appreciated!*
