### PR TITLE
[WIP] minimum_confirmations = 10

### DIFF
--- a/servers/tests/framework/mod.rs
+++ b/servers/tests/framework/mod.rs
@@ -314,7 +314,7 @@ impl LocalServerContainer {
 		wallet.keychain = Some(keychain);
 		let parent_id = keychain::ExtKeychain::derive_key_id(2, 0, 0, 0, 0);
 		let _ = wallet::libwallet::internal::updater::refresh_outputs(&mut wallet, &parent_id);
-		wallet::libwallet::internal::updater::retrieve_info(&mut wallet, &parent_id).unwrap()
+		wallet::libwallet::internal::updater::retrieve_info(&mut wallet, &parent_id, 1).unwrap()
 	}
 
 	pub fn send_amount_to(

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -984,7 +984,7 @@ fn replicate_tx_fluff_failure() {
 	let wallet2 = create_wallet("target/tmp/tx_fluff/wallet2", client2.clone());
 
 	wallet::controller::owner_single_use(wallet2, |api| {
-		let res = api.retrieve_summary_info(true).unwrap();
+		let res = api.retrieve_summary_info(true, 1).unwrap();
 		assert_eq!(res.1.amount_currently_spendable, amount);
 		Ok(())
 	}).unwrap();

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -31,7 +31,6 @@ use keychain;
 use servers::start_webwallet_server;
 use util::file::get_first_line;
 
-
 pub fn _init_wallet_seed(wallet_config: WalletConfig) {
 	if let Err(_) = WalletSeed::from_file(&wallet_config) {
 		WalletSeed::init_file(&wallet_config).expect("Failed to create wallet seed file.");
@@ -437,9 +436,7 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 				let minimum_confirmations: u64 = args
 					.value_of("minimum_confirmations")
 					.ok_or_else(|| {
-						ErrorKind::GenericError(
-							"Minimum confirmations required".to_string(),
-						)
+						ErrorKind::GenericError("Minimum confirmations required".to_string())
 					}).and_then(|v| {
 						v.parse().map_err(|e| {
 							ErrorKind::GenericError(format!(
@@ -448,12 +445,14 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 							))
 						})
 					})?;
-				let (validated, wallet_info) = api.retrieve_summary_info(true, minimum_confirmations).map_err(|e| {
-					ErrorKind::GenericError(format!(
-						"Error getting wallet info: {:?} Config: {:?}",
-						e, wallet_config
-					))
-				})?;
+				let (validated, wallet_info) = api
+					.retrieve_summary_info(true, minimum_confirmations)
+					.map_err(|e| {
+						ErrorKind::GenericError(format!(
+							"Error getting wallet info: {:?} Config: {:?}",
+							e, wallet_config
+						))
+					})?;
 				display::info(
 					account,
 					&wallet_info,

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -216,7 +216,7 @@ fn real_main() -> i32 {
 				.help("Minimum number of confirmations required for an output to be spendable.")
 				.short("c")
 				.long("min_conf")
-				.default_value("1")
+				.default_value("10")
 				.takes_value(true))
 			.arg(Arg::with_name("selection_strategy")
 				.help("Coin/Output selection strategy.")
@@ -284,7 +284,7 @@ fn real_main() -> i32 {
 				.help("Minimum number of confirmations required for an output to be spendable.")
 				.short("c")
 				.long("min_conf")
-				.default_value("1")
+				.default_value("10")
 				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("outputs")
@@ -329,7 +329,13 @@ fn real_main() -> i32 {
 				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("info")
-			.about("basic wallet contents summary"))
+			.about("basic wallet contents summary")
+			.arg(Arg::with_name("minimum_confirmations")
+				.help("Minimum number of confirmations required for an output to be spendable.")
+				.short("c")
+				.long("min_conf")
+				.default_value("10")
+				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("init")
 			.about("Initialize a new wallet seed file and database.")

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -256,8 +256,7 @@ pub fn info(
 ) {
 	println!(
 		"\n____ Wallet Summary Info - Account '{}' as of height {} ____\n",
-		account,
-		wallet_info.last_confirmed_height,
+		account, wallet_info.last_confirmed_height,
 	);
 
 	let mut table = table!();

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::core::{self, amount_to_hr_string};
+use core::global;
 use libwallet::types::{AcctPathMapping, OutputData, OutputStatus, TxLogEntry, WalletInfo};
 use libwallet::Error;
 use prettytable;
@@ -255,26 +256,70 @@ pub fn info(
 ) {
 	println!(
 		"\n____ Wallet Summary Info - Account '{}' as of height {} ____\n",
-		account, wallet_info.last_confirmed_height
+		account,
+		wallet_info.last_confirmed_height,
 	);
-	let mut table = if dark_background_color_scheme {
-		table!(
-			[bFG->"Total", FG->amount_to_hr_string(wallet_info.total, false)],
-			[bFY->"Awaiting Confirmation", FY->amount_to_hr_string(wallet_info.amount_awaiting_confirmation, false)],
-			[bFY->"Immature Coinbase", FY->amount_to_hr_string(wallet_info.amount_immature, false)],
-			[bFG->"Currently Spendable", FG->amount_to_hr_string(wallet_info.amount_currently_spendable, false)],
-			[Fw->"--------------------------------", Fw->"-------------"],
-			[Fr->"(Locked by previous transaction)", Fr->amount_to_hr_string(wallet_info.amount_locked, false)]
-		)
+
+	let mut table = table!();
+
+	if dark_background_color_scheme {
+		table.add_row(row![
+			bFG->"Total",
+			FG->amount_to_hr_string(wallet_info.total, false)
+		]);
+		// Only dispay "Immature Coinbase" if we have related outputs in the wallet.
+		// This row just introduces confusion if the wallet does not receive coinbase rewards.
+		if wallet_info.amount_immature > 0 {
+			table.add_row(row![
+				bFY->format!("Immature Coinbase (< {})", global::coinbase_maturity()),
+				FY->amount_to_hr_string(wallet_info.amount_immature, false)
+			]);
+		}
+		table.add_row(row![
+			bFY->format!("Awaiting Confirmation (< {})", wallet_info.minimum_confirmations),
+			FY->amount_to_hr_string(wallet_info.amount_awaiting_confirmation, false)
+		]);
+		table.add_row(row![
+			Fr->"Locked by previous transaction",
+			Fr->amount_to_hr_string(wallet_info.amount_locked, false)
+		]);
+		table.add_row(row![
+			Fw->"--------------------------------",
+			Fw->"-------------"
+		]);
+		table.add_row(row![
+			bFG->"Currently Spendable",
+			FG->amount_to_hr_string(wallet_info.amount_currently_spendable, false)
+		]);
 	} else {
-		table!(
-			[bFG->"Total", FG->amount_to_hr_string(wallet_info.total, false)],
-			[bFB->"Awaiting Confirmation", FB->amount_to_hr_string(wallet_info.amount_awaiting_confirmation, false)],
-			[bFB->"Immature Coinbase", FB->amount_to_hr_string(wallet_info.amount_immature, false)],
-			[bFG->"Currently Spendable", FG->amount_to_hr_string(wallet_info.amount_currently_spendable, false)],
-			[Fw->"--------------------------------", Fw->"-------------"],
-			[Fr->"(Locked by previous transaction)", Fr->amount_to_hr_string(wallet_info.amount_locked, false)]
-		)
+		table.add_row(row![
+			bFG->"Total",
+			FG->amount_to_hr_string(wallet_info.total, false)
+		]);
+		// Only dispay "Immature Coinbase" if we have related outputs in the wallet.
+		// This row just introduces confusion if the wallet does not receive coinbase rewards.
+		if wallet_info.amount_immature > 0 {
+			table.add_row(row![
+				bFB->format!("Immature Coinbase (< {})", global::coinbase_maturity()),
+				FB->amount_to_hr_string(wallet_info.amount_immature, false)
+			]);
+		}
+		table.add_row(row![
+			bFB->format!("Awaiting Confirmation (< {})", wallet_info.minimum_confirmations),
+			FB->amount_to_hr_string(wallet_info.amount_awaiting_confirmation, false)
+		]);
+		table.add_row(row![
+			Fr->"Locked by previous transaction",
+			Fr->amount_to_hr_string(wallet_info.amount_locked, false)
+		]);
+		table.add_row(row![
+			Fw->"--------------------------------",
+			Fw->"-------------"
+		]);
+		table.add_row(row![
+			bFG->"Currently Spendable",
+			FG->amount_to_hr_string(wallet_info.amount_currently_spendable, false)
+		]);
 	};
 	table.set_format(*prettytable::format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
 	table.printstd();

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -127,6 +127,7 @@ where
 	pub fn retrieve_summary_info(
 		&mut self,
 		refresh_from_node: bool,
+		minimum_confirmations: u64,
 	) -> Result<(bool, WalletInfo), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
@@ -137,7 +138,7 @@ where
 			validated = self.update_outputs(&mut w);
 		}
 
-		let wallet_info = updater::retrieve_info(&mut *w, &parent_key_id)?;
+		let wallet_info = updater::retrieve_info(&mut *w, &parent_key_id, minimum_confirmations)?;
 		let res = Ok((validated, wallet_info));
 
 		w.close()?;

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -351,7 +351,7 @@ where
 				} else {
 					unspent_total += out.value;
 				}
-			},
+			}
 			OutputStatus::Unconfirmed => {
 				// We ignore unconfirmed coinbase outputs completely.
 				if !out.is_coinbase {
@@ -361,11 +361,11 @@ where
 						unconfirmed_total += out.value;
 					}
 				}
-			},
+			}
 			OutputStatus::Locked => {
 				locked_total += out.value;
-			},
-			OutputStatus::Spent => {},
+			}
+			OutputStatus::Spent => {}
 		}
 	}
 

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -323,6 +323,7 @@ where
 pub fn retrieve_info<T: ?Sized, C, K>(
 	wallet: &mut T,
 	parent_key_id: &Identifier,
+	minimum_confirmations: u64,
 ) -> Result<WalletInfo, Error>
 where
 	T: WalletBackend<C, K>,
@@ -338,23 +339,39 @@ where
 	let mut immature_total = 0;
 	let mut unconfirmed_total = 0;
 	let mut locked_total = 0;
+
 	for out in outputs {
-		if out.status == OutputStatus::Unspent && out.lock_height <= current_height {
-			unspent_total += out.value;
-		}
-		if out.status == OutputStatus::Unspent && out.lock_height > current_height {
-			immature_total += out.value;
-		}
-		if out.status == OutputStatus::Unconfirmed && !out.is_coinbase {
-			unconfirmed_total += out.value;
-		}
-		if out.status == OutputStatus::Locked {
-			locked_total += out.value;
+		match out.status {
+			OutputStatus::Unspent => {
+				if out.is_coinbase && out.lock_height > current_height {
+					immature_total += out.value;
+				} else if out.num_confirmations(current_height) < minimum_confirmations {
+					// Treat anything less than minimum confirmations as "unconfirmed".
+					unconfirmed_total += out.value;
+				} else {
+					unspent_total += out.value;
+				}
+			},
+			OutputStatus::Unconfirmed => {
+				// We ignore unconfirmed coinbase outputs completely.
+				if !out.is_coinbase {
+					if minimum_confirmations == 0 {
+						unspent_total += out.value;
+					} else {
+						unconfirmed_total += out.value;
+					}
+				}
+			},
+			OutputStatus::Locked => {
+				locked_total += out.value;
+			},
+			OutputStatus::Spent => {},
 		}
 	}
 
 	Ok(WalletInfo {
 		last_confirmed_height: current_height,
+		minimum_confirmations,
 		total: unspent_total + unconfirmed_total + immature_total,
 		amount_awaiting_confirmation: unconfirmed_total,
 		amount_immature: immature_total,

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -519,6 +519,8 @@ pub struct CbData {
 pub struct WalletInfo {
 	/// height from which info was taken
 	pub last_confirmed_height: u64,
+	/// Minimum number of confirmations for an output to be treated as "spendable".
+	pub minimum_confirmations: u64,
 	/// total amount in the wallet
 	pub total: u64,
 	/// amount awaiting confirmation

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -31,7 +31,6 @@ use core::ser;
 use keychain::{Identifier, Keychain};
 
 use libtx::aggsig;
-use libtx::slate::Slate;
 use libwallet::error::{Error, ErrorKind};
 
 use util::secp::key::{PublicKey, SecretKey};

--- a/wallet/tests/accounts.rs
+++ b/wallet/tests/accounts.rs
@@ -128,7 +128,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Should have 5 in account1 (5 spendable), 5 in account (2 spendable)
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, 12);
 		assert_eq!(wallet1_info.total, 5 * reward);
@@ -145,9 +145,9 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	}
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
 		// check last confirmed height on this account is different from above (should be 0)
-		let (_, wallet1_info) = api.retrieve_summary_info(false)?;
+		let (_, wallet1_info) = api.retrieve_summary_info(false, 1)?;
 		assert_eq!(wallet1_info.last_confirmed_height, 0);
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, 12);
 		assert_eq!(wallet1_info.total, 7 * reward);
@@ -164,9 +164,9 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		w.set_parent_key_id_by_name("default")?;
 	}
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (_, wallet1_info) = api.retrieve_summary_info(false)?;
+		let (_, wallet1_info) = api.retrieve_summary_info(false, 1)?;
 		assert_eq!(wallet1_info.last_confirmed_height, 0);
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, 12);
 		assert_eq!(wallet1_info.total, 0,);
@@ -199,7 +199,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, 13);
 		let (_, txs) = api.retrieve_txs(true, None, None)?;
@@ -213,9 +213,9 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		w.set_parent_key_id_by_name("account2")?;
 	}
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (_, wallet1_info) = api.retrieve_summary_info(false)?;
+		let (_, wallet1_info) = api.retrieve_summary_info(false, 1)?;
 		assert_eq!(wallet1_info.last_confirmed_height, 12);
-		let (_, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (_, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert_eq!(wallet1_info.last_confirmed_height, 13);
 		let (_, txs) = api.retrieve_txs(true, None, None)?;
 		println!("{:?}", txs);
@@ -225,7 +225,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// wallet 2 should only have this tx on the listener account
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet2_refreshed);
 		assert_eq!(wallet2_info.last_confirmed_height, 13);
 		let (_, txs) = api.retrieve_txs(true, None, None)?;
@@ -238,9 +238,9 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		w.set_parent_key_id_by_name("default")?;
 	}
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let (_, wallet2_info) = api.retrieve_summary_info(false)?;
+		let (_, wallet2_info) = api.retrieve_summary_info(false, 1)?;
 		assert_eq!(wallet2_info.last_confirmed_height, 0);
-		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet2_refreshed);
 		assert_eq!(wallet2_info.last_confirmed_height, 13);
 		assert_eq!(wallet2_info.total, 0,);

