### PR TITLE
store pmmr cleanup

### DIFF
--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -59,7 +59,7 @@ pub trait Backend<T: PMMRable> {
 	/// Returns the data file path.. this is a bit of a hack now that doesn't
 	/// sit well with the design, but TxKernels have to be summed and the
 	/// fastest way to to be able to allow direct access to the file
-	fn get_data_file_path(&self) -> String;
+	fn get_data_file_path(&self) -> &str;
 
 	/// Also a bit of a hack...
 	/// Saves a snapshot of the rewound utxo file with the block hash as

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -369,7 +369,7 @@ where
 	}
 
 	/// Return the path of the data file (needed to sum kernels efficiently)
-	pub fn data_file_path(&self) -> String {
+	pub fn data_file_path(&self) -> &str {
 		self.backend.get_data_file_path()
 	}
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -291,7 +291,7 @@ pub fn serialize<W: Writeable>(sink: &mut Write, thing: &W) -> Result<(), Error>
 /// Utility function to serialize a writeable directly in memory using a
 /// Vec<u8>.
 pub fn ser_vec<W: Writeable>(thing: &W) -> Result<Vec<u8>, Error> {
-	let mut vec = Vec::new();
+	let mut vec = vec![];
 	serialize(&mut vec, thing)?;
 	Ok(vec)
 }

--- a/core/tests/vec_backend/mod.rs
+++ b/core/tests/vec_backend/mod.rs
@@ -118,8 +118,8 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		Ok(())
 	}
 
-	fn get_data_file_path(&self) -> String {
-		"".to_string()
+	fn get_data_file_path(&self) -> &str {
+		""
 	}
 
 	fn dump_stats(&self) {}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -23,7 +23,7 @@ use core::core::BlockHeader;
 use core::ser::{self, FixedLength, PMMRable};
 use leaf_set::LeafSet;
 use prune_list::PruneList;
-use types::{prune_noop, AppendOnlyFile, HashFile};
+use types::{prune_noop, DataFile, HashFile};
 
 const PMMR_HASH_FILE: &str = "pmmr_hash.bin";
 const PMMR_DATA_FILE: &str = "pmmr_data.bin";
@@ -53,10 +53,9 @@ pub struct PMMRBackend<T: PMMRable> {
 	data_dir: String,
 	prunable: bool,
 	hash_file: HashFile,
-	data_file: AppendOnlyFile,
+	data_file: DataFile<T>,
 	leaf_set: LeafSet,
 	prune_list: PruneList,
-	_marker: marker::PhantomData<T>,
 }
 
 impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
@@ -69,8 +68,11 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			let position = self.hash_file.size_unsync() + shift + 1;
 			self.leaf_set.add(position);
 		}
+
 		self.data_file
-			.append(&mut ser::ser_vec(&data.as_elmt()).unwrap());
+			.append(data)
+			.map_err(|e| format!("Failed to append data to file. {}", e))?;
+
 		for h in &hashes {
 			self.hash_file
 				.append(h)
@@ -91,22 +93,9 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.is_compacted(position) {
 			return None;
 		}
+		let flatfile_pos = pmmr::n_leaves(position);
 		let shift = self.prune_list.get_leaf_shift(position);
-		let pos = pmmr::n_leaves(position) - 1;
-
-		// Must be on disk, doing a read at the correct position
-		let file_offset = ((pos - shift) as usize) * T::E::LEN;
-		let data = self.data_file.read(file_offset, T::E::LEN);
-		match ser::deserialize(&mut &data[..]) {
-			Ok(h) => Some(h),
-			Err(e) => {
-				error!(
-					"Corrupted storage, could not read an entry from data store: {:?}",
-					e
-				);
-				None
-			}
-		}
+		self.data_file.read(flatfile_pos - shift)
 	}
 
 	/// Get the hash at pos.
@@ -143,9 +132,9 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.hash_file.rewind(position - shift);
 
 		// Rewind the data file accounting for pruned/compacted pos
-		let leaf_shift = self.prune_list.get_leaf_shift(position);
 		let flatfile_pos = pmmr::n_leaves(position);
-		let file_pos = (flatfile_pos - leaf_shift) * T::E::LEN as u64;
+		let leaf_shift = self.prune_list.get_leaf_shift(position);
+		let file_pos = (flatfile_pos - leaf_shift);
 		self.data_file.rewind(file_pos);
 
 		Ok(())
