### PR TITLE
use hash_file abstraction for pmmr backend

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -64,7 +64,7 @@ impl HashOnlyMMRHandle {
 		let path = Path::new(root_dir).join(sub_dir).join(file_name);
 		fs::create_dir_all(path.clone())?;
 		let backend = HashOnlyMMRBackend::new(path.to_str().unwrap())?;
-		let last_pos = backend.unpruned_size()?;
+		let last_pos = backend.unpruned_size();
 		Ok(HashOnlyMMRHandle { backend, last_pos })
 	}
 }
@@ -85,7 +85,7 @@ impl<T: PMMRable> PMMRHandle<T> {
 		let path = Path::new(root_dir).join(sub_dir).join(file_name);
 		fs::create_dir_all(path.clone())?;
 		let backend = PMMRBackend::new(path.to_str().unwrap().to_string(), prunable, header)?;
-		let last_pos = backend.unpruned_size()?;
+		let last_pos = backend.unpruned_size();
 		Ok(PMMRHandle { backend, last_pos })
 	}
 }

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -313,11 +313,8 @@ impl<T: PMMRable> PMMRBackend<T> {
 				pos as u64 - 1 - shift
 			});
 
-			self.hash_file.save_prune(
-				tmp_prune_file_hash.clone(),
-				&off_to_rm,
-				&prune_noop,
-			)?;
+			self.hash_file
+				.save_prune(tmp_prune_file_hash.clone(), &off_to_rm, &prune_noop)?;
 		}
 
 		// 2. Save compact copy of the data file, skipping removed leaves.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -71,7 +71,8 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		}
 		self.data_file.append(&mut ser::ser_vec(&data).unwrap());
 		for h in &hashes {
-			self.hash_file.append(h)
+			self.hash_file
+				.append(h)
 				.map_err(|e| format!("Failed to append hash to file. {}", e))?;
 		}
 		Ok(())
@@ -138,7 +139,8 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 		// Rewind the hash file accounting for pruned/compacted pos
 		let shift = self.prune_list.get_shift(position);
-		self.hash_file.rewind(position - shift)
+		self.hash_file
+			.rewind(position - shift)
 			.map_err(|e| format!("Failed to rewind hash file. {}", e))?;
 
 		// Rewind the data file accounting for pruned/compacted pos

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -88,9 +88,26 @@ impl HashFile {
 		self.file.discard()
 	}
 
-	/// Size of the hash file in bytes.
-	pub fn size(&self) -> io::Result<u64> {
-		self.file.size()
+	/// Size of the hash file in number of hashes (not bytes).
+	pub fn size(&self) -> u64 {
+		self.file.size() / Hash::LEN as u64
+	}
+
+	pub fn size_unsync(&self) -> u64 {
+		self.file.size_unsync() / Hash::LEN as u64
+	}
+
+	pub fn save_prune<T>(
+		&self,
+		target: String,
+		prune_offs: &[u64],
+		prune_cb: T,
+	) -> io::Result<()>
+	where
+		T: Fn(&[u8]),
+	{
+		let prune_offs = prune_offs.iter().map(|x| x * Hash::LEN as u64).collect::<Vec<_>>();
+		self.file.save_prune(target, prune_offs.as_slice(), Hash::LEN as u64, prune_cb)
 	}
 }
 
@@ -127,12 +144,11 @@ impl AppendOnlyFile {
 			buffer: vec![],
 			buffer_start_bak: 0,
 		};
-		// if we have a non-empty file then mmap it.
-		if let Ok(sz) = aof.size() {
-			if sz > 0 {
-				aof.buffer_start = sz as usize;
-				aof.mmap = Some(unsafe { memmap::Mmap::map(&aof.file)? });
-			}
+		// If we have a non-empty file then mmap it.
+		let sz = aof.size();
+		if sz > 0 {
+			aof.buffer_start = sz as usize;
+			aof.mmap = Some(unsafe { memmap::Mmap::map(&aof.file)? });
 		}
 		Ok(aof)
 	}
@@ -306,8 +322,8 @@ impl AppendOnlyFile {
 	}
 
 	/// Current size of the file in bytes.
