### PR TITLE
refactor secp errors in transaction

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1090,7 +1090,8 @@ impl Output {
 	/// Validates the range proof using the commitment
 	pub fn verify_proof(&self) -> Result<(), Error> {
 		let secp = static_secp_instance();
-		secp.lock().verify_bullet_proof(self.commit, self.proof, None)?;
+		secp.lock()
+			.verify_bullet_proof(self.commit, self.proof, None)?;
 		Ok(())
 	}
 
@@ -1100,7 +1101,8 @@ impl Output {
 		proofs: &Vec<RangeProof>,
 	) -> Result<(), Error> {
 		let secp = static_secp_instance();
-		secp.lock().verify_bullet_proof_multi(commits.clone(), proofs.clone(), None)?;
+		secp.lock()
+			.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None)?;
 		Ok(())
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1088,26 +1088,20 @@ impl Output {
 	}
 
 	/// Validates the range proof using the commitment
-	pub fn verify_proof(&self) -> Result<(), secp::Error> {
+	pub fn verify_proof(&self) -> Result<(), Error> {
 		let secp = static_secp_instance();
-		let secp = secp.lock();
-		match secp.verify_bullet_proof(self.commit, self.proof, None) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e),
-		}
+		secp.lock().verify_bullet_proof(self.commit, self.proof, None)?;
+		Ok(())
 	}
 
 	/// Batch validates the range proofs using the commitments
 	pub fn batch_verify_proofs(
 		commits: &Vec<Commitment>,
 		proofs: &Vec<RangeProof>,
-	) -> Result<(), secp::Error> {
+	) -> Result<(), Error> {
 		let secp = static_secp_instance();
-		let secp = secp.lock();
-		match secp.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e),
-		}
+		secp.lock().verify_bullet_proof_multi(commits.clone(), proofs.clone(), None)?;
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Return transaction error results and not secp error results for -

  * `verify_proof()` 
  * `batch_verify_proofs()`

