### PR TITLE
fix: stratum server handles any request ID

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -42,8 +42,16 @@ use crate::util;
 // RPC Methods
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum RpcId {
+    Null,
+    Number(serde_json::Number),
+    String(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 struct RpcRequest {
-	id: Value,
+	id: RpcId,
 	jsonrpc: String,
 	method: String,
 	params: Option<Value>,
@@ -51,7 +59,7 @@ struct RpcRequest {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcResponse {
-	id: Value,
+	id: RpcId,
 	jsonrpc: String,
 	method: String,
 	result: Option<Value>,
@@ -617,7 +625,7 @@ impl StratumServer {
 		// Issue #1159 - use a serde_json Value type to avoid extra quoting
 		let job_template_value: Value = serde_json::from_str(&job_template_json).unwrap();
 		let job_request = RpcRequest {
-			id: serde_json::json!("Stratum"),
+			id: RpcId::String(String::from("Stratum")),
 			jsonrpc: String::from("2.0"),
 			method: String::from("job"),
 			params: Some(job_template_value),

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -43,7 +43,7 @@ use crate::util;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcRequest {
-	id: String,
+	id: Value,
 	jsonrpc: String,
 	method: String,
 	params: Option<Value>,
@@ -51,7 +51,7 @@ struct RpcRequest {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcResponse {
-	id: String,
+	id: Value,
 	jsonrpc: String,
 	method: String,
 	result: Option<Value>,
@@ -617,7 +617,7 @@ impl StratumServer {
 		// Issue #1159 - use a serde_json Value type to avoid extra quoting
 		let job_template_value: Value = serde_json::from_str(&job_template_json).unwrap();
 		let job_request = RpcRequest {
-			id: String::from("Stratum"),
+			id: serde_json::json!("Stratum"),
 			jsonrpc: String::from("2.0"),
 			method: String::from("job"),
 			params: Some(job_template_value),


### PR DESCRIPTION
fixes #2149 to enable communication with a JSON RPC 2.0 compliant client. The only drawback of this fix is that the server accepts Bool, Array and Object values as ID, too.