### PR TITLE
decouple outputs from output MMR

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -102,7 +102,7 @@ pub struct TxHashSet {
 	/// via a "sync_extension".
 	sync_pmmr_h: PMMRHandle<BlockHeader>,
 
-	output_pmmr_h: PMMRHandle<OutputIdentifier>,
+	output_pmmr_h: PMMRHandle<Output>,
 	rproof_pmmr_h: PMMRHandle<RangeProof>,
 	kernel_pmmr_h: PMMRHandle<TxKernelEntry>,
 
@@ -163,7 +163,7 @@ impl TxHashSet {
 	pub fn is_unspent(&mut self, output_id: &OutputIdentifier) -> Result<(Hash, u64), Error> {
 		match self.commit_index.get_output_pos(&output_id.commit) {
 			Ok(pos) => {
-				let output_pmmr: PMMR<OutputIdentifier, _> =
+				let output_pmmr: PMMR<Output, _> =
 					PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 				if let Some(hash) = output_pmmr.get_hash(pos) {
 					if hash == output_id.hash_with_index(pos - 1) {
@@ -185,7 +185,7 @@ impl TxHashSet {
 	/// TODO: These need to return the actual data from the flat-files instead
 	/// of hashes now
 	pub fn last_n_output(&mut self, distance: u64) -> Vec<(Hash, OutputIdentifier)> {
-		let output_pmmr: PMMR<OutputIdentifier, _> =
+		let output_pmmr: PMMR<Output, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		output_pmmr.get_last_n_insertions(distance)
 	}
@@ -227,7 +227,7 @@ impl TxHashSet {
 		start_index: u64,
 		max_count: u64,
 	) -> (u64, Vec<OutputIdentifier>) {
-		let output_pmmr: PMMR<OutputIdentifier, _> =
+		let output_pmmr: PMMR<Output, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		output_pmmr.elements_from_insertion_index(start_index, max_count)
 	}
@@ -252,7 +252,7 @@ impl TxHashSet {
 	pub fn roots(&mut self) -> TxHashSetRoots {
 		let header_pmmr: PMMR<BlockHeader, _> =
 			PMMR::at(&mut self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
-		let output_pmmr: PMMR<OutputIdentifier, _> =
+		let output_pmmr: PMMR<Output, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		let rproof_pmmr: PMMR<RangeProof, _> =
 			PMMR::at(&mut self.rproof_pmmr_h.backend, self.rproof_pmmr_h.last_pos);
@@ -270,7 +270,7 @@ impl TxHashSet {
 	/// build a new merkle proof for the given position
 	pub fn merkle_proof(&mut self, commit: Commitment) -> Result<MerkleProof, String> {
 		let pos = self.commit_index.get_output_pos(&commit).unwrap();
-		let output_pmmr: PMMR<OutputIdentifier, _> =
+		let output_pmmr: PMMR<Output, _> =
 			PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		output_pmmr.merkle_proof(pos)
 	}
@@ -773,7 +773,7 @@ pub struct Extension<'a> {
 	header: BlockHeader,
 
 	header_pmmr: PMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
-	output_pmmr: PMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
+	output_pmmr: PMMR<'a, Output, PMMRBackend<Output>>,
 	rproof_pmmr: PMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 	kernel_pmmr: PMMR<'a, TxKernelEntry, PMMRBackend<TxKernelEntry>>,
 
@@ -967,7 +967,7 @@ impl<'a> Extension<'a> {
 		// push the new output to the MMR.
 		let output_pos = self
 			.output_pmmr
-			.push(OutputIdentifier::from_output(out))
+			.push(out.clone())
 			.map_err(&ErrorKind::TxHashSetErr)?;
 
 		// push the rangeproof to the MMR.

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -15,7 +15,7 @@
 //! Lightweight readonly view into output MMR for convenience.
 
 use core::core::pmmr::ReadonlyPMMR;
-use core::core::{Block, Input, Output, OutputIdentifier, Transaction};
+use core::core::{Block, Input, Output, Transaction};
 
 use error::{Error, ErrorKind};
 use grin_store::pmmr::PMMRBackend;
@@ -23,14 +23,14 @@ use store::Batch;
 
 /// Readonly view of the UTXO set (based on output MMR).
 pub struct UTXOView<'a> {
-	pmmr: ReadonlyPMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
+	pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 	batch: &'a Batch<'a>,
 }
 
 impl<'a> UTXOView<'a> {
 	/// Build a new UTXO view.
 	pub fn new(
-		pmmr: ReadonlyPMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
+		pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 		batch: &'a Batch,
 	) -> UTXOView<'a> {
 		UTXOView { pmmr, batch }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1146,6 +1146,15 @@ impl Readable for Output {
 	}
 }
 
+/// We can build an Output MMR but store instances of OutputIdentifier in the MMR data file.
+impl PMMRable for Output {
+	type E = OutputIdentifier;
+
+	fn as_elmt(self) -> Self::E {
+		self.into()
+	}
+}
+
 impl Output {
 	/// Commitment for the output
 	pub fn commitment(&self) -> Commitment {
@@ -1243,14 +1252,6 @@ impl FixedLength for OutputIdentifier {
 	const LEN: usize = 1 + secp::constants::PEDERSEN_COMMITMENT_SIZE;
 }
 
-impl PMMRable for OutputIdentifier {
-	type E = Self;
-
-	fn as_elmt(self) -> Self::E {
-		self
-	}
-}
-
 impl Writeable for OutputIdentifier {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		writer.write_u8(self.features.bits())?;
@@ -1267,6 +1268,15 @@ impl Readable for OutputIdentifier {
 			features,
 			commit: Commitment::read(reader)?,
 		})
+	}
+}
+
+impl From<Output> for OutputIdentifier {
+	fn from(out: Output) -> Self {
+		OutputIdentifier {
+			features: out.features,
+			commit: out.commit,
+		}
 	}
 }
 


### PR DESCRIPTION
We can now build an output MMR but continue to store `OutputIdentifier` in the data file.
Related - #2043.

We can take advantage of the "dependent type" introduce to `PMMRable` as part of the header MMR work to define what we store in the MMR data file.
For headers we store the header hash, for outputs we store the output_identifier etc.

