### PR TITLE
Actually cleanup old blocks if archive_mode=false

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -752,7 +752,7 @@ impl Chain {
 	/// *Only* runs if we are not in archive mode.
 	fn compact_blocks_db(&self) -> Result<(), Error> {
 		if self.archive_mode {
-			return Ok(())
+			return Ok(());
 		}
 
 		let horizon = global::cut_through_horizon() as u64;
@@ -762,9 +762,7 @@ impl Chain {
 
 		debug!(
 			"chain: compact_blocks_db: head height: {}, horizon: {}, cutoff: {}",
-			head.height,
-			horizon,
-			cutoff,
+			head.height, horizon, cutoff,
 		);
 
 		if cutoff == 0 {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -751,7 +751,7 @@ impl Chain {
 	/// Determine the cutoff height from the horizon and the current block height.
 	/// *Only* runs if we are not in archive mode.
 	fn compact_blocks_db(&self) -> Result<(), Error> {
-		if !self.archive_mode {
+		if self.archive_mode {
 			return Ok(())
 		}
 


### PR DESCRIPTION
🤦‍♀️ 

We were being _extra_ careful with archive_mode with a check here - 

https://github.com/mimblewimble/grin/blob/38cbd6eafba683f1bcd85bff7a338ee8c1df2514/chain/src/chain.rs#L815-L817

And here - 

https://github.com/mimblewimble/grin/blob/38cbd6eafba683f1bcd85bff7a338ee8c1df2514/chain/src/chain.rs#L753-L756

And that 2nd one is incorrect, so we were making sure we _never_ actually removed old blocks from the db...

I want to leave that 2nd check in there (after fixing it) just in case this code gets rewritten and somebody calls `compact_blocks_db()` on an "archive" node.

