### PR TITLE
replace ftruncate/ftruncate64 with a simple set_len() call

### DIFF
--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -250,17 +250,6 @@ impl AppendOnlyFile {
 		}
 	}
 
-	// /// Truncates the underlying file to the provided offset
-	// pub fn truncate(&self, offs: usize) -> io::Result<()> {
-	// 	let fd = self.file.as_raw_fd();
-	// 	let res = unsafe { ftruncate64(fd, offs as off64_t) };
-	// 	if res == -1 {
-	// 		Err(io::Error::last_os_error())
-	// 	} else {
-	// 		Ok(())
-	// 	}
-	// }
-
 	/// Saves a copy of the current file content, skipping data at the provided
 	/// prune indices. The prune Vec must be ordered.
 	pub fn save_prune<T>(

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -17,13 +17,7 @@ use memmap;
 use std::cmp;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
 use std::path::Path;
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-use libc::{ftruncate as ftruncate64, off_t as off64_t};
-#[cfg(any(target_os = "linux"))]
-use libc::{ftruncate64, off64_t};
 
 use core::core::hash::Hash;
 use core::ser::{self, FixedLength};
@@ -189,8 +183,8 @@ impl AppendOnlyFile {
 	/// written data accessible.
 	pub fn flush(&mut self) -> io::Result<()> {
 		if self.buffer_start_bak > 0 {
-			// flushing a rewound state, we need to truncate before applying
-			self.truncate(self.buffer_start)?;
+			// Flushing a rewound state, we need to truncate via set_len() before applying.
+			self.file.set_len(self.buffer_start as u64)?;
 			self.buffer_start_bak = 0;
 		}
 
@@ -256,16 +250,16 @@ impl AppendOnlyFile {
 		}
 	}
 
-	/// Truncates the underlying file to the provided offset
-	pub fn truncate(&self, offs: usize) -> io::Result<()> {
-		let fd = self.file.as_raw_fd();
-		let res = unsafe { ftruncate64(fd, offs as off64_t) };
-		if res == -1 {
-			Err(io::Error::last_os_error())
-		} else {
-			Ok(())
-		}
-	}
+	// /// Truncates the underlying file to the provided offset
+	// pub fn truncate(&self, offs: usize) -> io::Result<()> {
+	// 	let fd = self.file.as_raw_fd();
+	// 	let res = unsafe { ftruncate64(fd, offs as off64_t) };
+	// 	if res == -1 {
+	// 		Err(io::Error::last_os_error())
+	// 	} else {
+	// 		Ok(())
+	// 	}
+	// }
 
 	/// Saves a copy of the current file content, skipping data at the provided
 	/// prune indices. The prune Vec must be ordered.


### PR DESCRIPTION
Just took another look at our conditional `ftruncate/ftruncate64` stuff and now I'm wondering why we didn't just use `file.set_len()` originally...

Is there some reason that I'm missing that means we cannot just do this?

From the docs - 

https://doc.rust-lang.org/std/fs/struct.File.html#method.set_len

> Truncates or extends the underlying file, updating the size of this file to become size.
If the size is less than the current file's size, then the file will be shrunk. If it is greater than the current file's size, then the file will be extended to size and have all of the intermediate data filled in with 0s.
The file's cursor isn't changed. In particular, if the cursor was at the end and the file is shrunk using this operation, the cursor will now be past the end.