### PR TITLE
[DNM] prunable header mmrs

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -279,17 +279,13 @@ impl TxHashSet {
 		{
 			let cutoff_pos = pmmr::insertion_to_pmmr_index(horizon_header.height);
 			self.header_pmmr_h.backend.remove_range(0..cutoff_pos);
-			self.header_pmmr_h.backend.check_compact(
-				cutoff_pos,
-				&Bitmap::create(),
-				&prune_noop,
-			)?;
+			self.header_pmmr_h
+				.backend
+				.check_compact(cutoff_pos, &Bitmap::create(), &prune_noop)?;
 			self.sync_pmmr_h.backend.remove_range(0..cutoff_pos);
-			self.sync_pmmr_h.backend.check_compact(
-				cutoff_pos,
-				&Bitmap::create(),
-				&prune_noop,
-			)?;
+			self.sync_pmmr_h
+				.backend
+				.check_compact(cutoff_pos, &Bitmap::create(), &prune_noop)?;
 		}
 
 		// Compact the prunable output and rangeproof backends based on "spent" outputs.
@@ -697,9 +693,7 @@ impl<'a> HeaderExtension<'a> {
 	/// including the genesis block header.
 	pub fn truncate(&mut self) -> Result<(), Error> {
 		debug!("Truncating header extension.");
-		self.pmmr
-			.truncate()
-			.map_err(&ErrorKind::TxHashSetErr)?;
+		self.pmmr.truncate().map_err(&ErrorKind::TxHashSetErr)?;
 		Ok(())
 	}
 

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -36,6 +36,8 @@ pub trait Backend<T: PMMRable> {
 	/// during the rewind.
 	fn rewind(&mut self, position: u64, rewind_rm_pos: &Bitmap) -> Result<(), String>;
 
+	fn truncate(&mut self) -> Result<(), String>;
+
 	/// Get a Hash by insertion position.
 	fn get_hash(&self, position: u64) -> Option<Hash>;
 
@@ -50,10 +52,7 @@ pub trait Backend<T: PMMRable> {
 	/// (ignoring the remove log).
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
-	/// Remove Hash by insertion position. An index is also provided so the
-	/// underlying backend can implement some rollback of positions up to a
-	/// given index (practically the index is the height of a block that
-	/// triggered removal).
+	/// Remove by insertion position.
 	fn remove(&mut self, position: u64) -> Result<(), String>;
 
 	/// Returns the data file path.. this is a bit of a hack now that doesn't

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -211,6 +211,12 @@ where
 		Ok(())
 	}
 
+	pub fn truncate(&mut self) -> Result<(), String> {
+		self.backend.truncate()?;
+		self.last_pos = 0;
+		Ok(())
+	}
+
 	/// Rewind the PMMR to a previous position, as if all push operations after
 	/// that had been canceled. Expects a position in the PMMR to rewind and
 	/// bitmaps representing the positions added and removed that we want to

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -15,6 +15,7 @@
 //! Compact (roaring) bitmap representing the set of leaf positions
 //! that exist and are not currently pruned in the MMR.
 
+use std::ops::Range;
 use std::path::Path;
 
 use croaring::Bitmap;
@@ -52,6 +53,12 @@ impl LeafSet {
 			bitmap_bak: bitmap.clone(),
 			bitmap,
 		})
+	}
+
+	pub fn truncate(&mut self) -> io::Result<()> {
+		self.bitmap = Bitmap::create();
+		self.flush()?;
+		Ok(())
 	}
 
 	/// Copies a snapshot of the utxo file into the primary utxo file.
@@ -139,6 +146,11 @@ impl LeafSet {
 	/// Remove the provided position from the leaf_set.
 	pub fn remove(&mut self, pos: u64) {
 		self.bitmap.remove(pos as u32);
+	}
+
+	/// Remove the provided positions from the leaf_set.
+	pub fn remove_range(&mut self, pos: Range<u64>) {
+		self.bitmap.remove_range(pos);
 	}
 
 	/// Saves the utxo file tagged with block hash as filename suffix.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -13,6 +13,7 @@
 
 //! Implementation of the persistent Backend for the prunable MMR tree.
 
+use std::ops::Range;
 use std::{fs, io, time};
 
 use crate::core::core::hash::{Hash, Hashed};
@@ -118,6 +119,14 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			return None;
 		}
 		self.get_data_from_file(pos)
+	}
+
+	fn truncate(&mut self) -> Result<(), String> {
+		self.prune_list.truncate();
+		self.leaf_set.truncate();
+		self.hash_file.truncate();
+		self.data_file.truncate();
+		Ok(())
 	}
 
 	/// Rewind the PMMR backend to the given position.
