### PR TITLE
Dandelion cycle fix

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -393,7 +393,13 @@ impl Pool {
 		});
 	}
 
+	/// Size of the pool.
 	pub fn size(&self) -> usize {
 		self.entries.len()
+	}
+
+	/// Is the pool empty?
+	pub fn is_empty(&self) -> bool {
+		self.entries.is_empty()
 	}
 }

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -165,7 +165,12 @@ impl TransactionPool {
 		// If new tx - add it to our stempool.
 		// If we have seen any of the kernels before then fallback to fluff,
 		// adding directly to txpool.
-		if stem && self.stempool.find_matching_transactions(entry.tx.kernels()).is_empty() {
+		if stem
+			&& self
+				.stempool
+				.find_matching_transactions(entry.tx.kernels())
+				.is_empty()
+		{
 			self.add_to_stempool(entry, header)?;
 			return Ok(());
 		}

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -161,13 +161,17 @@ impl TransactionPool {
 			tx,
 		};
 
-		if stem {
-			// TODO - what happens to txs in the stempool in a re-org scenario?
+		// If we are in "stem" mode then check if this is a new tx or if we have seen it before.
+		// If new tx - add it to our stempool.
+		// If we have seen any of the kernels before then fallback to fluff,
+		// adding directly to txpool.
+		if stem && self.stempool.find_matching_transactions(entry.tx.kernels()).is_empty() {
 			self.add_to_stempool(entry, header)?;
-		} else {
-			self.add_to_txpool(entry.clone(), header)?;
-			self.add_to_reorg_cache(entry);
+			return Ok(());
 		}
+
+		self.add_to_txpool(entry.clone(), header)?;
+		self.add_to_reorg_cache(entry);
 		Ok(())
 	}
 


### PR DESCRIPTION
Related discussion #2176.

This plugs a recently discovered hole in our Dandelion implementation.

It is possible for any given stem path to contain a loop or cycle.

`A-> B -> C -> ... -> A`

In this situation a tx will propagate along the stem and A will see the same tx twice (or potentially an aggregated version of the original tx).

Currently we handle this by silently dropping the duplicate tx. But this results in the stem phase coming to a halt with no more tx propagation.
And the embargo timer eventually expires.

This PR changes this behavior to fall back to fluffing the duplicate tx if we have seen it (or any subset of it) before.

So in the previous example - 
`A-> B -> C -> ... -> A`

If A sees `Tx1`, stems it and forwards it on to B, then subsequently sees `(Tx1, Tx2)` still in stem phase we identify this as a cycle in the stem path and fall back to fluffing `(Tx1, Tx2)`.

Same thing would happen if A sees a duplicate `Tx1` without any aggregation having taken place. In this case we simply fluff the unaggregated tx `Tx1`.

This way we benefit from any prior aggregation that may have occurred along the stem path. But we also handle the cycle in the stem path robustly without needing to rely on the embargo timer kicking in.

We suspect that the combination of a relatively small number of nodes in testnet4 with relatively high connectedness between nodes means we have a good chance of hitting a cycle in any given stem path, which would explain why we see a high rate of embargo timer expirations.

