### PR TITLE
Remove header cache (remove need to invalidate the cache for orphans)

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -47,9 +47,9 @@ const BLOCK_SUMS_PREFIX: u8 = 'M' as u8;
 /// All chain-related database operations
 pub struct ChainStore {
 	db: store::Store,
-	header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
-	block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
-	block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
+	// header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
+	// block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
+	// block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
 }
 
 impl ChainStore {
@@ -58,9 +58,9 @@ impl ChainStore {
 		let db = store::Store::open(db_env, STORE_SUBPATH);
 		Ok(ChainStore {
 			db,
-			header_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
-			block_input_bitmap_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
-			block_sums_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
+			// header_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
+			// block_input_bitmap_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
+			// block_sums_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
 		})
 	}
 }
@@ -101,30 +101,31 @@ impl ChainStore {
 	}
 
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
-		{
-			let mut block_sums_cache = self.block_sums_cache.write();
-
-			// cache hit - return the value from the cache
-			if let Some(block_sums) = block_sums_cache.get_mut(h) {
-				return Ok(block_sums.clone());
-			}
-		}
+		// {
+		// 	let mut block_sums_cache = self.block_sums_cache.write();
+		//
+		// 	// cache hit - return the value from the cache
+		// 	if let Some(block_sums) = block_sums_cache.get_mut(h) {
+		// 		return Ok(block_sums.clone());
+		// 	}
+		// }
 
 		let block_sums: Result<BlockSums, Error> = option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
 			&format!("Block sums for block: {}", h),
 		);
+		block_sums
 
 		// cache miss - so adding to the cache for next time
-		if let Ok(block_sums) = block_sums {
-			{
-				let mut block_sums_cache = self.block_sums_cache.write();
-				block_sums_cache.insert(*h, block_sums.clone());
-			}
-			Ok(block_sums)
-		} else {
-			block_sums
-		}
+		// if let Ok(block_sums) = block_sums {
+		// 	{
+		// 		let mut block_sums_cache = self.block_sums_cache.write();
+		// 		block_sums_cache.insert(*h, block_sums.clone());
+		// 	}
+		// 	Ok(block_sums)
+		// } else {
+		// 	block_sums
+		// }
 	}
 
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
@@ -132,31 +133,32 @@ impl ChainStore {
 	}
 
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
-		{
-			let mut cache = self.header_cache.write();
-
-			// cache hit - return the value from the cache
-			if let Some(header) = cache.get_mut(h) {
-				return Ok(header.clone());
-			}
-		}
+		// {
+		// 	let mut cache = self.header_cache.write();
+		//
+		// 	// cache hit - return the value from the cache
+		// 	if let Some(header) = cache.get_mut(h) {
+		// 		return Ok(header.clone());
+		// 	}
+		// }
 
 		let header: Result<BlockHeader, Error> = option_to_not_found(
 			self.db
 				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 			&format!("BLOCK HEADER: {}", h),
 		);
+		header
 
-		// cache miss - so adding to the cache for next time
-		if let Ok(header) = header {
-			{
-				let mut cache = self.header_cache.write();
-				cache.insert(*h, header.clone());
-			}
-			Ok(header)
-		} else {
-			header
-		}
+		// // cache miss - so adding to the cache for next time
+		// if let Ok(header) = header {
+		// 	{
+		// 		let mut cache = self.header_cache.write();
+		// 		cache.insert(*h, header.clone());
+		// 	}
+		// 	Ok(header)
+		// } else {
+		// 	header
+		// }
 	}
 
 	pub fn get_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
@@ -208,9 +210,9 @@ impl ChainStore {
 	pub fn batch(&self) -> Result<Batch, Error> {
 		Ok(Batch {
 			db: self.db.batch()?,
-			header_cache: self.header_cache.clone(),
-			block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
-			block_sums_cache: self.block_sums_cache.clone(),
+			// header_cache: self.header_cache.clone(),
+			// block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
+			// block_sums_cache: self.block_sums_cache.clone(),
 		})
 	}
 }
@@ -219,9 +221,9 @@ impl ChainStore {
 /// discarded on error.
 pub struct Batch<'a> {
 	db: store::Batch<'a>,
-	header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
-	block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
-	block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
+	// header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
+	// block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
+	// block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
 }
 
 #[allow(missing_docs)]
