### PR TITLE
Replace "header by height" index with reads into the header MMR 

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -762,11 +762,17 @@ impl Chain {
 			);
 		}
 
+		//
+		// TODO - Investigate finding the "common header" by comparing header_mmr and
+		// sync_mmr (bytes will be identical up to the common header).
+		//
 		while let Ok(header) = current {
 			// break out of the while loop when we find a header common
 			// between the header chain and the current body chain
-			if let Ok(_) = self.is_on_current_chain(&header) {
-				break;
+			if header.height <= body_head.height {
+				if let Ok(_) = self.is_on_current_chain(&header) {
+					break;
+				}
 			}
 
 			oldest_height = header.height;
@@ -857,8 +863,6 @@ impl Chain {
 		{
 			let tip = Tip::from_header(&header);
 			batch.save_body_head(&tip)?;
-			batch.save_header_height(&header)?;
-			batch.build_by_height_index(&header, true)?;
 
 			// Reset the body tail to the body head after a txhashset write
 			batch.save_body_tail(&tip)?;
@@ -927,7 +931,7 @@ impl Chain {
 
 		let mut count = 0;
 		let batch = self.store.batch()?;
-		let mut current = batch.get_header_by_height(head.height - horizon - 1)?;
+		let mut current = self.get_header_by_height(head.height - horizon - 1)?;
 		loop {
 			// Go to the store directly so we can handle NotFoundErr robustly.
 			match self.store.get_block(&current.hash()) {
@@ -953,7 +957,7 @@ impl Chain {
 				Err(e) => return Err(From::from(e)),
 			}
 		}
-		let tail = batch.get_header_by_height(head.height - horizon)?;
+		let tail = self.get_header_by_height(head.height - horizon)?;
 		batch.save_body_tail(&Tip::from_header(&tail))?;
 		batch.commit()?;
 		debug!(
@@ -1093,9 +1097,14 @@ impl Chain {
 
 	/// Gets the block header at the provided height
 	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
-		self.store
-			.get_header_by_height(height)
-			.map_err(|e| ErrorKind::StoreErr(e, "chain get header by height".to_owned()).into())
+		let mut txhashset = self.txhashset.write();
+		let mut batch = self.store.batch()?;
+		let header = txhashset::header_extending(&mut txhashset, &mut batch, |extension| {
+			let header = extension.get_header_by_height(height)?;
+			Ok(header)
+		})?;
+
+		Ok(header)
 	}
 
 	/// Gets the block header in which a given output appears in the txhashset
@@ -1136,9 +1145,12 @@ impl Chain {
 	/// Checks the header_by_height index to verify the header is where we say
 	/// it is
 	pub fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {
-		self.store
-			.is_on_current_chain(header)
-			.map_err(|e| ErrorKind::StoreErr(e, "chain is_on_current_chain".to_owned()).into())
+		let chain_header = self.get_header_by_height(header.height)?;
+		if chain_header.hash() == header.hash() {
+			Ok(())
+		} else {
+			Err(ErrorKind::Other(format!("not on current chain")).into())
+		}
 	}
 
 	/// Get the tip of the current "sync" header chain.
@@ -1255,7 +1267,6 @@ fn setup_head(
 					// header and try again
 					let prev_header = batch.get_block_header(&head.prev_block_h)?;
 					let _ = batch.delete_block(&header.hash());
-					let _ = batch.setup_height(&prev_header, &head)?;
 					head = Tip::from_header(&prev_header);
 					batch.save_head(&head)?;
 				}
@@ -1269,7 +1280,6 @@ fn setup_head(
 
 			let tip = Tip::from_header(&genesis.header);
 			batch.save_head(&tip)?;
-			batch.setup_height(&genesis.header, &tip)?;
 
 			// Initialize our header MM with the genesis header.
 			txhashset::header_extending(txhashset, &mut batch, |extension| {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -537,11 +537,6 @@ fn update_head(b: &Block, ctx: &BlockContext) -> Result<Option<Tip>, Error> {
 	// when extending the head), update it
 	let head = ctx.batch.head()?;
 	if has_more_work(&b.header, &head) {
-		// Update the block height index based on this new head.
-		ctx.batch
-			.setup_height(&b.header, &head)
-			.map_err(|e| ErrorKind::StoreErr(e, "pipe setup height".to_owned()))?;
-
 		let tip = Tip::from_header(&b.header);
 
 		ctx.batch
@@ -601,7 +596,7 @@ pub fn rewind_and_apply_header_fork(
 ) -> Result<(), Error> {
 	let mut fork_hashes = vec![];
 	let mut current = ext.batch.get_previous_header(header)?;
-	while current.height > 0 && !ext.batch.is_on_current_chain(&current).is_ok() {
+	while current.height > 0 && !ext.is_on_current_chain(&current).is_ok() {
 		fork_hashes.push(current.hash());
 		current = ext.batch.get_previous_header(&current)?;
 	}
@@ -632,7 +627,7 @@ pub fn rewind_and_apply_fork(b: &Block, ext: &mut txhashset::Extension) -> Resul
 	// keeping the hashes of blocks along the fork
 	let mut fork_hashes = vec![];
 	let mut current = ext.batch.get_previous_header(&b.header)?;
-	while current.height > 0 && !ext.batch.is_on_current_chain(&current).is_ok() {
+	while current.height > 0 && !ext.is_on_current_chain(&current).is_ok() {
 		fork_hashes.push(current.hash());
 		current = ext.batch.get_previous_header(&current)?;
 	}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -204,6 +204,19 @@ impl TxHashSet {
 		kernel_pmmr.get_last_n_insertions(distance)
 	}
 
+	pub fn get_header_by_height(&mut self, height: u64) -> Result<BlockHeader, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+
+		let header_pmmr: PMMR<BlockHeader, _> =
+			PMMR::at(&mut self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
+		if let Some(hash) = header_pmmr.get_data(pos) {
+			let header = self.commit_index.get_block_header(&hash)?;
+			Ok(header)
+		} else {
+			Err(ErrorKind::Other(format!("get header by height")).into())
+		}
+	}
+
 	/// returns outputs from the given insertion (leaf) index up to the
 	/// specified limit. Also returns the last index actually populated
 	pub fn outputs_by_insertion_index(
@@ -267,7 +280,7 @@ impl TxHashSet {
 
 		// horizon for compacting is based on current_height
 		let horizon = current_height.saturating_sub(global::cut_through_horizon().into());
-		let horizon_header = self.commit_index.get_header_by_height(horizon)?;
+		let horizon_header = self.get_header_by_height(horizon)?;
 
 		let batch = self.commit_index.batch()?;
 
@@ -612,6 +625,25 @@ impl<'a> HeaderExtension<'a> {
 		self.pmmr.get_data(pos)
 	}
 
+	pub fn get_header_by_height(&mut self, height: u64) -> Result<BlockHeader, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		if let Some(hash) = self.get_header_hash(pos) {
+			let header = self.batch.get_block_header(&hash)?;
+			Ok(header)
+		} else {
+			Err(ErrorKind::Other(format!("get header by height")).into())
+		}
+	}
+
+	pub fn is_on_current_chain(&mut self, header: &BlockHeader) -> Result<(), Error> {
+		let chain_header = self.get_header_by_height(header.height)?;
+		if chain_header.hash() == header.hash() {
+			Ok(())
+		} else {
+			Err(ErrorKind::Other(format!("not on current chain")).into())
+		}
+	}
+
 	/// Force the rollback of this extension, no matter the result.
 	pub fn force_rollback(&mut self) {
 		self.rollback = true;
@@ -806,10 +838,9 @@ impl<'a> Extension<'a> {
 		UTXOView::new(self.output_pmmr.readonly_pmmr(), self.batch)
 	}
 
-	// TODO - move this into "utxo_view"
 	/// Verify we are not attempting to spend any coinbase outputs
 	/// that have not sufficiently matured.
-	pub fn verify_coinbase_maturity(&self, inputs: &Vec<Input>, height: u64) -> Result<(), Error> {
+	pub fn verify_coinbase_maturity(&mut self, inputs: &Vec<Input>, height: u64) -> Result<(), Error> {
 		// Find the greatest output pos of any coinbase
 		// outputs we are attempting to spend.
 		let pos = inputs
@@ -829,7 +860,7 @@ impl<'a> Extension<'a> {
 			// Find the "cutoff" pos in the output MMR based on the
 			// header from 1,000 blocks ago.
 			let cutoff_height = height.checked_sub(global::coinbase_maturity()).unwrap_or(0);
-			let cutoff_header = self.batch.get_header_by_height(cutoff_height)?;
+			let cutoff_header = self.get_header_by_height(cutoff_height)?;
 			let cutoff_pos = cutoff_header.output_mmr_size;
 
 			// If any output pos exceed the cutoff_pos
@@ -963,6 +994,30 @@ impl<'a> Extension<'a> {
 			.push(header.clone())
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		Ok(())
+	}
+
+	/// Get the header hash for the specified pos from the underlying MMR backend.
+	pub fn get_header_hash(&self, pos: u64) -> Option<Hash> {
+		self.header_pmmr.get_data(pos)
+	}
+
+	pub fn get_header_by_height(&mut self, height: u64) -> Result<BlockHeader, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		if let Some(hash) = self.get_header_hash(pos) {
+			let header = self.batch.get_block_header(&hash)?;
+			Ok(header)
+		} else {
+			Err(ErrorKind::Other(format!("get header by height")).into())
+		}
+	}
+
+	pub fn is_on_current_chain(&mut self, header: &BlockHeader) -> Result<(), Error> {
+		let chain_header = self.get_header_by_height(header.height)?;
+		if chain_header.hash() == header.hash() {
+			Ok(())
+		} else {
+			Err(ErrorKind::Other(format!("not on current chain")).into())
+		}
 	}
 
 	/// TODO - move this into "utxo_view"
@@ -1487,9 +1542,6 @@ pub fn input_pos_to_rewind(
 	head_header: &BlockHeader,
 	batch: &Batch,
 ) -> Result<Bitmap, Error> {
-	let mut current = head_header.hash();
-	let mut height = head_header.height;
-
 	if head_header.height < block_header.height {
 		debug!(
 			"input_pos_to_rewind: {} < {}, nothing to rewind",
@@ -1514,21 +1566,19 @@ pub fn input_pos_to_rewind(
 	};
 
 	let mut block_input_bitmaps: Vec<Bitmap> = vec![];
-	let bh = block_header.hash();
 
-	while current != bh {
-		// We cache recent block headers and block_input_bitmaps
-		// internally in our db layer (commit_index).
-		// I/O should be minimized or eliminated here for most
-		// rewind scenarios.
-		if let Ok(b_res) = batch.get_block_input_bitmap(&current) {
-			bitmap_fast_or(Some(b_res), &mut block_input_bitmaps);
-		}
-		if height == 0 {
+	let mut current = head_header.clone();
+	while current.hash() != block_header.hash() {
+		if current.height < 1 {
 			break;
 		}
-		height -= 1;
-		current = batch.get_hash_by_height(height)?;
+
+		// I/O should be minimized or eliminated here for most
+		// rewind scenarios.
+		if let Ok(b_res) = batch.get_block_input_bitmap(&current.hash()) {
+			bitmap_fast_or(Some(b_res), &mut block_input_bitmaps);
+		}
+		current = batch.get_previous_header(&current)?;
 	}
 
 	let bitmap = bitmap_fast_or(None, &mut block_input_bitmaps).unwrap();

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -840,7 +840,11 @@ impl<'a> Extension<'a> {
 
 	/// Verify we are not attempting to spend any coinbase outputs
 	/// that have not sufficiently matured.
-	pub fn verify_coinbase_maturity(&mut self, inputs: &Vec<Input>, height: u64) -> Result<(), Error> {
+	pub fn verify_coinbase_maturity(
+		&mut self,
+		inputs: &Vec<Input>,
+		height: u64,
+	) -> Result<(), Error> {
 		// Find the greatest output pos of any coinbase
 		// outputs we are attempting to spend.
 		let pos = inputs


### PR DESCRIPTION
The header MMR can be used as the "header by height" index.
MMR insertion index _is_ height for the header MMR.

#2013 was the impetus for this - ideally we'd like to be able to read a header at height `h-60` to validate difficulty adjustment. But we need to be able to do this for _both_ the header chain and the main block chain.

We cannot do this with the existing `header_by_height` index but we can do this with the header_mmr (tracking the main block chain) and sync_mmr (tracking the header chain during sync) pair.

Related - #2028 (we now store header hashes in the header MMR).

