### PR TITLE
Capabilities now deserialize safely

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -362,7 +362,7 @@ impl Writeable for Hand {
 impl Readable for Hand {
 	fn read(reader: &mut Reader) -> Result<Hand, ser::Error> {
 		let (version, capab, nonce) = ser_multiread!(reader, read_u32, read_u32, read_u64);
-		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
+		let capabilities = Capabilities::from_bits_truncate(capab);
 		let total_diff = Difficulty::read(reader)?;
 		let sender_addr = SockAddr::read(reader)?;
 		let receiver_addr = SockAddr::read(reader)?;
@@ -415,7 +415,7 @@ impl Writeable for Shake {
 impl Readable for Shake {
 	fn read(reader: &mut Reader) -> Result<Shake, ser::Error> {
 		let (version, capab) = ser_multiread!(reader, read_u32, read_u32);
-		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
+		let capabilities = Capabilities::from_bits_truncate(capab);
 		let total_diff = Difficulty::read(reader)?;
 		let ua = reader.read_vec()?;
 		let user_agent = String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData)?;
@@ -445,7 +445,7 @@ impl Writeable for GetPeerAddrs {
 impl Readable for GetPeerAddrs {
 	fn read(reader: &mut Reader) -> Result<GetPeerAddrs, ser::Error> {
 		let capab = reader.read_u32()?;
-		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
+		let capabilities = Capabilities::from_bits_truncate(capab);
 		Ok(GetPeerAddrs { capabilities })
 	}
 }

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -91,7 +91,7 @@ impl Readable for PeerData {
 			lc.unwrap()
 		};
 		let user_agent = String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData)?;
-		let capabilities = Capabilities::from_bits(capab).ok_or(ser::Error::CorruptedData)?;
+		let capabilities = Capabilities::from_bits_truncate(capab);
 		let ban_reason = ReasonForBan::from_i32(br).ok_or(ser::Error::CorruptedData)?;
 
 		match State::from_u8(fl) {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -216,8 +216,11 @@ bitflags! {
 		/// but we do not advertise this to other nodes.
 		const FULL_NODE = Capabilities::HEADER_HIST.bits
 			| Capabilities::TXHASHSET_HIST.bits
-			| Capabilities::PEER_LIST.bits
-			| Capabilities::TX_KERNEL_HASH.bits;
+			| Capabilities::PEER_LIST.bits;
+
+		// TODO - we cannot include TX_KERNEL_HASH in FULL_NODE right now
+		// as legacy nodes do not recognise these Capabilities safely.
+		// | Capabilities::TX_KERNEL_HASH.bits;
 	}
 }
 

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -55,19 +55,24 @@ fn test_capabilities() {
 	);
 
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b1111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b0111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b00000111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b11111111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b11110111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b00100111 as u32),
+		p2p::types::Capabilities::FULL_NODE
+	);
+
 	assert_eq!(
 		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32),
-		p2p::types::Capabilities::FULL_NODE
+		p2p::types::Capabilities::FULL_NODE | p2p::types::Capabilities::TX_KERNEL_HASH
 	);
 }

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -45,11 +45,29 @@ fn test_type_enum() {
 
 #[test]
 fn test_capabilities() {
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00000000 as u32), p2p::types::Capabilities::UNKNOWN);
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b10000000 as u32), p2p::types::Capabilities::UNKNOWN);
-	
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b1111 as u32), p2p::types::Capabilities::FULL_NODE);
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32), p2p::types::Capabilities::FULL_NODE);
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b11111111 as u32), p2p::types::Capabilities::FULL_NODE);
-	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32), p2p::types::Capabilities::FULL_NODE);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b00000000 as u32),
+		p2p::types::Capabilities::UNKNOWN
+	);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b10000000 as u32),
+		p2p::types::Capabilities::UNKNOWN
+	);
+
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b1111 as u32),
+		p2p::types::Capabilities::FULL_NODE
+	);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32),
+		p2p::types::Capabilities::FULL_NODE
+	);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b11111111 as u32),
+		p2p::types::Capabilities::FULL_NODE
+	);
+	assert_eq!(
+		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32),
+		p2p::types::Capabilities::FULL_NODE
+	);
 }

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -42,3 +42,14 @@ fn test_reason_for_ban_enum() {
 fn test_type_enum() {
 	assert_eq!(p2p::msg::Type::from_i32(0), Some(p2p::msg::Type::Error));
 }
+
+#[test]
+fn test_capabilities() {
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00000000 as u32), p2p::types::Capabilities::UNKNOWN);
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b10000000 as u32), p2p::types::Capabilities::UNKNOWN);
+	
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b1111 as u32), p2p::types::Capabilities::FULL_NODE);
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32), p2p::types::Capabilities::FULL_NODE);
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b11111111 as u32), p2p::types::Capabilities::FULL_NODE);
+	assert_eq!(p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32), p2p::types::Capabilities::FULL_NODE);
+}


### PR DESCRIPTION
Resolves #1945.

This allows us to be more flexible adding capabilities via previously unused bits without peers treating us as corrupted.