### PR TITLE
Do not use mem::size_of() when calculating serialized size of data

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -140,8 +140,7 @@ pub struct BlockHeader {
 	pub pow: ProofOfWork,
 }
 
-const FIXED_HEADER_SIZE: usize =
-	2 // version
+const FIXED_HEADER_SIZE: usize = 2 // version
 		+ 8 // height
 		+ 8 // timestamp
 		+ 5 * Hash::LEN // prev_hash, prev_root, output_root, range_proof_root, kernel_root

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -19,7 +19,6 @@ use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use std::collections::HashSet;
 use std::fmt;
 use std::iter::FromIterator;
-use std::mem;
 use std::sync::Arc;
 use util::RwLock;
 
@@ -35,7 +34,7 @@ use core::{
 use global;
 use keychain::{self, BlindingFactor};
 use pow::{Difficulty, Proof, ProofOfWork};
-use ser::{self, HashOnlyPMMRable, Readable, Reader, Writeable, Writer};
+use ser::{self, FixedLength, HashOnlyPMMRable, Readable, Reader, Writeable, Writer};
 use util::{secp, static_secp_instance};
 
 /// Errors thrown by Block validation
@@ -141,26 +140,27 @@ pub struct BlockHeader {
 	pub pow: ProofOfWork,
 }
 
+const FIXED_HEADER_SIZE: usize =
+	2 // version
+		+ 8 // height
+		+ 8 // timestamp
+		+ 5 * Hash::LEN // prev_hash, prev_root, output_root, range_proof_root, kernel_root
+		+ BlindingFactor::LEN // total_kernel_offset
+		+ 2 * 8 // output_mmr_size, kernel_mmr_size
+		+ Difficulty::LEN // total_difficulty
+		+ 4 // secondary_scaling
+		+ 8; // nonce
+
 /// Serialized size of fixed part of a BlockHeader, i.e. without pow
 fn fixed_size_of_serialized_header(_version: u16) -> usize {
-	let mut size: usize = 0;
-	size += mem::size_of::<u16>(); // version
-	size += mem::size_of::<u64>(); // height
-	size += mem::size_of::<i64>(); // timestamp
-	size += 5 * mem::size_of::<Hash>(); // prev_hash, prev_root, output_root, range_proof_root, kernel_root
-	size += mem::size_of::<BlindingFactor>(); // total_kernel_offset
-	size += 2 * mem::size_of::<u64>(); // output_mmr_size, kernel_mmr_size
-	size += mem::size_of::<Difficulty>(); // total_difficulty
-	size += mem::size_of::<u32>(); // secondary_scaling
-	size += mem::size_of::<u64>(); // nonce
-	size
+	FIXED_HEADER_SIZE
 }
 
 /// Serialized size of a BlockHeader
 pub fn serialized_size_of_header(version: u16, edge_bits: u8) -> usize {
 	let mut size = fixed_size_of_serialized_header(version);
 
-	size += mem::size_of::<u8>(); // pow.edge_bits
+	size += 1; // pow.edge_bits
 	let bitvec_len = global::proofsize() * edge_bits as usize;
 	size += bitvec_len / 8; // pow.nonces
 	if bitvec_len % 8 != 0 {
@@ -298,7 +298,7 @@ impl BlockHeader {
 	pub fn serialized_size(&self) -> usize {
 		let mut size = fixed_size_of_serialized_header(self.version);
 
-		size += mem::size_of::<u8>(); // pow.edge_bits
+		size += 1; // pow.edge_bits
 		let nonce_bits = self.pow.edge_bits() as usize;
 		let bitvec_len = global::proofsize() * nonce_bits;
 		size += bitvec_len / 8; // pow.nonces

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -23,7 +23,7 @@ use pow::siphash::siphash24;
 use std::hash::Hash;
 use std::io::Cursor;
 use std::ops::{BitOrAssign, Mul};
-use std::{fmt, mem};
+use std::fmt;
 
 /// Operations needed for edge type (going to be u32 or u64)
 pub trait EdgeType: PrimInt + ToPrimitive + Mul + BitOrAssign + Hash {}
@@ -82,7 +82,7 @@ pub fn set_header_nonce(header: &[u8], nonce: Option<u32>) -> Result<[u64; 4], E
 	if let Some(n) = nonce {
 		let len = header.len();
 		let mut header = header.to_owned();
-		header.truncate(len - mem::size_of::<u32>());
+		header.truncate(len - 4); // drop last 4 bytes (u32) off the end
 		header.write_u32::<LittleEndian>(n)?;
 		create_siphash_keys(&header)
 	} else {

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -20,10 +20,10 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use pow::error::{Error, ErrorKind};
 use pow::num::{PrimInt, ToPrimitive};
 use pow::siphash::siphash24;
+use std::fmt;
 use std::hash::Hash;
 use std::io::Cursor;
 use std::ops::{BitOrAssign, Mul};
-use std::fmt;
 
 /// Operations needed for edge type (going to be u32 or u64)
 pub trait EdgeType: PrimInt + ToPrimitive + Mul + BitOrAssign + Hash {}

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -24,7 +24,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use consensus::{graph_weight, SECOND_POW_EDGE_BITS, MIN_DIFFICULTY};
 use core::hash::Hashed;
 use global;
-use ser::{self, Readable, Reader, Writeable, Writer};
+use ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
 
 use pow::common::EdgeType;
 use pow::error::Error;
@@ -155,6 +155,10 @@ impl Readable for Difficulty {
 		let data = reader.read_u64()?;
 		Ok(Difficulty { num: data })
 	}
+}
+
+impl FixedLength for Difficulty {
+	const LEN: usize = 8;
 }
 
 impl Serialize for Difficulty {

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -21,7 +21,7 @@ use std::{fmt, iter};
 use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use consensus::{graph_weight, SECOND_POW_EDGE_BITS, MIN_DIFFICULTY};
+use consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
 use core::hash::Hashed;
 use global;
 use ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
@@ -66,12 +66,16 @@ impl Difficulty {
 
 	/// Difficulty of MIN_DIFFICULTY
 	pub fn min() -> Difficulty {
-		Difficulty { num: MIN_DIFFICULTY }
+		Difficulty {
+			num: MIN_DIFFICULTY,
+		}
 	}
 
 	/// Difficulty unit, which is the graph weight of minimal graph
 	pub fn unit() -> Difficulty {
-		Difficulty { num: global::initial_graph_weight() as u64 }
+		Difficulty {
+			num: global::initial_graph_weight() as u64,
+		}
 	}
 
 	/// Convert a `u32` into a `Difficulty`

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -22,12 +22,12 @@
 
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::mem::size_of;
 use std::net::TcpStream;
 use std::sync::{mpsc, Arc};
 use std::{cmp, thread, time};
 
 use core::ser;
+use core::ser::FixedLength;
 use msg::{read_body, read_exact, read_header, write_all, write_to_buf, MsgHeader, Type};
 use types::Error;
 use util::{RateCounter, RwLock};
@@ -259,7 +259,7 @@ fn poll<H>(
 					let received = received_bytes.clone();
 					{
 						let mut received_bytes = received_bytes.write();
-						received_bytes.inc(size_of::<MsgHeader>() as u64 + msg.header.msg_len);
+						received_bytes.inc(MsgHeader::LEN as u64 + msg.header.msg_len);
 					}
 
 					if let Some(Some(resp)) = try_break!(error_tx, handler.consume(msg, received)) {

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -23,7 +23,7 @@ use core::consensus;
 use core::core::hash::Hash;
 use core::core::BlockHeader;
 use core::pow::Difficulty;
-use core::ser::{self, Readable, Reader, Writeable, Writer};
+use core::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
 
 use types::{Capabilities, Error, ReasonForBan, MAX_BLOCK_HEADERS, MAX_LOCATORS, MAX_PEER_ADDRS};
 
@@ -35,9 +35,6 @@ pub const USER_AGENT: &'static str = concat!("MW/Grin ", env!("CARGO_PKG_VERSION
 
 /// Magic number expected in the header of every message
 const MAGIC: [u8; 2] = [0x54, 0x34];
-
-/// Size in bytes of a message header
-pub const HEADER_LEN: u64 = 11;
 
 /// Max theoretical size of a block filled with outputs.
 const MAX_BLOCK_SIZE: u64 =
@@ -197,7 +194,7 @@ pub fn write_all(conn: &mut Write, mut buf: &[u8], timeout: time::Duration) -> i
 /// underlying stream is async. Typically headers will be polled for, so
 /// we do not want to block.
 pub fn read_header(conn: &mut TcpStream, msg_type: Option<Type>) -> Result<MsgHeader, Error> {
-	let mut head = vec![0u8; HEADER_LEN as usize];
+	let mut head = vec![0u8; MsgHeader::LEN];
 	if Some(Type::Hand) == msg_type {
 		read_exact(conn, &mut head, time::Duration::from_millis(10), true)?;
 	} else {
@@ -284,11 +281,10 @@ impl MsgHeader {
 			msg_len: len,
 		}
 	}
+}
 
-	/// Serialized length of the header in bytes
-	pub fn serialized_len(&self) -> u64 {
-		HEADER_LEN
-	}
+impl FixedLength for MsgHeader {
+	const LEN: usize = 1 + 1 + 1 + 8;
 }
 
 impl Writeable for MsgHeader {


### PR DESCRIPTION
Resolves #1962.

We should not be using `mem::size_of()` to determine the _serialized_ size in bytes of various structs.
This is the size in bytes of the struct _in memory_ and _including alignment padding_.
This is _not_ the size in bytes of the serialized data.

From the docs - 

https://doc.rust-lang.org/std/mem/fn.size_of.html

> Returns the size of a type in bytes.
More specifically, this is the offset in bytes between successive elements in an array with that item type including alignment padding. Thus, for any type T and length n, [T; n] has a size of n * size_of::<T>().
In general, the size of a type is not stable across compilations, but specific types such as primitives are.

We are already using the `FixedLength` trait for various structs that we maintain in PMMRs.
So use the `FixedLength` trait to define known "lengths" of other serialized structs.
(We refactored `len()` out from `PMMRable` when we introduced the "hash only" MMR backed for the header MMR).

