### PR TITLE
fix a confusing log on body sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -767,7 +767,7 @@ impl Chain {
 
 		if body_head.total_difficulty >= header_head.total_difficulty {
 			debug!(
-				"{}: no need. header_head.total_difficulty: {} <= body_head.total_difficulty: {}",
+				"{}: no need txhashset. header_head.total_difficulty: {} <= body_head.total_difficulty: {}",
 				caller, header_head.total_difficulty, body_head.total_difficulty,
 			);
 			return false;
@@ -808,7 +808,7 @@ impl Chain {
 		if oldest_height < header_head.height.saturating_sub(horizon) {
 			if oldest_height > 0 {
 				debug!(
-					"{}: oldest block which is not on local chain: {} at {}",
+					"{}: need a state sync for txhashset. oldest block which is not on local chain: {} at {}",
 					caller, oldest_hash, oldest_height,
 				);
 				return true;


### PR DESCRIPTION
```
20181223 20:56:39.533 DEBUG grin_chain::chain - body_sync: no need. header_head.total_difficulty: 448508621 <= body_head.total_difficulty: 448508621
```
Actual this "body_sync: no need" means "no need a state sync (to download a txhashset)", make me confused for a few minutes...

