### PR TITLE
be careful resetting sync_head

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1098,12 +1098,20 @@ fn setup_head(
 	// Check we have the header corresponding to the header_head.
 	// If not then something is corrupted and we should reset our header_head.
 	// Either way we want to reset sync_head to match header_head.
+	let head = batch.head()?;
 	let header_head = batch.header_head()?;
 	if batch.get_block_header(&header_head.last_block_h).is_ok() {
 		// Reset sync_head to be consistent with current header_head.
 		batch.reset_sync_head()?;
 	} else {
 		// Reset both header_head and sync_head to be consistent with current head.
+		warn!(
+			"setup_head: header missing for {}, {}, resetting header_head and sync_head to head: {}, {}",
+			header_head.last_block_h,
+			header_head.height,
+			head.last_block_h,
+			head.height,
+		);
 		batch.reset_head()?;
 	}
 


### PR DESCRIPTION
* make sure we have the header corresponding to header_head
* and that nothing is corrupted from an earlier shutdown
* reset both header_head and sync_head to head if anything looks wrong

This should fix a hard to reproduce issue I saw locally where a node was failing to start up cleanly due to a `header not found`.
I'm not 100% sure I understand _why_ we got into a state where header_head was saved to the db, but the underlying header was not but it was likely a result of a bad shutdown/restart during testing.

