### PR TITLE
Remove fluff in SendTXArgs

### DIFF
--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -686,6 +686,4 @@ pub struct SendTXArgs {
 	pub num_change_outputs: usize,
 	/// whether to use all outputs (combine)
 	pub selection_strategy_is_use_all: bool,
-	/// dandelion control
-	pub fluff: bool,
 }


### PR DESCRIPTION
Fixes #1823. Fluff was actually never used.
Wallet and other implementations should update their implementations.
Grin-Web-Wallet PR https://github.com/mimblewimble/grin-web-wallet/pull/7