### PR TITLE
Improve crate descriptors to be more cargo-friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "grin_secp256k1zkp"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "grin_servers"
 version = "0.4.0"
 dependencies = [
@@ -897,12 +911,12 @@ dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_secp256k1zkp 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1zkp 0.7.1 (git+https://github.com/mimblewimble/rust-secp256k1-zkp?tag=grin_integration_28)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2018,20 +2032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1zkp"
-version = "0.7.1"
-source = "git+https://github.com/mimblewimble/rust-secp256k1-zkp?tag=grin_integration_28#3747af2eed1ad88796dc0f4bac018113523a7b6d"
-dependencies = [
- "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "security-framework"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +2779,7 @@ name = "yaml-rust"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2875,6 +2875,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum grin_secp256k1zkp 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "42fd2759f1fb49fcbbf74fc9a818a0a32be49622395e82d88a26bba42a9bdd71"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "24f58e8c2d8e886055c3ead7b28793e1455270b5fb39650984c224bc538ba581"
@@ -2994,7 +2995,6 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb8f61f9e6eadd062a71c380043d28036304a4706b3c4dd001ff3387ed00745a"
-"checksum secp256k1zkp 0.7.1 (git+https://github.com/mimblewimble/rust-secp256k1-zkp?tag=grin_integration_28)" = "<none>"
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,6 @@ grin_servers = { path = "./servers" }
 grin_util = { path = "./util"}
 grin_wallet = { path = "./wallet" }
 
-# TODO - once "patch" is available we should be able to clean up the workspace dependencies
-# [patch.crate-io]
-# secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
-
 [build-dependencies]
 built = "0.3"
 reqwest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,12 @@
 name = "grin"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
+readme = "README.md"
 exclude = ["**/*.grin", "**/*.grin2"]
-publish = false
-autobins = false
 build = "src/build/build.rs"
 
 [workspace]
@@ -27,14 +30,14 @@ serde_json = "1"
 log = "0.4"
 term = "0.5"
 
-grin_api = { path = "./api" }
-grin_config = { path = "./config" }
-grin_core = { path = "./core" }
-grin_keychain = { path = "./keychain" }
-grin_p2p = { path = "./p2p"}
-grin_servers = { path = "./servers" }
-grin_util = { path = "./util"}
-grin_wallet = { path = "./wallet" }
+grin_api = { path = "./api", version = "0.4.0" }
+grin_config = { path = "./config", version = "0.4.0" }
+grin_core = { path = "./core", version = "0.4.0" }
+grin_keychain = { path = "./keychain", version = "0.4.0" }
+grin_p2p = { path = "./p2p", version = "0.4.0" }
+grin_servers = { path = "./servers", version = "0.4.0" }
+grin_util = { path = "./util", version = "0.4.0" }
+grin_wallet = { path = "./wallet", version = "0.4.0" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_api"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -26,9 +30,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core" }
-grin_chain = { path = "../chain" }
-grin_p2p = { path = "../p2p" }
-grin_pool = { path = "../pool" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_chain = { path = "../chain", version = "0.4.0" }
+grin_p2p = { path = "../p2p", version = "0.4.0" }
+grin_pool = { path = "../pool", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_chain"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -18,12 +22,12 @@ serde_derive = "1"
 chrono = "0.4.4"
 lru-cache = "0.1"
 
-grin_core = { path = "../core" }
-grin_keychain = { path = "../keychain" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_keychain = { path = "../keychain", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet" }
+grin_wallet = { path = "../wallet", version = "0.4.0" }
 env_logger = "0.5"
 rand = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_config"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -12,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_servers = { path = "../servers" }
-grin_p2p = { path = "../p2p" }
-grin_util = { path = "../util" }
-grin_wallet = { path = "../wallet"}
+grin_servers = { path = "../servers", version = "0.4.0" }
+grin_p2p = { path = "../p2p", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
+grin_wallet = { path = "../wallet", version = "0.4.0" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_core"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_keychain"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = '..'
 publish = false
 
@@ -20,4 +24,4 @@ hmac = "0.6"
 ripemd160 = "0.7"
 sha2 = "0.7"
 
-grin_util = { path = "../util" }
+grin_util = { path = "../util", version = "0.4.0" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_p2p"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -18,9 +22,9 @@ serde_derive = "1"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool" }
+grin_pool = { path = "../pool", version = "0.4.0" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_pool"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = '..'
 publish = false
 
@@ -13,11 +17,11 @@ serde_derive = "1"
 log = "0.4"
 chrono = "0.4.4"
 
-grin_core = { path = "../core" }
-grin_keychain = { path = "../keychain" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_keychain = { path = "../keychain", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet" }
-grin_chain = { path = "../chain" }
+grin_wallet = { path = "../wallet", version = "0.4.0" }
+grin_chain = { path = "../chain", version = "0.4.0" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_servers"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -21,16 +25,16 @@ chrono = "0.4.4"
 bufstream = "~0.1"
 jsonrpc-core = "~8.0"
 
-grin_api = { path = "../api" }
-grin_chain = { path = "../chain" }
-grin_core = { path = "../core" }
-grin_keychain = { path = "../keychain" }
-grin_p2p = { path = "../p2p" }
-grin_pool = { path = "../pool" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
-grin_wallet = { path = "../wallet" }
+grin_api = { path = "../api", version = "0.4.0" }
+grin_chain = { path = "../chain", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_keychain = { path = "../keychain", version = "0.4.0" }
+grin_p2p = { path = "../p2p", version = "0.4.0" }
+grin_pool = { path = "../pool", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
+grin_wallet = { path = "../wallet", version = "0.4.0" }
 
 [dev-dependencies]
 blake2-rfc = "0.2"
-grin_config = { path = "../config" }
+grin_config = { path = "../config", version = "0.4.0" }

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -52,30 +52,27 @@ pub mod built_info {
 	include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-pub fn info_strings() -> (String, String, String) {
+pub fn info_strings() -> (String, String) {
 	(
 		format!(
 			"This is Grin version {}{}, built for {} by {}.",
 			built_info::PKG_VERSION,
 			built_info::GIT_VERSION.map_or_else(|| "".to_owned(), |v| format!(" (git {})", v)),
 			built_info::TARGET,
-			built_info::RUSTC_VERSION
+			built_info::RUSTC_VERSION,
 		).to_string(),
 		format!(
-			"Built with profile \"{}\", features \"{}\" on {}.",
+			"Built with profile \"{}\", features \"{}\".",
 			built_info::PROFILE,
 			built_info::FEATURES_STR,
-			built_info::BUILT_TIME_UTC
 		).to_string(),
-		format!("Dependencies:\n {}", built_info::DEPENDENCIES_STR).to_string(),
 	)
 }
 
 fn log_build_info() {
-	let (basic_info, detailed_info, deps) = info_strings();
+	let (basic_info, detailed_info) = info_strings();
 	info!("{}", basic_info);
 	debug!("{}", detailed_info);
-	trace!("{}", deps);
 }
 
 fn main() {

--- a/src/bin/tui/version.rs
+++ b/src/bin/tui/version.rs
@@ -31,7 +31,7 @@ pub struct TUIVersionView;
 impl TUIStatusListener for TUIVersionView {
 	/// Create basic status view
 	fn create() -> Box<View> {
-		let (basic_info, detailed_info, _) = info_strings();
+		let (basic_info, detailed_info) = info_strings();
 		let basic_status_view = BoxView::with_full_screen(
 			LinearLayout::new(Orientation::Vertical)
 				.child(TextView::new(basic_info))

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -53,11 +53,12 @@ fn main() {
 	// build and versioning information
 	let mut opts = built::Options::default();
 	opts.set_dependencies(true);
-	built::write_built_file_with_opts(
+	// don't fail the build if something's missing, may just be cargo release
+	let _ = built::write_built_file_with_opts(
 		&opts,
 		env!("CARGO_MANIFEST_DIR"),
 		format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs"),
-	).expect("Failed to acquire build-time information");
+	);
 
 	install_web_wallet();
 }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_store"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 
@@ -18,8 +22,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core" }
-grin_util = { path = "../util" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -19,8 +19,9 @@ walkdir = "2"
 zip = "0.4"
 parking_lot = {version = "0.6"}
 
-[dependencies.secp256k1zkp]
-git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
-tag = "grin_integration_28"
+[dependencies.grin_secp256k1zkp]
+#git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
+#tag = "grin_integration_28"
 #path = "../../rust-secp256k1-zkp"
+version = "0.7.1"
 features = ["bullet-proof-sizing"]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_util"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 publish = false
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -2,6 +2,10 @@
 name = "grin_wallet"
 version = "0.4.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
+description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
+license = "Apache-2.0"
+repository = "https://github.com/mimblewimble/grin"
+keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = '..'
 publish = false
 
@@ -26,12 +30,12 @@ uuid = { version = "0.6", features = ["serde", "v4"] }
 url = "1.7.0"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_api = { path = "../api" }
-grin_core = { path = "../core" }
-grin_keychain = { path = "../keychain" }
-grin_store = { path = "../store" }
-grin_util = { path = "../util" }
+grin_api = { path = "../api", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.0" }
+grin_keychain = { path = "../keychain", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.0" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain" }
-grin_store = { path = "../store" }
+grin_chain = { path = "../chain", version = "0.4.0" }
+grin_store = { path = "../store", version = "0.4.0" }


### PR DESCRIPTION
Adds details and fixes our various `Cargo.toml` to be more along the lines of what `cargo` wants and specifically `cargo publish`. Partially addresses #1843 