### PR TITLE
Add "User Agent" column to peers in TUI

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -141,6 +141,8 @@ pub struct PeerStats {
 	pub addr: String,
 	/// version running
 	pub version: u32,
+	/// Peer user agent string.
+	pub user_agent: String,
 	/// difficulty reported by peer
 	pub total_difficulty: u64,
 	/// height reported by peer on ping
@@ -181,7 +183,8 @@ impl PeerStats {
 		PeerStats {
 			state: state.to_string(),
 			addr: addr,
-			version: peer.info.version,
+			version: peer.info.version.clone(),
+			user_agent: peer.info.user_agent.clone(),
 			total_difficulty: peer.info.total_difficulty().to_num(),
 			height: peer.info.height(),
 			direction: direction.to_string(),

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -39,6 +39,7 @@ enum PeerColumn {
 	TotalDifficulty,
 	Direction,
 	Version,
+	UserAgent,
 }
 
 impl PeerColumn {
@@ -50,6 +51,7 @@ impl PeerColumn {
 			PeerColumn::Version => "Version",
 			PeerColumn::TotalDifficulty => "Total Difficulty",
 			PeerColumn::Direction => "Direction",
+			PeerColumn::UserAgent => "User Agent",
 		}
 	}
 }
@@ -77,6 +79,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			).to_string(),
 			PeerColumn::Direction => self.direction.clone(),
 			PeerColumn::Version => self.version.to_string(),
+			PeerColumn::UserAgent => self.user_agent.clone(),
 		}
 	}
 
@@ -104,6 +107,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::TotalDifficulty => self.total_difficulty.cmp(&other.total_difficulty),
 			PeerColumn::Direction => self.direction.cmp(&other.direction),
 			PeerColumn::Version => self.version.cmp(&other.version),
+			PeerColumn::UserAgent => self.user_agent.cmp(&other.user_agent),
 		}
 	}
 }
@@ -116,11 +120,12 @@ impl TUIStatusListener for TUIPeerView {
 			.column(PeerColumn::Address, "Address", |c| c.width_percent(16))
 			.column(PeerColumn::State, "State", |c| c.width_percent(8))
 			.column(PeerColumn::UsedBandwidth, "Used bandwidth", |c| {
-				c.width_percent(24)
+				c.width_percent(16)
 			}).column(PeerColumn::Direction, "Direction", |c| c.width_percent(8))
 			.column(PeerColumn::TotalDifficulty, "Total Difficulty", |c| {
 				c.width_percent(24)
-			}).column(PeerColumn::Version, "Version", |c| c.width_percent(16));
+			}).column(PeerColumn::Version, "Version", |c| c.width_percent(8))
+			.column(PeerColumn::UserAgent, "User Agent", |c| c.width_percent(16));
 		let peer_status_view = BoxView::with_full_screen(
 			LinearLayout::new(Orientation::Vertical)
 				.child(


### PR DESCRIPTION
Provides a way to visually see the state of an upgrade on the network, at least approximately based on _our_ peers.

Related #1947.

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Grin Version 0.4.0                                                                                                                                                                                                  │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────┐┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Basic Status      ││                                                                                                                                                                                                │
│Peers and Sync    ││ Total Peers: 12                                                                                                                                                                                │
│Mining            ││ Longest Chain: 1812925434 D @ 32139 H vs Us: 1812925434 D @ 32139 H                                                                                                                            │
│Version Info      ││                                                                                                                                                                                                │
│                  ││ ┌────────────────────────────────────────────────────────────────────────────────────┤ Connected Peers ├─────────────────────────────────────────────────────────────────────────────────────┐ │
│                  ││ │ Address                    [ ] ╷ State       [ ] ╷ Used bandwidth             [ ] ╷ Direction   [ ] ╷ Total Difficulty                          [ ] ╷ Version     [ ] ╷ User Agent     [^] │ │
│                  ││ │ ───────────────────────────────┴─────────────────┴────────────────────────────────┴─────────────────┴───────────────────────────────────────────────┴─────────────────┴─────────────────── │ │
│                  ││ │ 54.38.70.127:13414             ┆ Connected       ┆ S: 8 B, R: 24 B                ┆ Outbound        ┆ 1812925434 D @ 32139 H (4s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 80.211.155.34:13414            ┆ Connected       ┆ S: 8 B, R: 10 B                ┆ Outbound        ┆ 1812855128 D @ 32138 H (6s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 81.30.158.213:13414            ┆ Connected       ┆ S: 8 B, R: 3 B                 ┆ Outbound        ┆ 1856000 D @ 0 H (6s)                          ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 98.227.41.238:13414            ┆ Connected       ┆ S: 1 B, R: 3 B                 ┆ Outbound        ┆ 1856000 D @ 0 H (6s)                          ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 89.101.91.246:13414            ┆ Connected       ┆ S: 2 B, R: 53 B                ┆ Outbound        ┆ 1812925434 D @ 32139 H (5s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 212.183.189.246:13414          ┆ Connected       ┆ S: 8 B, R: 3 B                 ┆ Outbound        ┆ 1812855128 D @ 32138 H (6s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 204.48.26.36:13414             ┆ Connected       ┆ S: 17 B, R: 45 B               ┆ Outbound        ┆ 1812855128 D @ 32138 H (5s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 167.99.87.54:13414             ┆ Connected       ┆ S: 4 B, R: 174 B               ┆ Outbound        ┆ 1812855128 D @ 32138 H (6s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 109.74.202.16:13414            ┆ Connected       ┆ S: 8 B, R: 3 B                 ┆ Outbound        ┆ 1812925434 D @ 32139 H (3s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 51.15.219.12:13414             ┆ Connected       ┆ S: 8 B, R: 3 B                 ┆ Outbound        ┆ 1812855128 D @ 32138 H (6s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 198.245.50.26:13414            ┆ Connected       ┆ S: 8 B, R: 3 B                 ┆ Outbound        ┆ 1812925434 D @ 32139 H (1s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │ 167.99.53.226:13414            ┆ Connected       ┆ S: 2 B, R: 79 B                ┆ Outbound        ┆ 1812925434 D @ 32139 H (4s)                   ┆ 1               ┆ MW/Grin 0.4.0      │ │
│                  ││ │                                                                                                                                                                                            │ │
│                  ││ │                                                                                                                                                                                            │ │
│------------------││ │                                                                                                                                                                                            │ │
│Tab/Arrow : Cycle ││ │                                                                                                                                                                                            │ │
│Enter     : Select││ └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘ │
│Q         : Quit  ││                                                                                                                                                                                                │
└──────────────────┘└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```


