### PR TITLE
[WIP] Header info total difficulty

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -404,11 +404,11 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		let child_batch = ctx.batch.child()?;
 		let diff_iter = store::DifficultyIter::from_batch(prev.hash(), child_batch);
 		let next_header_info = consensus::next_difficulty(header.height, diff_iter);
-		if target_difficulty != next_header_info.difficulty {
+		if header.total_difficulty() != next_header_info.total_difficulty {
 			info!(
-				"validate_header: header target difficulty {} != {}",
-				target_difficulty.to_num(),
-				next_header_info.difficulty.to_num()
+				"validate_header: header target (cumulative) difficulty {} != {}",
+				header.total_difficulty().to_num(),
+				next_header_info.total_difficulty.to_num()
 			);
 			return Err(ErrorKind::WrongTotalDifficulty.into());
 		}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -24,7 +24,6 @@ use util::secp::pedersen::Commitment;
 use core::consensus::HeaderInfo;
 use core::core::hash::{Hash, Hashed};
 use core::core::{Block, BlockHeader, BlockSums};
-use core::pow::Difficulty;
 use grin_store as store;
 use grin_store::{option_to_not_found, to_key, Error};
 use types::Tip;
@@ -428,22 +427,9 @@ impl<'a> Iterator for DifficultyIter<'a> {
 				}
 			}
 
-			// let prev_difficulty = self
-			// 	.prev_header
-			// 	.clone()
-			// 	.map_or(Difficulty::zero(), |x| x.total_difficulty());
-			// let difficulty = header.total_difficulty() - prev_difficulty;
-
-			// TODO - We can now build a header_info from a single header.
-			// TODO - Rework this and get rid of the complex iterator.
-			Some(HeaderInfo::new(
-				header.timestamp.timestamp() as u64,
-				header.total_difficulty(),
-				header.pow.secondary_scaling,
-				header.pow.is_secondary(),
-			))
+			Some(header.into())
 		} else {
-			return None;
+			None
 		}
 	}
 }

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -428,17 +428,18 @@ impl<'a> Iterator for DifficultyIter<'a> {
 				}
 			}
 
-			let prev_difficulty = self
-				.prev_header
-				.clone()
-				.map_or(Difficulty::zero(), |x| x.total_difficulty());
-			let difficulty = header.total_difficulty() - prev_difficulty;
-			let scaling = header.pow.secondary_scaling;
+			// let prev_difficulty = self
+			// 	.prev_header
+			// 	.clone()
+			// 	.map_or(Difficulty::zero(), |x| x.total_difficulty());
+			// let difficulty = header.total_difficulty() - prev_difficulty;
 
+			// TODO - We can now build a header_info from a single header.
+			// TODO - Rework this and get rid of the complex iterator.
 			Some(HeaderInfo::new(
 				header.timestamp.timestamp() as u64,
-				difficulty,
-				scaling,
+				header.total_difficulty(),
+				header.pow.secondary_scaling,
 				header.pow.is_secondary(),
 			))
 		} else {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -344,8 +344,7 @@ where
 			} else {
 				(pair[1].total_difficulty - pair[0].total_difficulty).to_num()
 			}
