### PR TITLE
fix: mistake on the keybase recipients count

### DIFF
--- a/wallet/src/adapters/keybase.rs
+++ b/wallet/src/adapters/keybase.rs
@@ -344,7 +344,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 
 						// Reject multiple recipients channel for safety
 						{
-							if channel.matches(",").count() > 0 {
+							if channel.matches(",").count() > 1 {
 								error!(
 									"Incoming tx initiated on channel \"{}\" is rejected, multiple recipients channel! amount: {}(g), tx uuid: {}",
 									channel,
@@ -373,7 +373,7 @@ impl WalletCommAdapter for KeybaseWalletCommAdapter {
 							Ok(_) => match send(slate, channel, SLATE_SIGNED, TTL) {
 								true => {
 									notify_on_receive(
-										config.keybase_notify_ttl,
+										config.keybase_notify_ttl.unwrap_or(1440),
 										channel.to_string(),
 										tx_uuid.to_string(),
 									);

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -58,7 +58,7 @@ pub struct WalletConfig {
 	/// if enabled, wallet command output color will be suitable for black background terminal
 	pub dark_background_color_scheme: Option<bool>,
 	// The exploding lifetime (minutes) for keybase notification on coins received
-	pub keybase_notify_ttl: u16,
+	pub keybase_notify_ttl: Option<u16>,
 }
 
 impl Default for WalletConfig {
@@ -74,7 +74,7 @@ impl Default for WalletConfig {
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			dark_background_color_scheme: Some(true),
-			keybase_notify_ttl: 1440,
+			keybase_notify_ttl: Some(1440),
 		}
 	}
 }


### PR DESCRIPTION
- fix my silly mistake on the keybase recipients count, confused by 0 and 1 :(
- forgot the config compatibility with old version, otherwise:
```
thread 'main' panicked at 'Error loading wallet configuration: 
Error parsing configuration file at /home/garyyu/.grin/grin-wallet.toml 
- missing field `keybase_notify_ttl` for key `wallet`', src/bin/grin.rs:107:5
```