### PR TITLE
Block accepted reorg aware

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -283,7 +283,8 @@ impl Chain {
 				};
 
 				// notifying other parts of the system of the update
-				self.adapter.block_accepted(&b, is_more_work, is_reorg, opts);
+				self.adapter
+					.block_accepted(&b, is_more_work, is_reorg, opts);
 
 				Ok(head)
 			}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -38,7 +38,9 @@ use grin_store::Error::NotFoundErr;
 use pipe;
 use store;
 use txhashset;
-use types::{BlockStatus, ChainAdapter, NoStatus, Options, Tip, TxHashSetRoots, TxHashsetWriteStatus};
+use types::{
+	BlockStatus, ChainAdapter, NoStatus, Options, Tip, TxHashSetRoots, TxHashsetWriteStatus,
+};
 use util::secp::pedersen::{Commitment, RangeProof};
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
@@ -287,8 +289,7 @@ impl Chain {
 				let status = self.determine_status(head.clone(), prev_head);
 
 				// notifying other parts of the system of the update
-				self.adapter
-					.block_accepted(&b, status, opts);
+				self.adapter.block_accepted(&b, status, opts);
 
 				Ok(head)
 			}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -267,7 +267,8 @@ impl Chain {
 				add_to_hash_cache(b.hash());
 
 				// notifying other parts of the system of the update
-				self.adapter.block_accepted(&b, head.clone(), prev_head, opts);
+				self.adapter
+					.block_accepted(&b, head.clone(), prev_head, opts);
 
 				Ok(head)
 			}
