### PR TITLE
cleanup unnecessary reset_head calls

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1014,14 +1014,6 @@ impl Chain {
 		self.orphans.len()
 	}
 
-	/// Reset header_head and sync_head to head of current body chain
-	pub fn reset_head(&self) -> Result<(), Error> {
-		let batch = self.store.batch()?;
-		batch.reset_head()?;
-		batch.commit()?;
-		Ok(())
-	}
-
 	/// Tip (head) of the block chain.
 	pub fn head(&self) -> Result<Tip, Error> {
 		self.store
@@ -1159,14 +1151,6 @@ impl Chain {
 			.block_exists(&h)
 			.map_err(|e| ErrorKind::StoreErr(e, "chain block exists".to_owned()).into())
 	}
-
-	/// Reset sync_head to the provided head.
-	pub fn reset_sync_head(&self, head: &Tip) -> Result<(), Error> {
-		let batch = self.store.batch()?;
-		batch.save_sync_head(head)?;
-		batch.commit()?;
-		Ok(())
-	}
 }
 
 fn setup_head(
@@ -1296,7 +1280,8 @@ fn setup_head(
 			head.last_block_h,
 			head.height,
 		);
-		batch.reset_head()?;
+		batch.reset_header_head()?;
+		batch.reset_sync_head()?;
 	}
 
 	batch.commit()?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -175,16 +175,16 @@ impl<'a> Batch<'a> {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
+	/// Reset sync_head to the current head of the header chain.
 	pub fn reset_sync_head(&self) -> Result<(), Error> {
 		let head = self.header_head()?;
 		self.save_sync_head(&head)
 	}
 
-	// Reset both header_head and sync_head to the current head of the body chain
-	pub fn reset_head(&self) -> Result<(), Error> {
+	/// Reset header_head to the current head of the body chain.
+	pub fn reset_header_head(&self) -> Result<(), Error> {
 		let tip = self.head()?;
-		self.save_header_head(&tip)?;
-		self.save_sync_head(&tip)
+		self.save_header_head(&tip)
 	}
 
 	/// get block

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -66,9 +66,6 @@ impl HeaderSync {
 					header_head.height,
 				);
 
-				// Reset sync_head to the same as current header_head.
-				self.chain.reset_sync_head(&header_head).unwrap();
-
 				// Rebuild the sync MMR to match our updated sync_head.
 				self.chain.rebuild_sync_mmr(&header_head).unwrap();
 

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -198,8 +198,6 @@ impl SyncRunner {
 					ch.height,
 					ch.last_block_h
 				);
-
-				let _ = self.chain.reset_head();
 				is_syncing = false;
 			}
 		} else {


### PR DESCRIPTION
Resolves #2071.

Make `reset_header_head()` and `reset_sync_head()` more explicit.
We don't need to call `reset_head()` if we receive a bad header or block, the head will not be updated in this scenario.
Reorder the checks in `validate_chain()` so the fastest one (checking the config) comes first, so we skip chain validation quickly.

