### PR TITLE
Cleanup of wallet owner API, rustdoc documentation

### DIFF
--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -973,7 +973,7 @@ fn replicate_tx_fluff_failure() {
 		slate = client1_w.send_tx_sync(dest, &slate)?;
 		api.finalize_tx(&mut slate)?;
 		api.tx_lock_outputs(&slate, lock_fn)?;
-		api.post_tx(&slate, false)?;
+		api.post_tx(&slate.tx, false)?;
 		Ok(())
 	}).unwrap();
 

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -332,7 +332,7 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 				} else {
 					let label = create.unwrap();
 					let res = controller::owner_single_use(wallet, |api| {
-						api.new_account_path(label)?;
+						api.create_account_path(label)?;
 						thread::sleep(Duration::from_millis(200));
 						println!("Account: '{}' Created!", label);
 						Ok(())

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -15,11 +15,11 @@
 use clap::ArgMatches;
 use rpassword;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
-use std::fs::File;
-use std::io::Write;
 
 use serde_json as json;
 
@@ -657,8 +657,11 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 				let fluff = repost_args.is_present("fluff");
 				let (_, txs) = api.retrieve_txs(true, Some(tx_id), None)?;
 				let stored_tx = txs[0].get_stored_tx();
-				if stored_tx.is_none(){
-					println!("Transaction with id {} does not have transaction data. Not reposting.", tx_id);
+				if stored_tx.is_none() {
+					println!(
+						"Transaction with id {} does not have transaction data. Not reposting.",
+						tx_id
+					);
 					std::process::exit(0);
 				}
 				match dump_file {
@@ -671,7 +674,7 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 						info!("Reposted transaction at {}", tx_id);
 						println!("Reposted transaction at {}", tx_id);
 						Ok(())
-					},
+					}
 					Some(f) => {
 						let mut tx_file = File::create(f)?;
 						tx_file.write_all(json::to_string(&stored_tx).unwrap().as_bytes())?;

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -529,24 +529,6 @@ pub fn wallet_command(wallet_args: &ArgMatches, config: GlobalWalletConfig) -> i
 					}
 				}
 			}
-			("burn", Some(send_args)) => {
-				let amount = send_args
-					.value_of("amount")
-					.expect("Amount to burn required");
-				let amount = core::amount_from_hr_string(amount)
-					.expect("Could not parse amount as number with optional decimal point.");
-				let minimum_confirmations: u64 = send_args
-					.value_of("minimum_confirmations")
-					.unwrap()
-					.parse()
-					.expect("Could not parse minimum_confirmations as a whole number.");
-				let max_outputs = 500;
-				api.issue_burn_tx(amount, minimum_confirmations, max_outputs)
-					.unwrap_or_else(|e| {
-						panic!("Error burning tx: {:?} Config: {:?}", e, wallet_config)
-					});
-				Ok(())
-			}
 			("info", Some(args)) => {
 				let minimum_confirmations: u64 = args
 					.value_of("minimum_confirmations")

--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -439,18 +439,6 @@ where
 		)
 	}
 
