### PR TITLE
[DNM] Change default coin selection algo to 'smallest'

### DIFF
--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -149,7 +149,7 @@ subcommands:
                   possible_values:
                     - all
                     - smallest
-                  default_value: all
+                  default_value: smallest
                   takes_value: true
               - change_outputs:
                   help: Number of change outputs to generate (mainly for testing)


### PR DESCRIPTION
Using `all` as default seems to be a major privacy risk, especially coupled with the Keybase wallet option.

An attacker can send dust coins to any known Keybase username (I did the experiment with https://keybase.io/mcdallas who was running a Keybase wallet) and subsequently predict with 100% accuracy whenever the target recipient made a payment.

Here is me sending dust coins to `mcdallas`: https://grinscan.net/block/82584
Output `0800d1de2...` is what came back to me so the other output `08552d3e...` has to be his.

Now I look at block https://grinscan.net/block/82601 and know he did another transaction since that output is spent. I can keep doing this forever by sending him another dust marker after the previous known output is spent. Notably a user with a running Keybase wallet would not even notice this attack (unless they check their outputs manually).