@@ -255,6 +264,12 @@ impl<T: PMMRable> PMMRBackend<T> {
 		self.hash_file.discard();
 		self.leaf_set.discard();
 		self.data_file.discard();
+	}
+
+	/// Remove a range of positions from the backend.
+	pub fn remove_range(&mut self, pos: Range<u64>) {
+		assert!(self.prunable, "Remove on non-prunable MMR");
+		self.leaf_set.remove_range(pos);
 	}
 
 	/// Takes the leaf_set at a given cutoff_pos and generates an updated

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -62,6 +62,12 @@ impl PruneList {
 		}
 	}
 
+	pub fn truncate(&mut self) -> io::Result<()> {
+		self.bitmap = Bitmap::create();
+		self.flush()?;
+		Ok(())
+	}
+
 	/// Open an existing prune_list or create a new one.
 	pub fn open(path: &str) -> io::Result<PruneList> {
 		let file_path = Path::new(&path);
@@ -153,6 +159,7 @@ impl PruneList {
 
 	fn build_shift_cache(&mut self) {
 		if self.bitmap.is_empty() {
+			self.shift_cache.clear();
 			return;
 		}
 
@@ -194,6 +201,7 @@ impl PruneList {
 
 	fn build_leaf_shift_cache(&mut self) {
 		if self.bitmap.is_empty() {
+			self.leaf_shift_cache.clear();
 			return;
 		}
 
@@ -261,8 +269,10 @@ impl PruneList {
 
 	fn build_pruned_cache(&mut self) {
 		if self.bitmap.is_empty() {
+			self.pruned_cache = Bitmap::create();
 			return;
 		}
+
 		self.pruned_cache = Bitmap::create_with_capacity(self.bitmap.maximum());
 		for pos in 1..(self.bitmap.maximum() + 1) {
 			let path = path(pos as u64, self.bitmap.maximum() as u64);

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -41,6 +41,12 @@ where
 		})
 	}
 
+	pub fn truncate(&mut self) -> io::Result<()> {
+		self.rewind(0);
+		self.flush()?;
+		Ok(())
+	}
+
 	/// Append an element to the file.
 	/// Will not be written to disk until flush() is subsequently called.
 	/// Alternatively discard() may be called to discard any pending changes.


### PR DESCRIPTION
Related - #2137.

This PR demonstrates how we can aggressively prune the header MMR and still be able to validate the `prev_root` in each header (against the current root of the header MMR).

But - turns out we had forgotten that we are also using the header MMR as our canonical "header by height" index. And we need to maintain this all the way back to the genesis block so we can let other nodes sync headers from us (via the locator).

We have a couple of competing requirements here - 
* header by height index: maintain _all_ header hashes in the header MMR _forever_
* small header MMR: only maintain _recent_ header entries in the header MMR

I am putting this PR up so we have something to refer to. But closing it as we cannot enable pruning in the header MMR currently due to the locator requirements.

I'm still stating #2137 is a good idea and the trade offs are worth it.
But - we need to think more about how to support a header MMR that needs to maintain header hashes but is flexible around pruning of the associated difficulty data.

I think this bleeds into the discussion and design of the kernel MMR also - in terms of optional kernels and greater flexibility around the handling of MMR data.