### PR TITLE
Keybase notice on receiving grin transaction

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -404,11 +404,14 @@ fn comments() -> HashMap<String, String> {
 		.to_string(),
 	);
 	retval.insert(
-		"use_switch_commitments".to_string(),
+		"keybase_notify_ttl".to_string(),
 		"
-#Whether to use switch commitments for this wallet
+#The exploding lifetime for keybase notification on coins received.
+#Unit: Minute. Default value 1440 minutes for one day.
+#Refer to https://keybase.io/blog/keybase-exploding-messages for detail.
+#To disable this notification, set it as 0.
 "
-		.to_string(),
+			.to_string(),
 	);
 
 	retval.insert(

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -411,7 +411,7 @@ fn comments() -> HashMap<String, String> {
 #Refer to https://keybase.io/blog/keybase-exploding-messages for detail.
 #To disable this notification, set it as 0.
 "
-			.to_string(),
+		.to_string(),
 	);
 
 	retval.insert(

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -302,8 +302,8 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 
 												let msg = format!(
 													"[grin wallet notice]: \
-												 you could have some coins received from @{}\n\
-												 Transaction Id: {}",
+													 you could have some coins received from @{}\n\
+													 Transaction Id: {}",
 													sender, tx_uuid
 												);
 												notify(&msg, &receiver, config.keybase_notify_ttl);

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -393,9 +393,9 @@ fn notify_on_receive(keybase_notify_ttl: u16, channel: String, tx_uuid: String) 
 					sender, tx_uuid
 				);
 				notify(&msg, &receiver, keybase_notify_ttl);
-				info!("tx from @{} is done, please check on grin wallet. tx uuid: {}",
-					sender,
-					tx_uuid,
+				info!(
+					"tx from @{} is done, please check on grin wallet. tx uuid: {}",
+					sender, tx_uuid,
 				);
 			}
 		} else {

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -283,7 +283,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 	// Send a slate to a keybase username then wait for a response for TTL seconds.
 	fn send_tx_sync(&self, addr: &str, slate: &Slate) -> Result<Slate, Error> {
 		// Limit only one recipient
-		if addr.matches(",").count() > 1 {
+		if addr.matches(",").count() > 0 {
 			error!("Only one recipient is supported!");
 			return Err(ErrorKind::GenericError("Tx rejected".to_owned()))?;
 		}
@@ -344,7 +344,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 
 						// Reject multiple recipients channel for safety
 						{
-							if channel.matches(",").count() > 1 {
+							if channel.matches(",").count() > 0 {
 								error!(
 									"Incoming tx initiated on channel \"{}\" is rejected, multiple recipients channel! amount: {}(g), tx uuid: {}",
 									channel,

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -175,7 +175,7 @@ fn notify(message: &str, channel: &str, ttl: u16) -> bool {
 					}
 				}
 	))
-		.unwrap();
+	.unwrap();
 	let response = api_send(&payload);
 	match response["result"]["message"].as_str() {
 		Some("message sent") => true,
@@ -223,9 +223,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 		println!("Sent new slate to {}", addr);
 		// Wait for response from recipient with SLATE_SIGNED topic
 		match poll(TTL as u64, addr) {
-			Some(slate) => {
-				return Ok(slate)
-			},
+			Some(slate) => return Ok(slate),
 			None => return Err(ErrorKind::ClientCallback("Receiving reply from recipient"))?,
 		}
 	}

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -71,7 +71,7 @@ fn api_send(payload: &str) -> Result<Value, Error> {
 		let response: Value =
 			from_str(from_utf8(&output.stdout).expect("Bad output")).expect("Bad output");
 		let err_msg = format!("{}", response["error"]["message"]);
-		if err_msg.len() > 0 {
+		if err_msg.len() > 0 && err_msg != "null" {
 			error!("api_send got error: {}", err_msg);
 		}
 
@@ -95,7 +95,7 @@ fn whoami() -> Result<String, Error> {
 		let response: Value =
 			from_str(from_utf8(&output.stdout).expect("Bad output")).expect("Bad output");
 		let err_msg = format!("{}", response["error"]["message"]);
-		if err_msg.len() > 0 {
+		if err_msg.len() > 0 && err_msg != "null" {
 			error!("status query got error: {}", err_msg);
 		}
 

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -115,11 +115,10 @@ fn get_unread(topic: &str) -> HashMap<String, String> {
 		"method": "list",
 		"params": {
 			"options": {
-					"topic_type": "dev",
-				},
-			}
+				"topic_type": "dev",
+			},
 		}
-	))
+	}))
 	.unwrap();
 	let response = api_send(&payload);
 

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -140,15 +140,14 @@ fn send<T: Serialize>(message: T, channel: &str, topic: &str, ttl: u16) -> bool 
 			"options": {
 				"channel": {
 						"name": channel, "topic_name": topic, "topic_type": "dev"
-					},
-						"message": {
-								"body": to_string(&message).unwrap()
-							},
-							"exploding_lifetime": seconds
-						}
-					}
-				}
-	))
+				},
+				"message": {
+						"body": to_string(&message).unwrap()
+				},
+				"exploding_lifetime": seconds
+			}
+		}
+	}))
 	.unwrap();
 	let response = api_send(&payload);
 	match response["result"]["message"].as_str() {
@@ -166,15 +165,14 @@ fn notify(message: &str, channel: &str, ttl: u16) -> bool {
 			"options": {
 				"channel": {
 						"name": channel
-					},
-						"message": {
-								"body": message
-							},
-							"exploding_lifetime": minutes
-						}
-					}
-				}
-	))
+				},
+				"message": {
+						"body": message
+				},
+				"exploding_lifetime": minutes
+			}
+		}
+	}))
 	.unwrap();
 	let response = api_send(&payload);
 	match response["result"]["message"].as_str() {
@@ -273,8 +271,12 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 										let split = channel.split(",");
 										let vec: Vec<&str> = split.collect();
 										if vec.len() > 1 {
-											let msg = format!("[grin wallet notice]: you could have some coins received from @{}\nTransaction Id: {}",
-															  vec[1], tx_uuid);
+											let msg = format!(
+												"[grin wallet notice]: \
+												 you could have some coins received from @{}\n\
+												 Transaction Id: {}",
+												vec[1], tx_uuid
+											);
 											notify(&msg, vec[0], config.keybase_notify_ttl);
 										}
 									}

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -28,7 +28,8 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 const TTL: u16 = 60; // TODO: Pass this as a parameter
-const SLEEP_DURATION: Duration = Duration::from_millis(5000);
+const LISTEN_SLEEP_DURATION: Duration = Duration::from_millis(5000);
+const POLL_SLEEP_DURATION: Duration = Duration::from_millis(1000);
 
 // Which topic names to use for communication
 const SLATE_NEW: &str = "grin_slate_new";
