### PR TITLE
less txhashset locking

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -260,6 +260,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 		let max_height = self.chain().header_head().unwrap().height;
 
+		let txhashset = self.chain().txhashset();
+		let txhashset = txhashset.read();
+
 		// looks like we know one, getting as many following headers as allowed
 		let hh = header.height;
 		let mut headers = vec![];
@@ -268,7 +271,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				break;
 			}
 
-			if let Ok(header) = self.chain().get_header_by_height(h) {
+			if let Ok(header) = txhashset.get_header_by_height(h) {
 				headers.push(header);
 			} else {
 				error!("Failed to locate headers successfully.");
@@ -399,9 +402,12 @@ impl NetToChainAdapter {
 
 	// Find the first locator hash that refers to a known header on our main chain.
 	fn find_common_header(&self, locator: &[Hash]) -> Option<BlockHeader> {
+		let txhashset = self.chain().txhashset();
+		let txhashset = txhashset.read();
+
 		for hash in locator {
 			if let Ok(header) = self.chain().get_block_header(&hash) {
-				if let Ok(header_at_height) = self.chain().get_header_by_height(header.height) {
+				if let Ok(header_at_height) = txhashset.get_header_by_height(header.height) {
 					if header.hash() == header_at_height.hash() {
 						return Some(header);
 					}


### PR DESCRIPTION
* No need for a write lock on txhashset for `chain.get_header_by_height()`
* Take single lock (and then loop) in a few places.

