### PR TITLE
Fix capabilities

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -132,7 +132,7 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::FULL_NODE,
+			capabilities: Capabilities::HEADER_HIST | Capabilities::TXHASHSET_HIST | Capabilities::PEER_LIST,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -132,7 +132,9 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::HEADER_HIST | Capabilities::TXHASHSET_HIST | Capabilities::PEER_LIST,
+			capabilities: Capabilities::HEADER_HIST
+				| Capabilities::TXHASHSET_HIST
+				| Capabilities::PEER_LIST,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,


### PR DESCRIPTION
So we cannot safely add a new `capability` (and enable it) as old nodes do not recognize this and will not successfully connect as peers.

This PR fixes this problem by not enabling the new capability by default.

