### PR TITLE
Fix scaling diff in blocks for mining

### DIFF
--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -106,7 +106,7 @@ fn build_block(
 
 	// Determine the difficulty our block should be at.
 	// Note: do not keep the difficulty_iter in scope (it has an active batch).
-	let difficulty = consensus::next_difficulty(1, chain.difficulty_iter());
+	let difficulty = consensus::next_difficulty(head.height + 1, chain.difficulty_iter());
 
 	// extract current transaction from the pool
 	// TODO - we have a lot of unwrap() going on in this fn...


### PR DESCRIPTION
The expected fraction of secondary blocks depends on the height (starts at 90% and goes down 1% every 10080 blocks). This has influence on the difficulty scaling of the secondary PoW.

Currently, the miner will build blocks always assuming a ratio of 90%, which only works for blocks at height <10080. From that height onwards, the expected ratio drops and all blocks that are built will be invalid. This PR fixes the block builder.