### PR TITLE
[DNM] increase dandelion embargo timer from 3 mins to 10 mins

### DIFF
--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -30,7 +30,7 @@ use grin_keychain as keychain;
 const DANDELION_RELAY_SECS: u64 = 600;
 
 /// Dandelion embargo timer
-const DANDELION_EMBARGO_SECS: u64 = 180;
+const DANDELION_EMBARGO_SECS: u64 = 600;
 
 /// Dandelion patience timer
 const DANDELION_PATIENCE_SECS: u64 = 10;


### PR DESCRIPTION
Resolves #1982.

Lets discuss though (see #1982) - are we happy delaying txs for up to 10 mins when stemming them?
This should only happen rarely but its not a great user experience given that this is pretty much opaque once the tx is first sent.

Arguably we _need_ to delay them this long to give our Dandelion implementation sufficient time to operate correctly.

Also see #2176 for some early thoughts around basing our impl on Dandelion++ (rather than Dandelion) which may give us a way to _increase_ the patience timer while _reducing_ overall latency and potentially increasing aggregation.