@@ -332,11 +334,11 @@ impl<'a> Batch<'a> {
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
 		let hash = header.hash();
 
-		// Cache the header.
-		{
-			let mut header_cache = self.header_cache.write();
-			header_cache.insert(hash, header.clone());
-		}
+		// // Cache the header.
+		// {
+		// 	let mut header_cache = self.header_cache.write();
+		// 	header_cache.insert(hash, header.clone());
+		// }
 
 		// Store the header itself indexed by hash.
 		self.db
@@ -379,31 +381,32 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
-		{
-			let mut cache = self.header_cache.write();
-
-			// cache hit - return the value from the cache
-			if let Some(header) = cache.get_mut(h) {
-				return Ok(header.clone());
-			}
-		}
+		// {
+		// 	let mut cache = self.header_cache.write();
+		//
+		// 	// cache hit - return the value from the cache
+		// 	if let Some(header) = cache.get_mut(h) {
+		// 		return Ok(header.clone());
+		// 	}
+		// }
 
 		let header: Result<BlockHeader, Error> = option_to_not_found(
 			self.db
 				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 			&format!("BLOCK HEADER: {}", h),
 		);
+		header
 
-		// cache miss - so adding to the cache for next time
-		if let Ok(header) = header {
-			{
-				let mut cache = self.header_cache.write();
-				cache.insert(*h, header.clone());
-			}
-			Ok(header)
-		} else {
-			header
-		}
+		// // cache miss - so adding to the cache for next time
+		// if let Ok(header) = header {
+		// 	{
+		// 		let mut cache = self.header_cache.write();
+		// 		cache.insert(*h, header.clone());
+		// 	}
+		// 	Ok(header)
+		// } else {
+		// 	header
+		// }
 	}
 
 	fn save_block_input_bitmap(&self, bh: &Hash, bm: &Bitmap) -> Result<(), Error> {
@@ -419,40 +422,41 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_sums(&self, h: &Hash, sums: &BlockSums) -> Result<(), Error> {
-		{
-			let mut block_sums_cache = self.block_sums_cache.write();
-			block_sums_cache.insert(*h, sums.clone());
-		}
+		// {
+		// 	let mut block_sums_cache = self.block_sums_cache.write();
+		// 	block_sums_cache.insert(*h, sums.clone());
+		// }
 
 		self.db
 			.put_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())[..], &sums)
 	}
 
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
-		{
-			let mut block_sums_cache = self.block_sums_cache.write();
-
-			// cache hit - return the value from the cache
-			if let Some(block_sums) = block_sums_cache.get_mut(h) {
-				return Ok(block_sums.clone());
-			}
-		}
+		// {
+		// 	let mut block_sums_cache = self.block_sums_cache.write();
+		//
+		// 	// cache hit - return the value from the cache
+		// 	if let Some(block_sums) = block_sums_cache.get_mut(h) {
+		// 		return Ok(block_sums.clone());
+		// 	}
+		// }
 
 		let block_sums: Result<BlockSums, Error> = option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
 			&format!("Block sums for block: {}", h),
 		);
+		block_sums
 