--- a/wallet/tests/file.rs
+++ b/wallet/tests/file.rs
@@ -99,7 +99,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Should have 5 in account1 (5 spendable), 5 in account (2 spendable)
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward);
@@ -151,7 +151,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check total in mining account
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward - reward * 2);
@@ -160,7 +160,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check total in 'wallet 2' account
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet2_refreshed);
 		assert_eq!(wallet2_info.last_confirmed_height, bh);
 		assert_eq!(wallet2_info.total, 2 * reward);

--- a/wallet/tests/restore.rs
+++ b/wallet/tests/restore.rs
@@ -73,7 +73,7 @@ fn restore_wallet(base_dir: &str, wallet_dir: &str) -> Result<(), libwallet::Err
 	// perform the restore and update wallet info
 	wallet::controller::owner_single_use(wallet.clone(), |api| {
 		let _ = api.restore()?;
-		let _ = api.retrieve_summary_info(true)?;
+		let _ = api.retrieve_summary_info(true, 1)?;
 		Ok(())
 	})?;
 
@@ -135,14 +135,14 @@ fn compare_wallet_restore(
 
 	// Overall wallet info should be the same
 	wallet::controller::owner_single_use(wallet_source.clone(), |api| {
-		src_info = Some(api.retrieve_summary_info(true)?.1);
+		src_info = Some(api.retrieve_summary_info(true, 1)?.1);
 		src_txs = Some(api.retrieve_txs(true, None, None)?.1);
 		src_accts = Some(api.accounts()?);
 		Ok(())
 	})?;
 
 	wallet::controller::owner_single_use(wallet_dest.clone(), |api| {
-		dest_info = Some(api.retrieve_summary_info(true)?.1);
+		dest_info = Some(api.retrieve_summary_info(true, 1)?.1);
 		dest_txs = Some(api.retrieve_txs(true, None, None)?.1);
 		dest_accts = Some(api.accounts()?);
 		Ok(())
@@ -318,15 +318,15 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// update everyone
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let _ = api.retrieve_summary_info(true)?;
+		let _ = api.retrieve_summary_info(true, 1)?;
 		Ok(())
 	})?;
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let _ = api.retrieve_summary_info(true)?;
+		let _ = api.retrieve_summary_info(true, 1)?;
 		Ok(())
 	})?;
 	wallet::controller::owner_single_use(wallet3.clone(), |api| {
-		let _ = api.retrieve_summary_info(true)?;
+		let _ = api.retrieve_summary_info(true, 1)?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/self_send.rs
+++ b/wallet/tests/self_send.rs
@@ -87,7 +87,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Should have 5 in account1 (5 spendable), 5 in account (2 spendable)
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward);
@@ -119,7 +119,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check total in mining account
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward - reward * 2);
@@ -132,7 +132,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		w.set_parent_key_id_by_name("listener")?;
 	}
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet1_refreshed);
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, 2 * reward);

