### PR TITLE
start search with min height 0

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1130,7 +1130,7 @@ impl Chain {
 
 		let (_, pos) = txhashset.is_unspent(output_ref)?;
 
-		let mut min = 1;
+		let mut min = 0;
 		let mut max = {
 			let head = self.head()?;
 			head.height


### PR DESCRIPTION
Genesis now contains output(s) so we need to start the search with `min=0`.