-		// cache miss - so adding to the cache for next time
-		if let Ok(block_sums) = block_sums {
-			{
-				let mut block_sums_cache = self.block_sums_cache.write();
-				block_sums_cache.insert(*h, block_sums.clone());
-			}
-			Ok(block_sums)
-		} else {
-			block_sums
-		}
+		// // cache miss - so adding to the cache for next time
+		// if let Ok(block_sums) = block_sums {
+		// 	{
+		// 		let mut block_sums_cache = self.block_sums_cache.write();
+		// 		block_sums_cache.insert(*h, block_sums.clone());
+		// 	}
+		// 	Ok(block_sums)
+		// } else {
+		// 	block_sums
+		// }
 	}
 
 	fn delete_block_sums(&self, bh: &Hash) -> Result<(), Error> {
@@ -540,22 +544,22 @@ impl<'a> Batch<'a> {
 		// Save the bitmap to the db (via the batch).
 		self.save_block_input_bitmap(&block.hash(), &bitmap)?;
 
-		// Finally cache it locally for use later.
-		let mut cache = self.block_input_bitmap_cache.write();
-		cache.insert(block.hash(), bitmap.serialize());
+		// // Finally cache it locally for use later.
+		// let mut cache = self.block_input_bitmap_cache.write();
+		// cache.insert(block.hash(), bitmap.serialize());
 
 		Ok(bitmap)
 	}
 
 	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
-		{
-			let mut cache = self.block_input_bitmap_cache.write();
-
-			// cache hit - return the value from the cache
-			if let Some(bytes) = cache.get_mut(bh) {
-				return Ok(Bitmap::deserialize(&bytes));
-			}
-		}
+		// {
+		// 	let mut cache = self.block_input_bitmap_cache.write();
+		//
+		// 	// cache hit - return the value from the cache
+		// 	if let Some(bytes) = cache.get_mut(bh) {
+		// 		return Ok(Bitmap::deserialize(&bytes));
+		// 	}
+		// }
 
 		// cache miss - get it from db (build it, store it and cache it as necessary)
 		self.get_block_input_bitmap_db(bh)
@@ -592,9 +596,9 @@ impl<'a> Batch<'a> {
 	pub fn child(&mut self) -> Result<Batch, Error> {
 		Ok(Batch {
 			db: self.db.child()?,
-			header_cache: self.header_cache.clone(),
-			block_sums_cache: self.block_sums_cache.clone(),
-			block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
+			// header_cache: self.header_cache.clone(),
+			// block_sums_cache: self.block_sums_cache.clone(),
+			// block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
 		})
 	}
 }

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -15,11 +15,9 @@
 //! Implements storage primitives required by the chain
 
 use std::sync::Arc;
-use util::RwLock;
 
 use croaring::Bitmap;
 use lmdb;
-use lru_cache::LruCache;
 
 use util::secp::pedersen::Commitment;
 
@@ -47,21 +45,13 @@ const BLOCK_SUMS_PREFIX: u8 = 'M' as u8;
 /// All chain-related database operations
 pub struct ChainStore {
 	db: store::Store,
-	// header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
-	// block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
-	// block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
 }
 
 impl ChainStore {
 	/// Create new chain store
 	pub fn new(db_env: Arc<lmdb::Environment>) -> Result<ChainStore, Error> {
 		let db = store::Store::open(db_env, STORE_SUBPATH);
-		Ok(ChainStore {
-			db,
-			// header_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
-			// block_input_bitmap_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
-			// block_sums_cache: Arc::new(RwLock::new(LruCache::new(1_000))),
-		})
+		Ok(ChainStore { db })
 	}
 }
 
@@ -101,31 +91,10 @@ impl ChainStore {
 	}
 
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
-		// {
-		// 	let mut block_sums_cache = self.block_sums_cache.write();
-		//
-		// 	// cache hit - return the value from the cache
-		// 	if let Some(block_sums) = block_sums_cache.get_mut(h) {
-		// 		return Ok(block_sums.clone());
-		// 	}
-		// }
-
-		let block_sums: Result<BlockSums, Error> = option_to_not_found(
+		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
 			&format!("Block sums for block: {}", h),
-		);
-		block_sums
-
-		// cache miss - so adding to the cache for next time
-		// if let Ok(block_sums) = block_sums {
-		// 	{
-		// 		let mut block_sums_cache = self.block_sums_cache.write();
-		// 		block_sums_cache.insert(*h, block_sums.clone());
-		// 	}
-		// 	Ok(block_sums)
-		// } else {
-		// 	block_sums
-		// }
+		)
 	}
 
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
@@ -133,32 +102,11 @@ impl ChainStore {
 	}
 
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
-		// {
-		// 	let mut cache = self.header_cache.write();
-		//
-		// 	// cache hit - return the value from the cache
-		// 	if let Some(header) = cache.get_mut(h) {
-		// 		return Ok(header.clone());
-		// 	}
-		// }
-
-		let header: Result<BlockHeader, Error> = option_to_not_found(
+		option_to_not_found(
 			self.db
 				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 			&format!("BLOCK HEADER: {}", h),
-		);
-		header
-
-		// // cache miss - so adding to the cache for next time
-		// if let Ok(header) = header {
-		// 	{
-		// 		let mut cache = self.header_cache.write();
-		// 		cache.insert(*h, header.clone());
-		// 	}
-		// 	Ok(header)
-		// } else {
-		// 	header
-		// }
+		)
 	}
 
 	pub fn get_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
@@ -210,9 +158,6 @@ impl ChainStore {
 	pub fn batch(&self) -> Result<Batch, Error> {
 		Ok(Batch {
 			db: self.db.batch()?,
-			// header_cache: self.header_cache.clone(),
-			// block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
-			// block_sums_cache: self.block_sums_cache.clone(),
 		})
 	}
 }
@@ -221,9 +166,6 @@ impl ChainStore {
 /// discarded on error.
 pub struct Batch<'a> {
 	db: store::Batch<'a>,
-	// header_cache: Arc<RwLock<LruCache<Hash, BlockHeader>>>,
-	// block_sums_cache: Arc<RwLock<LruCache<Hash, BlockSums>>>,
-	// block_input_bitmap_cache: Arc<RwLock<LruCache<Hash, Vec<u8>>>>,
 }
 
 #[allow(missing_docs)]
