### PR TITLE
Adapter check compact archive

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -515,8 +515,8 @@ impl NetToChainAdapter {
 	}
 
 	fn check_compact(&self) {
-		// no compaction during sync or if we're in historical mode
-		if self.archive_mode || self.sync_state.is_syncing() {
+		// Skip compaction if we are syncing.
+		if self.sync_state.is_syncing() {
 			return;
 		}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -436,7 +436,9 @@ impl NetToChainAdapter {
 		// We cannot process blocks earlier than the horizon so check for this here.
 		{
 			let head = self.chain().head().unwrap();
-			let horizon = head.height.saturating_sub(global::cut_through_horizon() as u64);
+			let horizon = head
+				.height
+				.saturating_sub(global::cut_through_horizon() as u64);
 			if b.header.height < horizon {
 				return true;
 			}


### PR DESCRIPTION
The adapter was skipping chain compaction for archive nodes.
We _do_ want to trigger a chain compaction, internally we will skip deleting old blocks for archive nodes.

