### PR TITLE
[WIP] additional hard fork at 65,080 for secondary pow ratio changes

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -67,7 +67,7 @@ pub fn secondary_pow_ratio(height: u64) -> u64 {
 	if global::is_mainnet() {
 		90u64.saturating_sub(height / (2 * YEAR_HEIGHT / 90))
 	} else {
-		if height < T4_CUCKAROO_HARDFORK {
+		if height < T4_POW_RATIO_HARDFORK {
 			// Maintaining pre hardfork testnet4 behavior
 			90u64.saturating_sub(height / WEEK_HEIGHT)
 		} else {
@@ -88,6 +88,9 @@ pub const SECOND_POW_EDGE_BITS: u8 = 29;
 /// Block height at which testnet 4 hard forks to use Cuckaroo instead of
 /// Cuckatoo for ASIC-resistant PoW
 pub const T4_CUCKAROO_HARDFORK: u64 = 64_000;
+
+/// Block height at which testnet 4 hard forks with the adjusted secondary pow ratio calculation.
+pub const T4_POW_RATIO_HARDFORK: u64 = T4_CUCKAROO_HARDFORK + WEEK_HEIGHT;
 
 /// Original reference edge_bits to compute difficulty factors for higher
 /// Cuckoo graph sizes, changing this would hard fork

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -495,10 +495,10 @@ fn test_secondary_pow_ratio() {
 		assert_eq!(secondary_pow_ratio(two_weeks), 89);
 		assert_eq!(secondary_pow_ratio(two_weeks + 1), 89);
 
-		let t4_fork_height = 64_000;
-		assert_eq!(secondary_pow_ratio(t4_fork_height - 1), 85);
-		assert_eq!(secondary_pow_ratio(t4_fork_height), 85);
-		assert_eq!(secondary_pow_ratio(t4_fork_height + 1), 85);
+		let t4_fork_height = 64_000 + 10_080;
+		assert_eq!(secondary_pow_ratio(t4_fork_height - 1), 84);
+		assert_eq!(secondary_pow_ratio(t4_fork_height), 84);
+		assert_eq!(secondary_pow_ratio(t4_fork_height + 1), 84);
 
 		let one_year = one_week * 52;
 		assert_eq!(secondary_pow_ratio(one_year), 45);
@@ -537,10 +537,10 @@ fn test_secondary_pow_ratio() {
 		assert_eq!(secondary_pow_ratio(two_weeks), 88);
 		assert_eq!(secondary_pow_ratio(two_weeks + 1), 88);
 
-		let t4_fork_height = 64_000;
-		assert_eq!(secondary_pow_ratio(t4_fork_height - 1), 84);
-		assert_eq!(secondary_pow_ratio(t4_fork_height), 85);
-		assert_eq!(secondary_pow_ratio(t4_fork_height + 1), 85);
+		let t4_fork_height = 64_000 + 10_080;
+		assert_eq!(secondary_pow_ratio(t4_fork_height - 1), 83);
+		assert_eq!(secondary_pow_ratio(t4_fork_height), 84);
+		assert_eq!(secondary_pow_ratio(t4_fork_height + 1), 84);
 
 		let one_year = one_week * 52;
 		assert_eq!(secondary_pow_ratio(one_year), 45);


### PR DESCRIPTION
Related - #2037.

As discussed in #2037 it was maybe too aggressive to try and get this into the scheduled hard fork at height `64,000`.

This PR introduces a subsequent hard fork a week later at height `64,000 + 10,080 = 65,080`.

Regarding anyone who deployed the interim code that schedules this changes to activate (prematurely) at `64,000`, are we happy with just warning people via gitter and hoping they update?