-	fn issue_burn_tx(
-		&self,
-		_req: Request<Body>,
-		mut api: APIOwner<T, C, K>,
-	) -> Box<Future<Item = (), Error = Error> + Send> {
-		// TODO: Args
-		Box::new(match api.issue_burn_tx(60, 10, 1000) {
-			Ok(_) => ok(()),
-			Err(e) => err(e),
-		})
-	}
-
 	fn handle_post_request(&self, req: Request<Body>) -> WalletResponseFuture {
 		let api = APIOwner::new(self.wallet.clone());
 		match req
@@ -475,10 +463,6 @@ where
 			),
 			"post_tx" => Box::new(
 				self.post_tx(req, api)
-					.and_then(|_| ok(response(StatusCode::OK, ""))),
-			),
-			"issue_burn_tx" => Box::new(
-				self.issue_burn_tx(req, api)
 					.and_then(|_| ok(response(StatusCode::OK, ""))),
 			),
 			_ => Box::new(err(ErrorKind::GenericError(

--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -222,31 +222,31 @@ where
 		api.retrieve_txs(update_from_node, tx_id, tx_slate_id)
 	}
 
-	fn dump_stored_tx(
+	fn retrieve_stored_tx(
 		&self,
 		req: &Request<Body>,
 		api: APIOwner<T, C, K>,
-	) -> Result<Transaction, Error> {
+	) -> Result<(bool, Option<Transaction>), Error> {
 		let params = parse_params(req);
 		if let Some(id_string) = params.get("id") {
 			match id_string[0].parse() {
-				Ok(id) => match api.dump_stored_tx(id, false, "") {
-					Ok(tx) => Ok(tx),
+				Ok(id) => match api.retrieve_txs(true, Some(id), None) {
+					Ok((_, txs)) => Ok((txs[0].confirmed, txs[0].get_stored_tx())),
 					Err(e) => {
-						error!("dump_stored_tx: failed with error: {}", e);
+						error!("retrieve_stored_tx: failed with error: {}", e);
 						Err(e)
 					}
 				},
 				Err(e) => {
-					error!("dump_stored_tx: could not parse id: {}", e);
+					error!("retrieve_stored_tx: could not parse id: {}", e);
 					Err(ErrorKind::TransactionDumpError(
-						"dump_stored_tx: cannot dump transaction. Could not parse id in request.",
+						"retrieve_stored_tx: cannot dump transaction. Could not parse id in request.",
 					).into())
 				}
 			}
 		} else {
 			Err(ErrorKind::TransactionDumpError(
-				"dump_stored_tx: Cannot dump transaction. Missing id param in request.",
+				"retrieve_stored_tx: Cannot retrieve transaction. Missing id param in request.",
 			).into())
 		}
 	}
@@ -292,7 +292,7 @@ where
 			"retrieve_summary_info" => json_response(&self.retrieve_summary_info(req, api)?),
 			"node_height" => json_response(&self.node_height(req, api)?),
 			"retrieve_txs" => json_response(&self.retrieve_txs(req, api)?),
-			"dump_stored_tx" => json_response(&self.dump_stored_tx(req, api)?),
+			"retrieve_stored_tx" => json_response(&self.retrieve_stored_tx(req, api)?),
 			_ => response(StatusCode::BAD_REQUEST, ""),
 		})
 	}

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -29,7 +29,6 @@
 //! its operation, then 'close' the wallet (unloading references to the keychain and master
 //! seed).
 
-
 use std::fs::File;
 use std::io::Write;
 use std::marker::PhantomData;
@@ -80,7 +79,7 @@ where
 	/// [open_with_credentials](../types/trait.WalletBackend.html#tymethod.open_with_credentials)
 	/// (initialising a keychain with the master seed,) perform its operation, then close the keychain
 	/// with a call to [close](../types/trait.WalletBackend.html#tymethod.close)
-	
+
 	pub fn new(wallet_in: Arc<Mutex<W>>) -> Self {
 		APIOwner {
 			wallet: wallet_in,

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -68,7 +68,6 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-
 	/// Create a new API instance with the given wallet instance. All subsequent
 	/// API calls will operate on this instance of the wallet.
 	///
@@ -78,7 +77,7 @@ where
 	/// with a call to [close](../types/trait.WalletBackend.html#tymethod.close)
 	///
 	/// # Arguments
-	/// * `wallet_in` - A reference-counted mutex containing an implementation of the 
+	/// * `wallet_in` - A reference-counted mutex containing an implementation of the
 	/// [WalletBackend](../types/trait.WalletBackend.html) trait.
 	///
 	/// # Returns
@@ -101,7 +100,7 @@ where
 	///
 	/// let mut wallet_config = WalletConfig::default();
 	///
-	/// // A NodeClient must first be created to handle communication between 
+	/// // A NodeClient must first be created to handle communication between
 	/// // the wallet and the node.
 	///
 	/// let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
@@ -153,15 +152,15 @@ where
 	/// provided during wallet instantiation). If `false`, the results will
 	/// contain output information that may be out-of-date (from the last time
 	/// the wallet's output set was refreshed against the node).
-	/// * `tx_id` - If `Some(i)`, only return the outputs associated with 
+	/// * `tx_id` - If `Some(i)`, only return the outputs associated with
 	/// the transaction log entry of id `i`.
 	///
 	/// # Returns
 	/// * (`bool`, `Vec<OutputData, Commitment>`) - A tuple:
-	/// * The first `bool` element indicates whether the data was successfully 
-	/// refreshed from the node (note this may be false even if the `refresh_from_node` 
+	/// * The first `bool` element indicates whether the data was successfully
+	/// refreshed from the node (note this may be false even if the `refresh_from_node`
 	/// argument was set to `true`.
-	/// * The second element contains the result set, of which each element is 
+	/// * The second element contains the result set, of which each element is
 	/// a mapping between the wallet's internal [OutputData](../types/struct.OutputData.html)
 	/// and the Output commitment as identified in the chain's UTXO set
 	///
@@ -237,8 +236,8 @@ where
 	///
 	/// # Returns
 	/// * (`bool`, `Vec<[TxLogEntry](../types/struct.TxLogEntry.html)>`) - A tuple:
-	/// * The first `bool` element indicates whether the data was successfully 
-	/// refreshed from the node (note this may be false even if the `refresh_from_node` 
+	/// * The first `bool` element indicates whether the data was successfully
+	/// refreshed from the node (note this may be false even if the `refresh_from_node`
 	/// argument was set to `true`.
 	/// * The second element contains the set of retrieved
 	/// [TxLogEntries](../types/struct/TxLogEntry.html)

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -424,30 +424,6 @@ where
 		Ok(())
 	}
 
-	/// Issue a burn TX
-	pub fn issue_burn_tx(
-		&mut self,
-		amount: u64,
-		minimum_confirmations: u64,
-		max_outputs: usize,
-	) -> Result<(), Error> {
-		let mut w = self.wallet.lock();
-		w.open_with_credentials()?;
-		let parent_key_id = w.parent_key_id();
-		let tx_burn = tx::issue_burn_tx(
-			&mut *w,
-			amount,
-			minimum_confirmations,
-			max_outputs,
-			&parent_key_id,
-		)?;
-		let tx_hex = util::to_hex(ser::ser_vec(&tx_burn).unwrap());
-		w.w2n_client()
-			.post_tx(&TxWrapper { tx_hex: tx_hex }, false)?;
-		w.close()?;
-		Ok(())
-	}
-
 	/// Posts a transaction to the chain
 	pub fn post_tx(&self, tx: &Transaction, fluff: bool) -> Result<(), Error> {
 		let tx_hex = util::to_hex(ser::ser_vec(tx).unwrap());

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -122,7 +122,7 @@ where
 		}
 	}
 
-	/// Returns a list of accounts stored in the wallet (i.e. mappings between 
+	/// Returns a list of accounts stored in the wallet (i.e. mappings between
 	/// user-specified labels and BIP32 derivation paths.
 	///
 	/// # Returns
@@ -236,7 +236,7 @@ where
 	///
 	/// # Remarks
 	///
-	/// * Wallet parent paths are 2 path elements long, e.g. `m/0/0` is the path 
+	/// * Wallet parent paths are 2 path elements long, e.g. `m/0/0` is the path
 	/// labelled 'default'. Keys derived from this parent path are 3 elements long,
 	/// e.g. the secret keys derived from the `m/0/0` path will be  at paths `m/0/0/0`,
 	/// `m/0/0/1` etc...

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -34,9 +34,9 @@ use keychain::{Identifier, Keychain};
 use libtx::aggsig;
 use libwallet::error::{Error, ErrorKind};
 
+use util;
 use util::secp::key::{PublicKey, SecretKey};
 use util::secp::{self, pedersen, Secp256k1};
-use util;
 
 /// Combined trait to allow dynamic wallet dispatch
 pub trait WalletInst<C, K>: WalletBackend<C, K> + Send + Sync + 'static

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -26,6 +26,7 @@ use failure::ResultExt;
 use uuid::Uuid;
 
 use core::core::hash::Hash;
+use core::core::Transaction;
 use core::ser;
 
 use keychain::{Identifier, Keychain};
@@ -35,6 +36,7 @@ use libwallet::error::{Error, ErrorKind};
 
 use util::secp::key::{PublicKey, SecretKey};
 use util::secp::{self, pedersen, Secp256k1};
+use util;
 
 /// Combined trait to allow dynamic wallet dispatch
 pub trait WalletInst<C, K>: WalletBackend<C, K> + Send + Sync + 'static
@@ -638,6 +640,17 @@ impl TxLogEntry {
 	/// Update confirmation TS with now
 	pub fn update_confirmation_ts(&mut self) {
 		self.confirmation_ts = Some(Utc::now());
+	}
+
+	/// Retrieve the stored transaction, if any
+	pub fn get_stored_tx(&self) -> Option<Transaction> {
+		match self.tx_hex.as_ref() {
+			None => None,
+			Some(t) => {
+				let tx_bin = util::from_hex(t.clone()).unwrap();
+				Some(ser::deserialize::<Transaction>(&mut &tx_bin[..]).unwrap())
+			}
+		}
 	}
 }
 

--- a/wallet/tests/accounts.rs
+++ b/wallet/tests/accounts.rs
@@ -194,7 +194,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;
 		api.tx_lock_outputs(&slate, lock_fn)?;
 		api.finalize_tx(&mut slate)?;
-		api.post_tx(&slate, false)?;
+		api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/accounts.rs
+++ b/wallet/tests/accounts.rs
@@ -86,21 +86,21 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let new_path = api.new_account_path("account1").unwrap();
+		let new_path = api.create_account_path("account1").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 1, 0, 0, 0));
-		let new_path = api.new_account_path("account2").unwrap();
+		let new_path = api.create_account_path("account2").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 2, 0, 0, 0));
-		let new_path = api.new_account_path("account3").unwrap();
+		let new_path = api.create_account_path("account3").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 3, 0, 0, 0));
 		// trying to add same label again should fail
