### PR TITLE
fix: bzip2 format used is incompatible with the windows bzip2

### DIFF
--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use std::fs::{self, File};
-/// Wrappers around the `zip-rs` library to compress and decompress zip
-/// bzip2 archives.
+/// Wrappers around the `zip-rs` library to compress and decompress zip archives.
 use std::io;
 use std::path::Path;
 use walkdir::WalkDir;
@@ -23,8 +22,8 @@ use zip_rs;
 use zip_rs::result::{ZipError, ZipResult};
 use zip_rs::write::FileOptions;
 
-/// Compress a source directory recursively into a zip file using the
-/// bzip2 format. Permissions are set to 644 by default to avoid any
+/// Compress a source directory recursively into a zip file.
+/// Permissions are set to 644 by default to avoid any
 /// unwanted execution bits.
 pub fn compress(src_dir: &Path, dst_file: &File) -> ZipResult<()> {
 	if !Path::new(src_dir).is_dir() {
@@ -35,7 +34,7 @@ pub fn compress(src_dir: &Path, dst_file: &File) -> ZipResult<()> {
 	}
 
 	let options = FileOptions::default()
-		.compression_method(zip_rs::CompressionMethod::Bzip2)
+		.compression_method(zip_rs::CompressionMethod::Stored)
 		.unix_permissions(0o644);
 
 	let mut zip = zip_rs::ZipWriter::new(dst_file);


### PR DESCRIPTION
The txhashset bzip2 archives cannot be unzipped from windows using the standard bzip2 implementation from Julian Seward. Since the pmmr files are nearly indistinguishable from random anyway, we aren't gaining anything by compressing, so it's not worth the performance hit (bzip2 is known for being slow) and the lack of portability. This change is backward compatible, and should cause no disruptions.