### PR TITLE
Minor wallet recover fixes

### DIFF
--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -275,13 +275,13 @@ subcommands:
                   long: short_wordlist
                   takes_value: false
         - recover:
-            about: recover (create a new wallet.seed file) from a recovery phrase
+            about: Recover a wallet.seed file from a recovery phrase (default) or prints the recovery phrase for an existing seed file
             args:
               - recovery_phrase:
-                  help: 12 or 24 word recovery phrase (encased in quotes).
+                  help: Output the recovery phrase from the existing wallet.seed
                   short: p
                   long: recovery_phrase
-                  takes_value: true
+                  takes_value: false
         - restore:
             about: Initialize a new wallet seed file and database
  

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -88,9 +88,8 @@ pub fn recover(config: &WalletConfig, args: RecoverArgs) -> Result<(), Error> {
 		);
 		if let Err(e) = res {
 			error!(
-				"Error recovering seed with list '{}' - {}",
-				&args.recovery_phrase.as_ref().unwrap(),
-				e
+				"Error recovering seed - {}",
+				e,
 			);
 			return Err(e);
 		}

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -50,13 +50,7 @@ where
 	let mut outputs = wallet
 		.iter()
 		.filter(|out| out.root_key_id == *parent_key_id)
-		.filter(|out| {
-			if show_spent {
-				true
-			} else {
-				out.status != OutputStatus::Spent
-			}
-		})
+		.filter(|out| show_spent || out.status != OutputStatus::Spent)
 		.collect::<Vec<_>>();
 
 	// only include outputs with a given tx_id if provided

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -151,6 +151,9 @@ impl WalletSeed {
 		word_list: &str,
 		password: &str,
 	) -> Result<(), Error> {
+		// create directory if it doesn't exist
+		fs::create_dir_all(&wallet_config.data_file_dir).context(ErrorKind::IO)?;
+
 		let seed_file_path = &format!(
 			"{}{}{}",
 			wallet_config.data_file_dir, MAIN_SEPARATOR, SEED_FILE,


### PR DESCRIPTION
Couple of those are security sensitive:

1. Do not log the recovery phrase on error.
2. Prompt for the phrase instead of passing it as a command arg so it doesn't appear in any command line history.