### PR TITLE
Clean shutdown via stop_state

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -36,7 +36,7 @@ use crate::util::RwLock;
 use grin_store::Error::NotFoundErr;
 use std::collections::HashMap;
 use std::fs::File;
-use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -32,7 +32,7 @@ use crate::types::{
 	BlockStatus, ChainAdapter, NoStatus, Options, Tip, TxHashSetRoots, TxHashsetWriteStatus,
 };
 use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::RwLock;
+use crate::util::{Mutes, RwLock, StopState};
 use grin_store::Error::NotFoundErr;
 use std::collections::HashMap;
 use std::fs::File;
@@ -149,7 +149,7 @@ pub struct Chain {
 	// POW verification function
 	pow_verifier: fn(&BlockHeader) -> Result<(), pow::Error>,
 	archive_mode: bool,
-	stop: Arc<AtomicBool>,
+	stop_state: Arc<Mutex<StopState>>,
 	genesis: BlockHeader,
 }
 
@@ -165,7 +165,7 @@ impl Chain {
 		pow_verifier: fn(&BlockHeader) -> Result<(), pow::Error>,
 		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
 		archive_mode: bool,
-		stop: Arc<AtomicBool>,
+		stop_state: Arc<Mutex<StopState>>,
 	) -> Result<Chain, Error> {
 		let chain_store = store::ChainStore::new(db_env)?;
 
@@ -215,7 +215,7 @@ impl Chain {
 			pow_verifier,
 			verifier_cache,
 			archive_mode,
-			stop,
+			stop_state,
 			genesis: genesis.header.clone(),
 		})
 	}

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -128,6 +128,9 @@ pub enum ErrorKind {
 	/// Error from summing and verifying kernel sums via committed trait.
 	#[fail(display = "Committed Trait: Error summing and verifying kernel sums")]
 	Committed(committed::Error),
+	/// We cannot process data once the Grin server has been stopped.
+	#[fail(display = "Stopped (Grin Shutting Down)")]
+	Stopped,
 }
 
 impl Display for Error {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -199,8 +199,8 @@ impl<'a> Batch<'a> {
 	/// Save the block and the associated input bitmap.
 	/// Note: the block header is not saved to the db here, assumes this has already been done.
 	pub fn save_block(&self, b: &Block) -> Result<(), Error> {
-		// Build the "input bitmap" for this new block and cache it locally.
-		self.build_and_cache_block_input_bitmap(&b)?;
+		// Build the "input bitmap" for this new block and store it in the db.
+		self.build_and_store_block_input_bitmap(&b)?;
 
 		// Save the block itself to the db.
 		self.db
@@ -305,7 +305,7 @@ impl<'a> Batch<'a> {
 		Ok(bitmap)
 	}
 
-	fn build_and_cache_block_input_bitmap(&self, block: &Block) -> Result<Bitmap, Error> {
+	fn build_and_store_block_input_bitmap(&self, block: &Block) -> Result<Bitmap, Error> {
 		// Build the bitmap.
 		let bitmap = self.build_block_input_bitmap(block)?;
 
@@ -326,7 +326,7 @@ impl<'a> Batch<'a> {
 		} else {
 			match self.get_block(bh) {
 				Ok(block) => {
-					let bitmap = self.build_and_cache_block_input_bitmap(&block)?;
+					let bitmap = self.build_and_store_block_input_bitmap(&block)?;
 					Ok(bitmap)
 				}
 				Err(e) => Err(e),

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -21,7 +21,7 @@ use self::core::libtx;
 use self::core::pow::{self, Difficulty};
 use self::core::{consensus, genesis};
 use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
-use self::util::RwLock;
+use self::util::{Mutex, RwLock, StopState};
 use chrono::Duration;
 use grin_chain as chain;
 use grin_core as core;
@@ -50,8 +50,8 @@ fn setup(dir_name: &str) -> Chain {
 		pow::verify_size,
 		verifier_cache,
 		false,
-	)
-	.unwrap()
+		Arc::new(Mutex::new(StopState::new())),
+	).unwrap()
 }
 
 fn reload_chain(dir_name: &str) -> Chain {
@@ -65,8 +65,8 @@ fn reload_chain(dir_name: &str) -> Chain {
 		pow::verify_size,
 		verifier_cache,
 		false,
-	)
-	.unwrap()
+		Arc::new(Mutex::new(StopState::new())),
+	).unwrap()
 }
 
 #[test]

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -51,7 +51,8 @@ fn setup(dir_name: &str) -> Chain {
 		verifier_cache,
 		false,
 		Arc::new(Mutex::new(StopState::new())),
-	).unwrap()
+	)
+	.unwrap()
 }
 
 fn reload_chain(dir_name: &str) -> Chain {
@@ -66,7 +67,8 @@ fn reload_chain(dir_name: &str) -> Chain {
 		verifier_cache,
 		false,
 		Arc::new(Mutex::new(StopState::new())),
-	).unwrap()
+	)
+	.unwrap()
 }
 
 #[test]

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -51,7 +51,8 @@ fn setup(dir_name: &str, genesis: Block) -> Chain {
 		verifier_cache,
 		false,
 		Arc::new(Mutex::new(StopState::new())),
-	).unwrap()
+	)
+	.unwrap()
 }
 
 #[test]
