### PR TITLE
[Floonet] Switch commitments

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -406,6 +406,13 @@ fn comments() -> HashMap<String, String> {
 "
 		.to_string(),
 	);
+	retval.insert(
+		"use_switch_commitments".to_string(),
+		"
+#Whether to use switch commitments for this wallet
+"
+		.to_string(),
+	);
 
 	retval.insert(
 		"[logging]".to_string(),

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -251,24 +251,25 @@ pub fn verify_partial_sig(
 /// let msg = kernel_sig_msg(0, height, KernelFeatures::DEFAULT_KERNEL).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
-/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, &key_id, Some(&pubkey)).unwrap();
+/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, Some(&pubkey)).unwrap();
 /// ```
 
 pub fn sign_from_key_id<K>(
 	secp: &Secp256k1,
 	k: &K,
 	msg: &Message,
+	value: u64,
 	key_id: &Identifier,
 	blind_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error>
 where
 	K: Keychain,
 {
-	let skey = k.derive_key(key_id)?;
+	let skey = k.derive_key(value, key_id)?;
 	let sig = aggsig::sign_single(
 		secp,
 		&msg,
-		&skey.secret_key,
+		&skey,
 		None,
 		None,
 		None,
@@ -324,7 +325,7 @@ where
 /// let msg = kernel_sig_msg(0, height, KernelFeatures::DEFAULT_KERNEL).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
-/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, &key_id, Some(&pubkey)).unwrap();
+/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, Some(&pubkey)).unwrap();
 ///
 /// // Verify the signature from the excess commit
 /// let sig_verifies =

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -54,7 +54,7 @@ where
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
 			let commit = build.keychain.commit(value, &key_id).unwrap();
 			let input = Input::new(features, commit);
-			(tx.with_input(input), kern, sum.sub_key_id(key_id.to_path()))
+			(tx.with_input(input), kern, sum.sub_key_id(key_id.to_value_path(value)))
 		},
 	)
 }
@@ -102,7 +102,7 @@ where
 					proof: rproof,
 				}),
 				kern,
-				sum.add_key_id(key_id.to_path()),
+				sum.add_key_id(key_id.to_value_path(value)),
 			)
 		},
 	)

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -26,7 +26,7 @@ where
 	K: Keychain,
 {
 	// hash(commit|wallet root secret key (m)) as nonce
-	let root_key = k.derive_key(&K::root_key_id())?.secret_key;
+	let root_key = k.derive_key(0, &K::root_key_id())?;
 	let res = blake2::blake2b::blake2b(32, &commit.0, &root_key.0[..]);
 	let res = res.as_bytes();
 	let mut ret_val = [0; 32];
@@ -53,11 +53,11 @@ where
 	K: Keychain,
 {
 	let commit = k.commit(amount, key_id)?;
-	let skey = k.derive_key(key_id)?;
+	let skey = k.derive_key(amount, key_id)?;
 	let nonce = create_nonce(k, &commit)?;
 	let message = ProofMessage::from_bytes(&key_id.serialize_path());
 	Ok(k.secp()
-		.bullet_proof(amount, skey.secret_key, nonce, extra_data, Some(message)))
+		.bullet_proof(amount, skey, nonce, extra_data, Some(message)))
 }
 
 /// Verify a proof

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -59,7 +59,7 @@ where
 	// This output will not be spendable earlier than lock_height (and we sign this
 	// here).
 	let msg = kernel_sig_msg(0, height, KernelFeatures::COINBASE_KERNEL)?;
