### PR TITLE
Cleanup compact block logging

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -90,7 +90,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 	// spend resources reading the full block when its header is invalid
 
 	debug!(
-		"pipe: process_block {} at {}, in/out/kern: {}/{}/{}",
+		"pipe: process_block {} at {} [in/out/kern: {}/{}/{}]",
 		b.hash(),
 		b.header.height,
 		b.inputs().len(),

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -226,7 +226,7 @@ impl Pool {
 		self.validate_raw_tx(&agg_tx, header)?;
 
 		debug!(
-			"add_to_pool [{}]: {} ({}), in/out/kern: {}/{}/{}, pool: {} (at block {})",
+			"add_to_pool [{}]: {} ({}) [in/out/kern: {}/{}/{}] pool: {} (at block {})",
 			self.name,
 			entry.tx.hash(),
 			entry.src.debug_name,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -232,11 +232,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 	}
 
 	fn headers_received(&self, bhs: &[core::BlockHeader], addr: SocketAddr) -> bool {
-		info!(
-			"Received {} block headers from {}",
-			bhs.len(),
-			addr,
-		);
+		info!("Received {} block headers from {}", bhs.len(), addr,);
 
 		if bhs.len() == 0 {
 			return false;

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -90,7 +90,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		let header = self.chain().head_header().unwrap();
 
 		debug!(
-			"Received tx {}, inputs: {}, outputs: {}, kernels: {}, going to process.",
+			"Received tx {}, [in/out/kern: {}/{}/{}] going to process.",
 			tx_hash,
 			tx.inputs().len(),
 			tx.outputs().len(),
@@ -109,7 +109,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 	fn block_received(&self, b: core::Block, addr: SocketAddr) -> bool {
 		debug!(
-			"Received block {} at {} from {}, inputs: {}, outputs: {}, kernels: {}, going to process.",
+			"Received block {} at {} from {} [in/out/kern: {}/{}/{}] going to process.",
 			b.hash(),
 			b.header.height,
 			addr,
@@ -123,7 +123,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 	fn compact_block_received(&self, cb: core::CompactBlock, addr: SocketAddr) -> bool {
 		let bhash = cb.hash();
 		debug!(
-			"Received compact_block {} at {} from {}, outputs: {}, kernels: {}, kern_ids: {}, going to process.",
+			"Received compact_block {} at {} from {} [out/kern/kern_ids: {}/{}/{}] going to process.",
 			bhash,
 			cb.header.height,
 			addr,
@@ -138,7 +138,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			match core::Block::hydrate_from(cb, vec![]) {
 				Ok(block) => self.process_block(block, addr),
 				Err(e) => {
-					debug!("Invalid hydrated block {}: {}", cb_hash, e);
+					debug!("Invalid hydrated block {}: {:?}", cb_hash, e);
 					return false;
 				}
 			}
@@ -148,7 +148,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				.chain()
 				.process_block_header(&cb.header, self.chain_opts())
 			{
-				debug!("Invalid compact block header {}: {}", cb_hash, e);
+				debug!("Invalid compact block header {}: {:?}", cb_hash, e.kind());
 				return !e.is_bad_data();
 			}
 
@@ -172,7 +172,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			let block = match core::Block::hydrate_from(cb.clone(), txs) {
 				Ok(block) => block,
 				Err(e) => {
-					debug!("Invalid hydrated block {}: {}", cb.hash(), e);
+					debug!("Invalid hydrated block {}: {:?}", cb.hash(), e);
 					return false;
 				}
 			};
@@ -233,8 +233,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 	fn headers_received(&self, bhs: &[core::BlockHeader], addr: SocketAddr) -> bool {
 		info!(
-			"Received block headers {:?} from {}",
-			bhs.iter().map(|x| x.hash()).collect::<Vec<_>>(),
+			"Received {} block headers from {}",
+			bhs.len(),
 			addr,
 		);
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -17,7 +17,6 @@
 //! as a facade.
 
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::{thread, time};
 


### PR DESCRIPTION
* Cleaned up the multiline compact block debug/error logs.
* Cleaned up some other logs around `in/out/kern` counts for blocks and txs.

