### PR TITLE
validate root of header MMR when processing headers (during sync and full blocks)

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -143,9 +143,6 @@ impl OutputHandler {
 		let block = w(&self.chain)
 			.get_block(&header.hash())
 			.map_err(|_| ErrorKind::NotFound)?;
-		let previous = w(&self.chain)
-			.get_previous_header(&header)
-			.map_err(|_| ErrorKind::NotFound)?;
 		let outputs = block
 			.outputs()
 			.iter()
@@ -155,7 +152,7 @@ impl OutputHandler {
 			}).collect();
 
 		Ok(BlockOutputs {
-			header: BlockHeaderInfo::from_headers(&header, &previous),
+			header: BlockHeaderInfo::from_header(&header),
 			outputs: outputs,
 		})
 	}
@@ -590,10 +587,7 @@ impl HeaderHandler {
 
 	/// Convert a header into a "printable" version for json serialization.
 	fn convert_header(&self, header: &BlockHeader) -> Result<BlockHeaderPrintable, Error> {
-		let previous = w(&self.chain)
-			.get_previous_header(header)
-			.context(ErrorKind::NotFound)?;
-		return Ok(BlockHeaderPrintable::from_headers(header, &previous));
+		return Ok(BlockHeaderPrintable::from_header(header));
 	}
 
 	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -143,6 +143,9 @@ impl OutputHandler {
 		let block = w(&self.chain)
 			.get_block(&header.hash())
 			.map_err(|_| ErrorKind::NotFound)?;
+		let previous = w(&self.chain)
+			.get_previous_header(&header)
+			.map_err(|_| ErrorKind::NotFound)?;
 		let outputs = block
 			.outputs()
 			.iter()
@@ -152,7 +155,7 @@ impl OutputHandler {
 			}).collect();
 
 		Ok(BlockOutputs {
-			header: BlockHeaderInfo::from_header(&header),
+			header: BlockHeaderInfo::from_headers(&header, &previous),
 			outputs: outputs,
 		})
 	}

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -574,7 +574,7 @@ impl HeaderHandler {
 			match w(&self.chain).get_header_by_height(height) {
 				Ok(header) => {
 					return self.convert_header(&header);
-				},
+				}
 				Err(_) => return Err(ErrorKind::NotFound)?,
 			}
 		}
