### PR TITLE
Cleanup sync loop

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -15,7 +15,6 @@
 //! Server stat collection types, to be used by tests, logging or GUI/TUI
 //! to collect information about server status
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::SystemTime;
 use util::RwLock;
@@ -32,8 +31,6 @@ use p2p;
 /// and populated when required
 #[derive(Clone)]
 pub struct ServerStateInfo {
-	/// whether we're in a state of waiting for peers at startup
-	pub awaiting_peers: Arc<AtomicBool>,
 	/// Stratum stats
 	pub stratum_stats: Arc<RwLock<StratumStats>>,
 }
@@ -41,7 +38,6 @@ pub struct ServerStateInfo {
 impl Default for ServerStateInfo {
 	fn default() -> ServerStateInfo {
 		ServerStateInfo {
-			awaiting_peers: Arc::new(AtomicBool::new(false)),
 			stratum_stats: Arc::new(RwLock::new(StratumStats::default())),
 		}
 	}
@@ -58,8 +54,6 @@ pub struct ServerStats {
 	pub header_head: chain::Tip,
 	/// Whether we're currently syncing
 	pub sync_status: SyncStatus,
-	/// Whether we're awaiting peers
-	pub awaiting_peers: bool,
 	/// Handle to current stratum server stats
 	pub stratum_stats: StratumStats,
 	/// Peer stats

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -250,6 +250,9 @@ pub enum SyncStatus {
 	Initial,
 	/// Not syncing
 	NoSync,
+	/// Not enough peers to do anything yet, boolean indicates whether
+	/// we should wait at all or ignore and start ASAP
+	AwaitingPeers(bool),
 	/// Downloading block headers
 	HeaderSync {
 		current_height: u64,

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -54,7 +54,7 @@ impl HeaderSync {
 
 		let enable_header_sync = match status {
 			SyncStatus::BodySync { .. } | SyncStatus::HeaderSync { .. } => true,
-			SyncStatus::NoSync | SyncStatus::Initial => {
+			SyncStatus::NoSync | SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => {
 				// Reset sync_head to header_head on transition to HeaderSync,
 				// but ONLY on initial transition to HeaderSync state.
 				let sync_head = self.chain.get_sync_head().unwrap();
@@ -102,7 +102,7 @@ impl HeaderSync {
 
 		// always enable header sync on initial state transition from NoSync / Initial
 		let force_sync = match self.sync_state.status() {
-			SyncStatus::NoSync | SyncStatus::Initial => true,
+			SyncStatus::NoSync | SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => true,
 			_ => false,
 		};
 

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -87,90 +87,87 @@ impl TUIStatusListener for TUIStatusView {
 	fn update(c: &mut Cursive, stats: &ServerStats) {
 		//find and update here as needed
 		let basic_status = {
-			if stats.awaiting_peers {
-				"Waiting for peers".to_string()
-			} else {
-				match stats.sync_status {
-					SyncStatus::Initial => "Initializing".to_string(),
-					SyncStatus::NoSync => "Running".to_string(),
-					SyncStatus::HeaderSync {
-						current_height,
-						highest_height,
-					} => {
-						let percent = if highest_height == 0 {
-							0
+			match stats.sync_status {
+				SyncStatus::Initial => "Initializing".to_string(),
+				SyncStatus::NoSync => "Running".to_string(),
+				SyncStatus::AwaitingPeers(_) => "Waiting for peers".to_string(),
+				SyncStatus::HeaderSync {
+					current_height,
+					highest_height,
+				} => {
+					let percent = if highest_height == 0 {
+						0
+					} else {
+						current_height * 100 / highest_height
+					};
+					format!("Downloading headers: {}%, step 1/4", percent)
+				}
+				SyncStatus::TxHashsetDownload {
+					start_time,
+					downloaded_size,
+					total_size,
+				} => {
+					if total_size > 0 {
+						let percent = if total_size > 0 {
+							downloaded_size * 100 / total_size
 						} else {
-							current_height * 100 / highest_height
+							0
 						};
-						format!("Downloading headers: {}%, step 1/4", percent)
-					}
-					SyncStatus::TxHashsetDownload {
-						start_time,
-						downloaded_size,
-						total_size,
-					} => {
-						if total_size > 0 {
-							let percent = if total_size > 0 {
-								downloaded_size * 100 / total_size
-							} else {
-								0
-							};
-							let start = start_time.timestamp_nanos();
-							let fin = Utc::now().timestamp_nanos();
-							let dur_ms = (fin - start) as f64 * NANO_TO_MILLIS;
+						let start = start_time.timestamp_nanos();
+						let fin = Utc::now().timestamp_nanos();
+						let dur_ms = (fin - start) as f64 * NANO_TO_MILLIS;
 
-							format!("Downloading {}(MB) chain state for fast sync: {}% at {:.1?}(kB/s), step 2/4",
-									total_size / 1_000_000,
-									percent,
-									if dur_ms > 1.0f64 { downloaded_size as f64 / dur_ms as f64 } else { 0f64 },
-							)
-						} else {
-							let start = start_time.timestamp_millis();
-							let fin = Utc::now().timestamp_millis();
-							let dur_secs = (fin - start) / 1000;
+						format!("Downloading {}(MB) chain state for fast sync: {}% at {:.1?}(kB/s), step 2/4",
+						total_size / 1_000_000,
+						percent,
+						if dur_ms > 1.0f64 { downloaded_size as f64 / dur_ms as f64 } else { 0f64 },
+						)
+					} else {
+						let start = start_time.timestamp_millis();
+						let fin = Utc::now().timestamp_millis();
+						let dur_secs = (fin - start) / 1000;
 
-							format!("Downloading chain state for fast sync. Waiting remote peer to start: {}s, step 2/4",
-									dur_secs,
-							)
-						}
+						format!("Downloading chain state for fast sync. Waiting remote peer to start: {}s, step 2/4",
+										dur_secs,
+										)
 					}
-					SyncStatus::TxHashsetSetup => {
-						"Preparing chain state for validation, step 3/4".to_string()
-					}
-					SyncStatus::TxHashsetValidation {
-						kernels,
-						kernel_total,
-						rproofs,
-						rproof_total,
-					} => {
-						// 10% of overall progress is attributed to kernel validation
-						// 90% to range proofs (which are much longer)
-						let mut percent = if kernel_total > 0 {
-							kernels * 10 / kernel_total
-						} else {
-							0
-						};
-						percent += if rproof_total > 0 {
-							rproofs * 90 / rproof_total
-						} else {
-							0
-						};
-						format!("Validating chain state: {}%, step 3/4", percent)
-					}
-					SyncStatus::TxHashsetSave => {
-						"Finalizing chain state for fast sync, step 3/4".to_string()
-					}
-					SyncStatus::BodySync {
-						current_height,
-						highest_height,
-					} => {
-						let percent = if highest_height == 0 {
-							0
-						} else {
-							current_height * 100 / highest_height
-						};
-						format!("Downloading blocks: {}%, step 4/4", percent)
-					}
+				}
+				SyncStatus::TxHashsetSetup => {
+					"Preparing chain state for validation, step 3/4".to_string()
+				}
+				SyncStatus::TxHashsetValidation {
+					kernels,
+					kernel_total,
+					rproofs,
+					rproof_total,
+				} => {
+					// 10% of overall progress is attributed to kernel validation
+					// 90% to range proofs (which are much longer)
+					let mut percent = if kernel_total > 0 {
+						kernels * 10 / kernel_total
+					} else {
+						0
+					};
+					percent += if rproof_total > 0 {
+						rproofs * 90 / rproof_total
+					} else {
+						0
+					};
+					format!("Validating chain state: {}%, step 3/4", percent)
+				}
+				SyncStatus::TxHashsetSave => {
+					"Finalizing chain state for fast sync, step 3/4".to_string()
+				}
+				SyncStatus::BodySync {
+					current_height,
+					highest_height,
+				} => {
+					let percent = if highest_height == 0 {
+						0
+					} else {
+						current_height * 100 / highest_height
+					};
+					format!("Downloading blocks: {}%, step 4/4", percent)
 				}
 			}
 		};


### PR DESCRIPTION
* Add a struct to encapsulate common references and avoid passing
them around on every function.
* Consolidate `skip_sync_wait` and `awaiting_peers` in an
additional sync status.