### PR TITLE
Fix IPV6 address deserialization

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -29,7 +29,15 @@ macro_rules! map_vec {
 #[macro_export]
 macro_rules! try_map_vec {
 	($thing:expr, $mapfn:expr) => {
-		$thing.iter().map($mapfn).collect::<Result<Vec<_>, _>>()?;
+		try_iter_map_vec!($thing.iter(), $mapfn);
+	};
+}
+
+/// Same as try_map_vec when thing is an iterator
+#[macro_export]
+macro_rules! try_iter_map_vec {
+	($thing:expr, $mapfn:expr) => {
+		$thing.map($mapfn).collect::<Result<Vec<_>, _>>()?;
 	};
 }
 

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -551,7 +551,7 @@ impl Readable for SockAddr {
 				port,
 			))))
 		} else {
-			let ip = try_map_vec!([0..8], |_| reader.read_u16());
+			let ip = try_iter_map_vec!(0..8, |_| reader.read_u16());
 			let port = reader.read_u16()?;
 			Ok(SockAddr(SocketAddr::V6(SocketAddrV6::new(
 				Ipv6Addr::new(ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7]),


### PR DESCRIPTION
Fuzz test found that we don't read IPV6 addr (as part of p2p message)
properly. The code is supposed to read 8 dwords, but [0..8] is not a
slice of 8 ints, but a slice of one Range, so we always read just one
dword