### PR TITLE
[WIP] Thread-safe access to internal bitmaps in Chain

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -144,7 +144,7 @@ impl OrphanBlockPool {
 pub struct Chain {
 	db_root: String,
 	store: Arc<store::ChainStore>,
-	adapter: Arc<ChainAdapter>,
+	adapter: Arc<ChainAdapter + Send + Sync>,
 	orphans: Arc<OrphanBlockPool>,
 	txhashset: Arc<RwLock<txhashset::TxHashSet>>,
 	// Recently processed blocks to avoid double-processing
@@ -163,7 +163,7 @@ impl Chain {
 	pub fn init(
 		db_root: String,
 		db_env: Arc<lmdb::Environment>,
-		adapter: Arc<ChainAdapter>,
+		adapter: Arc<ChainAdapter + Send + Sync>,
 		genesis: Block,
 		pow_verifier: fn(&BlockHeader, u8) -> Result<(), pow::Error>,
 		verifier_cache: Arc<RwLock<VerifierCache>>,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -156,9 +156,6 @@ pub struct Chain {
 	genesis: BlockHeader,
 }
 
-unsafe impl Sync for Chain {}
-unsafe impl Send for Chain {}
-
 impl Chain {
 	/// Initializes the blockchain and returns a new Chain instance. Does a
 	/// check on the current chain head to make sure it exists and creates one
@@ -910,7 +907,8 @@ impl Chain {
 		if outputs.0 != rangeproofs.0 || outputs.1.len() != rangeproofs.1.len() {
 			return Err(ErrorKind::TxHashSetErr(String::from(
 				"Output and rangeproof sets don't match",
-			)).into());
+			))
+			.into());
 		}
 		let mut output_vec: Vec<Output> = vec![];
 		for (ref x, &y) in outputs.1.iter().zip(rangeproofs.1.iter()) {

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -16,7 +16,6 @@
 //! that exist and are not currently pruned in the MMR.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use croaring::Bitmap;
 

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -16,6 +16,7 @@
 //! that exist and are not currently pruned in the MMR.
 
 use std::path::Path;
+use std::sync::Mutex;
 
 use croaring::Bitmap;
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -24,7 +24,7 @@ use core::ser::{self, PMMRable};
 use leaf_set::LeafSet;
 use prune_list::PruneList;
 use types::{prune_noop, AppendOnlyFile, HashFile};
-use util::Mutex;
+use util::RwLock;
 
 const PMMR_HASH_FILE: &str = "pmmr_hash.bin";
 const PMMR_DATA_FILE: &str = "pmmr_data.bin";
@@ -55,7 +55,7 @@ pub struct PMMRBackend<T: PMMRable> {
 	prunable: bool,
 	hash_file: HashFile,
 	data_file: AppendOnlyFile,
-	data: Mutex<FragileData>,
+	data: RwLock<FragileData>,
 	_marker: marker::PhantomData<T>,
 }
 
@@ -66,8 +66,8 @@ struct FragileData {
 // FragileData contains multiple Bitmaps inside. "CRoaring library has no built-in thread support. Thus
 // whenever you modify a bitmap in one thread, it is unsafe to query it in others. It is safe however
 // to query bitmaps (without modifying them) from several distinct threads, as long as you do not use
-// the copy-on-write attribute." So it's sase to use it under Mutex. The only place when we use
-// FragileData is PMMRBackend, guarded by Mutex. To miminimize amount of unsafe code Sync and Send
+// the copy-on-write attribute." So it's sase to use it under RwLock. The only place when we use
+// FragileData is PMMRBackend, guarded by RwLock. To miminimize amount of unsafe code Sync and Send
 // are implemented for FragileData
 unsafe impl Sync for FragileData {}
 unsafe impl Send for FragileData {}
@@ -78,7 +78,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	#[allow(unused_variables)]
 	fn append(&mut self, data: T, hashes: Vec<Hash>) -> Result<(), String> {
 		if self.prunable {
-			let mut data = self.data.lock();
+			let mut data = self.data.write();
 			let shift = data.prune_list.get_total_shift();
 			let position = self.hash_file.size_unsync() + shift + 1;
 			data.leaf_set.add(position);
@@ -96,7 +96,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.is_compacted(position) {
 			return None;
 		}
-		let shift = self.data.lock().prune_list.get_shift(position);
+		let shift = self.data.read().prune_list.get_shift(position);
 		self.hash_file.read(position - shift)
 	}
 
@@ -104,7 +104,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.is_compacted(position) {
 			return None;
 		}
-		let shift = self.data.lock().prune_list.get_leaf_shift(position);
+		let shift = self.data.read().prune_list.get_leaf_shift(position);
 		let pos = pmmr::n_leaves(position) - 1;
 
 		// Must be on disk, doing a read at the correct position
@@ -126,7 +126,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Return None if pos is a leaf and it has been removed (or pruned or
 	/// compacted).
 	fn get_hash(&self, pos: u64) -> Option<(Hash)> {
-		if self.prunable && pmmr::is_leaf(pos) && !self.data.lock().leaf_set.includes(pos) {
+		if self.prunable && pmmr::is_leaf(pos) && !self.data.read().leaf_set.includes(pos) {
 			return None;
 		}
 		self.get_from_file(pos)
@@ -138,7 +138,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if !pmmr::is_leaf(pos) {
 			return None;
 		}
-		if self.prunable && !self.data.lock().leaf_set.includes(pos) {
+		if self.prunable && !self.data.read().leaf_set.includes(pos) {
 			return None;
 		}
 		self.get_data_from_file(pos)
@@ -147,7 +147,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Rewind the PMMR backend to the given position.
 	fn rewind(&mut self, position: u64, rewind_rm_pos: &Bitmap) -> Result<(), String> {
 		// First rewind the leaf_set with the necessary added and removed positions.
-		let mut data = self.data.lock();
+		let mut data = self.data.write();
 		if self.prunable {
 			data.leaf_set.rewind(position, rewind_rm_pos);
 		}
@@ -170,7 +170,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Remove by insertion position.
 	fn remove(&mut self, pos: u64) -> Result<(), String> {
 		assert!(self.prunable, "Remove on non-prunable MMR");
-		self.data.lock().leaf_set.remove(pos);
+		self.data.write().leaf_set.remove(pos);
 		Ok(())
 	}
 
@@ -181,7 +181,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	fn snapshot(&self, header: &BlockHeader) -> Result<(), String> {
 		self.data
-			.lock()
+			.write()
 			.leaf_set
 			.snapshot(header)
 			.map_err(|_| format!("Failed to save copy of leaf_set for {}", header.hash()))?;
@@ -190,7 +190,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	fn dump_stats(&self) {
 		let unpruned_size = self.unpruned_size();
-		let data = self.data.lock();
+		let data = self.data.read();
 		debug!(
 			"pmmr backend: unpruned: {}, hashes: {}, data: {}, leaf_set: {}, prune_list: {}",
 			unpruned_size,
@@ -224,7 +224,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 
 		let leaf_set = LeafSet::open(&leaf_set_path)?;
 		let prune_list = PruneList::open(&format!("{}/{}", data_dir, PMMR_PRUN_FILE))?;
-		let data = Mutex::new(FragileData {
+		let data = RwLock::new(FragileData {
 			leaf_set,
 			prune_list,
 		});
@@ -240,22 +240,22 @@ impl<T: PMMRable> PMMRBackend<T> {
 	}
 
 	fn is_pruned(&self, pos: u64) -> bool {
-		self.data.lock().prune_list.is_pruned(pos)
+		self.data.read().prune_list.is_pruned(pos)
 	}
 
 	fn is_pruned_root(&self, pos: u64) -> bool {
-		self.data.lock().prune_list.is_pruned_root(pos)
+		self.data.read().prune_list.is_pruned_root(pos)
 	}
 
 	fn is_compacted(&self, pos: u64) -> bool {
-		let data = self.data.lock();
+		let data = self.data.read();
 		data.prune_list.is_pruned(pos) && !data.prune_list.is_pruned_root(pos)
 	}
 
 	/// Number of elements in the PMMR stored by this backend. Only produces the
 	/// fully sync'd size.
 	pub fn unpruned_size(&self) -> u64 {
-		let total_shift = self.data.lock().prune_list.get_total_shift();
+		let total_shift = self.data.read().prune_list.get_total_shift();
 		let sz = self.hash_file.size();
 		sz + total_shift
 	}
@@ -285,7 +285,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		}
 
 		// Flush the leaf_set to disk.
-		self.data.lock().leaf_set.flush()?;
+		self.data.write().leaf_set.flush()?;
 
 		Ok(())
 	}
@@ -293,7 +293,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 	/// Discard the current, non synced state of the backend.
 	pub fn discard(&mut self) {
 		self.hash_file.discard();
-		self.data.lock().leaf_set.discard();
+		self.data.write().leaf_set.discard();
 		self.data_file.discard();
 	}
 
@@ -333,7 +333,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		// on the cutoff_pos provided.
 		let (leaves_removed, pos_to_rm) = self.pos_to_rm(cutoff_pos, rewind_rm_pos);
 
-		let mut data = self.data.lock();
+		let mut data = self.data.write();
 
 		// 1. Save compact copy of the hash file, skipping removed data.
 		{
@@ -401,7 +401,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		let mut expanded = Bitmap::create();
 
 		let leaf_pos_to_rm = {
-			let data = self.data.lock();
+			let data = self.data.write();
 			data.leaf_set
 				.removed_pre_cutoff(cutoff_pos, rewind_rm_pos, &data.prune_list)
 		};


### PR DESCRIPTION
Externalize all data structures with bitmaps (which are non thread-safe)  and wrap it into RwLock. Bitmaps support RwLock semantics (one writer or multiple readers). Also move unsafe Send/Sync implementation from Chain to this new data structure (FragileData) to decrease the surface of unsafe code. So instead of assuming that Chain is thread-safe we delegate this check to rust compiler and just assume that all non thread-safe code is in Fragile data, guarded by RwLock.