### PR TITLE
enable TX_KERNEL_HASH capability by default

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -132,9 +132,7 @@ impl Default for P2PConfig {
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,
-			capabilities: Capabilities::HEADER_HIST
-				| Capabilities::TXHASHSET_HIST
-				| Capabilities::PEER_LIST,
+			capabilities: Capabilities::FULL_NODE,
 			seeding_type: Seeding::default(),
 			seeds: None,
 			peers_allow: None,
@@ -214,13 +212,11 @@ bitflags! {
 		/// All nodes right now are "full nodes".
 		/// Some nodes internally may maintain longer block histories (archival_mode)
 		/// but we do not advertise this to other nodes.
+		/// All nodes by default will accept lightweight "kernel first" tx broadcast.
 		const FULL_NODE = Capabilities::HEADER_HIST.bits
 			| Capabilities::TXHASHSET_HIST.bits
-			| Capabilities::PEER_LIST.bits;
-
-		// TODO - we cannot include TX_KERNEL_HASH in FULL_NODE right now
-		// as legacy nodes do not recognise these Capabilities safely.
-		// | Capabilities::TX_KERNEL_HASH.bits;
+			| Capabilities::PEER_LIST.bits
+			| Capabilities::TX_KERNEL_HASH.bits;
 	}
 }
 

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -55,24 +55,29 @@ fn test_capabilities() {
 	);
 
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b0111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b1111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b00000111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b11110111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b11111111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b00100111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32),
 		p2p::types::Capabilities::FULL_NODE
 	);
 
-	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32),
-		p2p::types::Capabilities::FULL_NODE | p2p::types::Capabilities::TX_KERNEL_HASH
+	assert!(
+		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32)
+			.contains(p2p::types::Capabilities::FULL_NODE)
+	);
+
+	assert!(
+		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32)
+			.contains(p2p::types::Capabilities::TX_KERNEL_HASH)
 	);
 }


### PR DESCRIPTION
We have a pretty high ratio of `0.4.1` nodes on the network so I think its safe to enable the new `TX_KERNEL_HASH` capability by default.

This will allow other nodes to send "kernel first" (a single tx kernel hash) when broadcasting new txs.

This is one of the seed nodes running with this capability enabled -
 
```
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Grin Version 0.4.1                                                                                                                                                                                                           │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────┐┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Basic Status      ││                                                                                                                                                                                                         │
│Peers and Sync    ││ Total Peers: 18                                                                                                                                                                                         │
│Mining            ││ Longest Chain: 2138204944 D @ 37680 H vs Us: 2138204944 D @ 37680 H                                                                                                                                     │
│Version Info      ││                                                                                                                                                                                                         │
│                  ││ ┌─────────────────────────────────────────────────────────────────────────────────────────┤ Connected Peers ├─────────────────────────────────────────────────────────────────────────────────────────┐ │
│                  ││ │ Address                      [ ] ╷ State        [ ] ╷ Used bandwidth               [ ] ╷ Direction    [ ] ╷ Total Difficulty                            [ ] ╷ Ver      [ ] ╷ User Agent       [v]   │ │
│                  ││ │ ─────────────────────────────────┴──────────────────┴──────────────────────────────────┴──────────────────┴─────────────────────────────────────────────────┴──────────────┴──────────────────────  │ │
│                  ││ │ 163.172.177.250:13414            ┆ Connected        ┆ S: 12 B, R: 5 B                  ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        ▒ │ │
│                  ││ │ 52.23.180.2:13414                ┆ Connected        ┆ S: 12 B, R: 12 B                 ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        ▒ │ │
│                  ││ │ 217.182.192.59:13414             ┆ Connected        ┆ S: 6 B, R: 33 B                  ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        ▒ │ │
│                  ││ │ 198.245.50.26:13414              ┆ Connected        ┆ S: 5 B, R: 12 B                  ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        ▒ │ │
│                  ││ │ 109.74.202.16:13414              ┆ Connected        ┆ S: 12 B, R: 5 B                  ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        ▒ │ │
│                  ││ │ 95.216.193.239:13414             ┆ Connected        ┆ S: 5 B, R: 5 B                   ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        | │ │
│                  ││ │ 52.203.10.175:13414              ┆ Connected        ┆ S: 5 B, R: 12 B                  ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        | │ │
│                  ││ │ 74.214.154.211:13414             ┆ Connected        ┆ S: 5 B, R: 5 B                   ┆ Inbound          ┆ 1921815632 D @ 34065 H (3s)                     ┆ 1            ┆ MW/Grin 0.4.1        | │ │
│------------------││ │ 167.99.53.226:13414              ┆ Connected        ┆ S: 12 B, R: 12 B                 ┆ Inbound          ┆ 2138204944 D @ 37680 H (3s)                     ┆ 1            ┆ MW/Grin 0.4.1        | │ │
│Tab/Arrow : Cycle ││ │ 54.198.222.93:13414              ┆ Connected        ┆ S: 12 B, R: 12 B                 ┆ Outbound         ┆ 2138204944 D @ 37680 H (4s)                     ┆ 1            ┆ MW/Grin 0.4.1        | │ │
│Enter     : Select││ └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘ │
│Q         : Quit  ││                                                                                                                                                                                                         │
└──────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

And this is the node receiving a new tx on the network and broadcasting it on to its peers - 

```
20181113 12:00:35.285 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.286 DEBUG grin_p2p::peer - Requesting tx (kernel hash) 0a6c37d6 from peer 94.130.64.25:13414.
20181113 12:00:35.305 DEBUG grin_p2p::protocol - handle_payload: received tx: msg_len: 1672
20181113 12:00:35.305 DEBUG grin_servers::common::adapters - Received tx 9bc3d93f, inputs: 2, outputs: 2, kernels: 1, going to process.
20181113 12:00:35.309 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.311 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.314 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.315 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.319 DEBUG grin_pool::pool - add_to_pool [txpool]: 9bc3d93f (p2p), in/out/kern: 2/2/1, pool: 0 (at block 0678972b)
20181113 12:00:35.319 DEBUG grin_p2p::protocol - handle_payload: received tx kernel: 0a6c37d6, msg_len: 32
20181113 12:00:35.321 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 185.53.158.12:13414 (already seen)
20181113 12:00:35.321 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 54.38.70.127:13414 (already seen)
20181113 12:00:35.321 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 80.211.155.34:13414 (already seen)
20181113 12:00:35.321 DEBUG grin_p2p::peer - Send tx kernel hash 0a6c37d6 to 167.99.53.226:13414
20181113 12:00:35.321 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 54.90.220.136:13414
20181113 12:00:35.321 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 46.4.91.48:13414
20181113 12:00:35.321 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 52.203.10.175:13414
20181113 12:00:35.321 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 94.130.64.25:13414 (already seen)
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 74.214.154.211:13414
20181113 12:00:35.322 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 217.182.192.59:13414 (already seen)
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 54.198.222.93:13414
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 198.245.50.26:13414
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 52.23.180.2:13414
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 89.101.91.246:13414
20181113 12:00:35.322 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 95.216.193.239:13414
20181113 12:00:35.323 DEBUG grin_p2p::peer - Not sending tx 9bc3d93f to 109.74.202.16:13414 (already seen)
20181113 12:00:35.323 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 204.48.26.36:13414
20181113 12:00:35.323 DEBUG grin_p2p::peer - Send full tx 9bc3d93f to 163.172.177.250:13414
20181113 12:00:35.323 DEBUG grin_p2p::peers - broadcast_transaction: 9bc3d93f to 12 peers, done.
```

Logs are pretty noisy. We can quieten them down a bit once this has been running happily for a few days.