@@ -590,15 +590,16 @@ impl HeaderHandler {
 
 	/// Convert a header into a "printable" version for json serialization.
 	fn convert_header(&self, header: &BlockHeader) -> Result<BlockHeaderPrintable, Error> {
-		let previous = w(&self.chain).get_previous_header(header)
+		let previous = w(&self.chain)
+			.get_previous_header(header)
 			.context(ErrorKind::NotFound)?;
-		return Ok(BlockHeaderPrintable::from_headers(header, &previous))
+		return Ok(BlockHeaderPrintable::from_headers(header, &previous));
 	}
 
 	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {
 		let oid = get_output(&self.chain, &commit_id)?.1;
 		match w(&self.chain).get_header_for_output(&oid) {
-			Ok(header) =>  return self.convert_header(&header),
+			Ok(header) => return self.convert_header(&header),
 			Err(_) => return Err(ErrorKind::NotFound)?,
 		}
 	}

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -472,11 +472,11 @@ pub struct BlockHeaderInfo {
 }
 
 impl BlockHeaderInfo {
-	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderInfo {
+	pub fn from_headers(header: &core::BlockHeader, previous: &core::BlockHeader) -> BlockHeaderInfo {
 		BlockHeaderInfo {
-			hash: util::to_hex(h.hash().to_vec()),
-			height: h.height,
-			previous: util::to_hex(h.previous.to_vec()),
+			hash: util::to_hex(header.hash().to_vec()),
+			height: header.height,
+			previous: util::to_hex(previous.hash().to_vec()),
 		}
 	}
 }
@@ -516,23 +516,23 @@ pub struct BlockHeaderPrintable {
 }
 
 impl BlockHeaderPrintable {
-	pub fn from_header(h: &core::BlockHeader) -> BlockHeaderPrintable {
+	pub fn from_headers(header: &core::BlockHeader, previous: &core::BlockHeader) -> BlockHeaderPrintable {
 		BlockHeaderPrintable {
-			hash: util::to_hex(h.hash().to_vec()),
-			version: h.version,
-			height: h.height,
-			previous: util::to_hex(h.previous.to_vec()),
-			prev_root: util::to_hex(h.prev_root.to_vec()),
-			timestamp: h.timestamp.to_rfc3339(),
-			output_root: util::to_hex(h.output_root.to_vec()),
-			range_proof_root: util::to_hex(h.range_proof_root.to_vec()),
-			kernel_root: util::to_hex(h.kernel_root.to_vec()),
-			nonce: h.pow.nonce,
-			edge_bits: h.pow.edge_bits(),
-			cuckoo_solution: h.pow.proof.nonces.clone(),
-			total_difficulty: h.pow.total_difficulty.to_num(),
-			secondary_scaling: h.pow.secondary_scaling,
-			total_kernel_offset: h.total_kernel_offset.to_hex(),
+			hash: util::to_hex(header.hash().to_vec()),
+			version: header.version,
+			height: header.height,
+			previous: util::to_hex(previous.hash().to_vec()),
+			prev_root: util::to_hex(header.prev_root.to_vec()),
+			timestamp: header.timestamp.to_rfc3339(),
+			output_root: util::to_hex(header.output_root.to_vec()),
+			range_proof_root: util::to_hex(header.range_proof_root.to_vec()),
+			kernel_root: util::to_hex(header.kernel_root.to_vec()),
+			nonce: header.pow.nonce,
+			edge_bits: header.pow.edge_bits(),
+			cuckoo_solution: header.pow.proof.nonces.clone(),
+			total_difficulty: header.pow.total_difficulty.to_num(),
+			scaling_difficulty: header.pow.scaling_difficulty,
+			total_kernel_offset: header.total_kernel_offset.to_hex(),
 		}
 	}
 }

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -583,8 +583,9 @@ impl BlockPrintable {
 			.iter()
 			.map(|kernel| TxKernelPrintable::from_txkernel(kernel))
 			.collect();
+		let previous = chain.get_previous_header(&block.header).unwrap();
 		BlockPrintable {
-			header: BlockHeaderPrintable::from_header(&block.header),
+			header: BlockHeaderPrintable::from_headers(&block.header, &previous),
 			inputs: inputs,
 			outputs: outputs,
 			kernels: kernels,
@@ -622,8 +623,9 @@ impl CompactBlockPrintable {
 			.iter()
 			.map(|x| TxKernelPrintable::from_txkernel(x))
 			.collect();
+		let previous = chain.get_previous_header(&cb.header).unwrap();
 		CompactBlockPrintable {
-			header: BlockHeaderPrintable::from_header(&cb.header),
+			header: BlockHeaderPrintable::from_headers(&cb.header, &previous),
 			out_full,
 			kern_full,
 			kern_ids: cb.kern_ids().iter().map(|x| x.to_hex()).collect(),

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -472,9 +472,7 @@ pub struct BlockHeaderInfo {
 }
 
 impl BlockHeaderInfo {
-	pub fn from_header(
-		header: &core::BlockHeader,
-	) -> BlockHeaderInfo {
+	pub fn from_header(header: &core::BlockHeader) -> BlockHeaderInfo {
 		BlockHeaderInfo {
 			hash: util::to_hex(header.hash().to_vec()),
 			height: header.height,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -472,7 +472,10 @@ pub struct BlockHeaderInfo {
 }
 
 impl BlockHeaderInfo {
-	pub fn from_headers(header: &core::BlockHeader, previous: &core::BlockHeader) -> BlockHeaderInfo {
+	pub fn from_headers(
+		header: &core::BlockHeader,
+		previous: &core::BlockHeader,
+	) -> BlockHeaderInfo {
 		BlockHeaderInfo {
 			hash: util::to_hex(header.hash().to_vec()),
 			height: header.height,
@@ -516,7 +519,10 @@ pub struct BlockHeaderPrintable {
 }
 
 impl BlockHeaderPrintable {
-	pub fn from_headers(header: &core::BlockHeader, previous: &core::BlockHeader) -> BlockHeaderPrintable {
+	pub fn from_headers(
+		header: &core::BlockHeader,
+		previous: &core::BlockHeader,
+	) -> BlockHeaderPrintable {
 		BlockHeaderPrintable {
 			hash: util::to_hex(header.hash().to_vec()),
 			version: header.version,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -472,14 +472,13 @@ pub struct BlockHeaderInfo {
 }
 
 impl BlockHeaderInfo {
-	pub fn from_headers(
+	pub fn from_header(
 		header: &core::BlockHeader,
-		previous: &core::BlockHeader,
 	) -> BlockHeaderInfo {
 		BlockHeaderInfo {
 			hash: util::to_hex(header.hash().to_vec()),
 			height: header.height,
-			previous: util::to_hex(previous.hash().to_vec()),
+			previous: util::to_hex(header.prev_hash.to_vec()),
 		}
 	}
 }
@@ -519,15 +518,12 @@ pub struct BlockHeaderPrintable {
 }
 
 impl BlockHeaderPrintable {
-	pub fn from_headers(
-		header: &core::BlockHeader,
-		previous: &core::BlockHeader,
-	) -> BlockHeaderPrintable {
+	pub fn from_header(header: &core::BlockHeader) -> BlockHeaderPrintable {
 		BlockHeaderPrintable {
 			hash: util::to_hex(header.hash().to_vec()),
 			version: header.version,
 			height: header.height,
-			previous: util::to_hex(previous.hash().to_vec()),
+			previous: util::to_hex(header.prev_hash.to_vec()),
 			prev_root: util::to_hex(header.prev_root.to_vec()),
 			timestamp: header.timestamp.to_rfc3339(),
 			output_root: util::to_hex(header.output_root.to_vec()),
@@ -583,9 +579,8 @@ impl BlockPrintable {
 			.iter()
 			.map(|kernel| TxKernelPrintable::from_txkernel(kernel))
 			.collect();
-		let previous = chain.get_previous_header(&block.header).unwrap();
 		BlockPrintable {
-			header: BlockHeaderPrintable::from_headers(&block.header, &previous),
+			header: BlockHeaderPrintable::from_header(&block.header),
 			inputs: inputs,
 			outputs: outputs,
 			kernels: kernels,
@@ -623,9 +618,8 @@ impl CompactBlockPrintable {
 			.iter()
 			.map(|x| TxKernelPrintable::from_txkernel(x))
 			.collect();
-		let previous = chain.get_previous_header(&cb.header).unwrap();
 		CompactBlockPrintable {
-			header: BlockHeaderPrintable::from_headers(&cb.header, &previous),
+			header: BlockHeaderPrintable::from_header(&cb.header),
 			out_full,
 			kern_full,
 			kern_ids: cb.kern_ids().iter().map(|x| x.to_hex()).collect(),

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -537,7 +537,7 @@ impl BlockHeaderPrintable {
 			edge_bits: header.pow.edge_bits(),
 			cuckoo_solution: header.pow.proof.nonces.clone(),
 			total_difficulty: header.pow.total_difficulty.to_num(),
-			scaling_difficulty: header.pow.scaling_difficulty,
+			secondary_scaling: header.pow.secondary_scaling,
 			total_kernel_offset: header.total_kernel_offset.to_hex(),
 		}
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -248,16 +248,19 @@ impl Chain {
 			let mut txhashset = self.txhashset.write();
 			let batch = self.store.batch()?;
 			let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
-			let header_root = txhashset::header_extending(&mut ctx.txhashset, &mut ctx.batch, |extension| {
-				let root = extension.root();
-				error!("*** checking index, root of header MMR: {}", root);
-				Ok(root)
-			})?;
-			error!("*** got a root {}, now looking for header hash for it", header_root);
+			let header_root =
+				txhashset::header_extending(&mut ctx.txhashset, &mut ctx.batch, |extension| {
+					let root = extension.root();
+					error!("*** checking index, root of header MMR: {}", root);
+					Ok(root)
+				})?;
+			error!(
+				"*** got a root {}, now looking for header hash for it",
+				header_root
+			);
 			let h = ctx.batch.get_header_hash_by_root(&header_root)?;
 			error!("*** checking index, h: {}", h);
 		}
-
 
 		let add_to_hash_cache = |hash: Hash| {
 			// only add to hash cache below if block is definitively accepted

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -644,9 +644,7 @@ impl Chain {
 		header: &BlockHeader,
 		txhashset: &txhashset::TxHashSet,
 	) -> Result<(), Error> {
-		debug!(
-			"validate_kernel_history: rewinding and validating kernel history (readonly)"
-		);
+		debug!("validate_kernel_history: rewinding and validating kernel history (readonly)");
 
 		let mut count = 0;
 		let mut current = header.clone();

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -25,7 +25,7 @@ use util::RwLock;
 use lmdb;
 use lru_cache::LruCache;
 
-use core::core::hash::{Hash, Hashed};
+use core::core::hash::{Hash, Hashed, ZERO_HASH};
 use core::core::merkle_proof::MerkleProof;
 use core::core::verifier_cache::VerifierCache;
 use core::core::{Block, BlockHeader, BlockSums, Output, OutputIdentifier, Transaction, TxKernel};
@@ -1085,7 +1085,10 @@ fn setup_head(
 			}
 		}
 		Err(NotFoundErr(_)) => {
+			let header_root = ZERO_HASH;
+			batch.save_block_header(&genesis.header, &header_root)?;
 			batch.save_block(&genesis)?;
+
 			let tip = Tip::from_genesis(&genesis.header);
 			batch.save_head(&tip)?;
 			batch.setup_height(&genesis.header, &tip)?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -201,6 +201,16 @@ impl Chain {
 			);
 		}
 
+		{
+			let sync_head = store.get_sync_head()?;
+			debug!(
+				"Chain init: sync_head: {} @ {} [{}]",
+				sync_head.total_difficulty.to_num(),
+				sync_head.height,
+				sync_head.last_block_h,
+			);
+		}
+
 		Ok(Chain {
 			db_root: db_root,
 			store: store,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -987,12 +987,16 @@ impl Chain {
 		&self,
 		output_ref: &OutputIdentifier,
 	) -> Result<BlockHeader, Error> {
-		let mut txhashset = self.txhashset.write();
-		let (_, pos) = txhashset.is_unspent(output_ref)?;
+		let pos = {
+			let mut txhashset = self.txhashset.write();
+			let (_, pos) = txhashset.is_unspent(output_ref)?;
+			pos
+		};
+
 		let mut min = 1;
 		let mut max = {
-			let h = self.head()?;
-			h.height
+			let head = self.head()?;
+			head.height
 		};
 
 		loop {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -487,7 +487,11 @@ impl Chain {
 		})
 	}
 
-	pub fn set_txhashset_roots_forked(&self, b: &mut Block, prev: &BlockHeader) -> Result<(), Error> {
+	pub fn set_txhashset_roots_forked(
+		&self,
+		b: &mut Block,
+		prev: &BlockHeader,
+	) -> Result<(), Error> {
 		let prev_block = self.get_block(&prev.hash())?;
 		let mut txhashset = self.txhashset.write();
 		let (prev_root, roots, sizes) =

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -243,25 +243,6 @@ impl Chain {
 			// release the lock and let the batch go before post-processing
 		}
 
-		// Now check indices after committing the batch.
-		{
-			let mut txhashset = self.txhashset.write();
-			let batch = self.store.batch()?;
-			let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
-			let header_root =
-				txhashset::header_extending(&mut ctx.txhashset, &mut ctx.batch, |extension| {
-					let root = extension.root();
-					error!("*** checking index, root of header MMR: {}", root);
-					Ok(root)
-				})?;
-			error!(
-				"*** got a root {}, now looking for header hash for it",
-				header_root
-			);
-			let h = ctx.batch.get_header_hash_by_root(&header_root)?;
-			error!("*** checking index, h: {}", h);
-		}
-
 		let add_to_hash_cache = |hash: Hash| {
 			// only add to hash cache below if block is definitively accepted
 			// or rejected

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -184,7 +184,7 @@ impl Chain {
 		{
 			let head = store.head()?;
 			debug!(
-				"Chain init: head: {} @ {} [{}]",
+				"init: head: {} @ {} [{}]",
 				head.total_difficulty.to_num(),
 				head.height,
 				head.last_block_h,
@@ -194,7 +194,7 @@ impl Chain {
 		{
 			let header_head = store.header_head()?;
 			debug!(
-				"Chain init: header_head: {} @ {} [{}]",
+				"init: header_head: {} @ {} [{}]",
 				header_head.total_difficulty.to_num(),
 				header_head.height,
 				header_head.last_block_h,
@@ -204,7 +204,7 @@ impl Chain {
 		{
 			let sync_head = store.get_sync_head()?;
 			debug!(
-				"Chain init: sync_head: {} @ {} [{}]",
+				"init: sync_head: {} @ {} [{}]",
 				sync_head.total_difficulty.to_num(),
 				sync_head.height,
 				sync_head.last_block_h,
@@ -645,7 +645,7 @@ impl Chain {
 		txhashset: &txhashset::TxHashSet,
 	) -> Result<(), Error> {
 		debug!(
-			"chain: validate_kernel_history: rewinding and validating kernel history (readonly)"
+			"validate_kernel_history: rewinding and validating kernel history (readonly)"
 		);
 
 		let mut count = 0;
@@ -661,7 +661,7 @@ impl Chain {
 		})?;
 
 		debug!(
-			"chain: validate_kernel_history: validated kernel root on {} headers",
+			"validate_kernel_history: validated kernel root on {} headers",
 			count,
 		);
 
@@ -737,7 +737,7 @@ impl Chain {
 		self.validate_kernel_history(&header, &txhashset)?;
 
 		// all good, prepare a new batch and update all the required records
-		debug!("chain: txhashset_write: rewinding a 2nd time (writeable)");
+		debug!("txhashset_write: rewinding a 2nd time (writeable)");
 
 		let mut batch = self.store.batch()?;
 
@@ -761,7 +761,7 @@ impl Chain {
 			Ok(())
 		})?;
 
-		debug!("chain: txhashset_write: finished validating and rebuilding");
+		debug!("txhashset_write: finished validating and rebuilding");
 
 		status.on_save();
 
@@ -776,7 +776,7 @@ impl Chain {
 		// Commit all the changes to the db.
 		batch.commit()?;
 
-		debug!("chain: txhashset_write: finished committing the batch (head etc.)");
+		debug!("txhashset_write: finished committing the batch (head etc.)");
 
 		// Replace the chain txhashset with the newly built one.
 		{
@@ -784,7 +784,7 @@ impl Chain {
 			*txhashset_ref = txhashset;
 		}
 
-		debug!("chain: txhashset_write: replaced our txhashset with the new one");
+		debug!("txhashset_write: replaced our txhashset with the new one");
 
 		// Check for any orphan blocks and process them based on the new chain state.
 		self.check_orphans(header.height + 1);
@@ -825,7 +825,7 @@ impl Chain {
 		let cutoff = head.height.saturating_sub(horizon);
 
 		debug!(
-			"chain: compact_blocks_db: head height: {}, horizon: {}, cutoff: {}",
+			"compact_blocks_db: head height: {}, horizon: {}, cutoff: {}",
 			head.height, horizon, cutoff,
 		);
 
@@ -862,7 +862,7 @@ impl Chain {
 			}
 		}
 		batch.commit()?;
-		debug!("chain: compact_blocks_db: removed {} blocks.", count);
+		debug!("compact_blocks_db: removed {} blocks.", count);
 		Ok(())
 	}
 
@@ -1109,7 +1109,7 @@ fn setup_head(
 					if header.height > 0 && extension.batch.get_block_sums(&header.hash()).is_err()
 					{
 						debug!(
-							"chain: init: building (missing) block sums for {} @ {}",
+							"init: building (missing) block sums for {} @ {}",
 							header.height,
 							header.hash()
 						);
@@ -1129,7 +1129,7 @@ fn setup_head(
 					}
 
 					debug!(
-						"chain: init: rewinding and validating before we start... {} at {}",
+						"init: rewinding and validating before we start... {} at {}",
 						header.hash(),
 						header.height,
 					);
@@ -1171,7 +1171,7 @@ fn setup_head(
 			// Save the block_sums to the db for use later.
 			batch.save_block_sums(&genesis.hash(), &BlockSums::default())?;
 
-			info!("chain: init: saved genesis: {:?}", genesis.hash());
+			info!("init: saved genesis: {:?}", genesis.hash());
 		}
 		Err(e) => return Err(ErrorKind::StoreErr(e, "chain init load head".to_owned()))?,
 	};

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -530,11 +530,9 @@ fn apply_block_to_txhashset(block: &Block, ext: &mut txhashset::Extension) -> Re
 
 /// Officially adds the block to our chain.
 /// Header must be added separately (assume this has been done previously).
-fn add_block(
-	b: &Block,
-	ext: &txhashset::Extension,
-) -> Result<(), Error> {
-	ext.batch.save_block(b)
+fn add_block(b: &Block, ext: &txhashset::Extension) -> Result<(), Error> {
+	ext.batch
+		.save_block(b)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save block".to_owned()))?;
 	Ok(())
 }
@@ -545,7 +543,8 @@ fn add_block_header(
 	header_root: &Hash,
 	ext: &txhashset::HeaderExtension,
 ) -> Result<(), Error> {
-	ext.batch.save_block_header(bh, header_root)
+	ext.batch
+		.save_block_header(bh, header_root)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header".to_owned()))?;
 	Ok(())
 }
@@ -643,7 +642,10 @@ pub fn rewind_and_apply_header_fork(
 	// Rewind the txhashset state back to the block where we forked from the most work chain.
 	ext.rewind(&forked_header)?;
 
-	trace!("rewind_and_apply_header_fork: headers on fork: {:?}", fork_hashes);
+	trace!(
+		"rewind_and_apply_header_fork: headers on fork: {:?}",
+		fork_hashes
+	);
 
 	// Now re-apply all blocks on this fork.
 	for (_, h) in fork_hashes {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -147,9 +147,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, E
 	txhashset::extending(&mut ctx.txhashset, &mut ctx.batch, |mut extension| {
 		let prev = extension.batch.get_previous_header(&b.header)?;
 		if prev.hash() == head.last_block_h {
-			// Not a fork so we just need to rewind to put header MMR
-			// in the correct state for the full block.
-			extension.rewind(&prev)?;
+			// Not a fork so we do not need to rewind or reapply any blocks.
 		} else {
 			// Rewind and re-apply blocks on the forked chain to
 			// put the txhashset in the correct forked state

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -466,8 +466,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		if header.pow.secondary_scaling != next_header_info.secondary_scaling {
 			info!(
 				"validate_header: header secondary scaling {} != {}",
-				header.pow.secondary_scaling,
-				next_header_info.secondary_scaling
+				header.pow.secondary_scaling, next_header_info.secondary_scaling
 			);
 			return Err(ErrorKind::InvalidScaling.into());
 		}
@@ -547,10 +546,7 @@ fn add_block(b: &Block, batch: &store::Batch) -> Result<(), Error> {
 }
 
 /// Officially adds the block header to our header chain.
-fn add_block_header(
-	bh: &BlockHeader,
-	batch: &store::Batch,
-) -> Result<(), Error> {
+fn add_block_header(bh: &BlockHeader, batch: &store::Batch) -> Result<(), Error> {
 	batch
 		.save_block_header(bh)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header".to_owned()))?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -546,7 +546,11 @@ fn add_block(b: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
 }
 
 /// Officially adds the block header to our header chain.
-fn add_block_header(bh: &BlockHeader, header_root: &Hash, batch: &mut store::Batch) -> Result<(), Error> {
+fn add_block_header(
+	bh: &BlockHeader,
+	header_root: &Hash,
+	batch: &mut store::Batch,
+) -> Result<(), Error> {
 	batch
 		.save_block_header(bh, &header_root)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header".to_owned()).into())

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -402,7 +402,10 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 	}
 
 	// first I/O cost, better as late as possible
-	debug!("*** about to look for prev header using prev_root: {}", header.prev_root);
+	debug!(
+		"*** about to look for prev header using prev_root: {}",
+		header.prev_root
+	);
 	let prev = match ctx.batch.get_previous_header(&header) {
 		Ok(prev) => prev,
 		Err(grin_store::Error::NotFoundErr(_)) => return Err(ErrorKind::Orphan.into()),

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -59,7 +59,11 @@ pub struct BlockContext<'a> {
 /// Process a block header as part of processing a full block.
 /// We want to make sure the header is valid before we process the full block.
 fn process_header_for_block(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
-	debug!("*** process_header_for_block: prev_root: {}, hash: {}", header.prev_root, header.hash());
+	debug!(
+		"*** process_header_for_block: prev_root: {}, hash: {}",
+		header.prev_root,
+		header.hash()
+	);
 
 	txhashset::header_extending(&mut ctx.txhashset, &mut ctx.batch, |extension| {
 		// Optimize this if "next" header
@@ -373,7 +377,11 @@ fn check_prev_store(header: &BlockHeader, batch: &mut store::Batch) -> Result<()
 /// to make it as cheap as possible. The different validations are also
 /// arranged by order of cost to have as little DoS surface as possible.
 fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
-	error!("*** validate_header: prev_root: {}, hash: {}", header.prev_root, header.hash());
+	error!(
+		"*** validate_header: prev_root: {}, hash: {}",
+		header.prev_root,
+		header.hash()
+	);
 
 	// check version, enforces scheduled hard fork
 	if !consensus::valid_header_version(header.height, header.version) {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -56,12 +56,6 @@ pub struct BlockContext<'a> {
 	pub orphans: Arc<OrphanBlockPool>,
 }
 
-// Check if this block is the next block *immediately*
-// after our current chain head.
-fn is_next_block(header: &BlockHeader, head: &Tip) -> bool {
-	header.previous == head.last_block_h
-}
-
 /// Runs the block processing pipeline, including validation and finding a
 /// place for the new block in the chain.
 /// Returns new head if chain head updated.
@@ -103,8 +97,9 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, E
 	}
 
 	// Check if are processing the "next" block relative to the current chain head.
+	let prev = ctx.batch.get_previous_header(&b.header)?;
 	let head = ctx.batch.head()?;
-	if is_next_block(&b.header, &head) {
+	if prev.hash() == head.last_block_h {
 		// If this is the "next" block then either -
 		//   * common case where we process blocks sequentially.
 		//   * special case where this is the first fast sync full block
@@ -126,7 +121,8 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, E
 		// First we rewind the txhashset extension if necessary
 		// to put it into a consistent state for validating the block.
 		// We can skip this step if the previous header is the latest header we saw.
-		if is_next_block(&b.header, &head) {
+		let prev = extension.batch.get_previous_header(&b.header)?;
+		if prev.hash() == head.last_block_h {
 			// No need to rewind if we are processing the next block.
 		} else {
 			// Rewind and re-apply blocks on the forked chain to
@@ -209,7 +205,7 @@ pub fn sync_block_headers(
 		}
 
 		let first_header = headers.first().unwrap();
-		let prev_header = ctx.batch.get_block_header(&first_header.previous)?;
+		let prev_header = ctx.batch.get_previous_header(&first_header)?;
 		txhashset::sync_extending(&mut ctx.txhashset, &mut ctx.batch, |extension| {
 			// Optimize this if "next" header
 			extension.rewind(&prev_header)?;
@@ -329,7 +325,9 @@ fn check_known_store(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(),
 // We cannot assume we can use the chain head for this
 // as we may be dealing with a fork (with less work currently).
 fn check_prev_store(header: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
-	match batch.block_exists(&header.previous) {
+	// TODO - this is now 2 db calls (indirect previous link)
+	let prev = batch.get_previous_header(&header)?;
+	match batch.block_exists(&prev.hash()) {
 		Ok(true) => {
 			// We have the previous block in the store, so we can proceed.
 			Ok(())
@@ -381,12 +379,15 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 	}
 
 	// first I/O cost, better as late as possible
-	let prev = match ctx.batch.get_block_header(&header.previous) {
+	let prev = match ctx.batch.get_previous_header(&header) {
 		Ok(prev) => prev,
 		Err(grin_store::Error::NotFoundErr(_)) => return Err(ErrorKind::Orphan.into()),
 		Err(e) => {
 			return Err(
-				ErrorKind::StoreErr(e, format!("previous header {}", header.previous)).into(),
+				ErrorKind::StoreErr(
+					e,
+					format!("Failed to find previous header to {}", header.hash()),
+				).into(),
 			)
 		}
 	};
@@ -424,8 +425,9 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		// explicit check to ensure total_difficulty has increased by exactly
 		// the _network_ difficulty of the previous block
 		// (during testnet1 we use _block_ difficulty here)
+		let prev = ctx.batch.get_previous_header(&header)?;
 		let child_batch = ctx.batch.child()?;
-		let diff_iter = store::DifficultyIter::from_batch(header.previous, child_batch);
+		let diff_iter = store::DifficultyIter::from_batch(prev.hash(), child_batch);
 		let next_header_info = consensus::next_difficulty(header.height, diff_iter);
 		if target_difficulty != next_header_info.difficulty {
 			info!(
@@ -450,7 +452,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 }
 
 fn validate_block(block: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
-	let prev = ctx.batch.get_block_header(&block.header.previous)?;
+	let prev = ctx.batch.get_previous_header(&block.header)?;
 	block
 		.validate(&prev.total_kernel_offset, ctx.verifier_cache.clone())
 		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
@@ -472,8 +474,10 @@ fn verify_coinbase_maturity(block: &Block, ext: &mut txhashset::Extension) -> Re
 /// based on block_sums of previous block, accounting for the inputs|outputs|kernels
 /// of the new block.
 fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Error> {
+	// TODO - this is 2 db calls, can we optimize this?
 	// Retrieve the block_sums for the previous block.
-	let block_sums = ext.batch.get_block_sums(&b.header.previous)?;
+	let prev = ext.batch.get_previous_header(&b.header)?;
+	let block_sums = ext.batch.get_block_sums(&prev.hash())?;
 
 	// Overage is based purely on the new block.
 	// Previous block_sums have taken all previous overage into account.
@@ -540,7 +544,8 @@ fn update_head(b: &Block, ctx: &BlockContext) -> Result<Option<Tip>, Error> {
 			.setup_height(&b.header, &head)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe setup height".to_owned()))?;
 
-		let tip = Tip::from_block(&b.header);
+		let prev = ctx.batch.get_previous_header(&b.header)?;
+		let tip = Tip::from_headers(&b.header, &prev);
 
 		ctx.batch
 			.save_body_head(&tip)
@@ -564,7 +569,8 @@ fn has_more_work(header: &BlockHeader, head: &Tip) -> bool {
 
 /// Update the sync head so we can keep syncing from where we left off.
 fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Error> {
-	let tip = Tip::from_block(bh);
+	let prev = batch.get_previous_header(bh)?;
+	let tip = Tip::from_headers(bh, &prev);
 	batch
 		.save_sync_head(&tip)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save sync head".to_owned()))?;
@@ -576,7 +582,8 @@ fn update_sync_head(bh: &BlockHeader, batch: &mut store::Batch) -> Result<(), Er
 fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option<Tip>, Error> {
 	let header_head = ctx.batch.header_head()?;
 	if has_more_work(&bh, &header_head) {
-		let tip = Tip::from_block(bh);
+		let prev = ctx.batch.get_previous_header(bh)?;
+		let tip = Tip::from_headers(bh, &prev);
 		ctx.batch
 			.save_header_head(&tip)
 			.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
@@ -599,20 +606,16 @@ fn update_header_head(bh: &BlockHeader, ctx: &mut BlockContext) -> Result<Option
 pub fn rewind_and_apply_fork(b: &Block, ext: &mut txhashset::Extension) -> Result<(), Error> {
 	// extending a fork, first identify the block where forking occurred
 	// keeping the hashes of blocks along the fork
-	let mut current = b.header.previous;
-	let mut fork_hashes = vec![];
-	loop {
-		let curr_header = ext.batch.get_block_header(&current)?;
 
-		if let Ok(_) = ext.batch.is_on_current_chain(&curr_header) {
-			break;
-		} else {
-			fork_hashes.insert(0, (curr_header.height, curr_header.hash()));
-			current = curr_header.previous;
-		}
+	let mut fork_hashes = vec![];
+	let mut current = ext.batch.get_previous_header(&b.header)?;
+
+	while ext.batch.is_on_current_chain(&current).is_ok() {
+		fork_hashes.insert(0, (current.height, current.hash()));
+		current = ext.batch.get_previous_header(&current)?;
 	}
 
-	let forked_header = ext.batch.get_block_header(&current)?;
+	let forked_header = current;
 
 	trace!(
 		"rewind_and_apply_fork @ {} [{}], was @ {} [{}]",

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -383,12 +383,10 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		Ok(prev) => prev,
 		Err(grin_store::Error::NotFoundErr(_)) => return Err(ErrorKind::Orphan.into()),
 		Err(e) => {
-			return Err(
-				ErrorKind::StoreErr(
-					e,
-					format!("Failed to find previous header to {}", header.hash()),
-				).into(),
-			)
+			return Err(ErrorKind::StoreErr(
+				e,
+				format!("Failed to find previous header to {}", header.hash()),
+			).into())
 		}
 	};
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -122,6 +122,14 @@ impl ChainStore {
 		}
 	}
 
+	pub fn get_header_by_prev_root(&self, h: &Hash) -> Result<BlockHeader, Error> {
+		unimplemented!("[wip]")
+	}
+
+	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
+		self.get_header_by_prev_root(&header.prev_root)
+	}
+
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		{
 			let mut header_cache = self.header_cache.write();
@@ -349,6 +357,14 @@ impl<'a> Batch<'a> {
 			.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
 	}
 
+	pub fn get_header_by_prev_root(&self, h: &Hash) -> Result<BlockHeader, Error> {
+		unimplemented!("[wip]")
+	}
+
+	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
+		self.get_header_by_prev_root(&header.prev_root)
+	}
+
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		{
 			let mut header_cache = self.header_cache.write();
@@ -479,7 +495,7 @@ impl<'a> Batch<'a> {
 		self.save_header_height(&header)?;
 
 		if header.height > 0 {
-			let mut prev_header = self.get_block_header(&header.previous)?;
+			let mut prev_header = self.get_previous_header(&header)?;
 			while prev_header.height > 0 {
 				if !force {
 					if let Ok(_) = self.is_on_current_chain(&prev_header) {
@@ -488,7 +504,7 @@ impl<'a> Batch<'a> {
 				}
 				self.save_header_height(&prev_header)?;
 
-				prev_header = self.get_block_header(&prev_header.previous)?;
+				prev_header = self.get_previous_header(&prev_header)?;
 			}
 		}
 		Ok(())
@@ -637,10 +653,10 @@ impl<'a> Iterator for DifficultyIter<'a> {
 		// Otherwise we are done.
 		if let Some(header) = self.header.clone() {
 			if let Some(ref batch) = self.batch {
-				self.prev_header = batch.get_block_header(&header.previous).ok();
+				self.prev_header = batch.get_previous_header(&header).ok();
 			} else {
 				if let Some(ref store) = self.store {
-					self.prev_header = store.get_block_header(&header.previous).ok();
+					self.prev_header = store.get_previous_header(&header).ok();
 				} else {
 					self.prev_header = None;
 				}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -330,7 +330,12 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_header(&self, header: &BlockHeader, header_root: &Hash) -> Result<(), Error> {
-		error!("***** saving block header: prev_root: {}, hash: {}, root: {}", header.prev_root, header.hash(), header_root);
+		error!(
+			"***** saving block header: prev_root: {}, hash: {}, root: {}",
+			header.prev_root,
+			header.hash(),
+			header_root
+		);
 		let hash = header.hash();
 
 		// TODO - cache the header by root.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -330,7 +330,7 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_header(&self, header: &BlockHeader, header_root: &Hash) -> Result<(), Error> {
-		error!("***** saving block header - {:?}, {}", header, header_root);
+		error!("***** saving block header: prev_root: {}, hash: {}, root: {}", header.prev_root, header.hash(), header_root);
 		let hash = header.hash();
 
 		// TODO - cache the header by root.
@@ -343,10 +343,6 @@ impl<'a> Batch<'a> {
 		}
 
 		// Store the header hash indexed by header root.
-		error!(
-			"*** saving header_root index: root: {}, hash: {}",
-			header_root, hash
-		);
 		self.db.put_ser(
 			&to_key(HEADER_ROOT_PREFIX, &mut header_root.to_vec())[..],
 			&hash,
@@ -355,6 +351,11 @@ impl<'a> Batch<'a> {
 		// Store the header itself indexed by hash.
 		self.db
 			.put_ser(&to_key(BLOCK_HEADER_PREFIX, &mut hash.to_vec())[..], header)?;
+
+		error!("*** about to check our indices for {}", header_root);
+		let foo = self.get_header_hash_by_root(&header_root)?;
+		let baz = self.get_block_header(&foo)?;
+
 		Ok(())
 	}
 
@@ -387,7 +388,8 @@ impl<'a> Batch<'a> {
 			.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
 	}
 
-	fn get_header_hash_by_root(&self, h: &Hash) -> Result<Hash, Error> {
+	pub fn get_header_hash_by_root(&self, h: &Hash) -> Result<Hash, Error> {
+		error!("*** get_header_hash_by_root: {}", h);
 		option_to_not_found(
 			self.db
 				.get_ser(&to_key(HEADER_ROOT_PREFIX, &mut h.to_vec())),

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -303,7 +303,8 @@ impl<'a> Batch<'a> {
 		self.build_and_cache_block_input_bitmap(&b)?;
 
 		// Save the block itself to the db.
-		self.db.put_ser(&to_key(BLOCK_PREFIX, &mut b.hash().to_vec())[..], b)?;
+		self.db
+			.put_ser(&to_key(BLOCK_PREFIX, &mut b.hash().to_vec())[..], b)?;
 
 		Ok(())
 	}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -133,9 +133,7 @@ impl ChainStore {
 
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		if header.height == 0 {
-			return Err(Error::NotFoundErr(String::from(
-				"genesis has no previous",
-			)));
+			return Err(Error::NotFoundErr(String::from("genesis has no previous")));
 		}
 		let hash = self.get_header_hash_by_root(&header.prev_root)?;
 		self.get_block_header(&hash)
@@ -345,7 +343,10 @@ impl<'a> Batch<'a> {
 		}
 
 		// Store the header hash indexed by header root.
-		error!("*** saving header_root index: root: {}, hash: {}", header_root, hash);
+		error!(
+			"*** saving header_root index: root: {}, hash: {}",
+			header_root, hash
+		);
 		self.db.put_ser(
 			&to_key(HEADER_ROOT_PREFIX, &mut header_root.to_vec())[..],
 			&hash,
@@ -396,9 +397,7 @@ impl<'a> Batch<'a> {
 
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		if header.height == 0 {
-			return Err(Error::NotFoundErr(String::from(
-				"genesis has no previous",
-			)));
+			return Err(Error::NotFoundErr(String::from("genesis has no previous")));
 		}
 		let hash = self.get_header_hash_by_root(&header.prev_root)?;
 		self.get_block_header(&hash)

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -324,8 +324,7 @@ impl<'a> Batch<'a> {
 		let hash = header.hash();
 
 		// TODO - cache the header by root.
-		{
-		}
+		{}
 
 		// Cache the header.
 		{
@@ -334,8 +333,10 @@ impl<'a> Batch<'a> {
 		}
 
 		// Store the header hash indexed by header root.
-		self.db
-			.put_ser(&to_key(HEADER_ROOT_PREFIX, &mut header_root.to_vec())[..], &hash)?;
+		self.db.put_ser(
+			&to_key(HEADER_ROOT_PREFIX, &mut header_root.to_vec())[..],
+			&hash,
+		)?;
 
 		// Store the header itself indexed by hash.
 		self.db

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -330,12 +330,6 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_header(&self, header: &BlockHeader, header_root: &Hash) -> Result<(), Error> {
-		error!(
-			"***** saving block header: prev_root: {}, hash: {}, root: {}",
-			header.prev_root,
-			header.hash(),
-			header_root
-		);
 		let hash = header.hash();
 
 		// TODO - cache the header by root.
@@ -356,10 +350,6 @@ impl<'a> Batch<'a> {
 		// Store the header itself indexed by hash.
 		self.db
 			.put_ser(&to_key(BLOCK_HEADER_PREFIX, &mut hash.to_vec())[..], header)?;
-
-		error!("*** about to check our indices for {}", header_root);
-		let foo = self.get_header_hash_by_root(&header_root)?;
-		let baz = self.get_block_header(&foo)?;
 
 		Ok(())
 	}
@@ -393,8 +383,7 @@ impl<'a> Batch<'a> {
 			.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
 	}
 
-	pub fn get_header_hash_by_root(&self, h: &Hash) -> Result<Hash, Error> {
-		error!("*** get_header_hash_by_root: {}", h);
+	fn get_header_hash_by_root(&self, h: &Hash) -> Result<Hash, Error> {
 		option_to_not_found(
 			self.db
 				.get_ser(&to_key(HEADER_ROOT_PREFIX, &mut h.to_vec())),

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -356,13 +356,16 @@ impl<'a> Batch<'a> {
 	pub fn save_block_header(&self, header: &BlockHeader, header_root: &Hash) -> Result<(), Error> {
 		let hash = header.hash();
 
-		// TODO - cache the header by root.
-		{}
-
 		// Cache the header.
 		{
 			let mut header_cache = self.header_cache.write();
 			header_cache.insert(hash, header.clone());
+		}
+
+		// Cache the header by root.
+		{
+			let mut header_root_cache = self.header_root_cache.write();
+			header_root_cache.insert(header_root.clone(), hash);
 		}
 
 		// Store the header hash indexed by header root.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -625,9 +625,9 @@ impl<'a> HeaderExtension<'a> {
 	/// extension.
 	pub fn apply_header(&mut self, header: &BlockHeader) -> Result<Hash, Error> {
 		self.pmmr
-			.push(header.clone())
+			.push(header)
 			.map_err(&ErrorKind::TxHashSetErr)?;
-		self.header = header;
+		self.header = header.clone();
 		Ok(self.root())
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -546,7 +546,6 @@ where
 
 	// We want to use the current head of the most work chain unless
 	// we explicitly rewind the extension.
-	// Note: this is *not* necessarily the head of the head chain (explain why).
 	let head = batch.head()?;
 	let header = batch.get_block_header(&head.last_block_h)?;
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -676,7 +676,7 @@ impl<'a> HeaderExtension<'a> {
 		let mut current = self.batch.get_block_header(&head.last_block_h)?;
 		while current.height > 0 {
 			header_hashes.push(current.hash());
-			current = self.batch.get_block_header(&current.previous)?;
+			current = self.batch.get_previous_header(&current)?;
 		}
 
 		header_hashes.reverse();

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -623,10 +623,12 @@ impl<'a> HeaderExtension<'a> {
 	/// Apply a new header to the header MMR extension.
 	/// This may be either the header MMR or the sync MMR depending on the
 	/// extension.
-	pub fn apply_header(&mut self, header: &BlockHeader) -> Result<(), Error> {
-		self.pmmr.push(&header).map_err(&ErrorKind::TxHashSetErr)?;
-		self.header = header.clone();
-		Ok(())
+	pub fn apply_header(&mut self, header: &BlockHeader) -> Result<Hash, Error> {
+		self.pmmr
+			.push(header.clone())
+			.map_err(&ErrorKind::TxHashSetErr)?;
+		self.header = header;
+		Ok(self.root())
 	}
 
 	/// Rewind the header extension to the specified header.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -624,9 +624,7 @@ impl<'a> HeaderExtension<'a> {
 	/// This may be either the header MMR or the sync MMR depending on the
 	/// extension.
 	pub fn apply_header(&mut self, header: &BlockHeader) -> Result<Hash, Error> {
-		self.pmmr
-			.push(header)
-			.map_err(&ErrorKind::TxHashSetErr)?;
+		self.pmmr.push(header).map_err(&ErrorKind::TxHashSetErr)?;
 		self.header = header.clone();
 		Ok(self.root())
 	}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -544,9 +544,10 @@ where
 	let res: Result<T, Error>;
 	let rollback: bool;
 
-	// We want to use the current head of the header chain unless
+	// We want to use the current head of the most work chain unless
 	// we explicitly rewind the extension.
-	let head = batch.header_head()?;
+	// Note: this is *not* necessarily the head of the head chain (explain why).
+	let head = batch.head()?;
 	let header = batch.get_block_header(&head.last_block_h)?;
 
 	// create a child transaction so if the state is rolled back by itself, all
@@ -618,6 +619,11 @@ impl<'a> HeaderExtension<'a> {
 			rollback: false,
 			batch,
 		}
+	}
+
+	/// Force the rollback of this extension, no matter the result.
+	pub fn force_rollback(&mut self) {
+		self.rollback = true;
 	}
 
 	/// Apply a new header to the header MMR extension.

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -95,6 +95,17 @@ impl Tip {
 	}
 }
 
+impl Default for Tip {
+	fn default() -> Self {
+		Tip {
+			height: 0,
+			last_block_h: ZERO_HASH,
+			prev_block_h: ZERO_HASH,
+			total_difficulty: Difficulty::one(),
+		}
+	}
+}
+
 /// Serialization of a tip, required to save to datastore.
 impl ser::Writeable for Tip {
 	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -64,32 +64,13 @@ pub struct Tip {
 }
 
 impl Tip {
-	/// Creates a new tip at height 1 and the provided genesis hash.
-	pub fn from_genesis(genesis: &BlockHeader) -> Tip {
-		Tip {
-			height: genesis.height,
-			last_block_h: genesis.hash(),
-			prev_block_h: ZERO_HASH,
-			total_difficulty: Difficulty::min(),
-		}
-	}
-
-	pub fn from_headers(header: &BlockHeader, previous: &BlockHeader) -> Tip {
+	/// TODO - why do we have Tip when we could just use a block header?
+	/// Creates a new tip based on header.
+	pub fn from_header(header: &BlockHeader) -> Tip {
 		Tip {
 			height: header.height,
 			last_block_h: header.hash(),
-			prev_block_h: previous.hash(),
-			total_difficulty: header.total_difficulty(),
-		}
-	}
-
-	/// TODO - check height etc and return error if not valid?
-	/// Append a new block to this tip, returning a new updated tip.
-	pub fn append_header(&self, header: &BlockHeader) -> Tip {
-		Tip {
-			height: header.height,
-			last_block_h: header.hash(),
-			prev_block_h: self.last_block_h,
+			prev_block_h: header.prev_hash,
 			total_difficulty: header.total_difficulty(),
 		}
 	}

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -101,7 +101,7 @@ impl Default for Tip {
 			height: 0,
 			last_block_h: ZERO_HASH,
 			prev_block_h: ZERO_HASH,
-			total_difficulty: Difficulty::one(),
+			total_difficulty: Difficulty::min(),
 		}
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -14,7 +14,7 @@
 
 //! Base types that the block chain pipeline requires.
 
-use core::core::hash::{Hash, Hashed};
+use core::core::hash::{Hash, Hashed, ZERO_HASH};
 use core::core::{Block, BlockHeader};
 use core::pow::Difficulty;
 use core::ser;
@@ -57,30 +57,40 @@ pub struct Tip {
 	pub height: u64,
 	/// Last block pushed to the fork
 	pub last_block_h: Hash,
-	/// Block previous to last
+	/// Previous block
 	pub prev_block_h: Hash,
 	/// Total difficulty accumulated on that fork
 	pub total_difficulty: Difficulty,
 }
 
 impl Tip {
-	/// Creates a new tip at height zero and the provided genesis hash.
-	pub fn new(gbh: Hash) -> Tip {
+	/// Creates a new tip at height 1 and the provided genesis hash.
+	pub fn from_genesis(genesis: &BlockHeader) -> Tip {
 		Tip {
 			height: 0,
-			last_block_h: gbh,
-			prev_block_h: gbh,
+			last_block_h: genesis.hash(),
+			prev_block_h: ZERO_HASH,
 			total_difficulty: Difficulty::min(),
 		}
 	}
 
-	/// Append a new block to this tip, returning a new updated tip.
-	pub fn from_block(bh: &BlockHeader) -> Tip {
+	pub fn from_headers(header: &BlockHeader, previous: &BlockHeader) -> Tip {
 		Tip {
-			height: bh.height,
-			last_block_h: bh.hash(),
-			prev_block_h: bh.previous,
-			total_difficulty: bh.total_difficulty(),
+			height: header.height,
+			last_block_h: header.hash(),
+			prev_block_h: previous.hash(),
+			total_difficulty: header.total_difficulty(),
+		}
+	}
+
+	/// TODO - check height etc and return error if not valid?
+	/// Append a new block to this tip, returning a new updated tip.
+	pub fn append_header(&self, header: &BlockHeader) -> Tip {
+		Tip {
+			height: header.height,
+			last_block_h: header.hash(),
+			prev_block_h: self.last_block_h,
+			total_difficulty: header.total_difficulty(),
 		}
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -67,7 +67,7 @@ impl Tip {
 	/// Creates a new tip at height 1 and the provided genesis hash.
 	pub fn from_genesis(genesis: &BlockHeader) -> Tip {
 		Tip {
-			height: 0,
+			height: genesis.height,
 			last_block_h: genesis.hash(),
 			prev_block_h: ZERO_HASH,
 			total_difficulty: Difficulty::min(),

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -92,7 +92,7 @@ fn data_files() {
 			b.header.timestamp = prev.timestamp + Duration::seconds(60);
 			b.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-			chain.set_txhashset_roots(&mut b, false).unwrap();
+			chain.set_txhashset_roots(&mut b).unwrap();
 
 			pow::pow_size(
 				&mut b.header,
@@ -118,7 +118,7 @@ fn data_files() {
 
 fn _prepare_block(kc: &ExtKeychain, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block {
 	let mut b = _prepare_block_nosum(kc, prev, diff, vec![]);
-	chain.set_txhashset_roots(&mut b, false).unwrap();
+	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
@@ -130,13 +130,13 @@ fn _prepare_block_tx(
 	txs: Vec<&Transaction>,
 ) -> Block {
 	let mut b = _prepare_block_nosum(kc, prev, diff, txs);
-	chain.set_txhashset_roots(&mut b, false).unwrap();
+	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
 fn _prepare_fork_block(kc: &ExtKeychain, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block {
 	let mut b = _prepare_block_nosum(kc, prev, diff, vec![]);
-	chain.set_txhashset_roots(&mut b, true).unwrap();
+	chain.set_txhashset_roots_forked(&mut b, prev).unwrap();
 	b
 }
 
@@ -148,7 +148,7 @@ fn _prepare_fork_block_tx(
 	txs: Vec<&Transaction>,
 ) -> Block {
 	let mut b = _prepare_block_nosum(kc, prev, diff, txs);
-	chain.set_txhashset_roots(&mut b, true).unwrap();
+	chain.set_txhashset_roots_forked(&mut b, prev).unwrap();
 	b
 }
 

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -101,7 +101,6 @@ fn data_files() {
 				global::min_edge_bits(),
 			).unwrap();
 
-			let _bhash = b.hash();
 			chain
 				.process_block(b.clone(), chain::Options::MINE)
 				.unwrap();

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -74,7 +74,7 @@ fn mine_empty_chain() {
 		b.header.timestamp = prev.timestamp + Duration::seconds(60);
 		b.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-		chain.set_txhashset_roots(&mut b, false).unwrap();
+		chain.set_txhashset_roots(&mut b).unwrap();
 
 		let edge_bits = if n == 2 {
 			global::min_edge_bits() + 1
@@ -201,45 +201,35 @@ fn longer_fork() {
 	// then send back on the 1st
 	let genesis = pow::mine_genesis_block().unwrap();
 	let chain = setup(".grin4", genesis.clone());
-	let chain_fork = setup(".grin5", genesis);
 
 	// add blocks to both chains, 20 on the main one, only the first 5
 	// for the forked chain
 	let mut prev = chain.head_header().unwrap();
 	for n in 0..10 {
 		let b = prepare_block(&kc, &prev, &chain, 2 * n + 2);
-		let bh = b.header.clone();
-
-		if n < 5 {
-			chain_fork
-				.process_block(b.clone(), chain::Options::SKIP_POW)
-				.unwrap();
-		}
-
+		prev = b.header.clone();
 		chain.process_block(b, chain::Options::SKIP_POW).unwrap();
-		prev = bh;
 	}
 
-	// check both chains are in the expected state
+	let forked_block = chain.get_header_by_height(5).unwrap();
+
 	let head = chain.head_header().unwrap();
 	assert_eq!(head.height, 10);
 	assert_eq!(head.hash(), prev.hash());
-	let head_fork = chain_fork.head_header().unwrap();
-	assert_eq!(head_fork.height, 5);
 
-	let mut prev_fork = head_fork.clone();
+	let mut prev = forked_block;
 	for n in 0..7 {
-		let b_fork = prepare_block(&kc, &prev_fork, &chain_fork, 2 * n + 11);
-		let bh_fork = b_fork.header.clone();
-
-		let b = b_fork.clone();
+		let b = prepare_fork_block(&kc, &prev, &chain, 2 * n + 11);
+		prev = b.header.clone();
 		chain.process_block(b, chain::Options::SKIP_POW).unwrap();
-
-		chain_fork
-			.process_block(b_fork, chain::Options::SKIP_POW)
-			.unwrap();
-		prev_fork = bh_fork;
 	}
+
+	let new_head = prev;
+
+	// After all this the chain should have switched to the fork.
+	let head = chain.head_header().unwrap();
+	assert_eq!(head.height, 12);
+	assert_eq!(head.hash(), new_head.hash());
 }
 
 #[test]
@@ -398,7 +388,7 @@ fn output_header_mappings() {
 		b.header.timestamp = prev.timestamp + Duration::seconds(60);
 		b.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-		chain.set_txhashset_roots(&mut b, false).unwrap();
+		chain.set_txhashset_roots(&mut b).unwrap();
 
 		let edge_bits = if n == 2 {
 			global::min_edge_bits() + 1
@@ -432,12 +422,13 @@ fn output_header_mappings() {
 		assert_eq!(header_for_output.height, n as u64);
 	}
 }
+
 fn prepare_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
 where
 	K: Keychain,
 {
 	let mut b = prepare_block_nosum(kc, prev, diff, vec![]);
-	chain.set_txhashset_roots(&mut b, false).unwrap();
+	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
@@ -452,16 +443,21 @@ where
 	K: Keychain,
 {
 	let mut b = prepare_block_nosum(kc, prev, diff, txs);
-	chain.set_txhashset_roots(&mut b, false).unwrap();
+	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
-fn prepare_fork_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
+fn prepare_fork_block<K>(
+	kc: &K,
+	prev: &BlockHeader,
+	chain: &Chain,
+	diff: u64,
+) -> Block
 where
 	K: Keychain,
 {
 	let mut b = prepare_block_nosum(kc, prev, diff, vec![]);
-	chain.set_txhashset_roots(&mut b, true).unwrap();
+	chain.set_txhashset_roots_forked(&mut b, prev).unwrap();
 	b
 }
 
@@ -476,7 +472,7 @@ where
 	K: Keychain,
 {
 	let mut b = prepare_block_nosum(kc, prev, diff, txs);
-	chain.set_txhashset_roots(&mut b, true).unwrap();
+	chain.set_txhashset_roots_forked(&mut b, prev).unwrap();
 	b
 }
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -447,12 +447,7 @@ where
 	b
 }
 
-fn prepare_fork_block<K>(
-	kc: &K,
-	prev: &BlockHeader,
-	chain: &Chain,
-	diff: u64,
-) -> Block
+fn prepare_fork_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
 where
 	K: Keychain,
 {

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -77,11 +77,7 @@ fn test_various_store_indices() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let genesis = pow::mine_genesis_block().unwrap();
 
-	setup_chain(
-		&mut txhashset,
-		&genesis,
-		chain_store.clone(),
-	).unwrap();
+	setup_chain(&mut txhashset, &genesis, chain_store.clone()).unwrap();
 
 	let reward = libtx::reward::output(&keychain, &key_id, 0, 1).unwrap();
 	let block = Block::new(&genesis.header, vec![], Difficulty::min(), reward).unwrap();
@@ -92,7 +88,9 @@ fn test_various_store_indices() {
 		let header_root = txhashset::header_extending(&mut txhashset, &mut batch, |extension| {
 			extension.apply_header(&block.header)
 		}).unwrap();
-		batch.save_block_header(&block.header, &header_root).unwrap();
+		batch
+			.save_block_header(&block.header, &header_root)
+			.unwrap();
 		batch.save_block(&block).unwrap();
 		let prev = batch.get_previous_header(&block.header).unwrap();
 		batch
@@ -151,11 +149,7 @@ fn test_store_header_height() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let genesis = pow::mine_genesis_block().unwrap();
 
-	setup_chain(
-		&mut txhashset,
-		&genesis,
-		chain_store.clone(),
-	).unwrap();
+	setup_chain(&mut txhashset, &genesis, chain_store.clone()).unwrap();
 
 	let mut block_header = BlockHeader::default();
 	block_header.height = 1;
@@ -165,7 +159,9 @@ fn test_store_header_height() {
 		let header_root = txhashset::header_extending(&mut txhashset, &mut batch, |extension| {
 			extension.apply_header(&block_header)
 		}).unwrap();
-		batch.save_block_header(&block_header, &header_root).unwrap();
+		batch
+			.save_block_header(&block_header, &header_root)
+			.unwrap();
 		batch.save_header_height(&block_header).unwrap();
 		batch.commit().unwrap();
 	}

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -58,6 +58,7 @@ fn test_various_store_indices() {
 
 	{
 		let batch = chain_store.batch().unwrap();
+		batch.save_block_header(&genesis.header).unwrap();
 		batch.save_block(&genesis).unwrap();
 		batch
 			.setup_height(&genesis.header, &Tip::new(genesis.hash()))
@@ -66,12 +67,12 @@ fn test_various_store_indices() {
 	}
 	{
 		let batch = chain_store.batch().unwrap();
+		batch.save_block_header(&block.header).unwrap();
 		batch.save_block(&block).unwrap();
 		let prev = batch.get_previous_header(&block.header).unwrap();
 		batch
 			.setup_height(&block.header, &Tip::from_headers(&block.header, &prev))
 			.unwrap();
-
 		batch.commit().unwrap();
 	}
 

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -35,10 +35,7 @@ fn clean_output_dir(dir_name: &str) {
 	let _ = fs::remove_dir_all(dir_name);
 }
 
-fn setup_chain(
-	genesis: &Block,
-	chain_store: Arc<chain::store::ChainStore>,
-) -> Result<(), Error> {
+fn setup_chain(genesis: &Block, chain_store: Arc<chain::store::ChainStore>) -> Result<(), Error> {
 	let batch = chain_store.batch()?;
 	batch.save_block_header(&genesis.header)?;
 	batch.save_block(&genesis)?;
@@ -76,9 +73,7 @@ fn test_various_store_indices() {
 
 	{
 		let batch = chain_store.batch().unwrap();
-		batch
-			.save_block_header(&block.header)
-			.unwrap();
+		batch.save_block_header(&block.header).unwrap();
 		batch.save_block(&block).unwrap();
 		batch
 			.setup_height(&block.header, &Tip::from_header(&block.header))
@@ -137,9 +132,7 @@ fn test_store_header_height() {
 
 	{
 		let batch = chain_store.batch().unwrap();
-		batch
-			.save_block_header(&block_header)
-			.unwrap();
+		batch.save_block_header(&block_header).unwrap();
 		batch.save_header_height(&block_header).unwrap();
 		batch.commit().unwrap();
 	}

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -67,8 +67,9 @@ fn test_various_store_indices() {
 	{
 		let batch = chain_store.batch().unwrap();
 		batch.save_block(&block).unwrap();
+		let prev = batch.get_previous_header(&block.header).unwrap();
 		batch
-			.setup_height(&block.header, &Tip::from_block(&block.header))
+			.setup_height(&block.header, &Tip::from_headers(&block.header, &prev))
 			.unwrap();
 
 		batch.commit().unwrap();

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -76,7 +76,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-	chain.set_txhashset_roots(&mut block, false).unwrap();
+	chain.set_txhashset_roots(&mut block).unwrap();
 
 	pow::pow_size(
 		&mut block.header,
@@ -123,7 +123,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-	chain.set_txhashset_roots(&mut block, false).unwrap();
+	chain.set_txhashset_roots(&mut block).unwrap();
 
 	// Confirm the tx attempting to spend the coinbase output
 	// is not valid at the current block height given the current chain state.
@@ -156,7 +156,7 @@ fn test_coinbase_maturity() {
 		block.header.timestamp = prev.timestamp + Duration::seconds(60);
 		block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-		chain.set_txhashset_roots(&mut block, false).unwrap();
+		chain.set_txhashset_roots(&mut block).unwrap();
 
 		pow::pow_size(
 			&mut block.header,
@@ -183,7 +183,7 @@ fn test_coinbase_maturity() {
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
 
-	chain.set_txhashset_roots(&mut block, false).unwrap();
+	chain.set_txhashset_roots(&mut block).unwrap();
 
 	pow::pow_size(
 		&mut block.header,

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -26,10 +26,7 @@ use std::sync::Arc;
 
 use chain::store::ChainStore;
 use chain::txhashset;
-use chain::types::Tip;
-use core::core::{Block, BlockHeader};
-use core::pow::Difficulty;
-use keychain::{ExtKeychain, ExtKeychainPath, Keychain};
+use core::core::BlockHeader;
 use util::file;
 
 fn clean_output_dir(dir_name: &str) {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -494,7 +494,7 @@ impl Block {
 			header: BlockHeader {
 				height: prev.height + 1,
 				timestamp,
-				// previous: prev.hash(),
+				deprecated_previous: prev.hash(),
 				total_kernel_offset,
 				pow: ProofOfWork {
 					total_difficulty: difficulty + prev.pow.total_difficulty,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -117,8 +117,10 @@ pub struct BlockHeader {
 	pub version: u16,
 	/// Height of this block since the genesis block (height 0)
 	pub height: u64,
-	/// Hash of the block previous to this in the chain.
-	pub previous: Hash,
+
+	// /// Hash of the block previous to this in the chain.
+	// pub previous: Hash,
+
 	/// Root hash of the header MMR at the previous header.
 	pub prev_root: Hash,
 	/// Timestamp at which the block was built.
@@ -147,10 +149,10 @@ fn fixed_size_of_serialized_header(_version: u16) -> usize {
 	size += mem::size_of::<u16>(); // version
 	size += mem::size_of::<u64>(); // height
 	size += mem::size_of::<i64>(); // timestamp
-								// previous, prev_root, output_root, range_proof_root, kernel_root
+	// prev_hash, prev_root, output_root, range_proof_root, kernel_root
 	size += 5 * mem::size_of::<Hash>();
 	size += mem::size_of::<BlindingFactor>(); // total_kernel_offset
-										   // output_mmr_size, kernel_mmr_size
+	// output_mmr_size, kernel_mmr_size
 	size += 2 * mem::size_of::<u64>();
 	size += mem::size_of::<Difficulty>(); // total_difficulty
 	size += mem::size_of::<u32>(); // secondary_scaling
@@ -177,7 +179,7 @@ impl Default for BlockHeader {
 			version: 1,
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
-			previous: ZERO_HASH,
+			// previous: ZERO_HASH,
 			prev_root: ZERO_HASH,
 			output_root: ZERO_HASH,
 			range_proof_root: ZERO_HASH,
@@ -213,7 +215,7 @@ impl Writeable for BlockHeader {
 impl Readable for BlockHeader {
 	fn read(reader: &mut Reader) -> Result<BlockHeader, ser::Error> {
 		let (version, height, timestamp) = ser_multiread!(reader, read_u16, read_u64, read_i64);
-		let previous = Hash::read(reader)?;
+		// let previous = Hash::read(reader)?;
 		let prev_root = Hash::read(reader)?;
 		let output_root = Hash::read(reader)?;
 		let range_proof_root = Hash::read(reader)?;
@@ -232,7 +234,7 @@ impl Readable for BlockHeader {
 			version,
 			height,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc),
-			previous,
+			// previous,
 			prev_root,
 			output_root,
 			range_proof_root,
@@ -253,7 +255,7 @@ impl BlockHeader {
 			[write_u16, self.version],
 			[write_u64, self.height],
 			[write_i64, self.timestamp.timestamp()],
-			[write_fixed_bytes, &self.previous],
+			// [write_fixed_bytes, &self.previous],
 			[write_fixed_bytes, &self.prev_root],
 			[write_fixed_bytes, &self.output_root],
 			[write_fixed_bytes, &self.range_proof_root],
@@ -494,7 +496,7 @@ impl Block {
 			header: BlockHeader {
 				height: prev.height + 1,
 				timestamp,
-				previous: prev.hash(),
+				// previous: prev.hash(),
 				total_kernel_offset,
 				pow: ProofOfWork {
 					total_difficulty: difficulty + prev.pow.total_difficulty,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -117,8 +117,8 @@ pub struct BlockHeader {
 	pub version: u16,
 	/// Height of this block since the genesis block (height 0)
 	pub height: u64,
-	/// Hash of the block previous to this in the chain (deprecated).
-	pub deprecated_previous: Hash,
+	/// Hash of the block previous to this in the chain.
+	pub prev_hash: Hash,
 	/// Root hash of the header MMR at the previous header.
 	pub prev_root: Hash,
 	/// Timestamp at which the block was built.
@@ -177,7 +177,7 @@ impl Default for BlockHeader {
 			version: 1,
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
-			deprecated_previous: ZERO_HASH,
+			prev_hash: ZERO_HASH,
 			prev_root: ZERO_HASH,
 			output_root: ZERO_HASH,
 			range_proof_root: ZERO_HASH,
@@ -213,7 +213,7 @@ impl Writeable for BlockHeader {
 impl Readable for BlockHeader {
 	fn read(reader: &mut Reader) -> Result<BlockHeader, ser::Error> {
 		let (version, height, timestamp) = ser_multiread!(reader, read_u16, read_u64, read_i64);
-		let deprecated_previous = Hash::read(reader)?;
+		let prev_hash = Hash::read(reader)?;
 		let prev_root = Hash::read(reader)?;
 		let output_root = Hash::read(reader)?;
 		let range_proof_root = Hash::read(reader)?;
@@ -232,7 +232,7 @@ impl Readable for BlockHeader {
 			version,
 			height,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc),
-			deprecated_previous,
+			prev_hash,
 			prev_root,
 			output_root,
 			range_proof_root,
@@ -253,7 +253,7 @@ impl BlockHeader {
 			[write_u16, self.version],
 			[write_u64, self.height],
 			[write_i64, self.timestamp.timestamp()],
-			[write_fixed_bytes, &self.deprecated_previous],
+			[write_fixed_bytes, &self.prev_hash],
 			[write_fixed_bytes, &self.prev_root],
 			[write_fixed_bytes, &self.output_root],
 			[write_fixed_bytes, &self.range_proof_root],
@@ -494,7 +494,7 @@ impl Block {
 			header: BlockHeader {
 				height: prev.height + 1,
 				timestamp,
-				deprecated_previous: prev.hash(),
+				prev_hash: prev.hash(),
 				total_kernel_offset,
 				pow: ProofOfWork {
 					total_difficulty: difficulty + prev.pow.total_difficulty,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -117,9 +117,8 @@ pub struct BlockHeader {
 	pub version: u16,
 	/// Height of this block since the genesis block (height 0)
 	pub height: u64,
-
-	// /// Hash of the block previous to this in the chain.
-	// pub previous: Hash,
+	/// Hash of the block previous to this in the chain (deprecated).
+	pub deprecated_previous: Hash,
 	/// Root hash of the header MMR at the previous header.
 	pub prev_root: Hash,
 	/// Timestamp at which the block was built.
@@ -178,7 +177,7 @@ impl Default for BlockHeader {
 			version: 1,
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
-			// previous: ZERO_HASH,
+			deprecated_previous: ZERO_HASH,
 			prev_root: ZERO_HASH,
 			output_root: ZERO_HASH,
 			range_proof_root: ZERO_HASH,
@@ -214,7 +213,7 @@ impl Writeable for BlockHeader {
 impl Readable for BlockHeader {
 	fn read(reader: &mut Reader) -> Result<BlockHeader, ser::Error> {
 		let (version, height, timestamp) = ser_multiread!(reader, read_u16, read_u64, read_i64);
-		// let previous = Hash::read(reader)?;
+		let deprecated_previous = Hash::read(reader)?;
 		let prev_root = Hash::read(reader)?;
 		let output_root = Hash::read(reader)?;
 		let range_proof_root = Hash::read(reader)?;
@@ -233,7 +232,7 @@ impl Readable for BlockHeader {
 			version,
 			height,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc),
-			// previous,
+			deprecated_previous,
 			prev_root,
 			output_root,
 			range_proof_root,
@@ -254,7 +253,7 @@ impl BlockHeader {
 			[write_u16, self.version],
 			[write_u64, self.height],
 			[write_i64, self.timestamp.timestamp()],
-			// [write_fixed_bytes, &self.previous],
+			[write_fixed_bytes, &self.deprecated_previous],
 			[write_fixed_bytes, &self.prev_root],
 			[write_fixed_bytes, &self.output_root],
 			[write_fixed_bytes, &self.range_proof_root],

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -120,7 +120,6 @@ pub struct BlockHeader {
 
 	// /// Hash of the block previous to this in the chain.
 	// pub previous: Hash,
-
 	/// Root hash of the header MMR at the previous header.
 	pub prev_root: Hash,
 	/// Timestamp at which the block was built.

--- a/core/src/core/pmmr/db_pmmr.rs
+++ b/core/src/core/pmmr/db_pmmr.rs
@@ -71,7 +71,6 @@ where
 
 	/// Rewind the MMR to the specified position.
 	pub fn rewind(&mut self, position: u64) -> Result<(), String> {
-		println!("hash pmmr: rewind: {}", position);
 		// Identify which actual position we should rewind to as the provided
 		// position is a leaf. We traverse the MMR to include any parent(s) that
 		// need to be included for the MMR to be valid.
@@ -81,7 +80,6 @@ where
 		}
 		self.backend.rewind(pos)?;
 		self.last_pos = pos;
-		println!("hash pmmr: rewind: last_pos now: {}", self.last_pos);
 		Ok(())
 	}
 
@@ -102,7 +100,6 @@ where
 	/// Push a new element into the MMR. Computes new related peaks at
 	/// the same time if applicable.
 	pub fn push(&mut self, elmt: &T) -> Result<u64, String> {
-		println!("*** push size: {}, {:?}", self.unpruned_size(), elmt);
 		let elmt_pos = self.last_pos + 1;
 		let mut current_hash = elmt.hash_with_index(elmt_pos - 1);
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -353,9 +353,9 @@ where
 		Ok(())
 	}
 
-	/// Check if this PMMR is (unpruned_size == 0).
+	/// Is the MMR empty?
 	pub fn is_empty(&self) -> bool {
-		self.unpruned_size() == 0
+		self.last_pos == 0
 	}
 
 	/// Total size of the tree, including intermediary nodes and ignoring any

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -27,7 +27,7 @@ use pow::{Difficulty, Proof, ProofOfWork};
 pub fn genesis_dev() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		previous: core::hash::Hash([0xff; 32]),
+		// previous: core::hash::Hash([0xff; 32]),
 		timestamp: Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
 		pow: ProofOfWork {
 			nonce: global::get_genesis_nonce(),
@@ -63,7 +63,7 @@ pub fn genesis_testnet1() -> core::Block {
 pub fn genesis_testnet2() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		previous: core::hash::Hash([0xff; 32]),
+		// previous: core::hash::Hash([0xff; 32]),
 		timestamp: Utc.ymd(2018, 3, 26).and_hms(16, 0, 0),
 		pow: ProofOfWork {
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),
@@ -86,7 +86,7 @@ pub fn genesis_testnet2() -> core::Block {
 pub fn genesis_testnet3() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		previous: core::hash::Hash([0xff; 32]),
+		// previous: core::hash::Hash([0xff; 32]),
 		timestamp: Utc.ymd(2018, 7, 8).and_hms(18, 0, 0),
 		pow: ProofOfWork {
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),
@@ -110,7 +110,7 @@ pub fn genesis_testnet3() -> core::Block {
 pub fn genesis_testnet4() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		previous: core::hash::Hash([0xff; 32]),
+		// previous: core::hash::Hash([0xff; 32]),
 		timestamp: Utc.ymd(2018, 10, 17).and_hms(20, 0, 0),
 		pow: ProofOfWork {
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),
@@ -133,7 +133,7 @@ pub fn genesis_testnet4() -> core::Block {
 pub fn genesis_main() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		previous: core::hash::Hash([0xff; 32]),
+		// previous: core::hash::Hash([0xff; 32]),
 		timestamp: Utc.ymd(2018, 8, 14).and_hms(0, 0, 0),
 		pow: ProofOfWork {
 			total_difficulty: Difficulty::from_num(global::initial_block_difficulty()),

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -119,7 +119,6 @@ fn test_transaction_pool_block_building() {
 	assert_eq!(txs.len(), 3);
 
 	let block = add_block(header, txs, &mut chain);
-	let header = block.header.clone();
 
 	// Now reconcile the transaction pool with the new block
 	// and check the resulting contents of the pool are what we expect.

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -67,12 +67,6 @@ fn test_transaction_pool_block_building() {
 
 	let block = add_block(BlockHeader::default(), vec![], &mut chain);
 	let header = block.header;
-	println!(
-		"***** block added: {}, {}, prev_root: {}",
-		header.hash(),
-		header.height,
-		header.prev_root
-	);
 
 	// Now create tx to spend that first coinbase (now matured).
 	// Provides us with some useful outputs to test with.
@@ -81,12 +75,6 @@ fn test_transaction_pool_block_building() {
 	// Mine that initial tx so we can spend it with multiple txs
 	let block = add_block(header, vec![initial_tx], &mut chain);
 	let header = block.header;
-	println!(
-		"***** block added: {}, {}, prev_root: {}",
-		header.hash(),
-		header.height,
-		header.prev_root
-	);
 
 	// Initialize a new pool with our chain adapter.
 	let pool = RwLock::new(test_setup(Arc::new(chain.clone()), verifier_cache));
@@ -132,12 +120,6 @@ fn test_transaction_pool_block_building() {
 
 	let block = add_block(header, txs, &mut chain);
 	let header = block.header.clone();
-	println!(
-		"***** block added: {}, {}, prev_root: {}",
-		header.hash(),
-		header.height,
-		header.prev_root
-	);
 
 	// Now reconcile the transaction pool with the new block
 	// and check the resulting contents of the pool are what we expect.

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -67,7 +67,12 @@ fn test_transaction_pool_block_building() {
 
 	let block = add_block(BlockHeader::default(), vec![], &mut chain);
 	let header = block.header;
-	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
+	println!(
+		"***** block added: {}, {}, prev_root: {}",
+		header.hash(),
+		header.height,
+		header.prev_root
+	);
 
 	// Now create tx to spend that first coinbase (now matured).
 	// Provides us with some useful outputs to test with.
@@ -76,7 +81,12 @@ fn test_transaction_pool_block_building() {
 	// Mine that initial tx so we can spend it with multiple txs
 	let block = add_block(header, vec![initial_tx], &mut chain);
 	let header = block.header;
-	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
+	println!(
+		"***** block added: {}, {}, prev_root: {}",
+		header.hash(),
+		header.height,
+		header.prev_root
+	);
 
 	// Initialize a new pool with our chain adapter.
 	let pool = RwLock::new(test_setup(Arc::new(chain.clone()), verifier_cache));
@@ -122,7 +132,12 @@ fn test_transaction_pool_block_building() {
 
 	let block = add_block(header, txs, &mut chain);
 	let header = block.header.clone();
-	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
+	println!(
+		"***** block added: {}, {}, prev_root: {}",
+		header.hash(),
+		header.height,
+		header.prev_root
+	);
 
 	// Now reconcile the transaction pool with the new block
 	// and check the resulting contents of the pool are what we expect.

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -28,6 +28,7 @@ pub mod common;
 use std::sync::Arc;
 use util::RwLock;
 
+use core::core::hash::Hashed;
 use core::core::verifier_cache::LruVerifierCache;
 use core::core::{Block, BlockHeader, Transaction};
 use core::pow::Difficulty;
@@ -55,20 +56,27 @@ fn test_transaction_pool_block_building() {
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let fee = txs.iter().map(|x| x.fee()).sum();
 		let reward = libtx::reward::output(&keychain, &key_id, fee, height).unwrap();
-		let block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
+		let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
+
+		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
+		block.header.prev_root = prev_header.hash();
 
 		chain.update_db_for_block(&block);
-		block.header
+		block
 	};
 
-	let header = add_block(BlockHeader::default(), vec![], &mut chain);
+	let block = add_block(BlockHeader::default(), vec![], &mut chain);
+	let header = block.header;
+	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
 
 	// Now create tx to spend that first coinbase (now matured).
 	// Provides us with some useful outputs to test with.
 	let initial_tx = test_transaction_spending_coinbase(&keychain, &header, vec![10, 20, 30, 40]);
 
 	// Mine that initial tx so we can spend it with multiple txs
-	let header = add_block(header, vec![initial_tx], &mut chain);
+	let block = add_block(header, vec![initial_tx], &mut chain);
+	let header = block.header;
+	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
 
 	// Initialize a new pool with our chain adapter.
 	let pool = RwLock::new(test_setup(Arc::new(chain.clone()), verifier_cache));
@@ -112,14 +120,9 @@ fn test_transaction_pool_block_building() {
 	// children should have been aggregated into parents
 	assert_eq!(txs.len(), 3);
 
-	let block = {
-		let key_id = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
-		let fees = txs.iter().map(|tx| tx.fee()).sum();
-		let reward = libtx::reward::output(&keychain, &key_id, fees, 0).unwrap();
-		Block::new(&header, txs, Difficulty::min(), reward)
-	}.unwrap();
-
-	chain.update_db_for_block(&block);
+	let block = add_block(header, txs, &mut chain);
+	let header = block.header.clone();
+	println!("***** block added: {}, {}, prev_root: {}", header.hash(), header.height, header.prev_root);
 
 	// Now reconcile the transaction pool with the new block
 	// and check the resulting contents of the pool are what we expect.

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -31,6 +31,7 @@ use util::RwLock;
 use core::core::{Block, BlockHeader};
 
 use common::*;
+use core::core::hash::Hashed;
 use core::core::verifier_cache::LruVerifierCache;
 use core::pow::Difficulty;
 use keychain::{ExtKeychain, Keychain};
@@ -53,7 +54,11 @@ fn test_transaction_pool_block_reconciliation() {
 		let height = 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let reward = libtx::reward::output(&keychain, &key_id, 0, height).unwrap();
-		let block = Block::new(&BlockHeader::default(), vec![], Difficulty::min(), reward).unwrap();
+		let genesis = BlockHeader::default();
+		let mut block = Block::new(&genesis, vec![], Difficulty::min(), reward).unwrap();
+
+		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
+		block.header.prev_root = genesis.hash();
 
 		chain.update_db_for_block(&block);
 
@@ -68,7 +73,10 @@ fn test_transaction_pool_block_reconciliation() {
 		let key_id = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 		let fees = initial_tx.fee();
 		let reward = libtx::reward::output(&keychain, &key_id, fees, 0).unwrap();
-		let block = Block::new(&header, vec![initial_tx], Difficulty::min(), reward).unwrap();
+		let mut block = Block::new(&header, vec![initial_tx], Difficulty::min(), reward).unwrap();
+
+		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
+		block.header.prev_root = header.hash();
 
 		chain.update_db_for_block(&block);
 
@@ -158,7 +166,10 @@ fn test_transaction_pool_block_reconciliation() {
 		let key_id = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 		let fees = block_txs.iter().map(|tx| tx.fee()).sum();
 		let reward = libtx::reward::output(&keychain, &key_id, fees, 0).unwrap();
-		let block = Block::new(&header, block_txs, Difficulty::min(), reward).unwrap();
+		let mut block = Block::new(&header, block_txs, Difficulty::min(), reward).unwrap();
+
+		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
+		block.header.prev_root = header.hash();
 
 		chain.update_db_for_block(&block);
 		block

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -66,15 +66,7 @@ impl ChainAdapter {
 
 	pub fn update_db_for_block(&self, block: &Block) {
 		let header = &block.header;
-
-		let prev = self.store.get_previous_header(&header);
-
-		let tip = if let Ok(prev) = prev {
-			Tip::from_headers(header, &prev)
-		} else {
-			Tip::from_genesis(header)
-		};
-
+		let tip = Tip::from_header(header);
 		let batch = self.store.batch().unwrap();
 
 		// For testing we are using the hash as the root (no MMR for a real root).

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -66,8 +66,9 @@ impl ChainAdapter {
 
 	pub fn update_db_for_block(&self, block: &Block) {
 		let header = &block.header;
+		let prev = self.store.get_previous_header(&header).unwrap();
 		let batch = self.store.batch().unwrap();
-		let tip = Tip::from_block(&header);
+		let tip = Tip::from_headers(&header, &prev);
 		batch.save_block_header(&header).unwrap();
 		batch.save_head(&tip).unwrap();
 

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -69,11 +69,7 @@ impl ChainAdapter {
 		let tip = Tip::from_header(header);
 		let batch = self.store.batch().unwrap();
 
-		// For testing we are using the hash as the root (no MMR for a real root).
-		{
-			let header_root = tip.last_block_h;
-			batch.save_block_header(header, &header_root).unwrap();
-		}
+		batch.save_block_header(header).unwrap();
 		batch.save_head(&tip).unwrap();
 
 		// Retrieve previous block_sums from the db.

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -442,6 +442,8 @@ impl NetToChainAdapter {
 		}
 
 		let bhash = b.hash();
+		let previous = self.chain().get_previous_header(&b.header);
+
 		match self.chain().process_block(b, self.chain_opts()) {
 			Ok(_) => {
 				self.validate_chain(bhash);
@@ -464,12 +466,12 @@ impl NetToChainAdapter {
 			Err(e) => {
 				match e.kind() {
 					chain::ErrorKind::Orphan => {
-						let previous = self.chain().get_previous_header(&b.header);
-
-						// make sure we did not miss the parent block
-						if !self.chain().is_orphan(&prev_hash) && !self.sync_state.is_syncing() {
-							debug!("adapter: process_block: received an orphan block, checking the parent: {:}", prev_hash);
-							self.request_block_by_hash(prev_hash, &addr)
+						if let Ok(previous) = previous {
+							// make sure we did not miss the parent block
+							if !self.chain().is_orphan(&previous.hash()) && !self.sync_state.is_syncing() {
+								debug!("adapter: process_block: received an orphan block, checking the parent: {:}", previous.hash());
+								self.request_block_by_hash(previous.hash(), &addr)
+							}
 						}
 						true
 					}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -159,7 +159,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				}
 			};
 
-			if let Ok(prev) = self.chain().get_block_header(&cb.header.previous) {
+			if let Ok(prev) = self.chain().get_previous_header(&cb.header) {
 				if block
 					.validate(&prev.total_kernel_offset, self.verifier_cache.clone())
 					.is_ok()
@@ -441,7 +441,6 @@ impl NetToChainAdapter {
 			}
 		}
 
-		let prev_hash = b.header.previous;
 		let bhash = b.hash();
 		match self.chain().process_block(b, self.chain_opts()) {
 			Ok(_) => {
@@ -465,6 +464,8 @@ impl NetToChainAdapter {
 			Err(e) => {
 				match e.kind() {
 					chain::ErrorKind::Orphan => {
+						let previous = self.chain().get_previous_header(&b.header);
+
 						// make sure we did not miss the parent block
 						if !self.chain().is_orphan(&prev_hash) && !self.sync_state.is_syncing() {
 							debug!("adapter: process_block: received an orphan block, checking the parent: {:}", prev_hash);

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -468,7 +468,9 @@ impl NetToChainAdapter {
 					chain::ErrorKind::Orphan => {
 						if let Ok(previous) = previous {
 							// make sure we did not miss the parent block
-							if !self.chain().is_orphan(&previous.hash()) && !self.sync_state.is_syncing() {
+							if !self.chain().is_orphan(&previous.hash())
+								&& !self.sync_state.is_syncing()
+							{
 								debug!("adapter: process_block: received an orphan block, checking the parent: {:}", previous.hash());
 								self.request_block_by_hash(previous.hash(), &addr)
 							}

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -105,7 +105,7 @@ impl BodySync {
 
 				hashes.push(header.hash());
 				oldest_height = header.height;
-				current = self.chain.get_block_header(&header.previous);
+				current = self.chain.get_previous_header(&header);
 			}
 		}
 		//+ remove me after #1880 root cause found

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use chain;
 use common::types::{SyncState, SyncStatus};
-use core::core::hash::{Hash, Hashed};
+use core::core::hash::Hashed;
 use core::global;
 use p2p;
 

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use chain;
 use common::types::{SyncState, SyncStatus};
-use core::core::hash::Hashed;
+use core::core::hash::{Hash, Hashed};
 use core::global;
 use p2p;
 

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -173,7 +173,7 @@ impl HeaderSync {
 						locator.push((header.height, header.hash()));
 						break;
 					}
-					header_cursor = self.chain.get_block_header(&header.previous);
+					header_cursor = self.chain.get_previous_header(&header);
 				}
 			}
 		}

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -67,7 +67,7 @@ impl HeaderSync {
 				// Reset sync_head to the same as current header_head.
 				self.chain.reset_sync_head(&header_head).unwrap();
 
-				// Rebuild the sync MMR to match our updates sync_head.
+				// Rebuild the sync MMR to match our updated sync_head.
 				self.chain.rebuild_sync_mmr(&header_head).unwrap();
 
 				self.history_locator.clear();

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -260,9 +260,7 @@ mod test {
 
 		// just 1 locator in history
 		let heights: Vec<u64> = vec![64, 62, 58, 50, 34, 2, 0];
-		let history_locator: Vec<(u64, Hash)> = vec![
-			(0, zh.clone()),
-		];
+		let history_locator: Vec<(u64, Hash)> = vec![(0, zh.clone())];
 		let mut locator: Vec<(u64, Hash)> = vec![];
 		for h in heights {
 			if let Some(l) = close_enough(&history_locator, h) {
@@ -288,7 +286,7 @@ mod test {
 
 		// more realistic test with 11 history
 		let heights: Vec<u64> = vec![
-			2554, 2552, 2548, 2540, 2524, 2492, 2428, 2300, 2044, 1532, 508, 0
+			2554, 2552, 2548, 2540, 2524, 2492, 2428, 2300, 2044, 1532, 508, 0,
 		];
 		let history_locator: Vec<(u64, Hash)> = vec![
 			(2043, zh.clone()),
@@ -310,15 +308,14 @@ mod test {
 			}
 		}
 		locator.dedup_by(|a, b| a.0 == b.0);
-		assert_eq!(locator, vec![
-			(2043, zh.clone()),
-			(1532, zh.clone()),
-			(0, zh.clone()),
-		]);
+		assert_eq!(
+			locator,
+			vec![(2043, zh.clone()), (1532, zh.clone()), (0, zh.clone()),]
+		);
 
 		// more realistic test with 12 history
 		let heights: Vec<u64> = vec![
-			4598, 4596, 4592, 4584, 4568, 4536, 4472, 4344, 4088, 3576, 2552, 504, 0
+			4598, 4596, 4592, 4584, 4568, 4536, 4472, 4344, 4088, 3576, 2552, 504, 0,
 		];
 		let history_locator: Vec<(u64, Hash)> = vec![
 			(4087, zh.clone()),
@@ -341,11 +338,14 @@ mod test {
 			}
 		}
 		locator.dedup_by(|a, b| a.0 == b.0);
-		assert_eq!(locator, vec![
-			(4087, zh.clone()),
-			(3576, zh.clone()),
-			(3065, zh.clone()),
-			(0, zh.clone()),
-		]);
+		assert_eq!(
+			locator,
+			vec![
+				(4087, zh.clone()),
+				(3576, zh.clone()),
+				(3065, zh.clone()),
+				(0, zh.clone()),
+			]
+		);
 	}
 }

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -153,7 +153,7 @@ impl StateSync {
 			for _ in 0..(horizon - horizon / 10) {
 				txhashset_head = self
 					.chain
-					.get_block_header(&txhashset_head.previous)
+					.get_previous_header(&txhashset_head)
 					.unwrap();
 			}
 			let bhash = txhashset_head.hash();

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -151,10 +151,7 @@ impl StateSync {
 				.get_block_header(&header_head.prev_block_h)
 				.unwrap();
 			for _ in 0..(horizon - horizon / 10) {
-				txhashset_head = self
-					.chain
-					.get_previous_header(&txhashset_head)
-					.unwrap();
+				txhashset_head = self.chain.get_previous_header(&txhashset_head).unwrap();
 			}
 			let bhash = txhashset_head.hash();
 			debug!(

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -139,7 +139,7 @@ fn build_block(
 	);
 
 	// Now set txhashset roots and sizes on the header of the block being built.
-	let roots_result = chain.set_txhashset_roots(&mut b, false);
+	let roots_result = chain.set_txhashset_roots(&mut b);
 
 	match roots_result {
 		Ok(_) => Ok((b, block_fees)),

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -157,9 +157,10 @@ impl Miner {
 			// we found a solution, push our block through the chain processing pipeline
 			if sol {
 				info!(
-					"(Server ID: {}) Found valid proof of work, adding block {}.",
+					"(Server ID: {}) Found valid proof of work, adding block {} (prev_root {}).",
 					self.debug_output_id,
-					b.hash()
+					b.hash(),
+					b.header.prev_root,
 				);
 				let res = self.chain.process_block(b, chain::Options::MINE);
 				if let Err(e) = res {

--- a/wallet/tests/common/mod.rs
+++ b/wallet/tests/common/mod.rs
@@ -99,7 +99,7 @@ pub fn add_block_with_reward(chain: &Chain, txs: Vec<&Transaction>, reward: CbDa
 	).unwrap();
 	b.header.timestamp = prev.timestamp + Duration::seconds(60);
 	b.header.pow.secondary_scaling = next_header_info.secondary_scaling;
-	chain.set_txhashset_roots(&mut b, false).unwrap();
+	chain.set_txhashset_roots(&mut b).unwrap();
 	pow::pow_size(
 		&mut b.header,
 		next_header_info.difficulty,


### PR DESCRIPTION
* `header` now contains the following - 
  * `prev_root`
  * `prev_hash` (was `previous`, renamed for consistency)
* introduce `batch.get_previous_header()` to hide the impl
* `pipe::process_block()` now leverages a `header_extension` to generate and validate the new `header_root` before proceeding to process the full block
* lots of cleanup

Edit: we were originally planning on deprecating/removing the `previous` hash from headers but recent discussions are leaning toward leaving it in (renamed to `prev_hash` in this PR).