### PR TITLE
fix the lock on the new mutex

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -285,6 +285,7 @@ impl Peer {
 			self.connection
 				.as_ref()
 				.unwrap()
+				.lock()
 				.send(h, msg::Type::TransactionKernel)?;
 			Ok(true)
 		} else {
@@ -359,6 +360,7 @@ impl Peer {
 		self.connection
 			.as_ref()
 			.unwrap()
+			.lock()
 			.send(&h, msg::Type::GetTransaction)
 	}
 


### PR DESCRIPTION
#1929 broke master, fixing (the merge missed a couple of uses of the new mutex).