-	let sig = aggsig::sign_from_key_id(&secp, keychain, &msg, &key_id, Some(&pubkey))?;
+	let sig = aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, Some(&pubkey))?;
 
 	let proof = TxKernel {
 		features: KernelFeatures::COINBASE_KERNEL,

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -23,7 +23,7 @@ use std::ops::Add;
 use std::{error, fmt};
 
 use crate::blake2::blake2b::blake2b;
-use crate::extkey_bip32::{self, ChildNumber, ExtendedPrivKey};
+use crate::extkey_bip32::{self, ChildNumber};
 use serde::{de, ser}; //TODO: Convert errors to use ErrorKind
 
 use crate::util;
@@ -44,6 +44,7 @@ pub enum Error {
 	KeyDerivation(extkey_bip32::Error),
 	Transaction(String),
 	RangeProof(String),
+	SwitchCommitment
 }
 
 impl From<secp::Error> for Error {
@@ -124,6 +125,13 @@ impl Identifier {
 
 	pub fn to_path(&self) -> ExtKeychainPath {
 		ExtKeychainPath::from_identifier(&self)
+	}
+
+	pub fn to_value_path(&self, value: u64) -> ValueExtKeychainPath {
+		ValueExtKeychainPath {
+			value,
+			ext_keychain_path: self.to_path()
+		}
 	}
 
 	/// output the path itself, for insertion into bulletproof
@@ -327,8 +335,8 @@ pub struct SplitBlindingFactor {
 /// factor as well as the "sign" with which they should be combined.
 #[derive(Clone, Debug, PartialEq)]
 pub struct BlindSum {
-	pub positive_key_ids: Vec<ExtKeychainPath>,
-	pub negative_key_ids: Vec<ExtKeychainPath>,
+	pub positive_key_ids: Vec<ValueExtKeychainPath>,
+	pub negative_key_ids: Vec<ValueExtKeychainPath>,
 	pub positive_blinding_factors: Vec<BlindingFactor>,
 	pub negative_blinding_factors: Vec<BlindingFactor>,
 }
@@ -344,12 +352,12 @@ impl BlindSum {
 		}
 	}
 
-	pub fn add_key_id(mut self, path: ExtKeychainPath) -> BlindSum {
+	pub fn add_key_id(mut self, path: ValueExtKeychainPath) -> BlindSum {
 		self.positive_key_ids.push(path);
 		self
 	}
 
-	pub fn sub_key_id(mut self, path: ExtKeychainPath) -> BlindSum {
+	pub fn sub_key_id(mut self, path: ValueExtKeychainPath) -> BlindSum {
 		self.negative_key_ids.push(path);
 		self
 	}
@@ -430,18 +438,26 @@ impl ExtKeychainPath {
 	}
 }
 
+/// Wrapper for amount + path
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize)]
+pub struct ValueExtKeychainPath {
+	pub value: u64,
+	pub ext_keychain_path: ExtKeychainPath
+}
+
 pub trait Keychain: Sync + Send + Clone {
-	fn from_seed(seed: &[u8]) -> Result<Self, Error>;
+	fn from_seed(seed: &[u8], use_switch_commitments: bool) -> Result<Self, Error>;
 	fn from_mnemonic(word_list: &str, extension_word: &str) -> Result<Self, Error>;
-	fn from_random_seed() -> Result<Self, Error>;
+	fn from_random_seed(use_switch_commitments: bool) -> Result<Self, Error>;
 	fn root_key_id() -> Identifier;
 	fn derive_key_id(depth: u8, d1: u32, d2: u32, d3: u32, d4: u32) -> Identifier;
-	fn derive_key(&self, id: &Identifier) -> Result<ExtendedPrivKey, Error>;
+	fn derive_key(&self, amount: u64, id: &Identifier) -> Result<SecretKey, Error>;
 	fn commit(&self, amount: u64, id: &Identifier) -> Result<Commitment, Error>;
 	fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error>;
-	fn sign(&self, msg: &Message, id: &Identifier) -> Result<Signature, Error>;
+	fn sign(&self, msg: &Message, amount: u64, id: &Identifier) -> Result<Signature, Error>;
 	fn sign_with_blinding(&self, _: &Message, _: &BlindingFactor) -> Result<Signature, Error>;
 	fn secp(&self) -> &Secp256k1;
+	fn use_switch_commitments(&self) -> Option<bool>;
 }
 
 #[cfg(test)]

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -170,7 +170,7 @@ fn build_block(
 ///
 fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, BlockFees), Error> {
 	warn!("Burning block fees: {:?}", block_fees);
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(true).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) =
 		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees, block_fees.height)

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -123,8 +123,7 @@ where
 	fn open_with_credentials(&mut self) -> Result<(), Error> {
 		let wallet_seed = WalletSeed::from_file(&self.config, &self.passphrase)
 			.context(ErrorKind::CallbackImpl("Error opening wallet"))?;
-		let keychain = wallet_seed.derive_keychain();
-		self.keychain = Some(keychain.context(ErrorKind::CallbackImpl("Error deriving keychain"))?);
+		self.keychain = Some(wallet_seed.derive_keychain(self.config.use_switch_commitments).context(ErrorKind::CallbackImpl("Error deriving keychain"))?);
 		Ok(())
 	}
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -50,13 +50,15 @@ pub struct WalletConfig {
 	pub check_node_api_http_addr: String,
 	// The directory in which wallet files are stored
 	pub data_file_dir: String,
-	/// TLS ceritificate file
+	/// TLS certificate file
 	pub tls_certificate_file: Option<String>,
-	/// TLS ceritificate private key file
+	/// TLS certificate private key file
 	pub tls_certificate_key: Option<String>,
 	/// Whether to use the black background color scheme for command line
 	/// if enabled, wallet command output color will be suitable for black background terminal
 	pub dark_background_color_scheme: Option<bool>,
+	/// Whether we want to use switch commitments for this wallet
+	pub use_switch_commitments: bool
 }
 
 impl Default for WalletConfig {
@@ -72,6 +74,7 @@ impl Default for WalletConfig {
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			dark_background_color_scheme: Some(true),
+			use_switch_commitments: false // TODO: possibly change to true when we want it on by default
 		}
 	}
 }