-		let res = api.new_account_path("account1");
+		let res = api.create_account_path("account1");
 		assert!(res.is_err());
 		Ok(())
 	})?;
 
 	// add account to wallet 2
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let new_path = api.new_account_path("listener_account").unwrap();
+		let new_path = api.create_account_path("listener_account").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 1, 0, 0, 0));
 		Ok(())
 	})?;

--- a/wallet/tests/common/testclient.rs
+++ b/wallet/tests/common/testclient.rs
@@ -376,11 +376,11 @@ impl WalletCommAdapter for LocalWalletClient {
 
 	fn listen(
 		&self,
-		params: HashMap<String, String>,
-		config: WalletConfig,
-		passphrase: &str,
-		account: &str,
-		node_api_secret: Option<String>,
+		_params: HashMap<String, String>,
+		_config: WalletConfig,
+		_passphrase: &str,
+		_account: &str,
+		_node_api_secret: Option<String>,
 	) -> Result<(), libwallet::Error> {
 		unimplemented!();
 	}

--- a/wallet/tests/file.rs
+++ b/wallet/tests/file.rs
@@ -141,7 +141,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		let adapter = FileWalletCommAdapter::new();
 		let mut slate = adapter.receive_tx_async(&receive_file)?;
 		api.finalize_tx(&mut slate)?;
-		api.post_tx(&slate, false);
+		api.post_tx(&slate.tx, false)?;
 		bh += 1;
 		Ok(())
 	})?;