@@ -256,7 +257,7 @@ fn poll(nseconds: u64, channel: &str) -> Option<Slate> {
 				Err(_) => (),
 			}
 		}
-		sleep(SLEEP_DURATION);
+		sleep(POLL_SLEEP_DURATION);
 	}
 	error!(
 		"No response from @{} in {} seconds. Grin send failed!",
@@ -384,7 +385,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 					Err(_) => (),
 				}
 			}
-			sleep(SLEEP_DURATION);
+			sleep(LISTEN_SLEEP_DURATION);
 		}
 		Ok(())
 	}

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -283,9 +283,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 	// Send a slate to a keybase username then wait for a response for TTL seconds.
 	fn send_tx_sync(&self, addr: &str, slate: &Slate) -> Result<Slate, Error> {
 		// Limit only one recipient
-		let split = addr.split(",");
-		let vec: Vec<&str> = split.collect();
-		if vec.len() > 1 {
+		if addr.matches(",").count() > 1 {
 			error!("Only one recipient is supported!");
 			return Err(ErrorKind::GenericError("Tx rejected".to_owned()))?;
 		}
@@ -346,9 +344,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 
 						// Reject multiple recipients channel for safety
 						{
-							let split = channel.split(",");
-							let vec: Vec<&str> = split.collect();
-							if vec.len() > 2 {
+							if channel.matches(",").count() > 1 {
 								error!(
 									"Incoming tx initiated on channel \"{}\" is rejected, multiple recipients channel! amount: {}(g), tx uuid: {}",
 									channel,

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -61,7 +61,7 @@ fn api_send(payload: &str) -> Result<Value, Error> {
 	proc.args(&["chat", "api", "-m", &payload]);
 	let output = proc.output().expect("No output");
 	if !output.status.success() {
-		info!(
+		error!(
 			"keybase api fail: {} {}",
 			String::from_utf8_lossy(&output.stdout),
 			String::from_utf8_lossy(&output.stderr)

--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -70,6 +70,11 @@ fn api_send(payload: &str) -> Result<Value, Error> {
 	} else {
 		let response: Value =
 			from_str(from_utf8(&output.stdout).expect("Bad output")).expect("Bad output");
+		let err_msg = format!("{}", response["error"]["message"]);
+		if err_msg.len() > 0 {
+			error!("api_send got error: {}", err_msg);
+		}
+
 		Ok(response)
 	}
 }
@@ -89,6 +94,10 @@ fn whoami() -> Result<String, Error> {
 	} else {
 		let response: Value =
 			from_str(from_utf8(&output.stdout).expect("Bad output")).expect("Bad output");
+		let err_msg = format!("{}", response["error"]["message"]);
+		if err_msg.len() > 0 {
+			error!("status query got error: {}", err_msg);
+		}
 
 		let username = response["Username"].as_str();
 		if let Some(s) = username {

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -254,11 +254,11 @@ pub fn send(
 			let result = api.post_tx(&slate.tx, args.fluff);
 			match result {
 				Ok(_) => {
-					info!("Tx sent",);
+					info!("Tx sent ok",);
 					return Ok(());
 				}
 				Err(e) => {
-					error!("Tx not sent: {}", e);
+					error!("Tx sent fail: {}", e);
 					return Err(e);
 				}
 			}

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -57,6 +57,8 @@ pub struct WalletConfig {
 	/// Whether to use the black background color scheme for command line
 	/// if enabled, wallet command output color will be suitable for black background terminal
 	pub dark_background_color_scheme: Option<bool>,
+	// The exploding lifetime (minutes) for keybase notification on coins received
+	pub keybase_notify_ttl: u16,
 }
 
 impl Default for WalletConfig {
@@ -72,6 +74,7 @@ impl Default for WalletConfig {
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			dark_background_color_scheme: Some(true),
+			keybase_notify_ttl: 1440,
 		}
 	}
 }


### PR DESCRIPTION
1. Keybase notification message (from self) on receive transaction
2. A new configuration item in `grin-wallet.tom` to message exploding TTL:
```
#The exploding lifetime for keybase notification on coins received.
#Unit: Minute. Default value 1440 minutes for one day.
#Refer to https://keybase.io/blog/keybase-exploding-messages for detail.
#To disable this notification, set it as 0.
keybase_notify_ttl = 1440
```