### PR TITLE
decouple kernels from the kernel MMR

### DIFF
--- a/chain/src/txhashset/rewindable_kernel_view.rs
+++ b/chain/src/txhashset/rewindable_kernel_view.rs
@@ -15,7 +15,7 @@
 //! Lightweight readonly view into kernel MMR for convenience.
 
 use core::core::pmmr::RewindablePMMR;
-use core::core::{BlockHeader, TxKernelEntry};
+use core::core::{BlockHeader, TxKernel};
 
 use error::{Error, ErrorKind};
 use grin_store::pmmr::PMMRBackend;
@@ -23,7 +23,7 @@ use store::Batch;
 
 /// Rewindable (but readonly) view of the kernel set (based on kernel MMR).
 pub struct RewindableKernelView<'a> {
-	pmmr: RewindablePMMR<'a, TxKernelEntry, PMMRBackend<TxKernelEntry>>,
+	pmmr: RewindablePMMR<'a, TxKernel, PMMRBackend<TxKernel>>,
 	batch: &'a Batch<'a>,
 	header: BlockHeader,
 }
@@ -31,7 +31,7 @@ pub struct RewindableKernelView<'a> {
 impl<'a> RewindableKernelView<'a> {
 	/// Build a new readonly kernel view.
 	pub fn new(
-		pmmr: RewindablePMMR<'a, TxKernelEntry, PMMRBackend<TxKernelEntry>>,
+		pmmr: RewindablePMMR<'a, TxKernel, PMMRBackend<TxKernel>>,
 		batch: &'a Batch,
 		header: BlockHeader,
 	) -> RewindableKernelView<'a> {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -104,7 +104,7 @@ pub struct TxHashSet {
 
 	output_pmmr_h: PMMRHandle<OutputIdentifier>,
 	rproof_pmmr_h: PMMRHandle<RangeProof>,
-	kernel_pmmr_h: PMMRHandle<TxKernelEntry>,
+	kernel_pmmr_h: PMMRHandle<TxKernel>,
 
 	// chain store used as index of commitments to MMR positions
 	commit_index: Arc<ChainStore>,
@@ -199,7 +199,7 @@ impl TxHashSet {
 
 	/// as above, for kernels
 	pub fn last_n_kernel(&mut self, distance: u64) -> Vec<(Hash, TxKernelEntry)> {
-		let kernel_pmmr: PMMR<TxKernelEntry, _> =
+		let kernel_pmmr: PMMR<TxKernel, _> =
 			PMMR::at(&mut self.kernel_pmmr_h.backend, self.kernel_pmmr_h.last_pos);
 		kernel_pmmr.get_last_n_insertions(distance)
 	}
@@ -256,7 +256,7 @@ impl TxHashSet {
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		let rproof_pmmr: PMMR<RangeProof, _> =
 			PMMR::at(&mut self.rproof_pmmr_h.backend, self.rproof_pmmr_h.last_pos);
-		let kernel_pmmr: PMMR<TxKernelEntry, _> =
+		let kernel_pmmr: PMMR<TxKernel, _> =
 			PMMR::at(&mut self.kernel_pmmr_h.backend, self.kernel_pmmr_h.last_pos);
 
 		TxHashSetRoots {
@@ -775,7 +775,7 @@ pub struct Extension<'a> {
 	header_pmmr: PMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
 	output_pmmr: PMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
 	rproof_pmmr: PMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
-	kernel_pmmr: PMMR<'a, TxKernelEntry, PMMRBackend<TxKernelEntry>>,
+	kernel_pmmr: PMMR<'a, TxKernel, PMMRBackend<TxKernel>>,
 
 	/// Rollback flag.
 	rollback: bool,
@@ -996,7 +996,7 @@ impl<'a> Extension<'a> {
 	/// Push kernel onto MMR (hash and data files).
 	fn apply_kernel(&mut self, kernel: &TxKernel) -> Result<(), Error> {
 		self.kernel_pmmr
-			.push(TxKernelEntry::from(kernel.clone()))
+			.push(kernel.clone())
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		Ok(())
 	}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -188,6 +188,15 @@ impl Readable for TxKernel {
 	}
 }
 
+/// We store TxKernelEntry in the kernel MMR.
+impl PMMRable for TxKernel {
+	type E = TxKernelEntry;
+
+	fn as_elmt(self) -> Self::E {
+		self.into()
+	}
+}
+
 impl TxKernel {
 	/// Return the excess commitment for this tx_kernel.
 	pub fn excess(&self) -> Commitment {
@@ -308,14 +317,6 @@ impl FixedLength for TxKernelEntry {
 	const LEN: usize = 17 // features plus fee and lock_height
 		+ secp::constants::PEDERSEN_COMMITMENT_SIZE
 		+ secp::constants::AGG_SIGNATURE_SIZE;
-}
-
-impl PMMRable for TxKernelEntry {
-	type E = Self;
-
-	fn as_elmt(self) -> Self::E {
-		self
-	}
 }
 
 /// TransactionBody is a common abstraction for transaction and block


### PR DESCRIPTION
The header MMR changes introduced a "dependent type" to `PMMRable` so we could build an MMR from headers, but store hashes.

We can use this to cleanup the code around `TxKernel` and `TxKernelEntry` (which we store in the MMR).

Going to do a similar cleanup for `Output` and `OutputIdentifier` in a separate PR.

Nothing changes here in terms of the data itself - we were already storing `TxKernelEntry` in the data file. This refactor just allows us to build a `kernel MMR` and not need to explicitly state this (we just defined the relationship between `TxKernel` and `TxKernelEntry` once in the `PMMRable` trait implementation which I think is clearer and reads better.