-		})
-		.sum();
+		}).sum();
 
 	// adjust time delta toward goal subject to dampening and clamping
 	let adj_ts = clamp(
@@ -357,7 +356,10 @@ where
 	// minimum difficulty avoids getting stuck due to dampening
 	let next_diff = Difficulty::from_num(max(MIN_DIFFICULTY, diff_sum * BLOCK_TIME_SEC / adj_ts));
 
-	let total_diff = next_diff + diff_data.last().map(|x| x.total_difficulty).unwrap_or(Difficulty::zero());
+	let total_diff = next_diff + diff_data
+		.last()
+		.map(|x| x.total_difficulty)
+		.unwrap_or(Difficulty::zero());
 
 	HeaderInfo::from_diff_scaling(total_diff, sec_pow_scaling)
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -245,21 +245,6 @@ pub struct HeaderInfo {
 }
 
 impl HeaderInfo {
-	/// Default constructor.
-	pub fn new(
-		timestamp: u64,
-		total_difficulty: Difficulty,
-		secondary_scaling: u32,
-		is_secondary: bool,
-	) -> HeaderInfo {
-		HeaderInfo {
-			timestamp,
-			total_difficulty,
-			secondary_scaling,
-			is_secondary,
-		}
-	}
-
 	/// Constructor from a timestamp and difficulty, setting a default secondary
 	/// PoW factor
 	pub fn from_ts_diff(timestamp: u64, total_difficulty: Difficulty) -> HeaderInfo {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -22,7 +22,7 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 use util::RwLock;
 
-use consensus::{self, HeaderInfo, reward, REWARD};
+use consensus::{self, reward, HeaderInfo, REWARD};
 use core::committed::{self, Committed};
 use core::compact_block::{CompactBlock, CompactBlockBody};
 use core::hash::{Hash, Hashed, ZERO_HASH};

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -22,7 +22,7 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 use util::RwLock;
 
-use consensus::{self, reward, REWARD};
+use consensus::{self, HeaderInfo, reward, REWARD};
 use core::committed::{self, Committed};
 use core::compact_block::{CompactBlock, CompactBlockBody};
 use core::hash::{Hash, Hashed, ZERO_HASH};
@@ -164,6 +164,18 @@ impl PMMRable for BlockHeader {
 
 	fn as_elmt(&self) -> Self::E {
 		self.hash()
+	}
+}
+
+/// Convert into HeaderInfo from BlockHeader.
+impl From<BlockHeader> for HeaderInfo {
+	fn from(header: BlockHeader) -> Self {
+		HeaderInfo {
+			timestamp: header.timestamp.timestamp() as u64,
+			total_difficulty: header.total_difficulty(),
+			secondary_scaling: header.pow.secondary_scaling,
+			is_secondary: header.pow.is_secondary(),
+		}
 	}
 }
 

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -22,7 +22,7 @@ use consensus::{
 	DAY_HEIGHT, DEFAULT_MIN_EDGE_BITS, DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY, PROOFSIZE,
 	SECOND_POW_EDGE_BITS, STATE_SYNC_THRESHOLD, T4_CUCKAROO_HARDFORK, UNIT_DIFFICULTY,
 };
-use pow::{self, new_cuckaroo_ctx, new_cuckatoo_ctx, EdgeType, PoWContext};
+use pow::{self, new_cuckaroo_ctx, new_cuckatoo_ctx, Difficulty, EdgeType, PoWContext};
 /// An enum collecting sets of parameters used throughout the
 /// code wherever mining is needed. This should allow for
 /// different sets of parameters for different purposes,
@@ -338,13 +338,12 @@ where
 		} else {
 			BLOCK_TIME_SEC
 		};
-		let last_diff = last_n[0].difficulty;
 
 		// fill in simulated blocks with values from the previous real block
 		let mut last_ts = last_n.last().unwrap().timestamp;
 		for _ in n..needed_block_count {
 			last_ts = last_ts.saturating_sub(last_ts_delta);
-			last_n.push(HeaderInfo::from_ts_diff(last_ts, last_diff.clone()));
+			last_n.push(HeaderInfo::from_ts_diff(last_ts, Difficulty::zero()));
 		}
 	}
 	last_n.reverse();

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -86,12 +86,17 @@ fn repeat(interval: u64, diff: HeaderInfo, len: u64, cur_time: Option<u64>) -> V
 	let pairs = times.zip(diffs.iter());
 	pairs
 		.map(|(t, d)| {
-			HeaderInfo::new(
-				cur_time + t as u64,
-				d.clone(),
-				diff.secondary_scaling,
-				diff.is_secondary,
-			)
+			// HeaderInfo::new(
+			// 	cur_time + t as u64,
+			// 	d.clone(),
+			// 	diff.secondary_scaling,
+			// 	diff.is_secondary,
+			// )
+			HeaderInfo {
+				timestamp: cur_time + t as u64,
+				total_difficulty,
+				..diff,
+			}
 		}).collect::<Vec<_>>()
 }
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -373,26 +373,30 @@ impl Server {
 					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
 
-			let mut last_time = last_blocks[0].timestamp;
+			// let mut last_time = last_blocks[0].timestamp;
+
 			let tip_height = self.chain.head().unwrap().height as i64;
 			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
 			let mut i = 1;
 
+			// TODO - iteate over windows(2) and drop the skip...
 			let diff_entries: Vec<DiffBlock> = last_blocks
-				.iter()
-				.skip(1)
-				.map(|n| {
-					let dur = n.timestamp - last_time;
+				.windows(2)
+				.map(|pair| {
+					let prev = &pair[0];
+					let curr = &pair[1];
+
+					// TODO - just trakc single current height?
 					let height = earliest_block_height + i;
 					i += 1;
-					last_time = n.timestamp;
+
 					DiffBlock {
 						block_number: height,
-						difficulty: n.difficulty.to_num(),
-						time: n.timestamp,
-						duration: dur,
-						secondary_scaling: n.secondary_scaling,
-						is_secondary: n.is_secondary,
+						difficulty: (curr.total_difficulty - prev.total_difficulty).to_num(),
+						time: curr.timestamp,
+						duration: curr.timestamp - prev.timestamp,
+						secondary_scaling: curr.secondary_scaling,
+						is_secondary: curr.is_secondary,
 					}
 				}).collect();
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -373,20 +373,17 @@ impl Server {
 					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
 
-			// let mut last_time = last_blocks[0].timestamp;
-
 			let tip_height = self.chain.head().unwrap().height as i64;
 			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
 			let mut i = 1;
 
-			// TODO - iteate over windows(2) and drop the skip...
 			let diff_entries: Vec<DiffBlock> = last_blocks
 				.windows(2)
 				.map(|pair| {
 					let prev = &pair[0];
 					let curr = &pair[1];
 
-					// TODO - just trakc single current height?
+					// TODO - just track single current height?
 					let height = earliest_block_height + i;
 					i += 1;
 

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -205,9 +205,11 @@ impl SyncRunner {
 			let threshold = self
 				.chain
 				.difficulty_iter()
-				.map(|x| x.difficulty)
+				.collect::<Vec<_>>()
+				.windows(2)
 				.take(5)
-				.fold(Difficulty::zero(), |sum, val| sum + val);
+				// .map(|pair|)
+				.fold(Difficulty::zero(), |sum, pair| sum + (pair[1].total_difficulty - pair[0].total_difficulty));
 
 			let peer_diff = peer_info.total_difficulty();
 			if peer_diff > local_diff.clone() + threshold.clone() {

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -209,7 +209,9 @@ impl SyncRunner {
 				.windows(2)
 				.take(5)
 				// .map(|pair|)
-				.fold(Difficulty::zero(), |sum, pair| sum + (pair[1].total_difficulty - pair[0].total_difficulty));
+				.fold(Difficulty::zero(), |sum, pair| {
+					sum + (pair[1].total_difficulty - pair[0].total_difficulty)
+				});
 
 			let peer_diff = peer_info.total_difficulty();
 			if peer_diff > local_diff.clone() + threshold.clone() {

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -120,7 +120,10 @@ fn build_block(
 	};
 
 	let (output, kernel, block_fees) = get_coinbase(wallet_listener_url, block_fees)?;
-	let mut b = core::Block::with_reward(&head, txs, output, kernel, difficulty.difficulty)?;
+
+	// TODO - clean the total_diff vs. next_diff up
+	let next_diff = difficulty.total_difficulty - head.total_difficulty();
+	let mut b = core::Block::with_reward(&head, txs, output, kernel, next_diff)?;
 
 	// making sure we're not spending time mining a useless block
 	b.validate(&head.total_kernel_offset, verifier_cache)?;


### PR DESCRIPTION
This PR reworks `HeaderInfo` to maintain `total_difficulty` and not `difficulty` for consistency with `BlockHeader` itself.

This allows us to build header_infos from headers directly, without needing to iterate over previous/current headers to calculate the difficulty change per header.

Why would this be preferable? 

Right now we can only build a `header_info` from the header and its previous header. This need for pairs of headers complicates the code in various places as we need access to the db to obtain the previous header.

The `DifficultyIter` for example is relatively complex - we need to pass an active `batch` or `store` into the iterator to allow us to iterate back over these previous headers.

Being able to build header_infos from instances of header will allow us to to simply retrieve a vec of headers from the db and then convert them, via `into()` to `header_infos` as part of the difficulty validation step later on. And we will not need an iterator with an active db batch.

It also opens up the possibility of storing `header_infos` (or something similar) in the header MMR (right now we just store header hashes). This would potentially allow us to validate header difficulty looking only at the header MMR and without needing to retrieve headers from the db.

We could use the header MMR effectively as the "cache" of header infos, knowing that it was always consistent with the current chain head.

Related - #2013 (attempt at caching headers for difficulty validation).