--- a/wallet/tests/file.rs
+++ b/wallet/tests/file.rs
@@ -74,15 +74,15 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.new_account_path("mining")?;
-		api.new_account_path("listener")?;
+		api.create_account_path("mining")?;
+		api.create_account_path("listener")?;
 		Ok(())
 	})?;
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.new_account_path("account1")?;
-		api.new_account_path("account2")?;
+		api.create_account_path("account1")?;
+		api.create_account_path("account2")?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/repost.rs
+++ b/wallet/tests/repost.rs
@@ -75,15 +75,15 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.new_account_path("mining")?;
-		api.new_account_path("listener")?;
+		api.create_account_path("mining")?;
+		api.create_account_path("listener")?;
 		Ok(())
 	})?;
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.new_account_path("account1")?;
-		api.new_account_path("account2")?;
+		api.create_account_path("account1")?;
+		api.create_account_path("account2")?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/repost.rs
+++ b/wallet/tests/repost.rs
@@ -155,7 +155,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	// Now repost from cached
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
 		let (_, txs) = api.retrieve_txs(true, None, Some(slate.id))?;
-		api.post_stored_tx(txs[0].id, false)?;
+		api.post_tx(&txs[0].get_stored_tx().unwrap(), false)?;
 		bh += 1;
 		Ok(())
 	})?;
