### PR TITLE
avoid long display of TxLogEntryType

### DIFF
--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -555,11 +555,11 @@ pub enum TxLogEntryType {
 impl fmt::Display for TxLogEntryType {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
-			TxLogEntryType::ConfirmedCoinbase => write!(f, "Confirmed Coinbase"),
+			TxLogEntryType::ConfirmedCoinbase => write!(f, "Confirmed \nCoinbase"),
 			TxLogEntryType::TxReceived => write!(f, "Received Tx"),
 			TxLogEntryType::TxSent => write!(f, "Sent Tx"),
-			TxLogEntryType::TxReceivedCancelled => write!(f, "Received Tx - Cancelled"),
-			TxLogEntryType::TxSentCancelled => write!(f, "Send Tx - Cancelled"),
+			TxLogEntryType::TxReceivedCancelled => write!(f, "Received Tx\n- Cancelled"),
+			TxLogEntryType::TxSentCancelled => write!(f, "Send Tx\n- Cancelled"),
 		}
 	}
 }


### PR DESCRIPTION
Before change:
![screen shot 2018-10-31 at 2 01 07 pm](https://user-images.githubusercontent.com/1852227/47769071-76ae8280-dd15-11e8-9df3-57d96194eb22.png)


After change:
![screen shot 2018-10-31 at 2 01 38 pm](https://user-images.githubusercontent.com/1852227/47769085-88902580-dd15-11e8-9b12-c77cd2fa8022.png)

