### PR TITLE
Fix panic in `get_locator`

### DIFF
--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -190,7 +190,7 @@ impl HeaderSync {
 				.zip(locator.clone().into_iter())
 				.collect();
 			tmp.reverse();
-			if self.history_locators.len() > 0 && tmp[0].0 == 0 {
+			if self.history_locators.len() > 0 && tmp.len() > 0 && tmp[0].0 == 0 {
 				tmp = tmp[1..].to_vec();
 			}
 			self.history_locators.append(&mut tmp);


### PR DESCRIPTION
```
  10:     0x55d42c48bbc6 - core::slice::<impl core::ops::index::Index<I> for [T]>::index::ha9bd9698d0c84f8a
                        at /checkout/src/libcore/slice/mod.rs:1953
  11:     0x55d42c4585c2 - <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index::hde444f1de14c11b9
                        at /checkout/src/liballoc/vec.rs:1714
  12:     0x55d42c4c82ea - grin_servers::grin::sync::header_sync::HeaderSync::get_locator::hfe47aaa3c8677eb8
                        at servers/src/grin/sync/header_sync.rs:193
  13:     0x55d42c4c72f7 - grin_servers::grin::sync::header_sync::HeaderSync::request_headers::h431692480453f779
                        at servers/src/grin/sync/header_sync.rs:140
```
Fixes #1855