### PR TITLE
Improve serve command error message when no subcommand provided

### DIFF
--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -174,6 +174,9 @@ pub fn server_command(server_args: Option<&ArgMatches>, mut global_config: Globa
 				}
 			}
 			("stop", _) => println!("TODO. Just 'kill $pid' for now. Maybe /tmp/grin.pid is $pid"),
+			("", _) => {
+				println!("Subcommand required, use 'grin help server' for details");
+			}
 			(cmd, _) => {
 				println!(":: {:?}", server_args);
 				panic!(


### PR DESCRIPTION
Update the command matcher for the server command to log a more helpful
message when it's called without a subcommand.

Before:
```sh
$ target/debug/grin server
:: Some(ArgMatches { args: {}, subcommand: None, usage: Some("USAGE:\n    grin server [OPTIONS] [SUBCOMMAND]") })
```

After:
```sh
$ target/debug/grin server
Subcommand required, use 'grin help server' for details
```