### PR TITLE
fix: remove TODO for counting of bytes that was already done

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -144,7 +144,6 @@ impl<'a> Response<'a> {
 
 pub const SEND_CHANNEL_CAP: usize = 10;
 
-// TODO count sent and received
 pub struct Tracker {
 	/// Bytes we've sent.
 	pub sent_bytes: Arc<RwLock<u64>>,


### PR DESCRIPTION
Just removes `TODO` mark that was left out by #1770.