### PR TITLE
[DNM] experimental UTXO commitments

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -811,7 +811,11 @@ impl Chain {
 			let mut utxo_set = self.utxo_set.write();
 			utxo_set::extending(&mut utxo_set, |utxo_extension| {
 				utxo_extension.rebuild(&utxo_view)?;
-				warn!("********** UTXO root: {} (output root: {})", utxo_extension.root(), utxo_view.root());
+				warn!(
+					"********** UTXO root: {} (output root: {})",
+					utxo_extension.root(),
+					utxo_view.root()
+				);
 				Ok(())
 			})?;
 

--- a/chain/src/txhashset/mod.rs
+++ b/chain/src/txhashset/mod.rs
@@ -17,6 +17,7 @@
 
 mod rewindable_kernel_view;
 mod txhashset;
+pub mod utxo_set;
 mod utxo_view;
 
 pub use self::rewindable_kernel_view::*;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -29,7 +29,9 @@ use core::core::committed::Committed;
 use core::core::hash::{Hash, Hashed};
 use core::core::merkle_proof::MerkleProof;
 use core::core::pmmr::{self, ReadonlyPMMR, RewindablePMMR, DBPMMR, PMMR};
-use core::core::{Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel, UTXOEntry};
+use core::core::{
+	Block, BlockHeader, Input, Output, OutputFeatures, OutputIdentifier, TxKernel, UTXOEntry,
+};
 use core::global;
 use core::ser::{PMMRIndexHashable, PMMRable};
 
@@ -38,8 +40,8 @@ use grin_store;
 use grin_store::pmmr::{HashOnlyMMRBackend, PMMRBackend, PMMR_FILES};
 use grin_store::types::prune_noop;
 use store::{Batch, ChainStore};
-use txhashset::{RewindableKernelView, UTXOView};
 use txhashset::utxo_set::UTXOSet;
+use txhashset::{RewindableKernelView, UTXOView};
 use types::{Tip, TxHashSetRoots, TxHashsetWriteStatus};
 use util::{file, secp_static, zip};
 
@@ -141,11 +143,7 @@ impl TxHashSet {
 				HEADERHASHSET_SUBDIR,
 				HEADER_HEAD_SUBDIR,
 			)?,
-			sync_pmmr_h: HashOnlyMMRHandle::new(
-				&root_dir,
-				HEADERHASHSET_SUBDIR,
-				SYNC_HEAD_SUBDIR,
-			)?,
+			sync_pmmr_h: HashOnlyMMRHandle::new(&root_dir, HEADERHASHSET_SUBDIR, SYNC_HEAD_SUBDIR)?,
 			output_pmmr_h: PMMRHandle::new(
 				&root_dir,
 				TXHASHSET_SUBDIR,

--- a/chain/src/txhashset/utxo_set.rs
+++ b/chain/src/txhashset/utxo_set.rs
@@ -18,7 +18,7 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
 use core::core::hash::Hash;
-use core::core::pmmr::{self, DBPMMR, ReadonlyPMMR};
+use core::core::pmmr::{self, ReadonlyPMMR, DBPMMR};
 use core::core::{Block, Input, Output, OutputIdentifier, Transaction, UTXOEntry};
 use error::{Error, ErrorKind};
 use grin_store::pmmr::{HashOnlyMMRBackend, PMMRBackend};
@@ -48,15 +48,9 @@ pub struct UTXOSet {
 }
 
 impl UTXOSet {
-	pub fn open(
-		root_dir: String,
-	) -> Result<UTXOSet, Error> {
+	pub fn open(root_dir: String) -> Result<UTXOSet, Error> {
 		Ok(UTXOSet {
-			pmmr_h: HashOnlyMMRHandle::new(
-				&root_dir,
-				UTXOSET_SUBDIR,
-				UTXOSET_UTXO_SUBDIR,
-			)?,
+			pmmr_h: HashOnlyMMRHandle::new(&root_dir, UTXOSET_SUBDIR, UTXOSET_UTXO_SUBDIR)?,
 		})
 	}
 }
@@ -82,10 +76,7 @@ pub struct Extension<'a> {
 impl<'a> Extension<'a> {
 	fn new(utxo: &'a mut UTXOSet) -> Extension<'a> {
 		Extension {
-			pmmr: DBPMMR::at(
-				&mut utxo.pmmr_h.backend,
-				utxo.pmmr_h.last_pos,
-			)
+			pmmr: DBPMMR::at(&mut utxo.pmmr_h.backend, utxo.pmmr_h.last_pos),
 		}
 	}
 
@@ -100,10 +91,7 @@ impl<'a> Extension<'a> {
 	}
 
 	fn apply_entry(&mut self, entry: &UTXOEntry) -> Result<(u64), Error> {
-		let pos = self
-			.pmmr
-			.push(entry)
-			.map_err(&ErrorKind::TxHashSetErr)?;
+		let pos = self.pmmr.push(entry).map_err(&ErrorKind::TxHashSetErr)?;
 		Ok(pos)
 	}
 

--- a/chain/src/txhashset/utxo_set.rs
+++ b/chain/src/txhashset/utxo_set.rs
@@ -1,0 +1,126 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hash only MMR over UTXO set (spent outputs are zero'd out).
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use core::core::hash::Hash;
+use core::core::pmmr::{self, DBPMMR, ReadonlyPMMR};
+use core::core::{Block, Input, Output, OutputIdentifier, Transaction, UTXOEntry};
+use error::{Error, ErrorKind};
+use grin_store::pmmr::{HashOnlyMMRBackend, PMMRBackend};
+use txhashset::utxo_view::UTXOView;
+
+const UTXOSET_SUBDIR: &'static str = "utxoset";
+const UTXOSET_UTXO_SUBDIR: &'static str = "utxo";
+
+struct HashOnlyMMRHandle {
+	backend: HashOnlyMMRBackend,
+	last_pos: u64,
+}
+
+impl HashOnlyMMRHandle {
+	fn new(root_dir: &str, sub_dir: &str, file_name: &str) -> Result<HashOnlyMMRHandle, Error> {
+		let path = Path::new(root_dir).join(sub_dir).join(file_name);
+		fs::create_dir_all(path.clone())?;
+		let backend = HashOnlyMMRBackend::new(path.to_str().unwrap())?;
+		let last_pos = backend.unpruned_size()?;
+		Ok(HashOnlyMMRHandle { backend, last_pos })
+	}
+}
+
+/// MMR over the UTXO set.
+pub struct UTXOSet {
+	pmmr_h: HashOnlyMMRHandle,
+}
+
+impl UTXOSet {
+	pub fn open(
+		root_dir: String,
+	) -> Result<UTXOSet, Error> {
+		Ok(UTXOSet {
+			pmmr_h: HashOnlyMMRHandle::new(
+				&root_dir,
+				UTXOSET_SUBDIR,
+				UTXOSET_UTXO_SUBDIR,
+			)?,
+		})
+	}
+}
+
+pub fn extending<'a, F, T>(utxo_set: &'a mut UTXOSet, inner: F) -> Result<T, Error>
+where
+	F: FnOnce(&mut Extension) -> Result<T, Error>,
+{
+	let res = {
+		let mut extension = Extension::new(utxo_set);
+		inner(&mut extension)
+	};
+
+	utxo_set.pmmr_h.backend.discard();
+
+	res
+}
+
+pub struct Extension<'a> {
+	pmmr: DBPMMR<'a, UTXOEntry, HashOnlyMMRBackend>,
+}
+
+impl<'a> Extension<'a> {
+	fn new(utxo: &'a mut UTXOSet) -> Extension<'a> {
+		Extension {
+			pmmr: DBPMMR::at(
+				&mut utxo.pmmr_h.backend,
+				utxo.pmmr_h.last_pos,
+			)
+		}
+	}
+
+	pub fn root(&self) -> Hash {
+		self.pmmr.root()
+	}
+
+	pub fn truncate(&mut self) -> Result<(), Error> {
+		debug!("Truncating utxo_set extension.");
+		self.pmmr.rewind(0).map_err(&ErrorKind::TxHashSetErr)?;
+		Ok(())
+	}
+
+	fn apply_entry(&mut self, entry: &UTXOEntry) -> Result<(u64), Error> {
+		let pos = self
+			.pmmr
+			.push(entry)
+			.map_err(&ErrorKind::TxHashSetErr)?;
+		Ok(pos)
+	}
+
+	pub fn rebuild(&mut self, utxo_view: &UTXOView) -> Result<(), Error> {
+		debug!("*** rebuild: rebuilding the utxo_set (rewinding aka truncating to pos 0 first).");
+		// Trucate the extension (back to pos 0).
+		self.truncate()?;
+
+		for n in 1..utxo_view.size() + 1 {
+			if pmmr::is_leaf(n) {
+				if let Some(out) = utxo_view.get(n) {
+					self.apply_entry(&UTXOEntry::Unspent(out))?;
+				} else {
+					self.apply_entry(&UTXOEntry::Spent)?;
+				}
+			}
+		}
+		Ok(())
+	}
+}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -14,6 +14,7 @@
 
 //! Lightweight readonly view into output MMR for convenience.
 
+use core::core::hash::Hash;
 use core::core::pmmr::ReadonlyPMMR;
 use core::core::{Block, Input, Output, OutputIdentifier, Transaction};
 
@@ -28,12 +29,25 @@ pub struct UTXOView<'a> {
 }
 
 impl<'a> UTXOView<'a> {
-	/// Build a new UTXO view.
+	/// Build a new readonly UTXO view.
 	pub fn new(
 		pmmr: ReadonlyPMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
 		batch: &'a Batch,
 	) -> UTXOView<'a> {
 		UTXOView { pmmr, batch }
+	}
+
+	/// The size of the MMR (this is *not* the size of the UTXO set).
+	pub fn size(&self) -> u64 {
+		self.pmmr.unpruned_size()
+	}
+
+	pub fn root(&self) -> Hash {
+		self.pmmr.root()
+	}
+
+	pub fn get(&self, pos: u64) -> Option<OutputIdentifier> {
+		self.pmmr.get_data(pos)
 	}
 
 	/// Validate a block against the current UTXO set.

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -17,8 +17,8 @@
 use std::marker;
 
 use core::hash::{Hash, ZERO_HASH};
-use core::pmmr::{peaks, is_leaf, Backend};
-use ser::{PMMRable, PMMRIndexHashable};
+use core::pmmr::{is_leaf, peaks, Backend};
+use ser::{PMMRIndexHashable, PMMRable};
 
 /// Readonly view of a PMMR.
 pub struct ReadonlyPMMR<'a, T, B>

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -26,7 +26,7 @@ use core::hash::Hashed;
 use core::verifier_cache::VerifierCache;
 use core::{committed, Committed};
 use keychain::{self, BlindingFactor};
-use ser::{self, read_multi, FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
+use ser::{self, read_multi, FixedLength, HashOnlyPMMRable, PMMRable, Readable, Reader, Writeable, Writer};
 use util;
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::secp::{self, Message, Signature};
@@ -1108,6 +1108,24 @@ impl Output {
 			Ok(_) => Ok(()),
 			Err(e) => Err(e),
 		}
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum UTXOEntry {
+	Spent,
+	Unspent(OutputIdentifier),
+}
+
+impl HashOnlyPMMRable for UTXOEntry {}
+
+impl Writeable for UTXOEntry {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		match self {
+			UTXOEntry::Spent => writer.write_fixed_bytes(&[0; 32])?,
+			UTXOEntry::Unspent(out) => out.write(writer)?,
+		}
+		Ok(())
 	}
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -26,7 +26,9 @@ use core::hash::Hashed;
 use core::verifier_cache::VerifierCache;
 use core::{committed, Committed};
 use keychain::{self, BlindingFactor};
-use ser::{self, read_multi, FixedLength, HashOnlyPMMRable, PMMRable, Readable, Reader, Writeable, Writer};
+use ser::{
+	self, read_multi, FixedLength, HashOnlyPMMRable, PMMRable, Readable, Reader, Writeable, Writer,
+};
 use util;
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::secp::{self, Message, Signature};


### PR DESCRIPTION
Playing around with possible approaches/implementation for "UTXO commitments". Not sure if this would be useful in its current state.

This PR allows a parallel UTXO PMMR to be built alongside the existing output (aka TXO) PMMR.
Too expensive to do this in realtime so hooked it up to run on demand.

Also too complex to maintain in realtime to handle rewind, sync etc.

We can trigger a UTXO PMMR rebuild via the `/compact` API endpoint (easiest place to hook it into) -

```
curl -X POST 127.0.0.1:13413/v1/chain/compact
```

```
...
2018-11-03T13:25:56.755685+00:00 DEBUG grin_chain::chain - Rebuilding UTXO set (experimental).
2018-11-03T13:25:56.755747+00:00 DEBUG grin_chain::txhashset::utxo_set - *** rebuild: rebuilding the utxo_set (rewinding aka truncating to pos 0 first).
2018-11-03T13:25:56.755758+00:00 DEBUG grin_chain::txhashset::utxo_set - Truncating utxo_set extension.
2018-11-03T13:25:56.794249+00:00 WARN grin_chain::chain - ********** UTXO root: 21025ec4 (output root: f0e58c30)
...
```

Approx 40ms to rebuild the UTXO MMR in testnet4 based on the existing output MMR (can be pruned/compacted). This is rebuilding from scratch with no thought put into optimizing this.

The existing output MMR is "append only". spending an output does not change the data in the MMR and will not affect the root of the MMR. Only by appending new outputs to the MMR will the root change.
We can prune and compact the output MMR and leave the root unaffected by removing spent outputs.

To construct the UTXO MMR we simply replace spent outputs with a "zero" sentinel value.
Each leaf is then hashed via `hash_with_index("zero", pos)`.
The interesting thing is these can roll-up to parent nodes in a deterministic way.
For example, if pos 1 and pos 2 are both spent we can hash them as - 

* hash<sub>1</sub> = hash_with_index("zero", 1)
* hash<sub>2</sub> = hash_with_index("zero", 2)

and the parent node at pos 3 can be generated as before -

* hash<sub>3</sub> = hash_with_index((hash<sub>1</sub>, hash<sub>2</sub>), 3)

And we can recreate the hash at pos 3 without needing to know anything about the underlying data beyond them both having been removed/spent.

Related - https://github.com/mimblewimble/grin/issues/1883 (@tromp suggested "zeroing out" spent commitments to fix the spent hash "malleability").
Related - https://github.com/mimblewimble/grin/issues/1733 (proof of "unspentness")

Inspiration from - https://petertodd.org/2016/delayed-txo-commitments (Delayed TXO commitments).

Thinking out loud - 
Maybe we don't need to do this in realtime - maybe there are ways we can do this in a "delayed" fashion. We commit to the UTXO MMR every 60 blocks (hourly) or 1,440 blocks (daily) say.
This would allow us to generate a Merkle proof for any unspent output older than a day, for example.
Nodes could generate proofs for their own outputs by maintaining some subset of the UTXO MMR.
Nodes could verify this without needing to maintain the full UTXO set etc.

Thoughts? @tromp @ignopeverell  


