### PR TITLE
Disable authentication for OPTIONS requests

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -39,6 +39,9 @@ impl Handler for BasicAuthMiddleware {
 		req: Request<Body>,
 		mut handlers: Box<dyn Iterator<Item = HandlerObj>>,
 	) -> ResponseFuture {
+		if req.method().as_str() == "OPTIONS" {
+			return handlers.next().unwrap().call(req, handlers);
+		}
 		if req.headers().contains_key(AUTHORIZATION)
 			&& verify_slices_are_equal(
 				req.headers()[AUTHORIZATION].as_bytes(),


### PR DESCRIPTION
*Should fix* the issue experienced by @gavinmcdermott https://github.com/mimblewimble/grin/issues/1525.
Preflight requests (`OPTIONS` requests) now bypass BasicAuth.

 @gavinmcdermott could you give it a try?