### PR TITLE
take lock once in get_header_for_output

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1123,11 +1123,9 @@ impl Chain {
 		&self,
 		output_ref: &OutputIdentifier,
 	) -> Result<BlockHeader, Error> {
-		let pos = {
-			let txhashset = self.txhashset.read();
-			let (_, pos) = txhashset.is_unspent(output_ref)?;
-			pos
-		};
+		let txhashset = self.txhashset.read();
+
+		let (_, pos) = txhashset.is_unspent(output_ref)?;
 
 		let mut min = 1;
 		let mut max = {
@@ -1137,8 +1135,8 @@ impl Chain {
 
 		loop {
 			let search_height = max - (max - min) / 2;
-			let h = self.get_header_by_height(search_height)?;
-			let h_prev = self.get_header_by_height(search_height - 1)?;
+			let h = txhashset.get_header_by_height(search_height)?;
+			let h_prev = txhashset.get_header_by_height(search_height - 1)?;
 			if pos > h.output_mmr_size {
 				min = search_height;
 			} else if pos < h_prev.output_mmr_size {


### PR DESCRIPTION
Resolves #2160.

```
> time ../target/release/grin wallet restore
20181215 16:51:26.501 INFO grin_wallet::libwallet::internal::restore - Starting restore.
20181215 16:51:26.824 INFO grin_wallet::libwallet::internal::restore - Retrieved 1000 outputs, up to index 217479. (Highest index: 6891)
20181215 16:51:26.824 INFO grin_wallet::libwallet::internal::restore - Scanning 1000 outputs in the current Grin utxo set
20181215 16:51:27.206 INFO grin_wallet::libwallet::internal::restore - Retrieved 1000 outputs, up to index 217479. (Highest index: 9335)
20181215 16:51:27.206 INFO grin_wallet::libwallet::internal::restore - Scanning 1000 outputs in the current Grin utxo set
...
20181215 16:51:43.641 INFO grin_wallet::libwallet::internal::restore - Retrieved 1000 outputs, up to index 217479. (Highest index: 216681)
20181215 16:51:43.641 INFO grin_wallet::libwallet::internal::restore - Scanning 1000 outputs in the current Grin utxo set
20181215 16:51:43.948 INFO grin_wallet::libwallet::internal::restore - Retrieved 793 outputs, up to index 217479. (Highest index: 217479)
20181215 16:51:43.949 INFO grin_wallet::libwallet::internal::restore - Scanning 793 outputs in the current Grin utxo set
...
20181215 16:51:43.987 INFO grin_wallet::command - Wallet restore complete
Command 'restore' completed successfully
../target/release/grin wallet restore  3.31s user 0.31s system 16% cpu 21.785 total
```