--- a/wallet/tests/transaction.rs
+++ b/wallet/tests/transaction.rs
@@ -84,7 +84,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check wallet 1 contents are as expected
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		debug!(
 			"Wallet 1 Info Pre-Transaction, after {} blocks: {:?}",
 			wallet1_info.last_confirmed_height, wallet1_info
@@ -119,7 +119,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check transaction log for wallet 1
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (_, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (_, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		let (refreshed, txs) = api.retrieve_txs(true, None, None)?;
 		assert!(refreshed);
 		let fee = wallet::libtx::tx_fee(
@@ -163,7 +163,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check wallet 1 contents are as expected
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		debug!(
 			"Wallet 1 Info Post Transaction, after {} blocks: {:?}",
 			wallet1_info.last_confirmed_height, wallet1_info
@@ -203,7 +203,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// refresh wallets and retrieve info/tests for each wallet after maturity
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		debug!("Wallet 1 Info: {:?}", wallet1_info);
 		assert!(wallet1_refreshed);
 		assert_eq!(
@@ -218,7 +218,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet2_refreshed);
 		assert_eq!(wallet2_info.amount_currently_spendable, amount);
 
@@ -252,7 +252,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
-		let (refreshed, _wallet1_info) = sender_api.retrieve_summary_info(true)?;
+		let (refreshed, _wallet1_info) = sender_api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		let (_, txs) = sender_api.retrieve_txs(true, None, None)?;
 
@@ -262,7 +262,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			.find(|t| t.tx_slate_id == Some(slate.id))
 			.unwrap();
 		sender_api.post_stored_tx(tx.id, false)?;
-		let (_, wallet1_info) = sender_api.retrieve_summary_info(true)?;
+		let (_, wallet1_info) = sender_api.retrieve_summary_info(true, 1)?;
 		// should be mined now
 		assert_eq!(
 			wallet1_info.total,
@@ -276,7 +276,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// check wallet2 has stored transaction
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(wallet2_refreshed);
 		assert_eq!(wallet2_info.amount_currently_spendable, amount * 3);
 
@@ -347,7 +347,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Check transaction log for wallet 1
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let (refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		println!(
 			"last confirmed height: {}",
 			wallet1_info.last_confirmed_height
@@ -392,7 +392,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 		}
 		assert_eq!(outputs.len(), 1);
 		assert_eq!(unconfirmed_count, 1);
-		let (refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		assert_eq!(wallet2_info.amount_currently_spendable, 0,);
 		assert_eq!(wallet2_info.total, amount);
@@ -413,7 +413,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 			.find(|t| t.tx_slate_id == Some(slate.id))
 			.unwrap();
 		api.cancel_tx(Some(tx.id), None)?;
-		let (refreshed, wallet1_info) = api.retrieve_summary_info(true)?;
+		let (refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		println!(
 			"last confirmed height: {}",
@@ -440,7 +440,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 			.find(|t| t.tx_slate_id == Some(slate.id))
 			.unwrap();
 		api.cancel_tx(Some(tx.id), None)?;
-		let (refreshed, wallet2_info) = api.retrieve_summary_info(true)?;
+		let (refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		// check all eligible inputs should be now be spendable
 		assert_eq!(wallet2_info.amount_currently_spendable, 0,);


### PR DESCRIPTION
Resolves #1647.

* default `minimum_confirmations` to 10
* new `minimum_confirmations` param for `grin wallet info`
* rework `grin wallet info` output a bit for clarity (specifically around immature/unconfirmed)

TODO - 
- [x] fix merge conflicts
- [x] fix tests

----

Sample output from `grin wallet info`.
User testing mode so coinbase maturity is 3 blocks and minimum confirmations defaults to 10.

```
____ Wallet Summary Info - Account 'default' as of height 42 ____

 Total                            | 2519.999000000 
 Immature Coinbase (< 3)          | 180.000000000 
 Awaiting Confirmation (< 10)     | 2339.999000000 
 Locked by previous transaction   | 1980.000000000 
 -------------------------------- | ------------- 
 Currently Spendable              | 0.000000000 
```