### PR TITLE
find_common_header() does not need to be recursive

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -408,40 +408,18 @@ impl NetToChainAdapter {
 			.expect("Failed to upgrade weak ref to our chain.")
 	}
 
-	// recursively go back through the locator vector and stop when we find
-	// a header that we recognize this will be a header shared in common
-	// between us and the peer
+	// Find the first locator hash that refers to a known header on our main chain.
 	fn find_common_header(&self, locator: Vec<Hash>) -> Option<BlockHeader> {
-		if locator.len() == 0 {
-			return None;
-		}
-
-		let known = self.chain().get_block_header(&locator[0]);
-
-		match known {
-			Ok(header) => {
-				// even if we know the block, it may not be on our winning chain
-				let known_winning = self.chain().get_header_by_height(header.height);
-				if let Ok(known_winning) = known_winning {
-					if known_winning.hash() != header.hash() {
-						self.find_common_header(locator[1..].to_vec())
-					} else {
-						Some(header)
+		for hash in locator {
+			if let Ok(header) = self.chain().get_block_header(&hash) {
+				if let Ok(header_at_height) = self.chain().get_header_by_height(header.height) {
+					if header.hash() == header_at_height.hash() {
+						return Some(header);
 					}
-				} else {
-					self.find_common_header(locator[1..].to_vec())
 				}
 			}
-			Err(e) => match e.kind() {
-				chain::ErrorKind::StoreErr(store::Error::NotFoundErr(_), _) => {
-					self.find_common_header(locator[1..].to_vec())
-				}
-				_ => {
-					error!("Could not build header locator: {:?}", e);
-					None
-				}
-			},
 		}
+		None
 	}
 
 	// pushing the new block through the chain pipeline


### PR DESCRIPTION
We don't need to do this recursively and we can avoid repeatedly building vecs from slices.

We just want to find the first hash in the locator that refers to a header that we - 
a) know about, and
b) is on our main chain (header by height index is consistent)

