### PR TITLE
fix: specify allowed headers on http responses

### DIFF
--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -636,7 +636,7 @@ fn create_error_response(e: Error) -> Response<Body> {
 	Response::builder()
 		.status(StatusCode::INTERNAL_SERVER_ERROR)
 		.header("access-control-allow-origin", "*")
-		.header("access-control-allow-headers", "Content-Type")
+		.header("access-control-allow-headers", "Content-Type, Authorization")
 		.body(format!("{}", e).into())
 		.unwrap()
 }
@@ -645,6 +645,7 @@ fn create_ok_response(json: &str) -> Response<Body> {
 	Response::builder()
 		.status(StatusCode::OK)
 		.header("access-control-allow-origin", "*")
+		.header("access-control-allow-headers", "Content-Type, Authorization")
 		.body(json.to_string().into())
 		.unwrap()
 }
@@ -653,6 +654,7 @@ fn response<T: Into<Body>>(status: StatusCode, text: T) -> Response<Body> {
 	Response::builder()
 		.status(status)
 		.header("access-control-allow-origin", "*")
+		.header("access-control-allow-headers", "Content-Type, Authorization")
 		.body(text.into())
 		.unwrap()
 }


### PR DESCRIPTION
This PR is the second portion of a fix @quentinlesceller started in [PR 2131](https://github.com/mimblewimble/grin/pull/2131). 

In a nutshell, the current api server isn't explicitly allowing an `Authorization` header to be set in follow-on (post-`OPTIONS`) protected api requests. The fix is to explicitly state which headers can be used in requests. This PR simply applies a small tweak to the responses in `/wallet/controller.rs` to allow the headers `Content-Type` and `Authorization`.

Here's a little more [background](https://stackoverflow.com/questions/32500073/request-header-field-access-control-allow-headers-is-not-allowed-by-itself-in-pr).