-	pub fn size(&self) -> io::Result<u64> {
-		fs::metadata(&self.path).map(|md| md.len())
+	pub fn size(&self) -> u64 {
+		fs::metadata(&self.path).map(|md| md.len()).unwrap_or(0)
 	}
 
 	/// Current size of the (unsynced) file in bytes.

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -93,10 +93,12 @@ impl HashFile {
 		self.file.size() / Hash::LEN as u64
 	}
 
+	/// Size of the unsync'd hash file, in hashes (not bytes).
 	pub fn size_unsync(&self) -> u64 {
 		self.file.size_unsync() / Hash::LEN as u64
 	}
 
+	/// Rewrite the hash file out to disk, pruning removed hashes.
 	pub fn save_prune<T>(&self, target: String, prune_offs: &[u64], prune_cb: T) -> io::Result<()>
 	where
 		T: Fn(&[u8]),

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -97,17 +97,16 @@ impl HashFile {
 		self.file.size_unsync() / Hash::LEN as u64
 	}
 
-	pub fn save_prune<T>(
-		&self,
-		target: String,
-		prune_offs: &[u64],
-		prune_cb: T,
-	) -> io::Result<()>
+	pub fn save_prune<T>(&self, target: String, prune_offs: &[u64], prune_cb: T) -> io::Result<()>
 	where
 		T: Fn(&[u8]),
 	{
-		let prune_offs = prune_offs.iter().map(|x| x * Hash::LEN as u64).collect::<Vec<_>>();
-		self.file.save_prune(target, prune_offs.as_slice(), Hash::LEN as u64, prune_cb)
+		let prune_offs = prune_offs
+			.iter()
+			.map(|x| x * Hash::LEN as u64)
+			.collect::<Vec<_>>();
+		self.file
+			.save_prune(target, prune_offs.as_slice(), Hash::LEN as u64, prune_cb)
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -248,7 +248,7 @@ fn pmmr_reload() {
 			.unwrap();
 		backend.sync().unwrap();
 
-		assert_eq!(backend.unpruned_size().unwrap(), mmr_size);
+		assert_eq!(backend.unpruned_size(), mmr_size);
 
 		// prune some more to get rm log data
 		{
@@ -256,14 +256,14 @@ fn pmmr_reload() {
 			pmmr.prune(5).unwrap();
 		}
 		backend.sync().unwrap();
-		assert_eq!(backend.unpruned_size().unwrap(), mmr_size);
+		assert_eq!(backend.unpruned_size(), mmr_size);
 	}
 
 	// create a new backend referencing the data files
 	// and check everything still works as expected
 	{
 		let mut backend = store::pmmr::PMMRBackend::new(data_dir.to_string(), true, None).unwrap();
-		assert_eq!(backend.unpruned_size().unwrap(), mmr_size);
+		assert_eq!(backend.unpruned_size(), mmr_size);
 		{
 			let pmmr: PMMR<TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root());
@@ -397,7 +397,7 @@ fn pmmr_rewind() {
 	assert_eq!(backend.get_data(9), Some(elems[5]));
 	assert_eq!(backend.get_hash(9), Some(elems[5].hash_with_index(8)));
 
-	assert_eq!(backend.data_size().unwrap(), 2);
+	assert_eq!(backend.data_size(), 2);
 
 	{
 		let mut pmmr: PMMR<TestElem, _> = PMMR::at(&mut backend, 10);
@@ -419,7 +419,7 @@ fn pmmr_rewind() {
 
 	// check we have no data in the backend after
 	// pruning, compacting and rewinding
-	assert_eq!(backend.data_size().unwrap(), 0);
+	assert_eq!(backend.data_size(), 0);
 
 	teardown(data_dir);
 }
@@ -510,8 +510,8 @@ fn pmmr_compact_horizon() {
 
 	// 0010012001001230
 	// 9 leaves
-	assert_eq!(backend.data_size().unwrap(), 19);
-	assert_eq!(backend.hash_size().unwrap(), 35);
+	assert_eq!(backend.data_size(), 19);
+	assert_eq!(backend.hash_size(), 35);
 
 	let pos_1_hash = backend.get_hash(1).unwrap();
 	let pos_2_hash = backend.get_hash(2).unwrap();
@@ -589,8 +589,8 @@ fn pmmr_compact_horizon() {
 		let backend =
 			store::pmmr::PMMRBackend::<TestElem>::new(data_dir.to_string(), true, None).unwrap();
 
-		assert_eq!(backend.data_size().unwrap(), 19);
-		assert_eq!(backend.hash_size().unwrap(), 35);
+		assert_eq!(backend.data_size(), 19);
+		assert_eq!(backend.hash_size(), 35);
 
 		// check we can read a hash by pos correctly from recreated backend
 		assert_eq!(backend.get_hash(7), Some(pos_7_hash));
@@ -625,8 +625,8 @@ fn pmmr_compact_horizon() {
 
 		// 0010012001001230
 
-		assert_eq!(backend.data_size().unwrap(), 13);
-		assert_eq!(backend.hash_size().unwrap(), 27);
+		assert_eq!(backend.data_size(), 13);
+		assert_eq!(backend.hash_size(), 27);
 
 		// check we can read a hash by pos correctly from recreated backend
 		// get_hash() and get_from_file() should return the same value


### PR DESCRIPTION
We introduced a `HashFile` wrapping an `AppendOnlyFile` for the header MMR backend.

This PR uses this `Hashfile` as part of the regular PMMR backend for consistency.

Also made the various `size()` calls on the backend return a simple `u64` and not an `io::Result<u64>` (just default to `0` if the file is missing etc.)