@@ -542,7 +543,8 @@ fn actual_diff_iter_output() {
 		verifier_cache,
 		false,
 		Arc::new(Mutex::new(StopState::new())),
-	).unwrap();
+	)
+	.unwrap();
 	let iter = chain.difficulty_iter();
 	let mut last_time = 0;
 	let mut first = true;

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -23,7 +23,7 @@ use self::core::libtx::{self, build, reward};
 use self::core::pow::Difficulty;
 use self::core::{consensus, global, pow};
 use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
-use self::util::RwLock;
+use self::util::{Mutex, RwLock, StopState};
 use chrono::Duration;
 use grin_chain as chain;
 use grin_core as core;
@@ -50,8 +50,8 @@ fn setup(dir_name: &str, genesis: Block) -> Chain {
 		pow::verify_size,
 		verifier_cache,
 		false,
-	)
-	.unwrap()
+		Arc::new(Mutex::new(StopState::new())),
+	).unwrap()
 }
 
 #[test]
@@ -541,8 +541,8 @@ fn actual_diff_iter_output() {
 		pow::verify_size,
 		verifier_cache,
 		false,
-	)
-	.unwrap();
+		Arc::new(Mutex::new(StopState::new())),
+	).unwrap();
 	let iter = chain.difficulty_iter();
 	let mut last_time = 0;
 	let mut first = true;

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -56,7 +56,8 @@ fn test_coinbase_maturity() {
 		verifier_cache,
 		false,
 		Arc::new(Mutex::new(StopState::new())),
-	).unwrap();
+	)
+	.unwrap();
 
 	let prev = chain.head_header().unwrap();
 

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -21,7 +21,7 @@ use self::core::libtx::{self, build};
 use self::core::pow::Difficulty;
 use self::core::{consensus, pow};
 use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
-use self::util::RwLock;
+use self::util::{Mutex, RwLock, StopState};
 use chrono::Duration;
 use env_logger;
 use grin_chain as chain;
@@ -55,8 +55,8 @@ fn test_coinbase_maturity() {
 		pow::verify_size,
 		verifier_cache,
 		false,
-	)
-	.unwrap();
+		Arc::new(Mutex::new(StopState::new())),
+	).unwrap();
 
 	let prev = chain.head_header().unwrap();
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -29,6 +29,7 @@ use crate::peer::Peer;
 use crate::peers::Peers;
 use crate::store::PeerStore;
 use crate::types::{Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, TxHashSetRead};
+use crate::util::{Mutex, StopState};
 use chrono::prelude::{DateTime, Utc};
 
 /// P2P server implementation, handling bootstrapping to find and connect to
