### PR TITLE
Enhance share rejection messages to include nonce and hash

### DIFF
--- a/doc/stratum.md
+++ b/doc/stratum.md
@@ -524,7 +524,7 @@ Grin Stratum protocol implementation contains the following error message:
 
 Miners SHOULD, MAY or MUST respect the following rules:
 
-- Miners SHOULD randomize the job nonce before starting (not the way it is now, the way it should be)
+- Miners SHOULD randomize the job nonce before starting
 - Miners MUST continue mining the same job until the server sends a new one, though a miner MAY request a new job at any time
 - Miners MUST NOT send an rpc response to a job request from the server
 - Miners MAY set the RPC "id" and expect responses to have that same id


### PR DESCRIPTION
This change enhances the stale and invalid share log messages:
When possible share rejection messages now include nonce and hash
This will make it easier to audit the pool records against the server logs. Without that info its not clear which exact share the message is for.