### PR TITLE
Coin selection with small amounts fix

### DIFF
--- a/wallet/src/adapters/http.rs
+++ b/wallet/src/adapters/http.rs
@@ -49,7 +49,7 @@ impl WalletCommAdapter for HTTPWalletCommAdapter {
 		debug!("Posting transaction slate to {}", url);
 
 		let res = api::client::post(url.as_str(), None, slate)
-			.context(ErrorKind::ClientCallback("Posting transaction slate"))?;
+			.context(ErrorKind::ClientCallback("Posting transaction slate (is recipient listening?)"))?;
 		Ok(res)
 	}
 

--- a/wallet/src/adapters/http.rs
+++ b/wallet/src/adapters/http.rs
@@ -48,8 +48,9 @@ impl WalletCommAdapter for HTTPWalletCommAdapter {
 		let url = format!("{}/v1/wallet/foreign/receive_tx", dest);
 		debug!("Posting transaction slate to {}", url);
 
-		let res = api::client::post(url.as_str(), None, slate)
-			.context(ErrorKind::ClientCallback("Posting transaction slate (is recipient listening?)"))?;
+		let res = api::client::post(url.as_str(), None, slate).context(
+			ErrorKind::ClientCallback("Posting transaction slate (is recipient listening?)"),
+		)?;
 		Ok(res)
 	}
 

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -235,7 +235,7 @@ where
 	K: Keychain,
 {
 	// select some spendable coins from the wallet
-	let (max_outputs, coins) = select_coins(
+	let (max_outputs, mut coins) = select_coins(
 		wallet,
 		amount,
 		current_height,
@@ -291,7 +291,7 @@ where
 			}
 
 			// select some spendable coins from the wallet
-			let (_, coins) = select_coins(
+			coins = select_coins(
 				wallet,
 				amount_with_fee,
 				current_height,
@@ -299,7 +299,7 @@ where
 				max_outputs,
 				selection_strategy_is_use_all,
 				parent_key_id,
-			);
+			).1;
 			fee = tx_fee(coins.len(), num_outputs, 1, None);
 			total = coins.iter().map(|c| c.value).sum();
 			amount_with_fee = amount + fee;

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -299,7 +299,8 @@ where
 				max_outputs,
 				selection_strategy_is_use_all,
 				parent_key_id,
-			).1;
+			)
+			.1;
 			fee = tx_fee(coins.len(), num_outputs, 1, None);
 			total = coins.iter().map(|c| c.value).sum();
 			amount_with_fee = amount + fee;


### PR DESCRIPTION
Should be a fix for
https://github.com/mimblewimble/grin/issues/2076

Was attempting to select coins properly, but putting the result in another scoped `coins` variable instead of modifying the outer one before calling `inputs_and_change`
