### PR TITLE
validate prev_root at height 1 (against root for genesis at height 0)

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -713,7 +713,7 @@ impl<'a> HeaderExtension<'a> {
 	pub fn validate_root(&self, header: &BlockHeader) -> Result<(), Error> {
 		// If we are validating the genesis block then we have no prev_root.
 		// So we are done here.
-		if header.height == 1 {
+		if header.height == 0 {
 			return Ok(());
 		}
 
@@ -1102,7 +1102,7 @@ impl<'a> Extension<'a> {
 	/// Validate the provided header by comparing its prev_root to the
 	/// root of the current header MMR.
 	pub fn validate_header_root(&self, header: &BlockHeader) -> Result<(), Error> {
-		if header.height == 1 {
+		if header.height == 0 {
 			return Ok(());
 		}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -17,7 +17,7 @@ use std::u64;
 
 use croaring::Bitmap;
 
-use core::hash::Hash;
+use core::hash::{Hash, ZERO_HASH};
 use core::merkle_proof::MerkleProof;
 use core::pmmr::{Backend, ReadonlyPMMR};
 use core::BlockHeader;
@@ -124,6 +124,9 @@ where
 	/// Computes the root of the MMR. Find all the peaks in the current
 	/// tree and "bags" them to get a single peak.
 	pub fn root(&self) -> Hash {
+		if self.is_empty() {
+			return ZERO_HASH;
+		}
 		let mut res = None;
 		for peak in self.peaks().iter().rev() {
 			res = match res {
@@ -348,6 +351,11 @@ where
 			}
 		}
 		Ok(())
+	}
+
+	/// Check if this PMMR is (unpruned_size == 0).
+	pub fn is_empty(&self) -> bool {
+		self.unpruned_size() == 0
 	}
 
 	/// Total size of the tree, including intermediary nodes and ignoring any


### PR DESCRIPTION
* genesis is `height 0` so we can _and should_ validate header_root at `height 1`
* we then need to safely handle empty PMMRs when calling `root()` 
  * output/rangeproof/kernel MMRs at genesis are empty (vs. the header MMR which has a single leaf in it).

Resolves #1890 
