### PR TITLE
feat: add an option to configure owner_api address and port

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -322,6 +322,20 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"owner_api_listen_interface".to_string(),
+		"
+#host IP for owner_api listener
+".to_string(),
+	);
+
+	retval.insert(
+		"owner_api_listen_port".to_string(),
+		"
+#port for owner_api listener
+".to_string(),
+	);
+
+	retval.insert(
 		"api_secret_path".to_string(),
 		"
 #path of the secret token used by the API to authenticate the calls

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -165,25 +165,32 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) {
 					});
 			}
 			("owner_api", Some(_api_args)) => {
-				// TLS is disabled because we bind to localhost
-				controller::owner_listener(wallet, "127.0.0.1:13420", api_secret, None)
-					.unwrap_or_else(|e| {
-						panic!(
-							"Error creating wallet api listener: {:?} Config: {:?}",
-							e, wallet_config
-						)
-					});
+				controller::owner_listener(
+					wallet,
+					&wallet_config.owner_api_listen_addr(),
+					api_secret,
+					tls_conf,
+				).unwrap_or_else(|e| {
+					panic!(
+						"Error creating wallet owner api listener: {:?} Config: {:?}",
+						e, wallet_config
+					)
+				});
 			}
 			("web", Some(_api_args)) => {
 				// start owner listener and run static file server
 				start_webwallet_server();
-				controller::owner_listener(wallet, "127.0.0.1:13420", api_secret, tls_conf)
-					.unwrap_or_else(|e| {
-						panic!(
-							"Error creating wallet api listener: {:?} Config: {:?}",
-							e, wallet_config
-						)
-					});
+				controller::owner_listener(
+					wallet,
+					&wallet_config.owner_api_listen_addr(),
+					api_secret,
+					tls_conf,
+				).unwrap_or_else(|e| {
+					panic!(
+						"Error creating wallet owner api listener: {:?} Config: {:?}",
+						e, wallet_config
+					)
+				});
 			}
 			_ => {}
 		};

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -38,6 +38,11 @@ pub struct WalletConfig {
 	pub api_listen_interface: String,
 	// The port this wallet will run on
 	pub api_listen_port: u16,
+	// The api interface/ip_address that the owner api server will run
+	// by default this is 127.0.0.1 (and will not accept connections from external clients)
+	pub owner_api_listen_interface: String,
+	// The port the owner api will run on
+	pub owner_api_listen_port: u16,
 	/// Location of the secret for basic auth on the Owner API
 	pub api_secret_path: Option<String>,
 	/// Location of the node api secret for basic auth on the Grin API
@@ -59,6 +64,8 @@ impl Default for WalletConfig {
 			chain_type: Some(ChainTypes::Testnet4),
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 13415,
+			owner_api_listen_interface: "127.0.0.1".to_string(),
+			owner_api_listen_port: 13420,
 			api_secret_path: Some(".api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
@@ -72,6 +79,13 @@ impl Default for WalletConfig {
 impl WalletConfig {
 	pub fn api_listen_addr(&self) -> String {
 		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
+	}
+
+	pub fn owner_api_listen_addr(&self) -> String {
+		format!(
+			"{}:{}",
+			self.owner_api_listen_interface, self.owner_api_listen_port
+		)
 	}
 }
 


### PR DESCRIPTION
Currently `grin wallet owner_api` listen address is hardcoded to `127.0.0.1:13420`. This PR adds the option to configure the listen address and port in the `grin-wallet.toml` file.

This is required for web and mobile wallets that need to query the api remotely.