### PR TITLE
Make sure the entire buffer was written

### DIFF
--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -178,7 +178,7 @@ impl AppendOnlyFile {
 		}
 
 		self.buffer_start += self.buffer.len();
-		self.file.write(&self.buffer[..])?;
+		self.file.write_all(&self.buffer[..])?;
 		self.file.sync_all()?;
 
 		self.buffer = vec![];


### PR DESCRIPTION
We may write just a part of the buffer and we don't check the result, so
write_all is probably what we need here