### PR TITLE
bump 0.4.0 -> 0.4.1 (tx kernel broadcast support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -667,14 +667,14 @@ dependencies = [
  "cursive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 0.4.0",
- "grin_config 0.4.0",
- "grin_core 0.4.0",
- "grin_keychain 0.4.0",
- "grin_p2p 0.4.0",
- "grin_servers 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_api 0.4.1",
+ "grin_config 0.4.1",
+ "grin_core 0.4.1",
+ "grin_keychain 0.4.1",
+ "grin_p2p 0.4.1",
+ "grin_servers 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,17 +686,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 0.4.0",
- "grin_core 0.4.0",
- "grin_p2p 0.4.0",
- "grin_pool 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
+ "grin_chain 0.4.1",
+ "grin_core 0.4.1",
+ "grin_p2p 0.4.1",
+ "grin_pool 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,11 +726,11 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 0.4.0",
- "grin_keychain 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_core 0.4.1",
+ "grin_keychain 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_p2p 0.4.0",
- "grin_servers 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_p2p 0.4.1",
+ "grin_servers 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,9 +766,9 @@ dependencies = [
  "croaring 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_keychain 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -782,12 +782,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 0.4.0",
+ "grin_util 0.4.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -801,16 +801,16 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 0.4.0",
- "grin_pool 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
+ "grin_core 0.4.1",
+ "grin_pool 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -822,16 +822,16 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 0.4.0",
- "grin_core 0.4.0",
- "grin_keychain 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_chain 0.4.1",
+ "grin_core 0.4.1",
+ "grin_keychain 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,22 +854,22 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 0.4.0",
- "grin_chain 0.4.0",
- "grin_config 0.4.0",
- "grin_core 0.4.0",
- "grin_keychain 0.4.0",
- "grin_p2p 0.4.0",
- "grin_pool 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
- "grin_wallet 0.4.0",
+ "grin_api 0.4.1",
+ "grin_chain 0.4.1",
+ "grin_config 0.4.1",
+ "grin_core 0.4.1",
+ "grin_keychain 0.4.1",
+ "grin_p2p 0.4.1",
+ "grin_pool 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
+ "grin_wallet 0.4.1",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -893,8 +893,8 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 0.4.0",
- "grin_util 0.4.0",
+ "grin_core 0.4.1",
+ "grin_util 0.4.1",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -933,12 +933,12 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 0.4.0",
- "grin_chain 0.4.0",
- "grin_core 0.4.0",
- "grin_keychain 0.4.0",
- "grin_store 0.4.0",
- "grin_util 0.4.0",
+ "grin_api 0.4.1",
+ "grin_chain 0.4.1",
+ "grin_core 0.4.1",
+ "grin_keychain 0.4.1",
+ "grin_store 0.4.1",
+ "grin_util 0.4.1",
  "hyper 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,14 +30,14 @@ serde_json = "1"
 log = "0.4"
 term = "0.5"
 
-grin_api = { path = "./api", version = "0.4.0" }
-grin_config = { path = "./config", version = "0.4.0" }
-grin_core = { path = "./core", version = "0.4.0" }
-grin_keychain = { path = "./keychain", version = "0.4.0" }
-grin_p2p = { path = "./p2p", version = "0.4.0" }
-grin_servers = { path = "./servers", version = "0.4.0" }
-grin_util = { path = "./util", version = "0.4.0" }
-grin_wallet = { path = "./wallet", version = "0.4.0" }
+grin_api = { path = "./api", version = "0.4.1" }
+grin_config = { path = "./config", version = "0.4.1" }
+grin_core = { path = "./core", version = "0.4.1" }
+grin_keychain = { path = "./keychain", version = "0.4.1" }
+grin_p2p = { path = "./p2p", version = "0.4.1" }
+grin_servers = { path = "./servers", version = "0.4.1" }
+grin_util = { path = "./util", version = "0.4.1" }
+grin_wallet = { path = "./wallet", version = "0.4.1" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ serde_json = "1"
 log = "0.4"
 tokio = "0.1.7"
 tokio-core = "0.1.17"
-tokio-tcp = "0.1" 
+tokio-tcp = "0.1"
 tokio-rustls = "0.7"
 http = "0.1.5"
 hyper-rustls = "0.14"
@@ -30,9 +30,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "0.4.0" }
-grin_chain = { path = "../chain", version = "0.4.0" }
-grin_p2p = { path = "../p2p", version = "0.4.0" }
-grin_pool = { path = "../pool", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_chain = { path = "../chain", version = "0.4.1" }
+grin_p2p = { path = "../p2p", version = "0.4.1" }
+grin_pool = { path = "../pool", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,12 +22,12 @@ serde_derive = "1"
 chrono = "0.4.4"
 lru-cache = "0.1"
 
-grin_core = { path = "../core", version = "0.4.0" }
-grin_keychain = { path = "../keychain", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_keychain = { path = "../keychain", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet", version = "0.4.0" }
+grin_wallet = { path = "../wallet", version = "0.4.1" }
 env_logger = "0.5"
 rand = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_servers = { path = "../servers", version = "0.4.0" }
-grin_p2p = { path = "../p2p", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
-grin_wallet = { path = "../wallet", version = "0.4.0" }
+grin_servers = { path = "../servers", version = "0.4.1" }
+grin_p2p = { path = "../p2p", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
+grin_wallet = { path = "../wallet", version = "0.4.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -24,4 +24,4 @@ hmac = "0.6"
 ripemd160 = "0.7"
 sha2 = "0.7"
 
-grin_util = { path = "../util", version = "0.4.0" }
+grin_util = { path = "../util", version = "0.4.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,9 +22,9 @@ serde_derive = "1"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "0.4.0" }
+grin_pool = { path = "../pool", version = "0.4.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -17,11 +17,11 @@ serde_derive = "1"
 log = "0.4"
 chrono = "0.4.4"
 
-grin_core = { path = "../core", version = "0.4.0" }
-grin_keychain = { path = "../keychain", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_keychain = { path = "../keychain", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet", version = "0.4.0" }
-grin_chain = { path = "../chain", version = "0.4.0" }
+grin_wallet = { path = "../wallet", version = "0.4.1" }
+grin_chain = { path = "../chain", version = "0.4.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,16 +25,16 @@ chrono = "0.4.4"
 bufstream = "~0.1"
 jsonrpc-core = "~8.0"
 
-grin_api = { path = "../api", version = "0.4.0" }
-grin_chain = { path = "../chain", version = "0.4.0" }
-grin_core = { path = "../core", version = "0.4.0" }
-grin_keychain = { path = "../keychain", version = "0.4.0" }
-grin_p2p = { path = "../p2p", version = "0.4.0" }
-grin_pool = { path = "../pool", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
-grin_wallet = { path = "../wallet", version = "0.4.0" }
+grin_api = { path = "../api", version = "0.4.1" }
+grin_chain = { path = "../chain", version = "0.4.1" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_keychain = { path = "../keychain", version = "0.4.1" }
+grin_p2p = { path = "../p2p", version = "0.4.1" }
+grin_pool = { path = "../pool", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
+grin_wallet = { path = "../wallet", version = "0.4.1" }
 
 [dev-dependencies]
 blake2-rfc = "0.2"
-grin_config = { path = "../config", version = "0.4.0" }
+grin_config = { path = "../config", version = "0.4.1" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,8 +22,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,12 +30,12 @@ uuid = { version = "0.6", features = ["serde", "v4"] }
 url = "1.7.0"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_api = { path = "../api", version = "0.4.0" }
-grin_core = { path = "../core", version = "0.4.0" }
-grin_keychain = { path = "../keychain", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
-grin_util = { path = "../util", version = "0.4.0" }
+grin_api = { path = "../api", version = "0.4.1" }
+grin_core = { path = "../core", version = "0.4.1" }
+grin_keychain = { path = "../keychain", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }
+grin_util = { path = "../util", version = "0.4.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "0.4.0" }
-grin_store = { path = "../store", version = "0.4.0" }
+grin_chain = { path = "../chain", version = "0.4.1" }
+grin_store = { path = "../store", version = "0.4.1" }


### PR DESCRIPTION
Related #1947.
Related #1949.
Once we see a majority of peers on 0.4.1 we should be safe to enable `TX_KERNEL_HASH` in our capabilities.