### PR TITLE
adjust the title format of wallet txs output

### DIFF
--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -122,13 +122,13 @@ pub fn txs(
 		bMG->"Creation Time",
 		bMG->"Confirmed?",
 		bMG->"Confirmation Time",
-		bMG->"Num. Inputs",
-		bMG->"Num. Outputs",
-		bMG->"Amount Credited",
-		bMG->"Amount Debited",
+		bMG->"Num. \nInputs",
+		bMG->"Num. \nOutputs",
+		bMG->"Amount \nCredited",
+		bMG->"Amount \nDebited",
 		bMG->"Fee",
-		bMG->"Net Difference",
-		bMG->"Tx Data",
+		bMG->"Net \nDifference",
+		bMG->"Tx \nData",
 	]);
 
 	for t in txs {


### PR DESCRIPTION
Small adjustment on the title.

Before change:
![screen shot 2018-10-30 at 8 25 47 pm](https://user-images.githubusercontent.com/1852227/47717913-0b67a080-dc82-11e8-8ae1-2ab5e5f67aaf.png)


After change:
![screen shot 2018-10-30 at 8 26 19 pm](https://user-images.githubusercontent.com/1852227/47717959-19b5bc80-dc82-11e8-9bfa-179587b5a878.png)
