### PR TITLE
[WIP] Store completed transactions in files instead of DB

### DIFF
--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -408,7 +408,7 @@ mod wallet_tests {
 			Ok(())
 		})?;
 
-		// Try using the self-send method
+		// Try using the self-send method, splitting up outputs for the fun of it
 		let arg_vec = vec![
 			"grin",
 			"wallet",
@@ -423,6 +423,8 @@ mod wallet_tests {
 			"mining",
 			"-g",
 			"Self love",
+			"-o",
+			"75",
 			"-s",
 			"smallest",
 			"10",

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -178,7 +178,7 @@ pub fn txs(
 			)
 		};
 		let tx_data = match t.tx_hex {
-			Some(_) => format!("Exists"),
+			Some(t) => format!("{}", t),
 			None => "None".to_owned(),
 		};
 		if dark_background_color_scheme {

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -113,6 +113,7 @@ where
 		t.amount_debited = amount_debited;
 
 		// write the output representing our change
+		error!("OUTTING LOADS OF OUTPUTS");
 		for (change_amount, id) in &change_amounts_derivations {
 			t.num_outputs += 1;
 			t.amount_credited += change_amount;
@@ -128,6 +129,7 @@ where
 				tx_log_entry: Some(log_id),
 			})?;
 		}
+		error!("SAVING TX LOG ENTRY: {}", t.tx_slate_id.as_ref().unwrap());
 		batch.save_tx_log_entry(t, &parent_key_id)?;
 		batch.commit()?;
 		Ok(())

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -228,7 +228,7 @@ where
 		None => return Err(ErrorKind::TransactionDoesntExist(slate.id.to_string()))?,
 	};
 	tx.tx_hex = Some(tx_hex);
-	let batch = wallet.batch()?;
+	let mut batch = wallet.batch()?;
 	batch.save_tx_log_entry(tx.clone(), &tx.parent_key_id)?;
 	batch.commit()?;
 	Ok(())

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -156,7 +156,7 @@ where
 	fn tx_log_iter(&self) -> Box<dyn Iterator<Item = TxLogEntry>>;
 
 	/// save a tx log entry
-	fn save_tx_log_entry(&self, t: TxLogEntry, parent_id: &Identifier) -> Result<(), Error>;
+	fn save_tx_log_entry(&mut self, t: TxLogEntry, parent_id: &Identifier) -> Result<(), Error>;
 
 	/// save an account label -> path mapping
 	fn save_acct_path(&mut self, mapping: AcctPathMapping) -> Result<(), Error>;


### PR DESCRIPTION
Cause of https://github.com/mimblewimble/grin/issues/2069, turns out it was a bad idea to store completed transactions in the DB for the 'repost' command, as there appears to be some sort of record size limit that LMDB is silently refusing to commit. When the number of outputs gets beyond a certain point, TxLogEntries with large completed transactions just aren't committed, with no error messages saying anything is wrong.

Makes more sense to store these completed transactions as file data, anyhow, but not 100% sure how to do that without breaking abstraction layers... currently tried to swap out the `tx_hex` in TxLogEntry with contents of a file on db read/write, however that doesn't entirely work because of iteration methods. Still thinking about how to fix this properly (and fix is very much needed if we want to test large transactions or test performance on wallets with many outputs)