### PR TITLE
TUI Mining Screen (block hash and block height)

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use crate::core::consensus::graph_weight;
+use crate::core::core::hash::Hash;
 
 use chrono::prelude::*;
 
@@ -118,8 +119,10 @@ pub struct DiffStats {
 /// Last n blocks for difficulty calculation purposes
 #[derive(Clone, Debug)]
 pub struct DiffBlock {
-	/// Block number (can be negative for a new chain)
-	pub block_number: i64,
+	/// Block height (can be negative for a new chain)
+	pub block_height: i64,
+	/// Block hash (may be synthetic for a new chain)
+	pub block_hash: Hash,
 	/// Block network difficulty
 	pub difficulty: u64,
 	/// Time block was found (epoch seconds)

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -27,8 +27,8 @@ use crate::common::adapters::{
 };
 use crate::common::stats::{DiffBlock, DiffStats, PeerStats, ServerStateInfo, ServerStats};
 use crate::common::types::{Error, ServerConfig, StratumServerConfig, SyncState, SyncStatus};
-use crate::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use crate::core::core::hash::{Hashed, ZERO_HASH};
+use crate::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use crate::core::{consensus, genesis, global, pow};
 use crate::grin::{dandelion_monitor, seed, sync};
 use crate::mining::stratumserver;
@@ -369,21 +369,20 @@ impl Server {
 			let last_blocks: Vec<consensus::HeaderInfo> =
 				global::difficulty_data_to_vector(self.chain.difficulty_iter())
 					.into_iter()
-					.take(consensus::DIFFICULTY_ADJUST_WINDOW as usize)
 					.collect();
 
-			let mut last_time = last_blocks[0].timestamp;
 			let tip_height = self.chain.head().unwrap().height as i64;
-			let earliest_block_height = tip_height as i64 - last_blocks.len() as i64;
-			let mut i = 1;
+			let mut height = tip_height as i64 - last_blocks.len() as i64 + 1;
 
 			let diff_entries: Vec<DiffBlock> = last_blocks
-				.iter()
-				.map(|n| {
-					let dur = n.timestamp - last_time;
-					let height = earliest_block_height + i;
+				.windows(2)
+				.map(|pair| {
+					let prev = &pair[0];
+					let next = &pair[1];
 
-					// Use header hash if rela header.
+					height += 1;
+
+					// Use header hash if real header.
 					// Default to "zero" hash if synthetic header_info.
 					let hash = if height >= 0 {
 						if let Ok(header) = self.chain.get_header_by_height(height as u64) {
@@ -395,16 +394,14 @@ impl Server {
 						ZERO_HASH
 					};
 
-					i += 1;
-					last_time = n.timestamp;
 					DiffBlock {
 						block_height: height,
 						block_hash: hash,
-						difficulty: n.difficulty.to_num(),
-						time: n.timestamp,
-						duration: dur,
-						secondary_scaling: n.secondary_scaling,
-						is_secondary: n.is_secondary,
+						difficulty: next.difficulty.to_num(),
+						time: next.timestamp,
+						duration: next.timestamp - prev.timestamp,
+						secondary_scaling: next.secondary_scaling,
+						is_secondary: next.is_secondary,
 					}
 				})
 				.collect();
@@ -412,7 +409,7 @@ impl Server {
 			let block_time_sum = diff_entries.iter().fold(0, |sum, t| sum + t.duration);
 			let block_diff_sum = diff_entries.iter().fold(0, |sum, d| sum + d.difficulty);
 			DiffStats {
-				height: tip_height as u64,
+				height: height as u64,
 				last_blocks: diff_entries,
 				average_block_time: block_time_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),
 				average_difficulty: block_diff_sum / (consensus::DIFFICULTY_ADJUST_WINDOW - 1),

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -99,7 +99,8 @@ impl TableViewItem<StratumWorkerColumn> for WorkerStats {
 }
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum DiffColumn {
-	BlockNumber,
+	Height,
+	Hash,
 	PoWType,
 	Difficulty,
 	SecondaryScaling,
@@ -110,7 +111,8 @@ enum DiffColumn {
 impl DiffColumn {
 	fn _as_str(&self) -> &str {
 		match *self {
-			DiffColumn::BlockNumber => "Block Number",
+			DiffColumn::Height => "Height",
+			DiffColumn::Hash => "Hash",
 			DiffColumn::PoWType => "Type",
 			DiffColumn::Difficulty => "Network Difficulty",
 			DiffColumn::SecondaryScaling => "Sec. Scaling",
@@ -130,7 +132,8 @@ impl TableViewItem<DiffColumn> for DiffBlock {
 		};
 
 		match column {
-			DiffColumn::BlockNumber => self.block_number.to_string(),
+			DiffColumn::Height => self.block_height.to_string(),
+			DiffColumn::Hash => self.block_hash.to_string(),
 			DiffColumn::PoWType => pow_type,
 			DiffColumn::Difficulty => self.difficulty.to_string(),
 			DiffColumn::SecondaryScaling => self.secondary_scaling.to_string(),
@@ -144,7 +147,8 @@ impl TableViewItem<DiffColumn> for DiffBlock {
 		Self: Sized,
 	{
 		match column {
-			DiffColumn::BlockNumber => Ordering::Equal,
+			DiffColumn::Height => Ordering::Equal,
+			DiffColumn::Hash => Ordering::Equal,
 			DiffColumn::PoWType => Ordering::Equal,
 			DiffColumn::Difficulty => Ordering::Equal,
 			DiffColumn::SecondaryScaling => Ordering::Equal,
@@ -264,8 +268,11 @@ impl TUIStatusListener for TUIMiningView {
 			);
 
 		let diff_table_view = TableView::<DiffBlock, DiffColumn>::new()
-			.column(DiffColumn::BlockNumber, "Block Number", |c| {
-				c.width_percent(15)
+			.column(DiffColumn::Height, "Height", |c| {
+				c.width_percent(10)
+			})
+			.column(DiffColumn::Hash, "Hash", |c| {
+				c.width_percent(10)
 			})
 			.column(DiffColumn::PoWType, "Type", |c| c.width_percent(10))
 			.column(DiffColumn::Difficulty, "Network Difficulty", |c| {

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -268,12 +268,8 @@ impl TUIStatusListener for TUIMiningView {
 			);
 
 		let diff_table_view = TableView::<DiffBlock, DiffColumn>::new()
-			.column(DiffColumn::Height, "Height", |c| {
-				c.width_percent(10)
-			})
-			.column(DiffColumn::Hash, "Hash", |c| {
-				c.width_percent(10)
-			})
+			.column(DiffColumn::Height, "Height", |c| c.width_percent(10))
+			.column(DiffColumn::Hash, "Hash", |c| c.width_percent(10))
 			.column(DiffColumn::PoWType, "Type", |c| c.width_percent(10))
 			.column(DiffColumn::Difficulty, "Network Difficulty", |c| {
 				c.width_percent(15)


### PR DESCRIPTION
* Display block hash and block height (was just block number aka height)
* Fix off-by-one error (we were not showing the current header in there...)

```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Grin Version 0.4.2                                                                                                                                                                         │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────┐┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Basic Status      ││                                                                                                                                                                       │
│Peers and Sync    ││ ┌────────────────────┐┌──────────┐                                                                                                                                    │
│Mining            ││ │Mining Server Status││Difficulty│                                                                                                                                    │
│Version Info      ││ └────────────────────┘└──────────┘                                                                                                                                    │
│                  ││                                                                                                                                                                       │
│                  ││  Tip Height: 79213                                                                                                                                                    │
│                  ││  Difficulty Adjustment Window: 60                                                                                                                                     │
│                  ││  Average Block Time: 65 Secs                                                                                                                                          │
│                  ││  Average Difficulty: 30166                                                                                                                                            │
│                  ││  ┌───────────────────────────────────────────────────────────────────┤ Mining Difficulty Data ├────────────────────────────────────────────────────────────────────┐  │
│                  ││  │ Height       [^] ╷ Hash         [ ] ╷ Type         [ ] ╷ Network Difficulty   [ ] ╷ Sec. Scaling [ ] ╷ Block Time                           [ ] ╷ Duration  [ ] │  │
│                  ││  │ ─────────────────┴──────────────────┴──────────────────┴──────────────────────────┴──────────────────┴──────────────────────────────────────────┴────────────── │  │
│                  ││  │ 79213            ┆ 024cb9f4         ┆ Secondary        ┆ 29031                    ┆ 328              ┆ 2018-12-12 16:44:50 UTC                  ┆ 19s         ▒ │  │
│                  ││  │ 79212            ┆ 01245073         ┆ Secondary        ┆ 28804                    ┆ 328              ┆ 2018-12-12 16:44:31 UTC                  ┆ 13s         ▒ │  │
│                  ││  │ 79211            ┆ 000ab4a6         ┆ Secondary        ┆ 28785                    ┆ 328              ┆ 2018-12-12 16:44:18 UTC                  ┆ 19s         | │  │
│                  ││  │ 79210            ┆ 00e04694         ┆ Secondary        ┆ 28597                    ┆ 328              ┆ 2018-12-12 16:43:59 UTC                  ┆ 79s         | │  │
│                  ││  │ 79209            ┆ 015cd311         ┆ Secondary        ┆ 28428                    ┆ 328              ┆ 2018-12-12 16:42:40 UTC                  ┆ 2s          | │  │
│                  ││  │ 79208            ┆ 01c6bca3         ┆ Secondary        ┆ 28378                    ┆ 328              ┆ 2018-12-12 16:42:38 UTC                  ┆ 45s         | │  │
│                  ││  │ 79207            ┆ 011b34b0         ┆ Secondary        ┆ 28331                    ┆ 328              ┆ 2018-12-12 16:41:53 UTC                  ┆ 5s          | │  │
│                  ││  │ 79206            ┆ 01de85c4         ┆ Secondary        ┆ 27872                    ┆ 328              ┆ 2018-12-12 16:41:48 UTC                  ┆ 8s          | │  │
│                  ││  │ 79205            ┆ 021dca36         ┆ Secondary        ┆ 28178                    ┆ 329              ┆ 2018-12-12 16:41:40 UTC                  ┆ 137s        | │  │
│                  ││  │ 79204            ┆ 020d224f         ┆ Secondary        ┆ 28126                    ┆ 329              ┆ 2018-12-12 16:39:23 UTC                  ┆ 19s         | │  │
│                  ││  │ 79203            ┆ 0000dbb6         ┆ Secondary        ┆ 28227                    ┆ 329              ┆ 2018-12-12 16:39:04 UTC                  ┆ 4s          | │  │
│------------------││  │ 79202            ┆ 02a37d5a         ┆ Secondary        ┆ 27751                    ┆ 329              ┆ 2018-12-12 16:39:00 UTC                  ┆ 97s         | │  │
│Tab/Arrow : Cycle ││  └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘  │
│Enter     : Select││                                                                                                                                                                       │
│Q         : Quit  ││                                                                                                                                                                       │
└──────────────────┘└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```