### PR TITLE
full node == fast sync (no full archival guarantees)

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -168,7 +168,7 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"host".to_string(),
 		"
-#The interface on which to listen. 
+#The interface on which to listen.
 #0.0.0.0 will listen on all interfaces, allowing others to interact
 #127.0.0.1 will listen on the local machine only
 ".to_string(),
@@ -213,7 +213,6 @@ fn comments() -> HashMap<String, String> {
 #peer_min_preferred_count = 8
 
 # 7 = Bit flags for FULL_NODE
-# 6 = Bit flags for FAST_SYNC_NODE
 #This structure needs to be changed internally, to make it more configurable
 ".to_string(),
 	);

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -233,8 +233,7 @@ impl GlobalConfig {
 		file.read_to_string(&mut contents)?;
 		let decoded: Result<ConfigMembers, toml::de::Error> = toml::from_str(&contents);
 		match decoded {
-			Ok(mut gc) => {
-				gc.server.validation_check();
+			Ok(gc) => {
 				self.members = Some(gc);
 				return Ok(self);
 			}

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -79,9 +79,11 @@ pub const PEER_EXPIRATION_REMOVE_TIME: i64 = PEER_EXPIRATION_DAYS * 24 * 3600;
 /// 1_000 times natural scale factor for cuckatoo29
 pub const TESTNET4_INITIAL_DIFFICULTY: u64 = 1_000 * (2 << (29 - 24)) * 29;
 
-/// Trigger compaction check on average every day for FAST_SYNC_NODE,
-/// roll the dice on every block to decide,
-/// all blocks lower than (BodyHead.height - CUT_THROUGH_HORIZON) will be removed.
+/// Trigger compaction check on average every day for all nodes.
+/// Randomized per node - roll the dice on every block to decide.
+/// Will compact the txhashset to remove pruned data.
+/// Will also remove old blocks and associated data from the database.
+/// For a node configured as "archival_mode = true" only the txhashset will be compacted.
 pub const COMPACTION_CHECK: u64 = DAY_HEIGHT;
 
 /// Types of chain a server can run with, dictates the genesis block and

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -168,35 +168,9 @@ impl Peers {
 		max_peers
 	}
 
-	// Return vec of connected peers that currently advertise more work
-	// (total_difficulty) than we do and are also full archival nodes.
-	pub fn more_work_archival_peers(&self) -> Vec<Arc<Peer>> {
-		let peers = self.connected_peers();
-		if peers.len() == 0 {
-			return vec![];
-		}
-
-		let total_difficulty = self.total_difficulty();
-
-		let mut max_peers = peers
-			.into_iter()
-			.filter(|x| {
-				x.info.total_difficulty() > total_difficulty
-					&& x.info.capabilities.contains(Capabilities::FULL_HIST)
-			}).collect::<Vec<_>>();
-
-		thread_rng().shuffle(&mut max_peers);
-		max_peers
-	}
-
 	/// Returns single random peer with more work than us.
 	pub fn more_work_peer(&self) -> Option<Arc<Peer>> {
 		self.more_work_peers().pop()
-	}
-
-	/// Returns single random archival peer with more work than us.
-	pub fn more_work_archival_peer(&self) -> Option<Arc<Peer>> {
-		self.more_work_archival_peers().pop()
 	}
 
 	/// Return vec of connected peers that currently have the most worked

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -49,32 +49,14 @@ impl Server {
 	/// Creates a new idle p2p server with no peers
 	pub fn new(
 		db_env: Arc<lmdb::Environment>,
-		mut capab: Capabilities,
+		capab: Capabilities,
 		config: P2PConfig,
 		adapter: Arc<ChainAdapter>,
 		genesis: Hash,
 		stop: Arc<AtomicBool>,
 		_archive_mode: bool,
-		block_1_hash: Option<Hash>,
+		_block_1_hash: Option<Hash>,
 	) -> Result<Server, Error> {
-		// In the case of an archive node, check that we do have the first block.
-		// In case of first sync we do not perform this check.
-		if capab.contains(Capabilities::FULL_HIST) && adapter.total_height() > 0 {
-			// Check that we have block 1
-			match block_1_hash {
-				Some(hash) => match adapter.get_block(hash) {
-					Some(_) => debug!("Full block 1 found, archive capabilities confirmed"),
-					None => {
-						debug!("Full block 1 not found, archive capabilities disabled");
-						capab.remove(Capabilities::FULL_HIST);
-					}
-				},
-				None => {
-					debug!("Block 1 not found, archive capabilities disabled");
-					capab.remove(Capabilities::FULL_HIST);
-				}
-			}
-		}
 		Ok(Server {
 			config: config.clone(),
 			capabilities: capab,

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -54,8 +54,6 @@ impl Server {
 		adapter: Arc<ChainAdapter>,
 		genesis: Hash,
 		stop: Arc<AtomicBool>,
-		_archive_mode: bool,
-		_block_1_hash: Option<Hash>,
 	) -> Result<Server, Error> {
 		Ok(Server {
 			config: config.clone(),

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -132,7 +132,7 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::FAST_SYNC_NODE,
+			capabilities: Capabilities::FULL_NODE,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,
@@ -193,26 +193,27 @@ impl Default for Seeding {
 }
 
 bitflags! {
-  /// Options for what type of interaction a peer supports
-  #[derive(Serialize, Deserialize)]
-  pub struct Capabilities: u32 {
-	/// We don't know (yet) what the peer can do.
-	const UNKNOWN = 0b00000000;
-	/// Full archival node, has the whole history without any pruning.
-	const FULL_HIST = 0b00000001;
-	/// Can provide block headers and the TxHashSet for some recent-enough
-	/// height.
-	const TXHASHSET_HIST = 0b00000010;
-	/// Can provide a list of healthy peers
-	const PEER_LIST = 0b00000100;
+	/// Options for what type of interaction a peer supports
+	#[derive(Serialize, Deserialize)]
+	pub struct Capabilities: u32 {
+		/// We don't know (yet) what the peer can do.
+		const UNKNOWN = 0b00000000;
+		/// Can provide full history of headers back to genesis
+		/// (for at least one arbitrary fork).
+		const HEADER_HIST = 0b00000001;
+		/// Can provide block headers and the TxHashSet for some recent-enough
+		/// height.
+		const TXHASHSET_HIST = 0b00000010;
+		/// Can provide a list of healthy peers
+		const PEER_LIST = 0b00000100;
 
-	const FAST_SYNC_NODE = Capabilities::TXHASHSET_HIST.bits
-		| Capabilities::PEER_LIST.bits;
-
-	const FULL_NODE = Capabilities::FULL_HIST.bits
-		| Capabilities::TXHASHSET_HIST.bits
-		| Capabilities::PEER_LIST.bits;
-  }
+		/// All nodes right now are "full nodes".
+		/// Some nodes internally may maintain longer block histories (archival_mode)
+		/// but we do not advertise this to other nodes.
+		const FULL_NODE = Capabilities::HEADER_HIST.bits
+			| Capabilities::TXHASHSET_HIST.bits
+			| Capabilities::PEER_LIST.bits;
+	}
 }
 
 /// Types of connection

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -58,8 +58,6 @@ fn peer_handshake() {
 			net_adapter.clone(),
 			Hash::from_vec(&vec![]),
 			Arc::new(AtomicBool::new(false)),
-			false,
-			None,
 		).unwrap(),
 	);
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -433,14 +433,11 @@ impl NetToChainAdapter {
 	// pushing the new block through the chain pipeline
 	// remembering to reset the head if we have a bad block
 	fn process_block(&self, b: core::Block, addr: SocketAddr) -> bool {
-		if !self.archive_mode {
+		// We cannot process blocks earlier than the horizon so check for this here.
+		{
 			let head = self.chain().head().unwrap();
-			// we have a fast sync'd node and are sent a block older than our horizon,
-			// only sync can do something with that
-			if b.header.height < head
-				.height
-				.saturating_sub(global::cut_through_horizon() as u64)
-			{
+			let horizon = head.height.saturating_sub(global::cut_through_horizon() as u64);
+			if b.header.height < horizon {
 				return true;
 			}
 		}

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -160,28 +160,6 @@ pub struct ServerConfig {
 	pub stratum_mining_config: Option<StratumServerConfig>,
 }
 
-impl ServerConfig {
-	/// Configuration items validation check
-	pub fn validation_check(&mut self) {
-		// TODO - we do not expose archive_mode as separate capability now, clean this up.
-		// check [server.p2p_config.capabilities] with 'archive_mode' in [server]
-		// if let Some(archive) = self.archive_mode {
-		// 	if archive != self
-		// 		.p2p_config
-		// 		.capabilities
-		// 		.contains(p2p::Capabilities::FULL_HIST)
-		// 	{
-		// 		// if conflict, 'archive_mode' win
-		// 		self.p2p_config
-		// 			.capabilities
-		// 			.toggle(p2p::Capabilities::FULL_HIST);
-		// 	}
-		// }
-
-		// todo: other checks if needed
-	}
-}
-
 impl Default for ServerConfig {
 	fn default() -> ServerConfig {
 		ServerConfig {

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -163,20 +163,20 @@ pub struct ServerConfig {
 impl ServerConfig {
 	/// Configuration items validation check
 	pub fn validation_check(&mut self) {
+		// TODO - we do not expose archive_mode as separate capability now, clean this up.
 		// check [server.p2p_config.capabilities] with 'archive_mode' in [server]
-		if let Some(archive) = self.archive_mode {
-			// note: slog not available before config loaded, only print here.
-			if archive != self
-				.p2p_config
-				.capabilities
-				.contains(p2p::Capabilities::FULL_HIST)
-			{
-				// if conflict, 'archive_mode' win
-				self.p2p_config
-					.capabilities
-					.toggle(p2p::Capabilities::FULL_HIST);
-			}
-		}
+		// if let Some(archive) = self.archive_mode {
+		// 	if archive != self
+		// 		.p2p_config
+		// 		.capabilities
+		// 		.contains(p2p::Capabilities::FULL_HIST)
+		// 	{
+		// 		// if conflict, 'archive_mode' win
+		// 		self.p2p_config
+		// 			.capabilities
+		// 			.toggle(p2p::Capabilities::FULL_HIST);
+		// 	}
+		// }
 
 		// todo: other checks if needed
 	}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -238,7 +238,7 @@ fn connect_to_seeds_and_preferred_peers(
 	peers_preferred_list: Option<Vec<SocketAddr>>,
 ) {
 	// check if we have some peers in db
-	let peers = peers.find_peers(p2p::State::Healthy, p2p::Capabilities::FULL_HIST, 100);
+	let peers = peers.find_peers(p2p::State::Healthy, p2p::Capabilities::FULL_NODE, 100);
 
 	// if so, get their addresses, otherwise use our seeds
 	let mut peer_addrs = if peers.len() > 3 {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -29,7 +29,6 @@ use common::adapters::{
 };
 use common::stats::{DiffBlock, DiffStats, PeerStats, ServerStateInfo, ServerStats};
 use common::types::{Error, ServerConfig, StratumServerConfig, SyncState, SyncStatus};
-use core::core::hash::Hashed;
 use core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use core::{consensus, genesis, global, pow};
 use grin::{dandelion_monitor, seed, sync};
@@ -111,21 +110,6 @@ impl Server {
 			Some(b) => b,
 		};
 
-		// TODO - we no longer advertise "archival_mode" as separate capability
-		// TODO - we also seem to be doing this in a couple of different places
-		// TODO - clean this up
-		// If archive mode is enabled then the flags should contains the FULL_HIST flag
-		// if archive_mode && !config
-		// 	.p2p_config
-		// 	.capabilities
-		// 	.contains(p2p::Capabilities::FULL_HIST)
-		// {
-		// 	config
-		// 		.p2p_config
-		// 		.capabilities
-		// 		.insert(p2p::Capabilities::FULL_HIST);
-		// }
-
 		let stop = Arc::new(AtomicBool::new(false));
 
 		// Shared cache for verification results.
@@ -182,11 +166,6 @@ impl Server {
 			config.clone(),
 		));
 
-		let block_1_hash = match shared_chain.get_header_by_height(1) {
-			Ok(header) => Some(header.hash()),
-			Err(_) => None,
-		};
-
 		let peer_db_env = Arc::new(store::new_named_env(config.db_root.clone(), "peer".into()));
 		let p2p_server = Arc::new(p2p::Server::new(
 			peer_db_env,
@@ -195,8 +174,6 @@ impl Server {
 			net_adapter.clone(),
 			genesis.hash(),
 			stop.clone(),
-			archive_mode,
-			block_1_hash,
 		)?);
 		chain_adapter.init(p2p_server.peers.clone());
 		pool_net_adapter.init(p2p_server.peers.clone());

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -111,17 +111,20 @@ impl Server {
 			Some(b) => b,
 		};
 
+		// TODO - we no longer advertise "archival_mode" as separate capability
+		// TODO - we also seem to be doing this in a couple of different places
+		// TODO - clean this up
 		// If archive mode is enabled then the flags should contains the FULL_HIST flag
-		if archive_mode && !config
-			.p2p_config
-			.capabilities
-			.contains(p2p::Capabilities::FULL_HIST)
-		{
-			config
-				.p2p_config
-				.capabilities
-				.insert(p2p::Capabilities::FULL_HIST);
-		}
+		// if archive_mode && !config
+		// 	.p2p_config
+		// 	.capabilities
+		// 	.contains(p2p::Capabilities::FULL_HIST)
+		// {
+		// 	config
+		// 		.p2p_config
+		// 		.capabilities
+		// 		.insert(p2p::Capabilities::FULL_HIST);
+		// }
 
 		let stop = Arc::new(AtomicBool::new(false));
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -236,7 +236,6 @@ impl Server {
 			sync_state.clone(),
 			p2p_server.peers.clone(),
 			shared_chain.clone(),
-			archive_mode,
 			stop.clone(),
 		);
 

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -86,9 +86,9 @@ impl BodySync {
 
 	fn body_sync(&mut self) {
 		let horizon = global::cut_through_horizon() as u64;
-		let body_head: chain::Tip = self.chain.head().unwrap();
-		let header_head: chain::Tip = self.chain.header_head().unwrap();
-		let sync_head: chain::Tip = self.chain.get_sync_head().unwrap();
+		let body_head = self.chain.head().unwrap();
+		let header_head = self.chain.header_head().unwrap();
+		let sync_head = self.chain.get_sync_head().unwrap();
 
 		self.reset();
 
@@ -121,15 +121,16 @@ impl BodySync {
 		}
 		hashes.reverse();
 
+		// TODO - clean this up
+		if oldest_height < header_head.height.saturating_sub(horizon) {
+			debug!("cannot sync full blocks earlier than horizon");
+			return;
+		};
+
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work
 		// also if the chain is already saturated with orphans, throttle
-		let peers = if oldest_height < header_head.height.saturating_sub(horizon) {
-			self.peers.more_work_archival_peers()
-		} else {
-			self.peers.more_work_peers()
-		};
-
+		let peers = self.peers.more_work_peers();
 		let block_count = cmp::min(
 			cmp::min(100, peers.len() * p2p::SEND_CHANNEL_CAP),
 			chain::MAX_ORPHAN_SIZE.saturating_sub(self.chain.orphans_len()) + 1,

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -121,16 +121,16 @@ impl BodySync {
 		}
 		hashes.reverse();
 
-		// TODO - clean this up
 		if oldest_height < header_head.height.saturating_sub(horizon) {
-			debug!("cannot sync full blocks earlier than horizon");
+			debug!("body_sync: cannot sync full blocks earlier than horizon.");
 			return;
-		};
+		}
+
+		let peers = self.peers.more_work_peers();
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work
 		// also if the chain is already saturated with orphans, throttle
-		let peers = self.peers.more_work_peers();
 		let block_count = cmp::min(
 			cmp::min(100, peers.len() * p2p::SEND_CHANNEL_CAP),
 			chain::MAX_ORPHAN_SIZE.saturating_sub(self.chain.orphans_len()) + 1,

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -32,7 +32,6 @@ pub struct StateSync {
 	sync_state: Arc<SyncState>,
 	peers: Arc<p2p::Peers>,
 	chain: Arc<chain::Chain>,
-	archive_mode: bool,
 
 	prev_fast_sync: Option<DateTime<Utc>>,
 	fast_sync_peer: Option<Arc<Peer>>,
@@ -43,13 +42,11 @@ impl StateSync {
 		sync_state: Arc<SyncState>,
 		peers: Arc<p2p::Peers>,
 		chain: Arc<chain::Chain>,
-		archive_mode: bool,
 	) -> StateSync {
 		StateSync {
 			sync_state,
 			peers,
 			chain,
-			archive_mode,
 			prev_fast_sync: None,
 			fast_sync_peer: None,
 		}
@@ -64,8 +61,8 @@ impl StateSync {
 		head: &chain::Tip,
 		highest_height: u64,
 	) -> bool {
-		let need_state_sync = !self.archive_mode
-			&& highest_height.saturating_sub(head.height) > global::cut_through_horizon() as u64;
+		let need_state_sync =
+			highest_height.saturating_sub(head.height) > global::cut_through_horizon() as u64;
 		if !need_state_sync {
 			return false;
 		}

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -29,13 +29,12 @@ pub fn run_sync(
 	sync_state: Arc<SyncState>,
 	peers: Arc<p2p::Peers>,
 	chain: Arc<chain::Chain>,
-	archive_mode: bool,
 	stop: Arc<AtomicBool>,
 ) {
 	let _ = thread::Builder::new()
 		.name("sync".to_string())
 		.spawn(move || {
-			let runner = SyncRunner::new(sync_state, peers, chain, archive_mode, stop);
+			let runner = SyncRunner::new(sync_state, peers, chain, stop);
 			runner.sync_loop();
 		});
 }
@@ -44,7 +43,6 @@ pub struct SyncRunner {
 	sync_state: Arc<SyncState>,
 	peers: Arc<p2p::Peers>,
 	chain: Arc<chain::Chain>,
-	archive_mode: bool,
 	stop: Arc<AtomicBool>,
 }
 
@@ -53,14 +51,12 @@ impl SyncRunner {
 		sync_state: Arc<SyncState>,
 		peers: Arc<p2p::Peers>,
 		chain: Arc<chain::Chain>,
-		archive_mode: bool,
 		stop: Arc<AtomicBool>,
 	) -> SyncRunner {
 		SyncRunner {
 			sync_state,
 			peers,
 			chain,
-			archive_mode,
 			stop,
 		}
 	}
@@ -118,7 +114,6 @@ impl SyncRunner {
 			self.sync_state.clone(),
 			self.peers.clone(),
 			self.chain.clone(),
-			self.archive_mode,
 		);
 
 		// Highest height seen on the network, generally useful for a fast test on


### PR DESCRIPTION
We have discussed this a few times - putting this up in a PR to see if there are any concerns around making "fast sync" the default behavior for "full nodes" (and changing the semantics of "archive mode").

* Simplify `Capabilities` -
  * combine `FULL_NODE` and `FAST_SYNC_NODE` (we now only have `FULL_NODE`)
  * peers no longer advertise any kind of "archival" capability
  * no need to filter peers by `more_work_archival` etc.
* change `archive_mode = true` behavior
  * the _only_ thing this does is prevent old blocks in the db from being deleted
  * _all_ nodes now run `check_compact()` and prune/compact the txhashset
  * _all_ nodes now fast-sync via a `txhashset.zip` download
* get rid of our special case "block 1" logic for "full archival nodes"

I think this will go a long way toward setting expectations around exactly what a _FULL NODE_ is in Grin.

For everyone wanting to build tooling (mining pools, blockchain explorers etc.) you will want to run nodes from day 1 to ensure you have full block history (if this is deemed important).
Otherwise it would be possible to obtain a full block history from another party by asking for an export of their database. But this may not be something that we would officially support.

Thoughts? Concerns?

TODO - 

- [x] Update `grin-server.toml` defaults and comments for `7` vs. `6` (all nodes should be a `7` by default now).

What will happen if we deploy this and some existing (legacy FAST_SYNC) nodes are configured with capabilities = `6` (i.e. they are not FULL_NODEs according to these rules?)