@@ -121,8 +124,8 @@ impl WalletSeed {
 		seed.as_bytes().to_vec()
 	}
 
-	pub fn derive_keychain<K: Keychain>(&self) -> Result<K, Error> {
-		let result = K::from_seed(&self.0)?;
+	pub fn derive_keychain<K: Keychain>(&self, use_switch_commitments: bool) -> Result<K, Error> {
+		let result = K::from_seed(&self.0, use_switch_commitments)?;
 		Ok(result)
 	}
 

--- a/wallet/tests/libwallet.rs
+++ b/wallet/tests/libwallet.rs
@@ -32,14 +32,16 @@ fn kernel_sig_msg() -> secp::Message {
 #[test]
 fn aggsig_sender_receiver_interaction() {
 	let sender_keychain = ExtKeychain::from_random_seed().unwrap();
+	sender_keychain.set_use_switch_commitments(false);
 	let receiver_keychain = ExtKeychain::from_random_seed().unwrap();
+	receiver_keychain.set_use_switch_commitments(false);
 
 	// Calculate the kernel excess here for convenience.
 	// Normally this would happen during transaction building.
 	let kernel_excess = {
 		let id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let skey1 = sender_keychain.derive_key(&id1).unwrap().secret_key;
-		let skey2 = receiver_keychain.derive_key(&id1).unwrap().secret_key;
+		let skey1 = sender_keychain.derive_key(0, &id1).unwrap().secret_key;
+		let skey2 = receiver_keychain.derive_key(0, &id1).unwrap().secret_key;
 
 		let keychain = ExtKeychain::from_random_seed().unwrap();
 		let blinding_factor = keychain
@@ -62,7 +64,7 @@ fn aggsig_sender_receiver_interaction() {
 	let (sender_pub_excess, _sender_pub_nonce) = {
 		let keychain = sender_keychain.clone();
 		let id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let skey = keychain.derive_key(&id1).unwrap().secret_key;
+		let skey = keychain.derive_key(0, &id1).unwrap().secret_key;
 
 		// dealing with an input here so we need to negate the blinding_factor
 		// rather than use it as is
@@ -85,7 +87,7 @@ fn aggsig_sender_receiver_interaction() {
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 		// let blind = blind_sum.secret_key(&keychain.secp())?;
-		let blind = keychain.derive_key(&key_id).unwrap().secret_key;
+		let blind = keychain.derive_key(0, &key_id).unwrap().secret_key;
 
 		rx_cx = Context::new(&keychain.secp(), blind);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());
@@ -236,7 +238,9 @@ fn aggsig_sender_receiver_interaction() {
 #[test]
 fn aggsig_sender_receiver_interaction_offset() {
 	let sender_keychain = ExtKeychain::from_random_seed().unwrap();
+	sender_keychain.set_use_switch_commitments(false);
 	let receiver_keychain = ExtKeychain::from_random_seed().unwrap();
+	receiver_keychain.set_use_switch_commitments(false);
 
 	// This is the kernel offset that we use to split the key
 	// Summing these at the block level prevents the
@@ -247,8 +251,8 @@ fn aggsig_sender_receiver_interaction_offset() {
 	// Normally this would happen during transaction building.
 	let kernel_excess = {
 		let id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let skey1 = sender_keychain.derive_key(&id1).unwrap().secret_key;
-		let skey2 = receiver_keychain.derive_key(&id1).unwrap().secret_key;
+		let skey1 = sender_keychain.derive_key(0, &id1).unwrap().secret_key;
+		let skey2 = receiver_keychain.derive_key(0, &id1).unwrap().secret_key;
 
 		let keychain = ExtKeychain::from_random_seed().unwrap();
 		let blinding_factor = keychain
@@ -274,7 +278,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 	let (sender_pub_excess, _sender_pub_nonce) = {
 		let keychain = sender_keychain.clone();
 		let id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let skey = keychain.derive_key(&id1).unwrap().secret_key;
+		let skey = keychain.derive_key(0, &id1).unwrap().secret_key;
 
 		// dealing with an input here so we need to negate the blinding_factor
 		// rather than use it as is
@@ -301,7 +305,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 		let keychain = receiver_keychain.clone();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
-		let blind = keychain.derive_key(&key_id).unwrap().secret_key;
+		let blind = keychain.derive_key(0, &key_id).unwrap().secret_key;
 
 		rx_cx = Context::new(&keychain.secp(), blind);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());


### PR DESCRIPTION
Re-opening this because I messed #2007 up.

This PR adds switch commitments following the scheme defined in #998. Blinding factors are modified to `x' = x + H(xG+vH | xJ)`

If in the future doubts arise about the existence of mechanisms that would break the discrete logarithm between `G` and `H`, we could require revealing the ElGamal commitment `(xG+vH, xJ)` (and a corresponding rangeproof) in order to spend an output.

Wallets that want to use switch commitments should add a configuration option `use_switch_commits=true`. The default value for now is `false`, we could consider changing it to `true` before mainnet, if we feel comfortable enough with this PR.

I have constructed this PR in a way that wallets can either use switch commitments, or not use them. I do not think it is a good idea to let wallets have both types (or possibly even more than 2) at the same time. This is because if we want to use switch commitments, _everyone_ should use them. In that case we don't want outputs that don't have the switch commitment lingering around. The same holds if we ever want to change to a different type of switch commitment. In those cases the users should create a new wallet and transfer their funds to it.

TODO:
- [ ] do more testing
- [ ] check built-in tests
- [ ] change `util/Cargo.toml` to the latest version of libsecp with switch commitments

PRs in underlying libraries: mimblewimble/secp256k1-zkp#34, mimblewimble/rust-secp256k1-zkp#38

Comments welcome!