@@ -38,8 +39,7 @@ pub struct Server {
 	capabilities: Capabilities,
 	handshake: Arc<Handshake>,
 	pub peers: Arc<Peers>,
-	stop: Arc<AtomicBool>,
-	pause: Arc<AtomicBool>,
+	stop_state: Arc<Mutex<StopState>>,
 }
 
 // TODO TLS
@@ -51,16 +51,14 @@ impl Server {
 		config: P2PConfig,
 		adapter: Arc<dyn ChainAdapter>,
 		genesis: Hash,
-		stop: Arc<AtomicBool>,
-		pause: Arc<AtomicBool>,
+		stop_state: Arc<Mutex<StopState>>,
 	) -> Result<Server, Error> {
 		Ok(Server {
 			config: config.clone(),
 			capabilities: capab,
 			handshake: Arc::new(Handshake::new(genesis, config.clone())),
 			peers: Arc::new(Peers::new(PeerStore::new(db_env)?, adapter, config)),
-			stop,
-			pause,
+			stop_state,
 		})
 	}
 
@@ -75,7 +73,7 @@ impl Server {
 		let sleep_time = Duration::from_millis(1);
 		loop {
 			// Pause peer ingress connection request. Only for tests.
-			if self.pause.load(Ordering::Relaxed) {
+			if self.stop_state.lock().is_paused() {
 				thread::sleep(Duration::from_secs(1));
 				continue;
 			}
@@ -95,7 +93,7 @@ impl Server {
 					warn!("Couldn't establish new client connection: {:?}", e);
 				}
 			}
-			if self.stop.load(Ordering::Relaxed) {
+			if self.stop_state.lock().is_stopped() {
 				break;
 			}
 			thread::sleep(sleep_time);
@@ -194,7 +192,7 @@ impl Server {
 	}
 
 	pub fn stop(&self) {
-		self.stop.store(true, Ordering::Relaxed);
+		self.stop_state.lock().stop();
 		self.peers.stop();
 	}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -14,7 +14,6 @@
 
 use std::fs::File;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{io, thread};

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -17,9 +17,9 @@ use grin_p2p as p2p;
 
 use grin_store as store;
 use grin_util as util;
+use grin_util::{Mutex, StopState};
 
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::{thread, time};
 
@@ -57,8 +57,7 @@ fn peer_handshake() {
 			p2p_config.clone(),
 			net_adapter.clone(),
 			Hash::from_vec(&vec![]),
-			Arc::new(AtomicBool::new(false)),
-			Arc::new(AtomicBool::new(false)),
+			Arc::new(Mutex::new(StopState::new())),
 		)
 		.unwrap(),
 	);

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -24,7 +24,6 @@ use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;
-use grin_pool as pool;
 use grin_util as util;
 use std::sync::Arc;
 

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -25,7 +25,6 @@ use crate::common::ChainAdapter;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;
-use grin_pool as pool;
 use grin_util as util;
 use std::sync::Arc;
 

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -25,7 +25,6 @@ use self::pool::types::*;
 use self::pool::TransactionPool;
 use self::util::secp::pedersen::Commitment;
 use self::util::RwLock;
-use crate::pool::types::*;
 use grin_chain as chain;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -23,7 +23,6 @@ use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;
-use grin_pool as pool;
 use grin_util as util;
 use std::sync::Arc;
 

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -15,7 +15,6 @@
 use crate::util::{Mutex, RwLock, StopState};
 use chrono::prelude::Utc;
 use rand::{thread_rng, Rng};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::util::RwLock;
+use crate::util::{Mutex, RwLock, StopState};
 use chrono::prelude::Utc;
 use rand::{thread_rng, Rng};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -37,7 +37,7 @@ pub fn monitor_transactions(
 	dandelion_config: DandelionConfig,
 	tx_pool: Arc<RwLock<TransactionPool>>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-	stop: Arc<AtomicBool>,
+	stop_state: Arc<Mutex<StopState>>,
 ) {
 	debug!("Started Dandelion transaction monitor.");
 
@@ -45,7 +45,7 @@ pub fn monitor_transactions(
 		.name("dandelion".to_string())
 		.spawn(move || {
 			loop {
-				if stop.load(Ordering::Relaxed) {
+				if stop_state.lock().is_stopped() {
 					break;
 				}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -21,7 +21,6 @@ use chrono::prelude::Utc;
 use chrono::{Duration, MIN_DATE};
 use rand::{thread_rng, Rng};
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::{cmp, io, str, thread, time};
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -28,6 +28,7 @@ use std::{cmp, io, str, thread, time};
 use crate::p2p;
 use crate::p2p::ChainAdapter;
 use crate::pool::DandelionConfig;
+use crate::util::{Mutex, StopState};
 
 // DNS Seeds with contact email associated
 const DNS_SEEDS: &'static [&'static str] = &[
@@ -40,8 +41,7 @@ pub fn connect_and_monitor(
 	dandelion_config: DandelionConfig,
 	seed_list: Box<dyn Fn() -> Vec<SocketAddr> + Send>,
 	preferred_peers: Option<Vec<SocketAddr>>,
-	stop: Arc<AtomicBool>,
-	pause: Arc<AtomicBool>,
+	stop_state: Arc<Mutex<StopState>>,
 ) {
 	let _ = thread::Builder::new()
 		.name("seed".to_string())
@@ -65,9 +65,13 @@ pub fn connect_and_monitor(
 			let mut prev_ping = Utc::now();
 			let mut start_attempt = 0;
 
-			while !stop.load(Ordering::Relaxed) {
+			loop {
+				if stop_state.lock().is_stopped() {
+					break;
+				}
+
 				// Pause egress peer connection request. Only for tests.
-				if pause.load(Ordering::Relaxed) {
+				if stop_state.lock().is_paused() {
 					thread::sleep(time::Duration::from_secs(1));
 					continue;
 				}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -438,9 +438,10 @@ impl Server {
 		self.p2p.pause();
 	}
 
-	/// Resume the p2p server.
+	/// Resume p2p server.
+	/// TODO - We appear not to resume the p2p server (peer connections) here?
 	pub fn resume(&self) {
-		self.stop_state.lock().unpause();
+		self.stop_state.lock().resume();
 	}
 
 	/// Stops the test miner without stopping the p2p layer

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -156,6 +156,7 @@ impl Server {
 			pow::verify_size,
 			verifier_cache.clone(),
 			archive_mode,
+			stop.clone(),
 		)?);
 
 		pool_adapter.set_chain(shared_chain.clone());

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -301,7 +301,11 @@ impl Server {
 	/// Start mining for blocks internally on a separate thread. Relies on
 	/// internal miner, and should only be used for automated testing. Burns
 	/// reward if wallet_listener_url is 'None'
-	pub fn start_test_miner(&self, wallet_listener_url: Option<String>, stop_state: Arc<Mutex<StopState>>) {
+	pub fn start_test_miner(
+		&self,
+		wallet_listener_url: Option<String>,
+		stop_state: Arc<Mutex<StopState>>,
+	) {
 		info!("start_test_miner - start",);
 		let sync_state = self.sync_state.clone();
 		let config_wallet_url = match wallet_listener_url.clone() {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -445,8 +445,8 @@ impl Server {
 	}
 
 	/// Stops the test miner without stopping the p2p layer
-	pub fn stop_test_miner(&self, stop: Arc<AtomicBool>) {
-		stop.store(true, Ordering::Relaxed);
+	pub fn stop_test_miner(&self, stop: Arc<Mutex<StopState>>) {
+		stop.lock().stop();
 		info!("stop_test_miner - stop",);
 	}
 }

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -37,7 +37,7 @@ use crate::p2p;
 use crate::pool;
 use crate::store;
 use crate::util::file::get_first_line;
-use crate::util::{StopState, Mutex, RwLock};
+use crate::util::{Mutex, RwLock, StopState};
 
 /// Grin server holding internal structures.
 pub struct Server {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -16,7 +16,6 @@
 //! the peer-to-peer server, the blockchain and the transaction pool) and acts
 //! as a facade.
 
-use crate::util::RwLock;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time;

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -30,13 +30,14 @@ use crate::core::core::{Block, BlockHeader};
 use crate::core::global;
 use crate::mining::mine_block;
 use crate::pool;
+use crate::util::{Mutex, StopState};
 
 pub struct Miner {
 	config: StratumServerConfig,
 	chain: Arc<chain::Chain>,
 	tx_pool: Arc<RwLock<pool::TransactionPool>>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-	stop: Arc<AtomicBool>,
+	stop_state: Arc<Mutex<StopState>>,
 
 	// Just to hold the port we're on, so this miner can be identified
 	// while watching debug output
@@ -51,7 +52,7 @@ impl Miner {
 		chain: Arc<chain::Chain>,
 		tx_pool: Arc<RwLock<pool::TransactionPool>>,
 		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-		stop: Arc<AtomicBool>,
+		stop_state: Arc<Mutex<StopState>>,
 	) -> Miner {
 		Miner {
 			config,
@@ -59,7 +60,7 @@ impl Miner {
 			tx_pool,
 			verifier_cache,
 			debug_output_id: String::from("none"),
-			stop,
+			stop_state,
 		}
 	}
 
@@ -135,7 +136,11 @@ impl Miner {
 		// nothing has changed. We only want to create a new key_id for each new block.
 		let mut key_id = None;
 
-		while !self.stop.load(Ordering::Relaxed) {
+		loop {
+			if self.stop_state.lock().is_stopped() {
+				break;
+			}
+
 			trace!("in miner loop. key_id: {:?}", key_id);
 
 			// get the latest chain state and build a block on top of it

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -19,7 +19,6 @@
 
 use crate::util::RwLock;
 use chrono::prelude::Utc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::chain;

--- a/servers/tests/framework.rs
+++ b/servers/tests/framework.rs
@@ -222,7 +222,7 @@ impl LocalServerContainer {
 				"starting test Miner on port {}",
 				self.config.p2p_server_port
 			);
-			s.start_test_miner(wallet_url, s.stop.clone());
+			s.start_test_miner(wallet_url, s.stop_state.clone());
 		}
 
 		for p in &mut self.peer_list {

--- a/servers/tests/stratum.rs
+++ b/servers/tests/stratum.rs
@@ -23,11 +23,11 @@ use bufstream::BufStream;
 use grin_core as core;
 use grin_servers as servers;
 use grin_util as util;
+use grin_util::{Mutex, StopState};
 use serde_json::Value;
 use std::io::prelude::{BufRead, Write};
 use std::net::TcpStream;
 use std::process;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::{thread, time};
 
@@ -140,7 +140,7 @@ fn basic_stratum_server() {
 	info!("stratum server and worker stats verification ok");
 
 	// Start mining blocks
-	let stop = Arc::new(AtomicBool::new(false));
+	let stop = Arc::new(Mutex::new(StopState::new()));
 	s.start_test_miner(None, stop.clone());
 	info!("test miner started");
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -13,7 +13,7 @@
 
 //! Implementation of the persistent Backend for the prunable MMR tree.
 
-use std::{fs, io, marker, time};
+use std::{fs, io, time};
 
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::pmmr::{self, family, Backend};

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -109,3 +109,37 @@ where
 pub fn to_base64(s: &str) -> String {
 	base64::encode(s)
 }
+
+pub struct StopState {
+	stopped: bool,
+	paused: bool,
+}
+
+impl StopState {
+	pub fn new() -> StopState {
+		StopState {
+			stopped: false,
+			paused: false,
+		}
+	}
+
+	pub fn is_stopped(&self) -> bool {
+		self.stopped
+	}
+
+	pub fn is_paused(&self) -> bool {
+		self.paused
+	}
+
+	pub fn stop(&mut self) {
+		self.stopped = true;
+	}
+
+	pub fn pause(&mut self) {
+		self.paused = true;
+	}
+
+	pub fn unpause(&mut self) {
+		self.paused = false;
+	}
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -110,12 +110,22 @@ pub fn to_base64(s: &str) -> String {
 	base64::encode(s)
 }
 
+/// Global stopped/paused state shared across various subcomponents of Grin.
+///
+/// Arc<Mutex<StopState>> allows the chain to lock the stop_state during critical processing.
+/// Other subcomponents cannot abruptly shutdown the server during block/header processing.
+/// This should prevent the chain ever ending up in an inconsistent state on restart.
+///
+/// "Stopped" allows a clean shutdown of the Grin server.
+/// "Paused" is used in some tests to allow nodes to reach steady state etc.
+///
 pub struct StopState {
 	stopped: bool,
 	paused: bool,
 }
 
 impl StopState {
+	/// Create a new stop_state in default "running" state.
 	pub fn new() -> StopState {
 		StopState {
 			stopped: false,
@@ -123,23 +133,28 @@ impl StopState {
 		}
 	}
 
+	/// Check if we are stopped.
 	pub fn is_stopped(&self) -> bool {
 		self.stopped
 	}
 
+	/// Check if we are paused.
 	pub fn is_paused(&self) -> bool {
 		self.paused
 	}
 
+	/// Stop the server.
 	pub fn stop(&mut self) {
 		self.stopped = true;
 	}
 
+	/// Pause the server (only used in tests).
 	pub fn pause(&mut self) {
 		self.paused = true;
 	}
 
-	pub fn unpause(&mut self) {
+	/// Resume a paused server (only used in tests).
+	pub fn resume(&mut self) {
 		self.paused = false;
 	}
 }

--- a/wallet/src/test_framework/testclient.rs
+++ b/wallet/src/test_framework/testclient.rs
@@ -110,8 +110,8 @@ where
 			pow::verify_size,
 			verifier_cache,
 			false,
-		)
-		.unwrap();
+			Arc::new(Mutex::new(StopState::new())),
+		).unwrap();
 		let (tx, rx) = channel();
 		let retval = WalletProxy {
 			chain_dir: chain_dir.to_owned(),

--- a/wallet/src/test_framework/testclient.rs
+++ b/wallet/src/test_framework/testclient.rs
@@ -26,7 +26,7 @@ use self::core::{pow, ser};
 use self::keychain::Keychain;
 use self::util::secp::pedersen;
 use self::util::secp::pedersen::Commitment;
-use self::util::{Mutex, RwLock};
+use self::util::{Mutex, RwLock, StopState};
 use crate::libwallet::types::*;
 use crate::{controller, libwallet, WalletCommAdapter, WalletConfig};
 use failure::ResultExt;


### PR DESCRIPTION
This PR introduces a new `StopState` struct.
We wrap this in a `Mutex<StopState>` and replace the usage of the simple stop `AtomicBool` flag.

#### Why?

The `AtomicBool` allowed us to share a `stop` flag across threads. And we could read/write it safely. 

The `Mutex<StopState>` allows us to not only check if the server is stopped, but to actually take a lock on the stop_state during critical processing.
i.e. We will not abruptly stop the server in the middle of processing a single block.

Specifically we take a lock on `stop_state` during critical sections of chain processing that mutate both the txhashset extension and the db - 
  * `chain::init()`
  * `chain.process_single_block()`
  * `chain.sync_block_headers()`
  * `chain.compact_txhashset()`

This allows us to guarantee the server will not shutdown _during_ these critical sections.
Setting the `stop` flag will now block until we exit a critical section, the server will then be "stopped" and we will not begin processing the next block.

Resolves #2113.