@@ -220,7 +220,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	// Now repost from cached
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
 		let (_, txs) = api.retrieve_txs(true, None, Some(slate.id))?;
-		api.post_stored_tx(txs[0].id, false)?;
+		api.post_tx(&txs[0].get_stored_tx().unwrap(), false)?;
 		bh += 1;
 		Ok(())
 	})?;

--- a/wallet/tests/restore.rs
+++ b/wallet/tests/restore.rs
@@ -198,8 +198,8 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// wallet 2 will use another account
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.new_account_path("account1")?;
-		api.new_account_path("account2")?;
+		api.create_account_path("account1")?;
+		api.create_account_path("account2")?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/restore.rs
+++ b/wallet/tests/restore.rs
@@ -240,7 +240,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
 		sender_api.finalize_tx(&mut slate)?;
-		sender_api.post_tx(&slate, false)?;
+		sender_api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 
@@ -261,7 +261,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 		slate = client1.send_tx_slate_direct("wallet3", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
 		sender_api.finalize_tx(&mut slate)?;
-		sender_api.post_tx(&slate, false)?;
+		sender_api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 
@@ -282,7 +282,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
 		sender_api.finalize_tx(&mut slate)?;
-		sender_api.post_tx(&slate, false)?;
+		sender_api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 
@@ -309,7 +309,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
 		sender_api.finalize_tx(&mut slate)?;
-		sender_api.post_tx(&slate, false)?;
+		sender_api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/self_send.rs
+++ b/wallet/tests/self_send.rs
@@ -72,8 +72,8 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.new_account_path("mining")?;
-		api.new_account_path("listener")?;
+		api.create_account_path("mining")?;
+		api.create_account_path("listener")?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/self_send.rs
+++ b/wallet/tests/self_send.rs
@@ -109,7 +109,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		})?;
 		api.finalize_tx(&mut slate)?;
 		api.tx_lock_outputs(&slate, lock_fn)?;
-		api.post_tx(&slate, false)?; // mines a block
+		api.post_tx(&slate.tx, false)?; // mines a block
 		bh += 1;
 		Ok(())
 	})?;

--- a/wallet/tests/transaction.rs
+++ b/wallet/tests/transaction.rs
@@ -157,7 +157,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// post transaction
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.post_tx(&slate, false)?;
+		api.post_tx(&slate.tx, false)?;
 		Ok(())
 	})?;
 
@@ -255,13 +255,12 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 		let (refreshed, _wallet1_info) = sender_api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		let (_, txs) = sender_api.retrieve_txs(true, None, None)?;
-
 		// find the transaction
 		let tx = txs
 			.iter()
 			.find(|t| t.tx_slate_id == Some(slate.id))
 			.unwrap();
-		sender_api.post_stored_tx(tx.id, false)?;
+		sender_api.post_tx(&tx.get_stored_tx().unwrap(), false)?;
 		let (_, wallet1_info) = sender_api.retrieve_summary_info(true, 1)?;
 		// should be mined now
 		assert_eq!(


### PR DESCRIPTION
Cleans up the libwallet::api::OwnerAPI somewhat:

* change `post_tx` to take a transaction instead of a slate
* remove `dump_stored_tx` and `post_stored_tx`. caller can instead just call `get_stored_tx` on a TxLogEntry and either save the results or call `post_tx` with it
* add `set_active_account` convenience function

Also, large chunk of proper rustdoc documentation for the API (about half-done in this PR). 

Note none of these changes affect the HTTP wrapper found in `wallet/src/controller.rs`, which are wired to work as before while using the changed OwnerAPI underneath. Cleanup of that wrapper is next on the list after cleaning up/documenting the underlying Owner/Foreign APIs.