### PR TITLE
ask for peers with PEER_LIST capability when asking for more peers

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -395,7 +395,7 @@ impl Peer {
 	}
 
 	pub fn send_peer_request(&self, capab: Capabilities) -> Result<(), Error> {
-		trace!("Asking {} for more peers.", self.info.addr);
+		trace!("Asking {} for more peers {:?}", self.info.addr, capab);
 		self.connection.as_ref().unwrap().lock().send(
 			&GetPeerAddrs {
 				capabilities: capab,


### PR DESCRIPTION
We were actually looking for peers with the _same_ capabilities as our local node when asking for more peers.
This meant we got into trouble whenever we modified or updated (or extended) our local capabilities (we had trouble finding "compatible" peers).
I think explains a couple of situations in the past when the network has effectively broken down (we changed what a `FULL_NODE` was and this cascaded into new nodes unable to find old nodes).

We now look for peers that advertise the `PEER_LIST` capability when asking for more peers. i.e. peers that can give us more peers.

At some point we will need to make our peer management more robust, so we maintain a good distribution of peers with various capabilities etc. But for now this improves the current situation.

