### PR TITLE
Support multiple chain configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ name = "grin_config"
 version = "0.4.2"
 dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 0.4.2",
  "grin_p2p 0.4.2",
  "grin_servers 0.4.2",
  "grin_util 0.4.2",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -16,6 +16,7 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
+grin_core = { path = "../core", version = "0.4.2" }
 grin_servers = { path = "../servers", version = "0.4.2" }
 grin_p2p = { path = "../p2p", version = "0.4.2" }
 grin_util = { path = "../util", version = "0.4.2" }

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -168,7 +168,7 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"[server.p2p_config]".to_string(),
 		"#test miner wallet URL (burns if this doesn't exist)
-#test_miner_wallet_url = \"http://127.0.0.1:13415\"
+#test_miner_wallet_url = \"http://127.0.0.1:3415\"
 
 #########################################
 ### SERVER P2P CONFIGURATION          ###
@@ -208,15 +208,15 @@ fn comments() -> HashMap<String, String> {
 		"[server.p2p_config.capabilities]".to_string(),
 		"#If the seeding type is List, the list of peers to connect to can
 #be specified as follows:
-#seeds = [\"192.168.0.1:13414\",\"192.168.0.2:13414\"]
+#seeds = [\"192.168.0.1:3414\",\"192.168.0.2:3414\"]
 
 #hardcoded peer lists for allow/deny
 #will *only* connect to peers in allow list
-#peers_allow = [\"192.168.0.1:13414\", \"192.168.0.2:13414\"]
+#peers_allow = [\"192.168.0.1:3414\", \"192.168.0.2:3414\"]
 #will *never* connect to peers in deny list
-#peers_deny = [\"192.168.0.3:13414\", \"192.168.0.4:13414\"]
+#peers_deny = [\"192.168.0.3:3414\", \"192.168.0.4:3414\"]
 #a list of preferred peers to connect to
-#peers_preferred = [\"192.168.0.1:13414\",\"192.168.0.2:13414\"]
+#peers_preferred = [\"192.168.0.1:3414\",\"192.168.0.2:3414\"]
 
 #how long a banned peer should stay banned
 #ban_window = 10800

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -26,6 +26,8 @@ use std::path::PathBuf;
 use toml;
 
 use crate::comments::insert_comments;
+use crate::core::global;
+use crate::p2p;
 use crate::servers::ServerConfig;
 use crate::types::{
 	ConfigError, ConfigMembers, GlobalConfig, GlobalWalletConfig, GlobalWalletConfigMembers,
@@ -45,21 +47,14 @@ const GRIN_CHAIN_DIR: &'static str = "chain_data";
 const GRIN_WALLET_DIR: &'static str = "wallet_data";
 const API_SECRET_FILE_NAME: &'static str = ".api_secret";
 
-fn get_grin_path() -> Result<PathBuf, ConfigError> {
+fn get_grin_path(chain_type: &global::ChainTypes) -> Result<PathBuf, ConfigError> {
 	// Check if grin dir exists
-	let grin_path = {
-		match dirs::home_dir() {
-			Some(mut p) => {
-				p.push(GRIN_HOME);
-				p
-			}
-			None => {
-				let mut pb = PathBuf::new();
-				pb.push(GRIN_HOME);
-				pb
-			}
-		}
+	let mut grin_path = match dirs::home_dir() {
+		Some(p) => p,
+		None => PathBuf::new(),
 	};
+	grin_path.push(GRIN_HOME);
+	grin_path.push(chain_type.shortname());
 	// Create if the default path doesn't exist
 	if !grin_path.exists() {
 		fs::create_dir_all(grin_path.clone())?;
@@ -107,8 +102,8 @@ fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 }
 
 /// Check that the api secret file exists and is valid
-fn check_api_secret_file() -> Result<(), ConfigError> {
-	let grin_path = get_grin_path()?;
+fn check_api_secret_file(chain_type: &global::ChainTypes) -> Result<(), ConfigError> {
+	let grin_path = get_grin_path(chain_type)?;
 	let mut api_secret_path = grin_path.clone();
 	api_secret_path.push(API_SECRET_FILE_NAME);
 	if !api_secret_path.exists() {
@@ -119,14 +114,14 @@ fn check_api_secret_file() -> Result<(), ConfigError> {
 }
 
 /// Handles setup and detection of paths for node
-pub fn initial_setup_server() -> Result<GlobalConfig, ConfigError> {
-	check_api_secret_file()?;
+pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalConfig, ConfigError> {
+	check_api_secret_file(chain_type)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(SERVER_CONFIG_FILE_NAME) {
 		GlobalConfig::new(p.to_str().unwrap())
 	} else {
 		// Check if grin dir exists
-		let grin_path = get_grin_path()?;
+		let grin_path = get_grin_path(chain_type)?;
 
 		// Get path to default config file
 		let mut config_path = grin_path.clone();
@@ -134,7 +129,7 @@ pub fn initial_setup_server() -> Result<GlobalConfig, ConfigError> {
 
 		// Spit it out if it doesn't exist
 		if !config_path.exists() {
-			let mut default_config = GlobalConfig::default();
+			let mut default_config = GlobalConfig::for_chain(chain_type);
 			// update paths relative to current dir
 			default_config.update_paths(&grin_path);
 			default_config.write_to_file(config_path.to_str().unwrap())?;
@@ -145,14 +140,16 @@ pub fn initial_setup_server() -> Result<GlobalConfig, ConfigError> {
 }
 
 /// Handles setup and detection of paths for wallet
-pub fn initial_setup_wallet() -> Result<GlobalWalletConfig, ConfigError> {
-	check_api_secret_file()?;
+pub fn initial_setup_wallet(
+	chain_type: &global::ChainTypes,
+) -> Result<GlobalWalletConfig, ConfigError> {
+	check_api_secret_file(chain_type)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(WALLET_CONFIG_FILE_NAME) {
 		GlobalWalletConfig::new(p.to_str().unwrap())
 	} else {
 		// Check if grin dir exists
-		let grin_path = get_grin_path()?;
+		let grin_path = get_grin_path(chain_type)?;
 
 		// Get path to default config file
 		let mut config_path = grin_path.clone();
@@ -208,6 +205,51 @@ impl Default for GlobalWalletConfig {
 }
 
 impl GlobalConfig {
+	/// Same as GlobalConfig::default() but further tweaks parameters to
+	/// apply defaults for each chain type
+	pub fn for_chain(chain_type: &global::ChainTypes) -> GlobalConfig {
+		let mut defaults_conf = GlobalConfig::default();
+		let mut defaults = &mut defaults_conf.members.as_mut().unwrap().server;
+		defaults.chain_type = chain_type.clone();
+
+		match *chain_type {
+			global::ChainTypes::Mainnet => {}
+			global::ChainTypes::Floonet => {
+				defaults.api_http_addr = "127.0.0.1:13413".to_owned();
+				defaults.p2p_config.port = 13414;
+				defaults
+					.stratum_mining_config
+					.as_mut()
+					.unwrap()
+					.stratum_server_addr = Some("127.0.0.1:13416".to_owned());
+				defaults
+					.stratum_mining_config
+					.as_mut()
+					.unwrap()
+					.wallet_listener_url = "127.0.0.1:13415".to_owned();
+			}
+			global::ChainTypes::UserTesting => {
+				defaults.api_http_addr = "127.0.0.1:23413".to_owned();
+				defaults.p2p_config.port = 23414;
+				defaults.p2p_config.seeding_type = p2p::Seeding::None;
+				defaults
+					.stratum_mining_config
+					.as_mut()
+					.unwrap()
+					.stratum_server_addr = Some("127.0.0.1:23416".to_owned());
+				defaults
+					.stratum_mining_config
+					.as_mut()
+					.unwrap()
+					.wallet_listener_url = "127.0.0.1:23415".to_owned();
+			}
+			global::ChainTypes::AutomatedTesting => {
+				panic!("Can't run automated testing directly");
+			}
+		}
+		defaults_conf
+	}
+
 	/// Requires the path to a config file
 	pub fn new(file_path: &str) -> Result<GlobalConfig, ConfigError> {
 		let mut return_value = GlobalConfig::default();
@@ -315,6 +357,29 @@ impl GlobalConfig {
 
 /// TODO: Properly templatize these structs (if it's worth the effort)
 impl GlobalWalletConfig {
+	/// Same as GlobalConfig::default() but further tweaks parameters to
+	/// apply defaults for each chain type
+	pub fn for_chain(chain_type: &global::ChainTypes) -> GlobalWalletConfig {
+		let mut defaults_conf = GlobalWalletConfig::default();
+		let mut defaults = &mut defaults_conf.members.as_mut().unwrap().wallet;
+		defaults.chain_type = Some(chain_type.clone());
+
+		match *chain_type {
+			global::ChainTypes::Mainnet => {}
+			global::ChainTypes::Floonet => {
+				defaults.api_listen_port = 13415;
+				defaults.check_node_api_http_addr = "http://127.0.0.1:13413".to_owned();
+			}
+			global::ChainTypes::UserTesting => {
+				defaults.api_listen_port = 23415;
+				defaults.check_node_api_http_addr = "http://127.0.0.1:23413".to_owned();
+			}
+			global::ChainTypes::AutomatedTesting => {
+				panic!("Can't run automated testing directly");
+			}
+		}
+		defaults_conf
+	}
 	/// Requires the path to a config file
 	pub fn new(file_path: &str) -> Result<GlobalWalletConfig, ConfigError> {
 		let mut return_value = GlobalWalletConfig::default();

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -26,6 +26,8 @@ use dirs;
 extern crate serde_derive;
 use toml;
 
+use grin_core as core;
+use grin_p2p as p2p;
 use grin_servers as servers;
 use grin_util as util;
 use grin_wallet as wallet;

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -93,6 +93,18 @@ pub enum ChainTypes {
 	Mainnet,
 }
 
+impl ChainTypes {
+	/// Short name representing the chain type ("floo", "main", etc.)
+	pub fn shortname(&self) -> String {
+		match *self {
+			ChainTypes::AutomatedTesting => "auto".to_owned(),
+			ChainTypes::UserTesting => "user".to_owned(),
+			ChainTypes::Floonet => "floo".to_owned(),
+			ChainTypes::Mainnet => "main".to_owned(),
+		}
+	}
+}
+
 impl Default for ChainTypes {
 	fn default() -> ChainTypes {
 		ChainTypes::Floonet
@@ -256,8 +268,7 @@ pub fn is_user_testing_mode() -> bool {
 /// Production defined as a live public network, testnet[n] or mainnet.
 pub fn is_production_mode() -> bool {
 	let param_ref = CHAIN_TYPE.read();
-	ChainTypes::Floonet == *param_ref
-		|| ChainTypes::Mainnet == *param_ref
+	ChainTypes::Floonet == *param_ref || ChainTypes::Mainnet == *param_ref
 }
 
 /// Are we in one of our (many) testnets?
@@ -288,6 +299,12 @@ pub fn get_genesis_nonce() -> u64 {
 		// Placeholder, obviously not the right value
 		ChainTypes::Mainnet => 0,
 	}
+}
+
+/// Short name representing the current chain type ("floo", "main", etc.)
+pub fn chain_shortname() -> String {
+	let param_ref = CHAIN_TYPE.read();
+	param_ref.shortname()
 }
 
 /// Converts an iterator of block difficulty data to more a more manageable

--- a/core/src/pow.rs
+++ b/core/src/pow.rs
@@ -136,11 +136,12 @@ mod test {
 	/// We'll be generating genesis blocks differently
 	#[test]
 	fn genesis_pow() {
-		global::set_mining_mode(ChainTypes::AutomatedTesting);
+		global::set_mining_mode(ChainTypes::UserTesting);
 
 		let mut b = genesis::genesis_dev();
-		b.header.pow.nonce = 485;
+		b.header.pow.nonce = 28106;
 		b.header.pow.proof.edge_bits = global::min_edge_bits();
+		println!("proof {}", global::proofsize());
 		pow_size(
 			&mut b.header,
 			Difficulty::min(),
@@ -148,8 +149,13 @@ mod test {
 			global::min_edge_bits(),
 		)
 		.unwrap();
+		println!("nonce {}", b.header.pow.nonce);
 		assert_ne!(b.header.pow.nonce, 310);
 		assert!(b.header.pow.to_difficulty(0) >= Difficulty::min());
-		assert!(verify_size(&b.header).is_ok());
+		let start = ::std::time::Instant::now();
+		for n in 0..100000 {
+			assert!(verify_size(&b.header).is_ok());
+		}
+		println!("==> {}", start.elapsed().as_secs());
 	}
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -132,7 +132,7 @@ impl Default for P2PConfig {
 		let ipaddr = "0.0.0.0".parse().unwrap();
 		P2PConfig {
 			host: ipaddr,
-			port: 13414,
+			port: 3414,
 			capabilities: Capabilities::FULL_NODE,
 			seeding_type: Seeding::default(),
 			seeds: None,

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -172,7 +172,7 @@ impl Default for ServerConfig {
 	fn default() -> ServerConfig {
 		ServerConfig {
 			db_root: "grin_chain".to_string(),
-			api_http_addr: "127.0.0.1:13413".to_string(),
+			api_http_addr: "127.0.0.1:3413".to_string(),
 			api_secret_path: Some(".api_secret".to_string()),
 			p2p_config: p2p::P2PConfig::default(),
 			dandelion_config: pool::DandelionConfig::default(),
@@ -218,12 +218,12 @@ pub struct StratumServerConfig {
 impl Default for StratumServerConfig {
 	fn default() -> StratumServerConfig {
 		StratumServerConfig {
-			wallet_listener_url: "http://127.0.0.1:13415".to_string(),
+			wallet_listener_url: "http://127.0.0.1:3415".to_string(),
 			burn_reward: false,
 			attempt_time_per_block: 15,
 			minimum_share_difficulty: 1,
 			enable_stratum_server: Some(false),
-			stratum_server_addr: Some("127.0.0.1:13416".to_string()),
+			stratum_server_addr: Some("127.0.0.1:3416".to_string()),
 		}
 	}
 }

--- a/src/bin/cmd/config.rs
+++ b/src/bin/cmd/config.rs
@@ -14,11 +14,12 @@
 
 /// Grin configuration file output command
 use crate::config::{GlobalConfig, GlobalWalletConfig};
+use crate::core::global;
 use std::env;
 
 /// Create a config file in the current directory
-pub fn config_command_server(file_name: &str) {
-	let mut default_config = GlobalConfig::default();
+pub fn config_command_server(chain_type: &global::ChainTypes, file_name: &str) {
+	let mut default_config = GlobalConfig::for_chain(chain_type);
 	let current_dir = env::current_dir().unwrap_or_else(|e| {
 		panic!("Error creating config file: {}", e);
 	});
@@ -44,8 +45,8 @@ pub fn config_command_server(file_name: &str) {
 }
 
 /// Create a config file in the current directory
-pub fn config_command_wallet(file_name: &str) {
-	let mut default_config = GlobalWalletConfig::default();
+pub fn config_command_wallet(chain_type: &global::ChainTypes, file_name: &str) {
+	let mut default_config = GlobalWalletConfig::for_chain(chain_type);
 	let current_dir = env::current_dir().unwrap_or_else(|e| {
 		panic!("Error creating config file: {}", e);
 	});

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -9,7 +9,7 @@ args:
       long: floonet
       takes_value: false
   - usernet:
-      help: Run grin against the Floonet (as opposed to mainnet)
+      help: Run grin as a local-only network. Doesn't block peer connections but will not connect to any peer or seed
       long: usernet
       takes_value: false
 subcommands:

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -3,6 +3,15 @@ version: "0.4.2"
 about: Lightweight implementation of the MimbleWimble protocol.
 author: The Grin Team
 
+args:
+  - floonet:
+      help: Run grin against the Floonet (as opposed to mainnet)
+      long: floonet
+      takes_value: false
+  - usernet:
+      help: Run grin against the Floonet (as opposed to mainnet)
+      long: usernet
+      takes_value: false
 subcommands:
   - server:
       about: Control the Grin server

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -64,10 +64,10 @@ impl Default for WalletConfig {
 		WalletConfig {
 			chain_type: Some(ChainTypes::Floonet),
 			api_listen_interface: "127.0.0.1".to_string(),
-			api_listen_port: 13415,
+			api_listen_port: 3415,
 			api_secret_path: Some(".api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
-			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
+			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
 			data_file_dir: ".".to_string(),
 			tls_certificate_file: None,
 			tls_certificate_key: None,


### PR DESCRIPTION
Supports generating the proper configuration for each chain type
(mainnet, floonet, usernet). Will run them by default under
their respective root directory (~/.grin/main, ~/.grin/floo, etc).

Assigned default ports for mainnet, overriding them to keep Floonet
ports unchanged.

For now, starting on mainnet will abort.