### PR TITLE
Tests in chain and pool crates don't depend on wallet anymore

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -27,6 +27,5 @@ grin_store = { path = "../store", version = "0.4.2" }
 grin_util = { path = "../util", version = "0.4.2" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet", version = "0.4.2" }
 env_logger = "0.5"
 rand = "0.5"

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -19,7 +19,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_store as store;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 extern crate rand;
 
 use chrono::Duration;

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -18,7 +18,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_store as store;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 extern crate rand;
 
 use chrono::Duration;

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -17,7 +17,6 @@ extern crate grin_chain as chain;
 extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_store as store;
-extern crate grin_wallet as wallet;
 extern crate rand;
 
 use std::fs;

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -19,7 +19,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_store as store;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 extern crate rand;
 
 use chrono::Duration;

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -22,5 +22,4 @@ grin_store = { path = "../store", version = "0.4.2" }
 grin_util = { path = "../util", version = "0.4.2" }
 
 [dev-dependencies]
-grin_wallet = { path = "../wallet", version = "0.4.2" }
 grin_chain = { path = "../chain", version = "0.4.2" }

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -18,7 +18,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_pool as pool;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 
 extern crate chrono;
 extern crate rand;

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -18,7 +18,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_pool as pool;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 
 extern crate chrono;
 extern crate rand;

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -18,7 +18,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_pool as pool;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 
 extern crate chrono;
 extern crate rand;

--- a/pool/tests/common/mod.rs
+++ b/pool/tests/common/mod.rs
@@ -21,7 +21,6 @@ extern crate grin_keychain as keychain;
 extern crate grin_pool as pool;
 extern crate grin_store as store;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 
 extern crate chrono;
 extern crate rand;

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -18,7 +18,6 @@ extern crate grin_core as core;
 extern crate grin_keychain as keychain;
 extern crate grin_pool as pool;
 extern crate grin_util as util;
-extern crate grin_wallet as wallet;
 
 extern crate chrono;
 extern crate rand;


### PR DESCRIPTION
Circular crate dependencies, including dev dependencies, make it impossible to push to crates.io. Thankfully, we don't need those anymore.