### PR TITLE
docs: be explicit about ARM-based systems not being supported

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -9,6 +9,7 @@ What's working so far?
 
 * Linux x86\_64 and MacOS [grin + mining + development]
 * Not Windows 10 yet [grin kind-of builds. No mining yet. Help wanted!]
+* Not ARM-based systems yet (eg. Raspberry Pi)
 
 ## Requirements
 


### PR DESCRIPTION
From what I can gather, Grin in its current state doesn't build on ARM-based systems.

For newbies like myself, it isn't clear that `Linux x86\_64` excludes ARM-based systems. 
This PR adds a 1 liner making it explicit.

Related: https://github.com/mimblewimble/grin/issues/1681, https://github.com/mimblewimble/grin/issues/2202