### PR TITLE
cleanup block hashes cache

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -20,11 +20,9 @@ use util::RwLock;
 use chrono::prelude::Utc;
 use chrono::Duration;
 
-use lru_cache::LruCache;
-
 use chain::OrphanBlockPool;
 use core::consensus;
-use core::core::hash::{Hash, Hashed};
+use core::core::hash::Hashed;
 use core::core::verifier_cache::VerifierCache;
 use core::core::Committed;
 use core::core::{Block, BlockHeader, BlockSums};
@@ -47,9 +45,6 @@ pub struct BlockContext<'a> {
 	pub txhashset: &'a mut txhashset::TxHashSet,
 	/// The active batch to use for block processing.
 	pub batch: store::Batch<'a>,
-
-	/// Recently processed blocks to avoid double-processing
-	pub block_hashes_cache: Arc<RwLock<LruCache<Hash, bool>>>,
 	/// The verifier cache (caching verifier for rangeproofs and kernel signatures)
 	pub verifier_cache: Arc<RwLock<VerifierCache>>,
 	/// Recent orphan blocks to avoid double-processing
@@ -84,7 +79,6 @@ fn process_header_for_block(
 // from cheapest to most expensive (delay hitting the db until last).
 fn check_known(block: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
 	check_known_head(&block.header, ctx)?;
-	check_known_cache(&block.header, ctx)?;
 	check_known_orphans(&block.header, ctx)?;
 	check_known_store(&block.header, ctx)?;
 	Ok(())
@@ -106,6 +100,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext) -> Result<Option<Tip>, E
 		b.kernels().len(),
 	);
 
+	// Check if we have already processed this block previously.
 	check_known(b, ctx)?;
 
 	// Delay hitting the db for current chain head until we know
@@ -287,17 +282,6 @@ fn check_known_head(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), 
 	let bh = header.hash();
 	if bh == head.last_block_h || bh == head.prev_block_h {
 		return Err(ErrorKind::Unfit("already known in head".to_string()).into());
-	}
-	Ok(())
-}
-
-/// Quick in-memory check to fast-reject any block handled recently.
-/// Keeps duplicates from the network in check.
-/// Checks against the cache of recently processed block hashes.
-fn check_known_cache(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), Error> {
-	let mut cache = ctx.block_hashes_cache.write();
-	if cache.contains_key(&header.hash()) {
-		return Err(ErrorKind::Unfit("already known in cache".to_string()).into());
 	}
 	Ok(())
 }


### PR DESCRIPTION
While we are cleaning up and removing caching logic -
* get rid of the "block hashes cache" used in block processing pipeline
* `check_known_head` and `check_known_orphans` already catch majority of cases
* we are already hitting the db to get the current chain head so we do not avoid all I/O with this cache anyway

TODO - 
- [x] collect perf numbers from a fast sync before/after this change (anecdotally it appears to make little difference)



