### PR TITLE
remember to reset sync head on first transition to header sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -213,6 +213,11 @@ impl Chain {
 		self.txhashset.clone()
 	}
 
+	/// Shared store instance.
+	pub fn store(&self) -> Arc<store::ChainStore> {
+		self.store.clone()
+	}
+
 	fn log_heads(store: &store::ChainStore) -> Result<(), Error> {
 		let head = store.head()?;
 		debug!(

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -246,6 +246,18 @@ impl Chain {
 		Ok(())
 	}
 
+	/// Reset sync_head to current header_head.
+	/// We do this when we first transition to header_sync to ensure we extend
+	/// the "sync" header MMR from a known consistent state and to ensure we track
+	/// the header chain correctly at the fork point.
+	pub fn reset_sync_head(&self) -> Result<Tip, Error> {
+		let batch = self.store.batch()?;
+		batch.reset_sync_head()?;
+		let head = batch.get_sync_head()?;
+		batch.commit()?;
+		Ok(head)
+	}
+
 	/// Processes a single block, then checks for orphans, processing
 	/// those as well if they're found
 	pub fn process_block(&self, b: Block, opts: Options) -> Result<Option<Tip>, Error> {

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -57,7 +57,7 @@ impl HeaderSync {
 			SyncStatus::NoSync | SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => {
 				let sync_head = self.chain.get_sync_head().unwrap();
 				debug!(
-					"sync: initial transition to HeaderSync. sync_head: {} at {}, reset to: {} at {}",
+					"sync: initial transition to HeaderSync. sync_head: {} at {}, resetting to: {} at {}",
 					sync_head.hash(),
 					sync_head.height,
 					header_head.hash(),
@@ -66,12 +66,13 @@ impl HeaderSync {
 
 				// Reset sync_head to header_head on transition to HeaderSync,
 				// but ONLY on initial transition to HeaderSync state.
-				{
-					let store = self.chain.store();
-					let batch = store.batch().unwrap();
-					batch.reset_sync_head().unwrap();
-					batch.commit().unwrap();
-				}
+				//
+				// The header_head and sync_head may diverge here in the presence of a fork
+				// in the header chain. Ensure we track the new advertised header chain here
+				// correctly, so reset any previous (and potentially stale) sync_head to match
+				// our last known "good" header_head.
+				//
+				self.chain.reset_sync_head().unwrap();
 
 				// Rebuild the sync MMR to match our updated sync_head.
 				self.chain.rebuild_sync_mmr(&header_head).unwrap();


### PR DESCRIPTION
Related https://github.com/mimblewimble/grin/pull/2072

I think we were overly aggressive cleaning up code in #2072.

This puts the "reset sync head" back on initial transition to header sync (which is needed).

