### PR TITLE
fix: Only MAX_BLOCK_HEADERS - 1 (511) headers sent during sync

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -267,7 +267,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		// looks like we know one, getting as many following headers as allowed
 		let hh = header.height;
 		let mut headers = vec![];
-		for h in (hh + 1)..(hh + (p2p::MAX_BLOCK_HEADERS as u64)) {
+		for h in (hh + 1)..=(hh + (p2p::MAX_BLOCK_HEADERS as u64)) {
 			if h > max_height {
 				break;
 			}


### PR DESCRIPTION
Only MAX_BLOCK_HEADERS - 1 (511) headers sent during sync, instead of MAX_BLOCK_HEADERS (512). Not a big deal, but figured I'd change it since the code supports receiving the full 512.