### PR TITLE
disconnect slow peer to avoid multiple parallel headers download

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -418,6 +418,10 @@ impl Peer {
 	/// Stops the peer, closing its connection
 	pub fn stop(&self) {
 		stop_with_connection(&self.connection.as_ref().unwrap().lock());
+		let mut state = self.state.write();
+		if State::Connected == *state {
+			*state = State::Disconnected;
+		}
 	}
 
 	fn check_connection(&self) -> bool {


### PR DESCRIPTION
Fix for problem found in https://github.com/mimblewimble/grin/issues/2152#issuecomment-447237343

We should avoid 2 parallel downloading of Headers, if one peer is on a very slow network speed, that will make thing a mess for header sync.

The "mess" here means something like this:
```
20181214 14:07:14.107 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 0aa40871 at 31670
20181214 14:07:14.151 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 032ca7a0 at 30520
...
20181214 14:07:38.671 DEBUG grin_chain::pipe - pipe: sync_block_headers: 31 headers from 069e9341 at 36046
20181214 14:07:39.649 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 02c9f847 at 34608
20181214 14:07:40.307 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 022b2a84 at 36077
...
20181214 14:08:06.261 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 01dd7ca6 at 38697
20181214 14:08:06.524 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 0158050d at 37770
20181214 14:08:06.908 DEBUG grin_chain::pipe - pipe: sync_block_headers: 32 headers from 01e78670 at 38729
...
```

