### PR TITLE
[DNM] Switch commitments

### DIFF
--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -126,6 +126,13 @@ impl Identifier {
 		ExtKeychainPath::from_identifier(&self)
 	}
 
+	pub fn to_value_path(&self, value: u64) -> ValueExtKeychainPath {
+		ValueExtKeychainPath {
+			value,
+			ext_keychain_path: self.to_path()
+		}
+	}
+
 	/// output the path itself, for insertion into bulletproof
 	/// recovery processes can grind through possiblities to find the
 	/// correct length if required
@@ -327,8 +334,8 @@ pub struct SplitBlindingFactor {
 /// factor as well as the "sign" with which they should be combined.
 #[derive(Clone, Debug, PartialEq)]
 pub struct BlindSum {
-	pub positive_key_ids: Vec<ExtKeychainPath>,
-	pub negative_key_ids: Vec<ExtKeychainPath>,
+	pub positive_key_ids: Vec<ValueExtKeychainPath>,
+	pub negative_key_ids: Vec<ValueExtKeychainPath>,
 	pub positive_blinding_factors: Vec<BlindingFactor>,
 	pub negative_blinding_factors: Vec<BlindingFactor>,
 }
@@ -344,12 +351,12 @@ impl BlindSum {
 		}
 	}
 
-	pub fn add_key_id(mut self, path: ExtKeychainPath) -> BlindSum {
+	pub fn add_key_id(mut self, path: ValueExtKeychainPath) -> BlindSum {
 		self.positive_key_ids.push(path);
 		self
 	}
 
-	pub fn sub_key_id(mut self, path: ExtKeychainPath) -> BlindSum {
+	pub fn sub_key_id(mut self, path: ValueExtKeychainPath) -> BlindSum {
 		self.negative_key_ids.push(path);
 		self
 	}
@@ -430,12 +437,20 @@ impl ExtKeychainPath {
 	}
 }
 
+/// Wrapper for amount + path
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize)]
+pub struct ValueExtKeychainPath {
+	pub value: u64,
+	pub ext_keychain_path: ExtKeychainPath
+}
+
 pub trait Keychain: Sync + Send + Clone {
 	fn from_seed(seed: &[u8]) -> Result<Self, Error>;
 	fn from_random_seed() -> Result<Self, Error>;
 	fn root_key_id() -> Identifier;
 	fn derive_key_id(depth: u8, d1: u32, d2: u32, d3: u32, d4: u32) -> Identifier;
 	fn derive_key(&self, id: &Identifier) -> Result<ExtendedPrivKey, Error>;
+	fn derive_switch_key(&self, amount: u64, id: &Identifier) -> Result<SecretKey, Error>;
 	fn commit(&self, amount: u64, id: &Identifier) -> Result<Commitment, Error>;
 	fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error>;
 	fn sign(&self, msg: &Message, id: &Identifier) -> Result<Signature, Error>;

--- a/wallet/src/libtx/build.rs
+++ b/wallet/src/libtx/build.rs
@@ -53,7 +53,7 @@ where
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
 			let commit = build.keychain.commit(value, &key_id).unwrap();
 			let input = Input::new(features, commit);
-			(tx.with_input(input), kern, sum.sub_key_id(key_id.to_path()))
+			(tx.with_input(input), kern, sum.sub_key_id(key_id.to_value_path(value)))
 		},
 	)
 }
@@ -101,7 +101,7 @@ where
 					proof: rproof,
 				}),
 				kern,
-				sum.add_key_id(key_id.to_path()),
+				sum.add_key_id(key_id.to_value_path(value)),
 			)
 		},
 	)

--- a/wallet/src/libtx/proof.rs
+++ b/wallet/src/libtx/proof.rs
@@ -53,11 +53,11 @@ where
 	K: Keychain,
 {
 	let commit = k.commit(amount, key_id)?;
-	let skey = k.derive_key(key_id)?;
+	let skey = k.derive_switch_key(amount, key_id)?;
 	let nonce = create_nonce(k, &commit)?;
 	let message = ProofMessage::from_bytes(&key_id.serialize_path());
 	Ok(k.secp()
-		.bullet_proof(amount, skey.secret_key, nonce, extra_data, Some(message)))
+		.bullet_proof(amount, skey, nonce, extra_data, Some(message)))
 }
 
 /// Verify a proof


### PR DESCRIPTION
Add switch commitments following the scheme defined in https://github.com/mimblewimble/grin/issues/998. Blinding factors are modified to `x' = x + H(xG+vH | xJ)`

If in the future doubts arise about the existence of mechanisms that would break the discrete logarithm between `G` and `H`, we could require revealing the ElGamal commitment `(xG+vH, xJ)` (and a corresponding rangeproof) in order to spend an output.

TODO: check for other places that need to be updated, testing

Note that this will break existing wallets, as they used the unmodified secret keys. How should we handle this case? @ignopeverell @yeastplume 