@@ -159,7 +148,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	}
 
 	/// Return data file path
-	fn get_data_file_path(&self) -> String {
+	fn get_data_file_path(&self) -> &str {
 		self.data_file.path()
 	}
 
@@ -191,7 +180,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		header: Option<&BlockHeader>,
 	) -> io::Result<PMMRBackend<T>> {
 		let hash_file = HashFile::open(&format!("{}/{}", data_dir, PMMR_HASH_FILE))?;
-		let data_file = AppendOnlyFile::open(&format!("{}/{}", data_dir, PMMR_DATA_FILE))?;
+		let data_file = DataFile::open(&format!("{}/{}", data_dir, PMMR_DATA_FILE))?;
 
 		let leaf_set_path = format!("{}/{}", data_dir, PMMR_LEAF_FILE);
 
@@ -212,7 +201,6 @@ impl<T: PMMRable> PMMRBackend<T> {
 			data_file,
 			leaf_set,
 			prune_list,
-			_marker: marker::PhantomData,
 		})
 	}
 
@@ -239,7 +227,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 	/// Number of elements in the underlying stored data. Extremely dependent on
 	/// pruning and compaction.
 	pub fn data_size(&self) -> u64 {
-		self.data_file.size() / T::E::LEN as u64
+		self.data_file.size()
 	}
 
 	/// Size of the underlying hashed data. Extremely dependent on pruning
@@ -320,15 +308,11 @@ impl<T: PMMRable> PMMRBackend<T> {
 			let off_to_rm = map_vec!(leaf_pos_to_rm, |&pos| {
 				let flat_pos = pmmr::n_leaves(pos);
 				let shift = self.prune_list.get_leaf_shift(pos);
-				(flat_pos - 1 - shift) * T::E::LEN as u64
+				(flat_pos - 1 - shift)
 			});
 
-			self.data_file.save_prune(
-				tmp_prune_file_data.clone(),
-				&off_to_rm,
-				T::E::LEN as u64,
-				prune_cb,
-			)?;
+			self.data_file
+				.save_prune(tmp_prune_file_data.clone(), &off_to_rm, prune_cb)?;
 		}
 
 		// 3. Update the prune list and write to disk.
@@ -351,7 +335,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			tmp_prune_file_data.clone(),
 			format!("{}/{}", self.data_dir, PMMR_DATA_FILE),
 		)?;
-		self.data_file = AppendOnlyFile::open(&format!("{}/{}", self.data_dir, PMMR_DATA_FILE))?;
+		self.data_file = DataFile::open(&format!("{}/{}", self.data_dir, PMMR_DATA_FILE))?;
 
 		// 6. Write the leaf_set to disk.
 		// Optimize the bitmap storage in the process.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -13,14 +13,14 @@
 
 //! Implementation of the persistent Backend for the prunable MMR tree.
 
-use std::{fs, io, marker};
+use std::{fs, io};
 
 use croaring::Bitmap;
 
 use core::core::hash::{Hash, Hashed};
 use core::core::pmmr::{self, family, Backend};
 use core::core::BlockHeader;
-use core::ser::{self, FixedLength, PMMRable};
+use core::ser::PMMRable;
 use leaf_set::LeafSet;
 use prune_list::PruneList;
 use types::{prune_noop, DataFile, HashFile};
@@ -134,8 +134,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		// Rewind the data file accounting for pruned/compacted pos
 		let flatfile_pos = pmmr::n_leaves(position);
 		let leaf_shift = self.prune_list.get_leaf_shift(position);
-		let file_pos = (flatfile_pos - leaf_shift);
-		self.data_file.rewind(file_pos);
+		self.data_file.rewind(flatfile_pos - leaf_shift);
 
 		Ok(())
 	}


### PR DESCRIPTION
* Introduce `DataFile`
    * wraps an `AppendOnlyFile`
    * aware of element size in bytes etc.
* Prefer `&str` over `String`
* Prefer slices `&[u8]` over `Vec<u8>`

Just realized there is actually nothing special about `HashFile`, its just a `DataFile` where the element happens to be `Hash`.

TODO - 
- [x] consolidate `HashFile` and `DataFile` implementations.

