### PR TITLE
verify message signature on wallet

### DIFF
--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -260,7 +260,7 @@ impl Slate {
 			if let Some(m) = message.clone() {
 				let hashed = blake2b(secp::constants::MESSAGE_SIZE, &[], &m.as_bytes()[..]);
 				let m = secp::Message::from_slice(&hashed.as_bytes())?;
-				let res = aggsig::sign_single(&keychain.secp(), &m, &sec_key, None)?;
+				let res = aggsig::sign_single(&keychain.secp(), &m, &sec_key, Some(&pub_key))?;
 				Some(res)
 			} else {
 				None
@@ -360,7 +360,7 @@ impl Slate {
 					&m,
 					None,
 					&p.public_blind_excess,
-					None,
+					Some(&p.public_blind_excess),
 					false,
 				) {
 					return Err(ErrorKind::Signature(

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -260,7 +260,7 @@ impl Slate {
 			if let Some(m) = message.clone() {
 				let hashed = blake2b(secp::constants::MESSAGE_SIZE, &[], &m.as_bytes()[..]);
 				let m = secp::Message::from_slice(&hashed.as_bytes())?;
-				let res = aggsig::sign_single(&keychain.secp(), &m, &sec_key, Some(&pub_key))?;
+				let res = aggsig::sign_single(&keychain.secp(), &m, &sec_key, None)?;
 				Some(res)
 			} else {
 				None
@@ -360,7 +360,7 @@ impl Slate {
 					&m,
 					None,
 					&p.public_blind_excess,
-					Some(&p.public_blind_excess),
+					None,
 					false,
 				) {
 					error!("verify_messages - participant message doesn't match signature. Message: \"{}\"",

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -351,8 +351,8 @@ impl Slate {
 	/// Verifies any messages in the slate's participant data match their signatures
 	pub fn verify_messages(&self, secp: &secp::Secp256k1) -> Result<(), Error> {
 		for p in self.participant_data.iter() {
-			if let Some(m) = p.message.clone() {
-				let hashed = blake2b(secp::constants::MESSAGE_SIZE, &[], &m.as_bytes()[..]);
+			if let Some(msg) = p.message.clone() {
+				let hashed = blake2b(secp::constants::MESSAGE_SIZE, &[], &msg.as_bytes()[..]);
 				let m = secp::Message::from_slice(&hashed.as_bytes())?;
 				if !aggsig::verify_single(
 					secp,
@@ -363,9 +363,14 @@ impl Slate {
 					Some(&p.public_blind_excess),
 					false,
 				) {
+					error!("verify_messages - participant message doesn't match signature. Message: \"{}\"",
+						   String::from_utf8_lossy(&msg.as_bytes()[..]));
 					return Err(ErrorKind::Signature(
 						"Optional participant messages do not match signatures".to_owned(),
 					))?;
+				} else {
+					info!("verify_messages - signature verified ok. Participant message: \"{}\"",
+						  String::from_utf8_lossy(&msg.as_bytes()[..]));
 				}
 			}
 		}

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -369,8 +369,10 @@ impl Slate {
 						"Optional participant messages do not match signatures".to_owned(),
 					))?;
 				} else {
-					info!("verify_messages - signature verified ok. Participant message: \"{}\"",
-						  String::from_utf8_lossy(&msg.as_bytes()[..]));
+					info!(
+						"verify_messages - signature verified ok. Participant message: \"{}\"",
+						String::from_utf8_lossy(&msg.as_bytes()[..])
+					);
 				}
 			}
 		}

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -282,6 +282,10 @@ pub fn receive(
 	let adapter = FileWalletCommAdapter::new();
 	let mut slate = adapter.receive_tx_async(&args.input)?;
 	controller::foreign_single_use(wallet, |api| {
+		if let Err(e) = api.verify_slate_messages(&slate) {
+			error!("Error validating participant messages: {}", e);
+			return Err(e);
+		}
 		api.receive_tx(&mut slate, Some(&g_args.account), args.message.clone())?;
 		Ok(())
 	})?;

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -830,6 +830,14 @@ where
 		res
 	}
 
+	/// Verifies all messages in the slate match their public keys
+	pub fn verify_slate_messages(&mut self, slate: &Slate) -> Result<(), Error> {
+		error!("verify_slate_messages - enter");
+		let secp = Secp256k1::with_caps(ContextFlag::VerifyOnly);
+		slate.verify_messages(&secp)?;
+		Ok(())
+	}
+
 	/// Receive a transaction from a sender
 	pub fn receive_tx(
 		&mut self,

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -832,7 +832,6 @@ where
 
 	/// Verifies all messages in the slate match their public keys
 	pub fn verify_slate_messages(&mut self, slate: &Slate) -> Result<(), Error> {
-		error!("verify_slate_messages - enter");
 		let secp = Secp256k1::with_caps(ContextFlag::VerifyOnly);
 		slate.verify_messages(&secp)?;
 		Ok(())


### PR DESCRIPTION
1. add verify_slate_messages for wallet receive
2. verify the sender's message signature when receive_tx in wallet listen
3. log the message content