### PR TITLE
Chain send sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -156,9 +156,6 @@ pub struct Chain {
 	genesis: BlockHeader,
 }
 
-unsafe impl Sync for Chain {}
-unsafe impl Send for Chain {}
-
 impl Chain {
 	/// Initializes the blockchain and returns a new Chain instance. Does a
 	/// check on the current chain head to make sure it exists and creates one

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -115,7 +115,7 @@ impl ser::Readable for Tip {
 /// Bridge between the chain pipeline and the rest of the system. Handles
 /// downstream processing of valid blocks by the rest of the system, most
 /// importantly the broadcasting of blocks to our peers.
-pub trait ChainAdapter {
+pub trait ChainAdapter: Send + Sync {
 	/// The blockchain pipeline has accepted this block as valid and added
 	/// it to our chain.
 	fn block_accepted(&self, b: &Block, opts: Options);

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -13,8 +13,8 @@
 
 //! Implementation of the persistent Backend for the prunable MMR tree.
 
-use std::{fs, io, marker};
 use std::sync::Arc;
+use std::{fs, io, marker};
 
 use croaring::Bitmap;
 
@@ -212,7 +212,10 @@ impl<T: PMMRable> PMMRBackend<T> {
 		}
 
 		let leaf_set = Arc::new(RwLock::new(LeafSet::open(&leaf_set_path)?));
-		let prune_list = Arc::new(RwLock::new(PruneList::open(&format!("{}/{}", data_dir, PMMR_PRUN_FILE))?));
+		let prune_list = Arc::new(RwLock::new(PruneList::open(&format!(
+			"{}/{}",
+			data_dir, PMMR_PRUN_FILE
+		))?));
 
 		Ok(PMMRBackend {
 			data_dir,


### PR DESCRIPTION
Chain does not need to be explicitly `Send + Sync`.

We can make this far more granular by wrapping `prune_list` and `leaf_set` in `Arc<RwLock<<_>>` and making the `PMMRBackend` itself `Send + Sync`.

`ChainAdaptor` needs to be `Send + Sync` to keep the api router code happy.