@@ -986,8 +987,7 @@ impl Chain {
 		if outputs.0 != rangeproofs.0 || outputs.1.len() != rangeproofs.1.len() {
 			return Err(ErrorKind::TxHashSetErr(String::from(
 				"Output and rangeproof sets don't match",
-			))
-			.into());
+			)).into());
 		}
 		let mut output_vec: Vec<Output> = vec![];
 		for (ref x, &y) in outputs.1.iter().zip(rangeproofs.1.iter()) {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -273,13 +273,15 @@ impl Chain {
 				// the previous block differs from the previous chain head.
 				// i.e. there is not a smooth progression from prev_head to new_head.
 				let is_reorg = {
-					let mut is_reorg = false;
+					let mut is_next_block = false;
 					if let Some(head) = head.clone() {
-						if head.prev_block_h != prev_head.last_block_h {
-							is_reorg = true;
+						if head.prev_block_h == prev_head.last_block_h {
+							is_next_block = true;
 						}
 					}
-					is_reorg
+					// Block caused a reorg if total work increased but we did not
+					// smoothly progress from one block to the next.
+					is_more_work && !is_next_block
 				};
 
 				// notifying other parts of the system of the update

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -53,4 +53,4 @@ pub mod types;
 pub use chain::{Chain, MAX_ORPHAN_SIZE};
 pub use error::{Error, ErrorKind};
 pub use store::ChainStore;
-pub use types::{ChainAdapter, Options, Tip, TxHashsetWriteStatus};
+pub use types::{BlockStatus, ChainAdapter, Options, Tip, TxHashsetWriteStatus};

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -118,7 +118,7 @@ impl ser::Readable for Tip {
 pub trait ChainAdapter {
 	/// The blockchain pipeline has accepted this block as valid and added
 	/// it to our chain.
-	fn block_accepted(&self, b: &Block, opts: Options);
+	fn block_accepted(&self, block: &Block, new_head: Option<Tip>, prev_head: Tip, opts: Options);
 }
 
 /// Inform the caller of the current status of a txhashset write operation,
@@ -151,5 +151,5 @@ impl TxHashsetWriteStatus for NoStatus {
 pub struct NoopAdapter {}
 
 impl ChainAdapter for NoopAdapter {
-	fn block_accepted(&self, _: &Block, _: Options) {}
+	fn block_accepted(&self, _b: &Block, _new_head: Option<Tip>, _prev_head: Tip, _opts: Options) {}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -118,7 +118,7 @@ impl ser::Readable for Tip {
 pub trait ChainAdapter {
 	/// The blockchain pipeline has accepted this block as valid and added
 	/// it to our chain.
-	fn block_accepted(&self, block: &Block, is_more_work: bool, is_reorg: bool, opts: Options);
+	fn block_accepted(&self, block: &Block, status: BlockStatus, opts: Options);
 }
 
 /// Inform the caller of the current status of a txhashset write operation,
@@ -151,5 +151,17 @@ impl TxHashsetWriteStatus for NoStatus {
 pub struct NoopAdapter {}
 
 impl ChainAdapter for NoopAdapter {
-	fn block_accepted(&self, _b: &Block, _is_more_work: bool, _is_reorg: bool, _opts: Options) {}
+	fn block_accepted(&self, _b: &Block, _status: BlockStatus, _opts: Options) {}
+}
+
+/// Status of an accepted block.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BlockStatus {
+	/// Block is the "next" block, updating the chain head.
+	Next,
+	/// Block does not update the chain head and is a fork.
+	Fork,
+	/// Block updates the chain head via a (potentially disruptive) "reorg".
+	/// Previous block was not our previous chain head.
+	Reorg,
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -118,7 +118,7 @@ impl ser::Readable for Tip {
 pub trait ChainAdapter {
 	/// The blockchain pipeline has accepted this block as valid and added
 	/// it to our chain.
-	fn block_accepted(&self, block: &Block, new_head: Option<Tip>, prev_head: Tip, opts: Options);
+	fn block_accepted(&self, block: &Block, is_more_work: bool, is_reorg: bool, opts: Options);
 }
 
 /// Inform the caller of the current status of a txhashset write operation,
@@ -151,5 +151,5 @@ impl TxHashsetWriteStatus for NoStatus {
 pub struct NoopAdapter {}
 
 impl ChainAdapter for NoopAdapter {
-	fn block_accepted(&self, _b: &Block, _new_head: Option<Tip>, _prev_head: Tip, _opts: Options) {}
+	fn block_accepted(&self, _b: &Block, _is_more_work: bool, _is_reorg: bool, _opts: Options) {}
 }

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -180,10 +180,7 @@ impl TransactionPool {
 		debug!("truncate_reorg_cache: size: {}", cache.len());
 	}
 
-	pub fn reconcile_reorg_cache(
-		&mut self,
-		header: &BlockHeader,
-	) -> Result<(), PoolError> {
+	pub fn reconcile_reorg_cache(&mut self, header: &BlockHeader) -> Result<(), PoolError> {
 		let entries = self.reorg_cache.read().iter().cloned().collect::<Vec<_>>();
 		debug!(
 			"reconcile_reorg_cache: size: {}, block: {:?} ...",
@@ -193,7 +190,10 @@ impl TransactionPool {
 		for entry in entries {
 			let _ = &self.add_to_txpool(entry.clone(), header);
 		}
-		debug!("reconcile_reorg_cache: block: {:?} ... done.", header.hash());
+		debug!(
+			"reconcile_reorg_cache: block: {:?} ... done.",
+			header.hash()
+		);
 		Ok(())
 	}
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -179,7 +179,11 @@ impl TransactionPool {
 		Ok(())
 	}
 
-	fn reconcile_reorg_cache(&mut self, header: &BlockHeader, is_reorg: bool) -> Result<(), PoolError> {
+	fn reconcile_reorg_cache(
+		&mut self,
+		header: &BlockHeader,
+		is_reorg: bool,
+	) -> Result<(), PoolError> {
 		// First "age out" any old txs in the reorg cache.
 		let cutoff = Utc::now() - Duration::minutes(30);
 		self.truncate_reorg_cache(cutoff);
@@ -187,13 +191,21 @@ impl TransactionPool {
 		let entries = self.reorg_cache.read().iter().cloned().collect::<Vec<_>>();
 
 		if is_reorg {
-			debug!("reconcile_reorg_cache: {:?}, size: {} ...", header.hash(), entries.len());
+			debug!(
+				"reconcile_reorg_cache: {:?}, size: {} ...",
+				header.hash(),
+				entries.len()
+			);
 			for entry in entries {
 				let _ = &self.add_to_txpool(entry.clone(), header);
 			}
 			debug!("reconcile_reorg_cache: {:?} ... done.", header.hash());
 		} else {
-			debug!("reconcile_reorg_cache: {:?}, size: {}, not a reorg, skipping.", header.hash(), entries.len());
+			debug!(
+				"reconcile_reorg_cache: {:?}, size: {}, not a reorg, skipping.",
+				header.hash(),
+				entries.len()
+			);
 		}
 
 		Ok(())

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -641,10 +641,6 @@ pub struct ChainToPoolAndNetAdapter {
 
 impl ChainAdapter for ChainToPoolAndNetAdapter {
 	fn block_accepted(&self, b: &core::Block, status: BlockStatus, opts: Options) {
-		if self.sync_state.is_syncing() {
-			return;
-		}
-
 		match status {
 			BlockStatus::Reorg => {
 				warn!(
@@ -670,6 +666,10 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 					b.header.total_difficulty(),
 				);
 			}
+		}
+
+		if self.sync_state.is_syncing() {
+			return;
 		}
 
 		// If we mined the block then we want to broadcast the compact block.

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -190,9 +190,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 						self.request_block(&cb.header, &addr);
 						true
 					} else {
-						debug!(
-							"block invalid after hydration, ignoring it, cause still syncing"
-						);
+						debug!("block invalid after hydration, ignoring it, cause still syncing");
 						true
 					}
 				}
@@ -469,10 +467,7 @@ impl NetToChainAdapter {
 				true
 			}
 			Err(ref e) if e.is_bad_data() => {
-				debug!(
-					"process_block: {} is a bad block, resetting head",
-					bhash
-				);
+				debug!("process_block: {} is a bad block, resetting head", bhash);
 				let _ = self.chain().reset_head();
 
 				// we potentially changed the state of the system here
@@ -644,7 +639,13 @@ pub struct ChainToPoolAndNetAdapter {
 }
 
 impl ChainAdapter for ChainToPoolAndNetAdapter {
-	fn block_accepted(&self, b: &core::Block, new_head: Option<Tip>, prev_head: Tip, opts: Options) {
+	fn block_accepted(
+		&self,
+		b: &core::Block,
+		new_head: Option<Tip>,
+		prev_head: Tip,
+		opts: Options,
+	) {
 		if self.sync_state.is_syncing() {
 			return;
 		}
@@ -666,11 +667,23 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 		};
 
 		if is_reorg {
-			warn!("block_accepted (reorg): {:?} at {}", b.hash(), b.header.height);
+			warn!(
+				"block_accepted (reorg): {:?} at {}",
+				b.hash(),
+				b.header.height
+			);
 		} else if !is_more_work {
-			debug!("block_accepted (not most work): {:?} at {}", b.hash(), b.header.height);
+			debug!(
+				"block_accepted (not most work): {:?} at {}",
+				b.hash(),
+				b.header.height
+			);
 		} else {
-			debug!("block_accepted (most work): {:?} at {}", b.hash(), b.header.height);
+			debug!(
+				"block_accepted (most work): {:?} at {}",
+				b.hash(),
+				b.header.height
+			);
 		}
 
 		// If we mined the block then we want to broadcast the compact block.

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -653,7 +653,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 					b.header.height,
 					b.header.total_difficulty(),
 				);
-			},
+			}
 			BlockStatus::Fork => {
 				debug!(
 					"block_accepted (fork?): {:?} at {} (diff: {})",
@@ -661,7 +661,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 					b.header.height,
 					b.header.total_difficulty(),
 				);
-			},
+			}
 			BlockStatus::Next => {
 				debug!(
 					"block_accepted (head+): {:?} at {} (diff: {})",

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -648,7 +648,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 		match status {
 			BlockStatus::Reorg => {
 				warn!(
-					" block_accepted (REORG): {:?} at {} (diff: {})", // keep alignment for logs
+					"block_accepted (REORG!): {:?} at {} (diff: {})",
 					b.hash(),
 					b.header.height,
 					b.header.total_difficulty(),

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -640,13 +640,7 @@ pub struct ChainToPoolAndNetAdapter {
 }
 
 impl ChainAdapter for ChainToPoolAndNetAdapter {
-	fn block_accepted(
-		&self,
-		b: &core::Block,
-		is_more_work: bool,
-		is_reorg: bool,
-		opts: Options,
-	) {
+	fn block_accepted(&self, b: &core::Block, is_more_work: bool, is_reorg: bool, opts: Options) {
 		if self.sync_state.is_syncing() {
 			return;
 		}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -668,13 +668,13 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 
 		if is_reorg {
 			warn!(
-				"block_accepted (reorg): {:?} at {}",
+				"block_accepted (reorg!): {:?} at {}",
 				b.hash(),
 				b.header.height
 			);
 		} else if !is_more_work {
 			debug!(
-				"block_accepted (not most work): {:?} at {}",
+				"block_accepted (fork?): {:?} at {}",
 				b.hash(),
 				b.header.height
 			);


### PR DESCRIPTION
Couple of optimizations for txpool - 

  * skip reconciling txpool against new block if we have _not_ extended most work chain
  * skip reconciling reorg_cache if block does _not_ result in a reorg
  * introduce `BlockStatus` enum to represent state of new accepted block - 
    * `Next`
    * `Fork`
    * `Reorg`

