### PR TITLE
Add fuzz tests for p2p crate

### DIFF
--- a/p2p/fuzz/Cargo.toml
+++ b/p2p/fuzz/Cargo.toml
@@ -1,0 +1,63 @@
+
+[package]
+name = "grin_p2p-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.grin_p2p]
+path = ".."
+[dependencies.grin_core]
+path = "../../core"
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "read_msg_header"
+path = "fuzz_targets/read_msg_header.rs"
+[[bin]]
+name = "read_hand"
+path = "fuzz_targets/read_hand.rs"
+[[bin]]
+name = "read_shake"
+path = "fuzz_targets/read_shake.rs"
+[[bin]]
+name = "read_get_peer_addrs"
+path = "fuzz_targets/read_get_peer_addrs.rs"
+[[bin]]
+name = "read_peer_addrs"
+path = "fuzz_targets/read_peer_addrs.rs"
+[[bin]]
+name = "read_peer_error"
+path = "fuzz_targets/read_peer_error.rs"
+[[bin]]
+name = "read_sock_addr"
+path = "fuzz_targets/read_sock_addr.rs"
+[[bin]]
+name = "read_locator"
+path = "fuzz_targets/read_locator.rs"
+[[bin]]
+name = "read_headers"
+path = "fuzz_targets/read_headers.rs"
+[[bin]]
+name = "read_ping"
+path = "fuzz_targets/read_ping.rs"
+[[bin]]
+name = "read_pong"
+path = "fuzz_targets/read_pong.rs"
+[[bin]]
+name = "read_ban_reason"
+path = "fuzz_targets/read_ban_reason.rs"
+[[bin]]
+name = "read_tx_hashset_request"
+path = "fuzz_targets/read_tx_hashset_request.rs"
+[[bin]]
+name = "read_tx_hashset_archive"
+path = "fuzz_targets/read_tx_hashset_archive.rs"

--- a/p2p/fuzz/README.md
+++ b/p2p/fuzz/README.md
@@ -1,0 +1,38 @@
+# Fuzz testing
+
+## Installation
+You have to use Rust nightly at the moment.
+Cargo-fuzz (https://github.com/rust-fuzz/cargo-fuzz) has been used. 
+To install it:
+
+```
+cargo install cargo-fuzz
+```
+
+## Pattern generation for corpus
+This step is optional, libFuzz will generate random patterns to populate
+corpus (in folder `corpus`). However we can genearete more meaningful pattern 
+e.g. use serialized form of a real block or transaction. To generate them:
+
+```
+cd fuzz
+
+cargo run --bin  gen-corpus
+```
+
+## Run tests
+Fuzz test is basically infinite test, run it for some period of time then
+stop if no failures are found.
+To run the tests make sure you are in the folder `p2p` otherwise you may get 
+some misleading errors, then run one of the following tests:
+
+```
+cargo fuzz run <fuzz_test_name>
+
+```
+
+Run
+```
+cargo fuzz list
+```
+or check `fuzz/Cargo.toml` for the full list of targets.

--- a/p2p/fuzz/fuzz_targets/read_ban_reason.rs
+++ b/p2p/fuzz/fuzz_targets/read_ban_reason.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::BanReason;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<BanReason, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_get_peer_addrs.rs
+++ b/p2p/fuzz/fuzz_targets/read_get_peer_addrs.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::GetPeerAddrs;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<GetPeerAddrs, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_hand.rs
+++ b/p2p/fuzz/fuzz_targets/read_hand.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Hand;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Hand, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_headers.rs
+++ b/p2p/fuzz/fuzz_targets/read_headers.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Headers;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Headers, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_locator.rs
+++ b/p2p/fuzz/fuzz_targets/read_locator.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Locator;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Locator, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_msg_header.rs
+++ b/p2p/fuzz/fuzz_targets/read_msg_header.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::MsgHeader;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<MsgHeader, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_peer_addrs.rs
+++ b/p2p/fuzz/fuzz_targets/read_peer_addrs.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::PeerAddrs;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<PeerAddrs, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_peer_error.rs
+++ b/p2p/fuzz/fuzz_targets/read_peer_error.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::PeerError;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<PeerError, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_ping.rs
+++ b/p2p/fuzz/fuzz_targets/read_ping.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Ping;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Ping, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_pong.rs
+++ b/p2p/fuzz/fuzz_targets/read_pong.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Pong;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Pong, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_shake.rs
+++ b/p2p/fuzz/fuzz_targets/read_shake.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::Shake;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<Shake, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_sock_addr.rs
+++ b/p2p/fuzz/fuzz_targets/read_sock_addr.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::SockAddr;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<SockAddr, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_tx_hashset_archive.rs
+++ b/p2p/fuzz/fuzz_targets/read_tx_hashset_archive.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::TxHashSetArchive;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<TxHashSetArchive, ser::Error> = ser::deserialize(&mut d);
+});

--- a/p2p/fuzz/fuzz_targets/read_tx_hashset_request.rs
+++ b/p2p/fuzz/fuzz_targets/read_tx_hashset_request.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate grin_core;
+extern crate grin_p2p;
+
+use grin_core::ser;
+use grin_p2p::msg::TxHashSetRequest;
+
+fuzz_target!(|data: &[u8]| {
+	let mut d = data.clone();
+	let _t: Result<TxHashSetRequest, ser::Error> = ser::deserialize(&mut d);
+});


### PR DESCRIPTION
So far found issues with reading `Hand`, `PeerAddress`, `SockAddr`