@@ -334,12 +276,6 @@ impl<'a> Batch<'a> {
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
 		let hash = header.hash();
 
-		// // Cache the header.
-		// {
-		// 	let mut header_cache = self.header_cache.write();
-		// 	header_cache.insert(hash, header.clone());
-		// }
-
 		// Store the header itself indexed by hash.
 		self.db
 			.put_ser(&to_key(BLOCK_HEADER_PREFIX, &mut hash.to_vec())[..], header)?;
@@ -381,32 +317,11 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
-		// {
-		// 	let mut cache = self.header_cache.write();
-		//
-		// 	// cache hit - return the value from the cache
-		// 	if let Some(header) = cache.get_mut(h) {
-		// 		return Ok(header.clone());
-		// 	}
-		// }
-
-		let header: Result<BlockHeader, Error> = option_to_not_found(
+		option_to_not_found(
 			self.db
 				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 			&format!("BLOCK HEADER: {}", h),
-		);
-		header
-
-		// // cache miss - so adding to the cache for next time
-		// if let Ok(header) = header {
-		// 	{
-		// 		let mut cache = self.header_cache.write();
-		// 		cache.insert(*h, header.clone());
-		// 	}
-		// 	Ok(header)
-		// } else {
-		// 	header
-		// }
+		)
 	}
 
 	fn save_block_input_bitmap(&self, bh: &Hash, bm: &Bitmap) -> Result<(), Error> {
@@ -422,41 +337,15 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_sums(&self, h: &Hash, sums: &BlockSums) -> Result<(), Error> {
-		// {
-		// 	let mut block_sums_cache = self.block_sums_cache.write();
-		// 	block_sums_cache.insert(*h, sums.clone());
-		// }
-
 		self.db
 			.put_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())[..], &sums)
 	}
 
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
-		// {
-		// 	let mut block_sums_cache = self.block_sums_cache.write();
-		//
-		// 	// cache hit - return the value from the cache
-		// 	if let Some(block_sums) = block_sums_cache.get_mut(h) {
-		// 		return Ok(block_sums.clone());
-		// 	}
-		// }
-
-		let block_sums: Result<BlockSums, Error> = option_to_not_found(
+		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
 			&format!("Block sums for block: {}", h),
-		);
-		block_sums
-
-		// // cache miss - so adding to the cache for next time
-		// if let Ok(block_sums) = block_sums {
-		// 	{
-		// 		let mut block_sums_cache = self.block_sums_cache.write();
-		// 		block_sums_cache.insert(*h, block_sums.clone());
-		// 	}
-		// 	Ok(block_sums)
-		// } else {
-		// 	block_sums
-		// }
+		)
 	}
 
 	fn delete_block_sums(&self, bh: &Hash) -> Result<(), Error> {
@@ -544,31 +433,12 @@ impl<'a> Batch<'a> {
 		// Save the bitmap to the db (via the batch).
 		self.save_block_input_bitmap(&block.hash(), &bitmap)?;
 
-		// // Finally cache it locally for use later.
-		// let mut cache = self.block_input_bitmap_cache.write();
-		// cache.insert(block.hash(), bitmap.serialize());
-
 		Ok(bitmap)
-	}
-
-	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
-		// {
-		// 	let mut cache = self.block_input_bitmap_cache.write();
-		//
-		// 	// cache hit - return the value from the cache
-		// 	if let Some(bytes) = cache.get_mut(bh) {
-		// 		return Ok(Bitmap::deserialize(&bytes));
-		// 	}
-		// }
-
-		// cache miss - get it from db (build it, store it and cache it as necessary)
-		self.get_block_input_bitmap_db(bh)
 	}
 
 	// Get the block input bitmap from the db or build the bitmap from
 	// the full block from the db (if the block is found).
-	// (bool, Bitmap) : (false if bitmap was built and not found in db)
-	fn get_block_input_bitmap_db(&self, bh: &Hash) -> Result<Bitmap, Error> {
+	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
 		if let Ok(Some(bytes)) = self
 			.db
 			.get(&to_key(BLOCK_INPUT_BITMAP_PREFIX, &mut bh.to_vec()))
@@ -596,9 +466,6 @@ impl<'a> Batch<'a> {
 	pub fn child(&mut self) -> Result<Batch, Error> {
 		Ok(Batch {
 			db: self.db.child()?,
-			// header_cache: self.header_cache.clone(),
-			// block_sums_cache: self.block_sums_cache.clone(),
-			// block_input_bitmap_cache: self.block_input_bitmap_cache.clone(),
 		})
 	}
 }


### PR DESCRIPTION
Resolves #2008.
Resolves #1936.

We tracked the issues in #1936 down to the "header cache" not being invalidated and getting out of sync with the actual header db.
We get limited benefit from the "header cache" in general so proposing we simply get rid of it from our store.

The place we _do_ see a performance benefit with the "header cache" is when we calculate `next_difficulty` via the `DifficultyIter`. Here we iterate over 60mins of recent block headers (approx 60 headers) and having them cached is obviously faster.

I think we should tackle that separately. 
And for the "happy path" during sync or during block propagation when we process headers in order - we can simply maintain a vec of `HeaderInfo` and simply cache data needed to calc the next diff.

Other than that specific piece of processing I don't think the complexity added by maintaining the header cache is worth the performance benefits we get from it.

