### PR TITLE
HeaderEntry for storing subset of header info in the header MMR

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -204,8 +204,8 @@ impl TxHashSet {
 		let pos = pmmr::insertion_to_pmmr_index(height + 1);
 		let header_pmmr =
 			ReadonlyPMMR::at(&self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
-		if let Some(hash) = header_pmmr.get_data(pos) {
-			let header = self.commit_index.get_block_header(&hash)?;
+		if let Some(entry) = header_pmmr.get_data(pos) {
+			let header = self.commit_index.get_block_header(&entry.hash())?;
 			Ok(header)
 		} else {
 			Err(ErrorKind::Other(format!("get header by height")).into())
@@ -613,7 +613,7 @@ impl<'a> HeaderExtension<'a> {
 
 	/// Get the header hash for the specified pos from the underlying MMR backend.
 	fn get_header_hash(&self, pos: u64) -> Option<Hash> {
-		self.pmmr.get_data(pos)
+		self.pmmr.get_data(pos).map(|x| x.hash())
 	}
 
 	/// Get the header at the specified height based on the current state of the header extension.
@@ -989,7 +989,7 @@ impl<'a> Extension<'a> {
 
 	/// Get the header hash for the specified pos from the underlying MMR backend.
 	fn get_header_hash(&self, pos: u64) -> Option<Hash> {
-		self.header_pmmr.get_data(pos)
+		self.header_pmmr.get_data(pos).map(|x| x.hash())
 	}
 
 	/// Get the header at the specified height based on the current state of the extension.

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -109,12 +109,15 @@ impl fmt::Display for Error {
 	}
 }
 
+/// Header entry for storing in the header MMR.
+/// Note: we hash the block header itself and maintain the hash in the entry.
+/// This allows us to lookup the original header from the db as necessary.
 pub struct HeaderEntry {
-	pub hash: Hash,
-	pub timestamp: u64,
-	pub total_difficulty: Difficulty,
-	pub secondary_scaling: u32,
-	pub is_secondary: bool,
+	hash: Hash,
+	timestamp: u64,
+	total_difficulty: Difficulty,
+	secondary_scaling: u32,
+	is_secondary: bool,
 }
 
 impl Readable for HeaderEntry {
@@ -159,6 +162,7 @@ impl FixedLength for HeaderEntry {
 }
 
 impl HeaderEntry {
+	/// The hash of the underlying block.
 	pub fn hash(&self) -> Hash {
 		self.hash
 	}

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -123,7 +123,9 @@ impl Readable for HeaderEntry {
 		let timestamp = reader.read_u64()?;
 		let total_difficulty = Difficulty::read(reader)?;
 		let secondary_scaling = reader.read_u32()?;
-		let is_secondary = reader.read_u8()? == 1;
+
+		// Using a full byte to represent the bool for now.
+		let is_secondary = reader.read_u8()? != 0;
 
 		Ok(HeaderEntry {
 			hash,
@@ -141,6 +143,8 @@ impl Writeable for HeaderEntry {
 		writer.write_u64(self.timestamp)?;
 		self.total_difficulty.write(writer)?;
 		writer.write_u32(self.secondary_scaling)?;
+
+		// Using a full byte to represent the bool for now.
 		if self.is_secondary {
 			writer.write_u8(1)?;
 		} else {


### PR DESCRIPTION
~Still a work in progress but it runs against testnet4 successfully right now.~

Tested successfully against testnet4.
Backward compatible - a node will check the header MMR on init, reading the latest hash.
If this does not match or cannot be read successfully then we rebuild the header MMR.
This PR increases the size of an entry in the header MMR, so we rebuild.

We need to retrieve difficulty information for the previous 60 headers to validate the difficulty adjustment on a block header.
So for every header and every block we validate, we pull 60 other block headers from the db.

Headers are stored in lmdb, indexed by header hash. So these 60 retrievals are effectively random access. lmdb is memory mapped, but they will not all be in memory as the db grows.

If we could retrieve the necessary data from the header MMR itself, we can take advantage of the fact that these reads would not all be random - the MMR is structured such that these header entries are all adjacent to each other. If a header entry is x bytes long, the previous 60 headers are stored as the last `60 * x` bytes in the MMR data file.
In theory we can retrieve all 60 header entries via a single read against the header MMR.

This should allow for a significant improvement on sync performance without needing to resort to caching of headers or header_info data (faster difficulty validation not yet implemented).
In effect we can leverage the header MMR as a kind of cache of header data (taking advantage of the fact they are inserted in order).

