### PR TITLE
fix: more readable timestamp format for logging

### DIFF
--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -54,7 +54,7 @@ lazy_static! {
 	static ref LOGGING_CONFIG: Mutex<LoggingConfig> = Mutex::new(LoggingConfig::default());
 }
 
-const LOGGING_PATTERN: &str = "{d(%m-%d %H:%M:%S%.3f)} {h({l})} {M} - {m}{n}";
+const LOGGING_PATTERN: &str = "{d(%Y%m%d %H:%M:%S%.3f)} {h({l})} {M} - {m}{n}";
 
 /// This filter is rejecting messages that doesn't start with "grin"
 /// in order to save log space for only Grin-related records

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -54,7 +54,7 @@ lazy_static! {
 	static ref LOGGING_CONFIG: Mutex<LoggingConfig> = Mutex::new(LoggingConfig::default());
 }
 
-const LOGGING_PATTERN: &str = "{d(%m-%d %H:%M:%S%.3f)} {l} {M} - {m}{n}";
+const LOGGING_PATTERN: &str = "{d(%m-%d %H:%M:%S%.3f)} {h({l})} {M} - {m}{n}";
 
 /// This filter is rejecting messages that doesn't start with "grin"
 /// in order to save log space for only Grin-related records

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -54,6 +54,8 @@ lazy_static! {
 	static ref LOGGING_CONFIG: Mutex<LoggingConfig> = Mutex::new(LoggingConfig::default());
 }
 
+const LOGGING_PATTERN: &str = "{d(%m-%d %H:%M:%S%.3f)} {l} {M} - {m}{n}";
+
 /// This filter is rejecting messages that doesn't start with "grin"
 /// in order to save log space for only Grin-related records
 #[derive(Debug)]
@@ -97,7 +99,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 
 		// Start logger
 		let stdout = ConsoleAppender::builder()
-			.encoder(Box::new(PatternEncoder::default()))
+			.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
 			.build();
 
 		let mut root = Root::builder();
@@ -132,7 +134,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 					Box::new(
 						RollingFileAppender::builder()
 							.append(c.log_file_append)
-							.encoder(Box::new(PatternEncoder::new("{d} {l} {M} - {m}{n}")))
+							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
 							.build(c.log_file_path, Box::new(policy))
 							.unwrap(),
 					)
@@ -140,7 +142,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 					Box::new(
 						FileAppender::builder()
 							.append(c.log_file_append)
-							.encoder(Box::new(PatternEncoder::new("{d} {l} {M} - {m}{n}")))
+							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
 							.build(c.log_file_path)
 							.unwrap(),
 					)


### PR DESCRIPTION
Closes #1849.

Example of log messages with new format:
```
11-02 14:49:30.859 DEBUG grin_servers::grin::sync::body_sync - body_sync: no pending block request, asking more
11-02 14:49:30.859 DEBUG grin_servers::grin::sync::body_sync - body_sync: body_head - 05898b89, 17955, header_head - 0a21a614, 22063, sync_head - 0a21a614, 22063
11-02 14:49:30.904 DEBUG grin_chain::pipe - pipe: head updated to 007b3b51 at 17956
11-02 14:49:30.906 DEBUG grin_chain::chain - check_orphans: get block 005f8748 at 17957
11-02 14:49:30.907 DEBUG grin_chain::pipe - pipe: process_block 005f8748 at 17957, in/out/kern: 0/1/1
```

?r @garyyu 