### PR TITLE
add feature for height locked kernels

### DIFF
--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -248,7 +248,7 @@ pub fn verify_partial_sig(
 /// let height = 20;
 /// let over_commit = secp.commit_value(reward(fees)).unwrap();
 /// let out_commit = output.commitment();
-/// let msg = kernel_sig_msg(0, height, KernelFeatures::DEFAULT_KERNEL).unwrap();
+/// let msg = kernel_sig_msg(0, height, KernelFeatures::HEIGHT_LOCKED_KERNEL).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
 /// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, &key_id, Some(&pubkey)).unwrap();
@@ -321,7 +321,7 @@ where
 /// let height = 20;
 /// let over_commit = secp.commit_value(reward(fees)).unwrap();
 /// let out_commit = output.commitment();
-/// let msg = kernel_sig_msg(0, height, KernelFeatures::DEFAULT_KERNEL).unwrap();
+/// let msg = kernel_sig_msg(0, height, KernelFeatures::HEIGHT_LOCKED_KERNEL).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
 /// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, &key_id, Some(&pubkey)).unwrap();


### PR DESCRIPTION
breaks consensus. also fails a wallet cmdline test:

running 1 test
2018-12-16T22:27:10.608446+01:00 INFO grin_util::logger - log4rs is initialized, stdout level: Debug, min. level: Debug
2018-12-16T22:27:10.623217+01:00 INFO grin_chain::chain - init: saved genesis: 5c9c297c
2018-12-16T22:27:10.623756+01:00 DEBUG grin_chain::chain - init: head: 3 @ 0 [5c9c297c]
2018-12-16T22:27:10.623808+01:00 DEBUG grin_chain::chain - init: header_head: 3 @ 0 [5c9c297c]
2018-12-16T22:27:10.623843+01:00 DEBUG grin_chain::chain - init: sync_head: 3 @ 0 [5c9c297c]
2018-12-16T22:27:10.623895+01:00 DEBUG grin_chain::chain - Starting txhashset compaction...
2018-12-16T22:27:10.627258+01:00 DEBUG grin_chain::chain - ... finished txhashset compaction.
2018-12-16T22:27:10.627536+01:00 DEBUG grin_chain::chain - compact_blocks_db: head height: 0, tail height: 0, horizon: 70, cutoff: 0
2018-12-16T22:27:10.645173+01:00 WARN grin_wallet::types - Generating wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:10.650969+01:00 INFO grin_wallet::command - Wallet seed file created
2018-12-16T22:27:10.659636+01:00 INFO grin_wallet::command - Wallet database backend created
2018-12-16T22:27:10.662502+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:10.664395+01:00 INFO grin::cmd::wallet_tests::wallet_tests - Using LMDB Backend for wallet
2018-12-16T22:27:10.667078+01:00 WARN grin_wallet::types - Generating wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:10.668392+01:00 INFO grin_wallet::command - Wallet seed file created
2018-12-16T22:27:10.675138+01:00 INFO grin_wallet::command - Wallet database backend created
2018-12-16T22:27:10.676319+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:10.679259+01:00 INFO grin::cmd::wallet_tests::wallet_tests - Using LMDB Backend for wallet
2018-12-16T22:27:10.681390+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:10.683845+01:00 INFO grin_wallet - Using LMDB Backend for wallet
2018-12-16T22:27:10.884587+01:00 INFO grin_wallet::command - Account: 'mining' Created!
2018-12-16T22:27:10.891475+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:10.894907+01:00 INFO grin_wallet - Using LMDB Backend for wallet
2018-12-16T22:27:11.099462+01:00 INFO grin_wallet::command - Account: 'account_1' Created!
2018-12-16T22:27:11.106349+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:11.109337+01:00 INFO grin_wallet - Using LMDB Backend for wallet
2018-12-16T22:27:11.310321+01:00 INFO grin_wallet::command - Account: 'account_1' Created!
2018-12-16T22:27:11.317255+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:11.319629+01:00 INFO grin_wallet - Using LMDB Backend for wallet
2018-12-16T22:27:11.529561+01:00 ERROR grin_wallet::command - Error creating account 'account_1': Account Label 'account_1' already exists
2018-12-16T22:27:11.531397+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:11.533700+01:00 INFO grin_wallet - Using LMDB Backend for wallet
2018-12-16T22:27:11.736188+01:00 INFO grin_wallet::command - Account: 'account_2' Created!
2018-12-16T22:27:11.743169+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:11.745503+01:00 INFO grin_wallet - Using LMDB Backend for wallet
 Name      | Parent BIP-32 Derivation Path 
-----------+-------------------------------
 account_1 | m/1/0 
 account_2 | m/2/0 
 default   | m/0/0 
2018-12-16T22:27:11.957781+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet2/wallet_data/wallet.seed
2018-12-16T22:27:11.962478+01:00 INFO grin_wallet - Using LMDB Backend for wallet
 Name      | Parent BIP-32 Derivation Path 
-----------+-------------------------------
 account_1 | m/1/0 
 account_2 | m/2/0 
 default   | m/0/0 
2018-12-16T22:27:12.173892+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:12.176097+01:00 INFO grin::cmd::wallet_tests::wallet_tests - Using LMDB Backend for wallet
2018-12-16T22:27:12.176329+01:00 DEBUG grin_wallet::types - Using wallet seed file at: /Users/tromp/grin/target/test_output/command_line/wallet1/wallet_data/wallet.seed
2018-12-16T22:27:12.246566+01:00 DEBUG grin_wallet::libwallet::internal::updater - receive_coinbase: built candidate output - Identifier(0300000001000000000000000000000000), 0300000001000000000000000000000000
2018-12-16T22:27:12.246930+01:00 DEBUG grin_wallet::libwallet::internal::updater - receive_coinbase: BlockFees { fees: 0, height: 1, key_id: Some(Identifier(0300000001000000000000000000000000)) }
test cmd::wallet_tests::wallet_tests::wallet_command_line ... FAILED

failures:

---- cmd::wallet_tests::wallet_tests::wallet_command_line stdout ----
File /Users/tromp/grin/target/test_output/command_line/wallet1/grin-wallet.toml configured and created
Please enter a password for your new wallet
Your recovery phrase is:
fluid pioneer kind crucial dust lion embrace book vote quit upgrade soul report torch stand junk will dynamic yard tunnel bless foam chef lottery
Please back-up these words in a non-digital format.
File /Users/tromp/grin/target/test_output/command_line/wallet2/grin-wallet.toml configured and created
Please enter a password for your new wallet
Your recovery phrase is:
also plastic awake add tell home music brave flee luggage maple million immense secret youth above hurt rely episode luxury video hint axis spring
Please back-up these words in a non-digital format.

____ Wallet Accounts ____



____ Wallet Accounts ____


thread 'cmd::wallet_tests::wallet_tests::wallet_command_line' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner: 

Transaction Error }', libcore/result.rs:1009:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    cmd::wallet_tests::wallet_tests::wallet_command_line

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--bin grin'