### PR TITLE
[re-floonet] Keychain Floonet BIP32 version/network option

### DIFF
--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -77,7 +77,7 @@ fn data_files() {
 	//new block so chain references should be freed
 	{
 		let chain = setup(chain_dir);
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
 		for n in 1..4 {
 			let prev = chain.head_header().unwrap();

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -58,7 +58,7 @@ fn setup(dir_name: &str, genesis: Block) -> Chain {
 #[test]
 fn mine_empty_chain() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	mine_some_on_top(".grin", pow::mine_genesis_block().unwrap(), &keychain);
 }
 
@@ -68,7 +68,7 @@ fn mine_genesis_reward_chain() {
 
 	// add coinbase data from the dev genesis block
 	let mut genesis = genesis::genesis_dev();
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = keychain::ExtKeychain::derive_key_id(0, 1, 0, 0, 0);
 	let reward = reward::output(&keychain, &key_id, 0).unwrap();
 	genesis = genesis.with_reward(reward.0, reward.1);
@@ -158,7 +158,7 @@ where
 fn mine_forks() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let chain = setup(".grin2", pow::mine_genesis_block().unwrap());
-	let kc = ExtKeychain::from_random_seed().unwrap();
+	let kc = ExtKeychain::from_random_seed(false).unwrap();
 
 	// add a first block to not fork genesis
 	let prev = chain.head_header().unwrap();
@@ -200,7 +200,7 @@ fn mine_forks() {
 #[test]
 fn mine_losing_fork() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
-	let kc = ExtKeychain::from_random_seed().unwrap();
+	let kc = ExtKeychain::from_random_seed(false).unwrap();
 	let chain = setup(".grin3", pow::mine_genesis_block().unwrap());
 
 	// add a first block we'll be forking from
@@ -232,7 +232,7 @@ fn mine_losing_fork() {
 #[test]
 fn longer_fork() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
-	let kc = ExtKeychain::from_random_seed().unwrap();
+	let kc = ExtKeychain::from_random_seed(false).unwrap();
 	// to make it easier to compute the txhashset roots in the test, we
 	// prepare 2 chains, the 2nd will be have the forked blocks we can
 	// then send back on the 1st
@@ -275,7 +275,7 @@ fn spend_in_fork_and_compact() {
 	util::init_test_logger();
 	let chain = setup(".grin6", pow::mine_genesis_block().unwrap());
 	let prev = chain.head_header().unwrap();
-	let kc = ExtKeychain::from_random_seed().unwrap();
+	let kc = ExtKeychain::from_random_seed(false).unwrap();
 
 	let mut fork_head = prev;
 
@@ -404,7 +404,7 @@ fn output_header_mappings() {
 		".grin_header_for_output",
 		pow::mine_genesis_block().unwrap(),
 	);
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let mut reward_outputs = vec![];
 
 	for n in 1..15 {

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -51,7 +51,7 @@ fn test_various_store_indices() {
 	let chain_dir = ".grin_idx_1";
 	clean_output_dir(chain_dir);
 
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 	let db_env = Arc::new(store::new_env(chain_dir.to_string()));
 

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -60,7 +60,7 @@ fn test_coinbase_maturity() {
 
 	let prev = chain.head_header().unwrap();
 
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 	let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 	let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -142,7 +142,7 @@ fn test_coinbase_maturity() {
 	for _ in 0..3 {
 		let prev = chain.head_header().unwrap();
 
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let pk = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 		let reward = libtx::reward::output(&keychain, &pk, 0).unwrap();

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1401,7 +1401,7 @@ mod test {
 
 	#[test]
 	fn test_kernel_ser_deser() {
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 		let commit = keychain.commit(5, &key_id).unwrap();
 
@@ -1446,7 +1446,7 @@ mod test {
 
 	#[test]
 	fn commit_consistency() {
-		let keychain = ExtKeychain::from_seed(&[0; 32]).unwrap();
+		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 		let commit = keychain.commit(1003, &key_id).unwrap();
@@ -1459,7 +1459,7 @@ mod test {
 
 	#[test]
 	fn input_short_id() {
-		let keychain = ExtKeychain::from_seed(&[0; 32]).unwrap();
+		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 		let commit = keychain.commit(5, &key_id).unwrap();
 

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -266,16 +266,7 @@ where
 	K: Keychain,
 {
 	let skey = k.derive_key(value, key_id)?;
-	let sig = aggsig::sign_single(
-		secp,
-		&msg,
-		&skey,
-		None,
-		None,
-		None,
-		blind_sum,
-		None,
-	)?;
+	let sig = aggsig::sign_single(secp, &msg, &skey, None, None, None, blind_sum, None)?;
 	Ok(sig)
 }
 

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -234,7 +234,7 @@ pub fn verify_partial_sig(
 /// use keychain::{Keychain, ExtKeychain};
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::Commit);
-/// let keychain = ExtKeychain::from_random_seed().unwrap();
+/// let keychain = ExtKeychain::from_random_seed(false).unwrap();
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -308,7 +308,7 @@ where
 ///
 /// // Create signature
 /// let secp = Secp256k1::with_caps(ContextFlag::Commit);
-/// let keychain = ExtKeychain::from_random_seed().unwrap();
+/// let keychain = ExtKeychain::from_random_seed(false).unwrap();
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -261,7 +261,7 @@ mod test {
 
 	#[test]
 	fn blind_simple_tx() {
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -284,7 +284,7 @@ mod test {
 
 	#[test]
 	fn blind_simple_tx_with_offset() {
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -307,7 +307,7 @@ mod test {
 
 	#[test]
 	fn blind_simpler_tx() {
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -54,7 +54,11 @@ where
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
 			let commit = build.keychain.commit(value, &key_id).unwrap();
 			let input = Input::new(features, commit);
-			(tx.with_input(input), kern, sum.sub_key_id(key_id.to_value_path(value)))
+			(
+				tx.with_input(input),
+				kern,
+				sum.sub_key_id(key_id.to_value_path(value)),
+			)
 		},
 	)
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -42,7 +42,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 // TODO: make this fast enough or add similar but faster test?
 #[allow(dead_code)]
 fn too_large_block() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let max_out = MAX_BLOCK_WEIGHT / BLOCK_OUTPUT_WEIGHT;
 
 	let mut pks = vec![];
@@ -83,7 +83,7 @@ fn very_empty_block() {
 #[test]
 // builds a block with a tx spending another and check that cut_through occurred
 fn block_with_cut_through() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -119,7 +119,7 @@ fn block_with_cut_through() {
 
 #[test]
 fn empty_block_with_coinbase_is_valid() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &prev, &key_id);
@@ -156,7 +156,7 @@ fn empty_block_with_coinbase_is_valid() {
 // invalidates the block and specifically it causes verify_coinbase to fail
 // additionally verifying the merkle_inputs_outputs also fails
 fn remove_coinbase_output_flag() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(vec![], &keychain, &prev, &key_id);
@@ -178,7 +178,7 @@ fn remove_coinbase_output_flag() {
 // test that flipping the COINBASE flag on the kernel features
 // invalidates the block and specifically it causes verify_coinbase to fail
 fn remove_coinbase_kernel_flag() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(vec![], &keychain, &prev, &key_id);
@@ -202,7 +202,7 @@ fn remove_coinbase_kernel_flag() {
 
 #[test]
 fn serialize_deserialize_block_header() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &prev, &key_id);
@@ -219,7 +219,7 @@ fn serialize_deserialize_block_header() {
 #[test]
 fn serialize_deserialize_block() {
 	let tx1 = tx1i2o();
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
@@ -237,7 +237,7 @@ fn serialize_deserialize_block() {
 
 #[test]
 fn empty_block_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &prev, &key_id);
@@ -249,7 +249,7 @@ fn empty_block_serialized_size() {
 
 #[test]
 fn block_single_tx_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -262,7 +262,7 @@ fn block_single_tx_serialized_size() {
 
 #[test]
 fn empty_compact_block_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &prev, &key_id);
@@ -275,7 +275,7 @@ fn empty_compact_block_serialized_size() {
 
 #[test]
 fn compact_block_single_tx_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -289,7 +289,7 @@ fn compact_block_single_tx_serialized_size() {
 
 #[test]
 fn block_10_tx_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	global::set_mining_mode(global::ChainTypes::Mainnet);
 
 	let mut txs = vec![];
@@ -308,7 +308,7 @@ fn block_10_tx_serialized_size() {
 
 #[test]
 fn compact_block_10_tx_serialized_size() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
 	let mut txs = vec![];
 	for _ in 0..10 {
@@ -327,7 +327,7 @@ fn compact_block_10_tx_serialized_size() {
 
 #[test]
 fn compact_block_hash_with_nonce() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let tx = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -357,7 +357,7 @@ fn compact_block_hash_with_nonce() {
 
 #[test]
 fn convert_block_to_compact_block() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -380,7 +380,7 @@ fn convert_block_to_compact_block() {
 
 #[test]
 fn hydrate_empty_compact_block() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &prev, &key_id);
@@ -393,7 +393,7 @@ fn hydrate_empty_compact_block() {
 
 #[test]
 fn serialize_deserialize_compact_block() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -29,7 +29,7 @@ use grin_keychain as keychain;
 
 // utility producing a transaction with 2 inputs and a single outputs
 pub fn tx2i1o() -> Transaction {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -48,7 +48,7 @@ pub fn tx2i1o() -> Transaction {
 
 // utility producing a transaction with a single input and output
 pub fn tx1i1o() -> Transaction {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 
@@ -63,7 +63,7 @@ pub fn tx1i1o() -> Transaction {
 // and two outputs (one change output)
 // Note: this tx has an "offset" kernel
 pub fn tx1i2o() -> Transaction {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -75,7 +75,7 @@ fn tx_double_ser_deser() {
 #[test]
 #[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
-	let mut keychain = ExtKeychain::from_random_seed().unwrap();
+	let mut keychain = ExtKeychain::from_random_seed(false).unwrap();
 	keychain.set_use_switch_commits(false);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
@@ -97,7 +97,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 
 #[test]
 fn build_tx_kernel() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -322,7 +322,7 @@ fn basic_transaction_deaggregation() {
 
 #[test]
 fn hash_output() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -377,7 +377,7 @@ fn tx_hash_diff() {
 /// 2 inputs, 2 outputs transaction.
 #[test]
 fn tx_build_exchange() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -415,7 +415,7 @@ fn tx_build_exchange() {
 
 #[test]
 fn reward_empty_block() {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let previous_header = BlockHeader::default();
@@ -430,7 +430,7 @@ fn reward_empty_block() {
 
 #[test]
 fn reward_with_tx_block() {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -450,7 +450,7 @@ fn reward_with_tx_block() {
 
 #[test]
 fn simple_block() {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -471,7 +471,7 @@ fn simple_block() {
 
 #[test]
 fn test_block_with_timelocked_tx() {
-	let keychain = keychain::ExtKeychain::from_random_seed().unwrap();
+	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -25,7 +25,7 @@ use grin_keychain as keychain;
 
 #[test]
 fn test_output_ser_deser() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let commit = keychain.commit(5, &key_id).unwrap();
 	let proof = proof::create(&keychain, 5, &key_id, commit, None).unwrap();

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -32,7 +32,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 fn test_verifier_cache_rangeproofs() {
 	let cache = verifier_cache();
 
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let commit = keychain.commit(5, &key_id).unwrap();
 	let proof = proof::create(&keychain, 5, &key_id, commit, None).unwrap();

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -108,13 +108,13 @@ impl BIP32GrinHasher {
 impl BIP32Hasher for BIP32GrinHasher {
 	fn network_priv(&self) -> [u8; 4] {
 		match self.is_floo {
-			true => [0x03, 0x27, 0x3A, 0x10], // fprv
+			true => [0x03, 0x27, 0x3A, 0x10],  // fprv
 			false => [0x03, 0x3C, 0x04, 0xA4], // gprv
 		}
 	}
 	fn network_pub(&self) -> [u8; 4] {
 		match self.is_floo {
-			true => [0x03, 0x27, 0x3E, 0x4A], // fpub
+			true => [0x03, 0x27, 0x3E, 0x4A],  // fpub
 			false => [0x03, 0x3C, 0x08, 0xDE], // gpub
 		}
 	}

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -78,8 +78,8 @@ impl Default for Fingerprint {
 /// not what the actual implementation is
 
 pub trait BIP32Hasher {
-	fn network_priv() -> [u8; 4];
-	fn network_pub() -> [u8; 4];
+	fn network_priv(&self) -> [u8; 4];
+	fn network_pub(&self) -> [u8; 4];
 	fn master_seed() -> [u8; 12];
 	fn init_sha512(&mut self, seed: &[u8]);
 	fn append_sha512(&mut self, value: &[u8]);
@@ -89,27 +89,34 @@ pub trait BIP32Hasher {
 }
 
 /// Implementation of the above that uses the standard BIP32 Hash algorithms
+#[derive(Clone, Debug)]
 pub struct BIP32GrinHasher {
+	is_floo: bool,
 	hmac_sha512: Hmac<Sha512>,
 }
 
 impl BIP32GrinHasher {
 	/// New empty hasher
-	pub fn new() -> BIP32GrinHasher {
+	pub fn new(is_floo: bool) -> BIP32GrinHasher {
 		BIP32GrinHasher {
+			is_floo: is_floo,
 			hmac_sha512: HmacSha512::new(GenericArray::from_slice(&[0u8; 128])),
 		}
 	}
 }
 
 impl BIP32Hasher for BIP32GrinHasher {
-	fn network_priv() -> [u8; 4] {
-		// gprv
-		[0x03, 0x3C, 0x04, 0xA4]
+	fn network_priv(&self) -> [u8; 4] {
+		match self.is_floo {
+			true => [0x03, 0x27, 0x3A, 0x10], // fprv
+			false => [0x03, 0x3C, 0x04, 0xA4], // gprv
+		}
 	}
-	fn network_pub() -> [u8; 4] {
-		// gpub
-		[0x03, 0x3C, 0x08, 0xDF]
+	fn network_pub(&self) -> [u8; 4] {
+		match self.is_floo {
+			true => [0x03, 0x27, 0x3E, 0x4A], // fpub
+			false => [0x03, 0x3C, 0x08, 0xDE], // gpub
+		}
 	}
 	fn master_seed() -> [u8; 12] {
 		b"IamVoldemort".to_owned()
@@ -357,7 +364,7 @@ impl ExtendedPrivKey {
 		let result = hasher.result_sha512();
 
 		Ok(ExtendedPrivKey {
-			network: H::network_priv(),
+			network: hasher.network_priv(),
 			depth: 0,
 			parent_fingerprint: Default::default(),
 			child_number: ChildNumber::from_normal_idx(0),
@@ -371,12 +378,13 @@ impl ExtendedPrivKey {
 		secp: &Secp256k1,
 		mnemonic: &str,
 		passphrase: &str,
+		is_floo: bool,
 	) -> Result<ExtendedPrivKey, Error> {
 		let seed = match mnemonic::to_seed(mnemonic, passphrase) {
 			Ok(s) => s,
 			Err(e) => return Err(Error::MnemonicError(e)),
 		};
-		let mut hasher = BIP32GrinHasher::new();
+		let mut hasher = BIP32GrinHasher::new(is_floo);
 		let key = r#try!(ExtendedPrivKey::new_master(secp, &mut hasher, &seed));
 		Ok(key)
 	}
@@ -449,7 +457,7 @@ impl ExtendedPrivKey {
 	{
 		let secp = Secp256k1::with_caps(ContextFlag::SignOnly);
 		// Compute extended public key
-		let pk: ExtendedPubKey = ExtendedPubKey::from_private::<H>(&secp, self);
+		let pk: ExtendedPubKey = ExtendedPubKey::from_private::<H>(&secp, self, hasher);
 		// Do SHA256 of just the ECDSA pubkey
 		let sha2_res = hasher.sha_256(&pk.public_key.serialize_vec(&secp, true)[..]);
 		// do RIPEMD160
@@ -469,12 +477,12 @@ impl ExtendedPrivKey {
 
 impl ExtendedPubKey {
 	/// Derives a public key from a private key
-	pub fn from_private<H>(secp: &Secp256k1, sk: &ExtendedPrivKey) -> ExtendedPubKey
+	pub fn from_private<H>(secp: &Secp256k1, sk: &ExtendedPrivKey, hasher: &mut H) -> ExtendedPubKey
 	where
 		H: BIP32Hasher,
 	{
 		ExtendedPubKey {
-			network: H::network_pub(),
+			network: hasher.network_pub(),
 			depth: sk.depth,
 			parent_fingerprint: sk.parent_fingerprint,
 			child_number: sk.child_number,
@@ -696,11 +704,11 @@ mod tests {
 	}
 
 	impl BIP32Hasher for BIP32ReferenceHasher {
-		fn network_priv() -> [u8; 4] {
+		fn network_priv(&self) -> [u8; 4] {
 			// bitcoin network (xprv) (for test vectors)
 			[0x04, 0x88, 0xAD, 0xE4]
 		}
-		fn network_pub() -> [u8; 4] {
+		fn network_pub(&self) -> [u8; 4] {
 			// bitcoin network (xpub) (for test vectors)
 			[0x04, 0x88, 0xB2, 0x1E]
 		}
@@ -743,7 +751,7 @@ mod tests {
 	) {
 		let mut h = BIP32ReferenceHasher::new();
 		let mut sk = ExtendedPrivKey::new_master(secp, &mut h, seed).unwrap();
-		let mut pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk);
+		let mut pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
 
 		// Check derivation convenience method for ExtendedPrivKey
 		assert_eq!(
@@ -771,7 +779,7 @@ mod tests {
 			match num {
 				ChildNumber::Normal { .. } => {
 					let pk2 = pk.ckd_pub(secp, &mut h, num).unwrap();
-					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk);
+					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
 					assert_eq!(pk, pk2);
 				}
 				ChildNumber::Hardened { .. } => {
@@ -779,7 +787,7 @@ mod tests {
 						pk.ckd_pub(secp, &mut h, num),
 						Err(Error::CannotDeriveFromHardenedKey)
 					);
-					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk);
+					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
 				}
 			}
 		}

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -114,8 +114,8 @@ impl BIP32Hasher for BIP32GrinHasher {
 	}
 	fn network_pub(&self) -> [u8; 4] {
 		match self.is_floo {
-			true => [0x03, 0x27, 0x3E, 0x4A],  // fpub
-			false => [0x03, 0x3C, 0x08, 0xDE], // gpub
+			true => [0x03, 0x27, 0x3E, 0x4B],  // fpub
+			false => [0x03, 0x3C, 0x08, 0xDF], // gpub
 		}
 	}
 	fn master_seed() -> [u8; 12] {

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -451,13 +451,13 @@ pub struct ValueExtKeychainPath {
 pub trait Keychain: Sync + Send + Clone {
 	/// Generates a keychain from a raw binary seed (which has already been
 	/// decrypted if applicable).
-	fn from_seed(seed: &[u8]) -> Result<Self, Error>;
+	fn from_seed(seed: &[u8], is_floo: bool) -> Result<Self, Error>;
 
 	/// Generates a keychain from a list of space-separated mnemonic words
-	fn from_mnemonic(word_list: &str, extension_word: &str) -> Result<Self, Error>;
+	fn from_mnemonic(word_list: &str, extension_word: &str, is_floo: bool) -> Result<Self, Error>;
 
 	/// Generates a keychain from a randomly generated seed. Mostly used for tests.
-	fn from_random_seed() -> Result<Self, Error>;
+	fn from_random_seed(is_floo: bool) -> Result<Self, Error>;
 
 	/// Root identifier for that keychain
 	fn root_key_id() -> Identifier;

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 #[test]
 fn test_transaction_pool_block_building() {
 	util::init_test_logger();
-	let keychain: ExtKeychain = Keychain::from_random_seed().unwrap();
+	let keychain: ExtKeychain = Keychain::from_random_seed(false).unwrap();
 
 	let db_root = ".grin_block_building".to_string();
 	clean_output_dir(db_root.clone());

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 
 #[test]
 fn test_transaction_pool_block_reconciliation() {
-	let keychain: ExtKeychain = Keychain::from_random_seed().unwrap();
+	let keychain: ExtKeychain = Keychain::from_random_seed(false).unwrap();
 
 	let db_root = ".grin_block_reconciliation".to_string();
 	clean_output_dir(db_root.clone());

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -67,7 +67,7 @@ impl BlockChain for CoinbaseMaturityErrorChainAdapter {
 /// Test we correctly verify coinbase maturity when adding txs to the pool.
 #[test]
 fn test_coinbase_maturity() {
-	let keychain: ExtKeychain = Keychain::from_random_seed().unwrap();
+	let keychain: ExtKeychain = Keychain::from_random_seed(false).unwrap();
 
 	// Mocking this up with an adapter that will raise an error for coinbase
 	// maturity.

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 /// Test we can add some txs to the pool (both stempool and txpool).
 #[test]
 fn test_the_transaction_pool() {
-	let keychain: ExtKeychain = Keychain::from_random_seed().unwrap();
+	let keychain: ExtKeychain = Keychain::from_random_seed(false).unwrap();
 
 	let db_root = ".grin_transaction_pool".to_string();
 	clean_output_dir(db_root.clone());

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use crate::chain;
 use crate::common::types::Error;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::core::{consensus, core, ser};
+use crate::core::{global, consensus, core, ser};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
 use crate::util;
@@ -170,7 +170,7 @@ fn build_block(
 ///
 fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, BlockFees), Error> {
 	warn!("Burning block fees: {:?}", block_fees);
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(global::is_floonet()).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) =
 		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees)

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use crate::chain;
 use crate::common::types::Error;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::core::{global, consensus, core, ser};
+use crate::core::{consensus, core, global, ser};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
 use crate::util;
@@ -173,8 +173,7 @@ fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, B
 	let keychain = ExtKeychain::from_random_seed(global::is_floonet()).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) =
-		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees)
-			.unwrap();
+		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees).unwrap();
 	Ok((out, kernel, block_fees))
 }
 

--- a/servers/tests/framework.rs
+++ b/servers/tests/framework.rs
@@ -306,7 +306,7 @@ impl LocalServerContainer {
 		wallet_seed: &wallet::WalletSeed,
 	) -> wallet::WalletInfo {
 		let keychain: keychain::ExtKeychain = wallet_seed
-			.derive_keychain()
+			.derive_keychain(false)
 			.expect("Failed to derive keychain from seed file and passphrase.");
 		let client_n = HTTPNodeClient::new(&config.check_node_api_http_addr, None);
 		let mut wallet = LMDBBackend::new(config.clone(), "", client_n)
@@ -332,7 +332,7 @@ impl LocalServerContainer {
 			wallet::WalletSeed::from_file(config, "").expect("Failed to read wallet seed file.");
 
 		let keychain: keychain::ExtKeychain = wallet_seed
-			.derive_keychain()
+			.derive_keychain(false)
 			.expect("Failed to derive keychain from seed file and passphrase.");
 
 		let client_n = HTTPNodeClient::new(&config.check_node_api_http_addr, None);

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -233,7 +233,7 @@ mod test {
 	// demonstrate that input.commitment == referenced output.commitment
 	// based on the public key and amount begin spent
 	fn output_commitment_equals_input_commitment_on_spend() {
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 		let tx1 = build::transaction(vec![build::output(105, key_id1.clone())], &keychain).unwrap();

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -32,7 +32,7 @@ use crate::keychain::{ChildNumber, ExtKeychain, Identifier, Keychain};
 use crate::store::{self, option_to_not_found, to_key, to_key_u64};
 
 use crate::core::core::Transaction;
-use crate::core::ser;
+use crate::core::{global, ser};
 use crate::libwallet::types::*;
 use crate::libwallet::{internal, Error, ErrorKind};
 use crate::types::{WalletConfig, WalletSeed};
@@ -178,7 +178,7 @@ where
 			.context(ErrorKind::CallbackImpl("Error opening wallet"))?;
 		self.keychain = Some(
 			wallet_seed
-				.derive_keychain()
+				.derive_keychain(global::is_floonet())
 				.context(ErrorKind::CallbackImpl("Error deriving keychain"))?,
 		);
 		Ok(())

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -217,7 +217,8 @@ impl WalletSeed {
 			let mut file = File::open(seed_file_path).context(ErrorKind::IO)?;
 			let mut buffer = String::new();
 			file.read_to_string(&mut buffer).context(ErrorKind::IO)?;
-			let enc_seed: EncryptedWalletSeed = serde_json::from_str(&buffer).context(ErrorKind::Format)?;
+			let enc_seed: EncryptedWalletSeed =
+				serde_json::from_str(&buffer).context(ErrorKind::Format)?;
 			let wallet_seed = enc_seed.decrypt(password)?;
 			Ok(wallet_seed)
 		} else {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -124,8 +124,8 @@ impl WalletSeed {
 		seed.as_bytes().to_vec()
 	}
 
-	pub fn derive_keychain<K: Keychain>(&self) -> Result<K, Error> {
-		let result = K::from_seed(&self.0)?;
+	pub fn derive_keychain<K: Keychain>(&self, is_floonet: bool) -> Result<K, Error> {
+		let result = K::from_seed(&self.0, is_floonet)?;
 		Ok(result)
 	}
 
@@ -217,37 +217,7 @@ impl WalletSeed {
 			let mut file = File::open(seed_file_path).context(ErrorKind::IO)?;
 			let mut buffer = String::new();
 			file.read_to_string(&mut buffer).context(ErrorKind::IO)?;
-			let enc_seed: EncryptedWalletSeed =
-				match serde_json::from_str(&buffer).context(ErrorKind::Format) {
-					Ok(s) => s,
-					Err(_) => {
-						println!("Attempting to convert old wallet seed file to new format");
-						// TODO: remove for mainnet
-						// try to convert from old format
-						let mut bak_file = File::create(format!("{}.bak", seed_file_path))
-							.context(ErrorKind::IO)?;
-						let mut file = File::create(seed_file_path).context(ErrorKind::IO)?;
-						let old_wallet_seed = WalletSeed::from_hex(&buffer.trim())?;
-						bak_file
-							.write_all(&old_wallet_seed.to_hex().as_bytes())
-							.context(ErrorKind::IO)?;
-						let mut c_wallet_seed = [0u8; 32];
-						c_wallet_seed.copy_from_slice(&old_wallet_seed.0[0..32]);
-						let converted_wallet_seed =
-							WalletSeed::derive_keychain_old(c_wallet_seed, password);
-						let enc_seed = EncryptedWalletSeed::from_seed(
-							&WalletSeed::from_bytes(&converted_wallet_seed),
-							password,
-						)?;
-						let enc_seed_json =
-							serde_json::to_string_pretty(&enc_seed).context(ErrorKind::Format)?;
-						file.write_all(&enc_seed_json.as_bytes())
-							.context(ErrorKind::IO)?;
-						println!("Seed file conversion done");
-						println!("Consider moving funds to a newly-created wallet to support recovery phrases");
-						enc_seed
-					}
-				};
+			let enc_seed: EncryptedWalletSeed = serde_json::from_str(&buffer).context(ErrorKind::Format)?;
 			let wallet_seed = enc_seed.decrypt(password)?;
 			Ok(wallet_seed)
 		} else {

--- a/wallet/tests/libwallet.rs
+++ b/wallet/tests/libwallet.rs
@@ -31,8 +31,8 @@ fn kernel_sig_msg() -> secp::Message {
 
 #[test]
 fn aggsig_sender_receiver_interaction() {
-	let sender_keychain = ExtKeychain::from_random_seed().unwrap();
-	let receiver_keychain = ExtKeychain::from_random_seed().unwrap();
+	let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+	let receiver_keychain = ExtKeychain::from_random_seed(true).unwrap();
 
 	// Calculate the kernel excess here for convenience.
 	// Normally this would happen during transaction building.
@@ -41,7 +41,7 @@ fn aggsig_sender_receiver_interaction() {
 		let skey1 = sender_keychain.derive_key(0, &id1).unwrap();
 		let skey2 = receiver_keychain.derive_key(0, &id1).unwrap();
 
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(true).unwrap();
 		let blinding_factor = keychain
 			.blind_sum(
 				&BlindSum::new()
@@ -224,7 +224,7 @@ fn aggsig_sender_receiver_interaction() {
 
 	// Check we can verify the sig using the kernel excess
 	{
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(true).unwrap();
 		let msg = kernel_sig_msg();
 		let sig_verifies =
 			aggsig::verify_single_from_commit(&keychain.secp(), &final_sig, &msg, &kernel_excess);
@@ -235,8 +235,8 @@ fn aggsig_sender_receiver_interaction() {
 
 #[test]
 fn aggsig_sender_receiver_interaction_offset() {
-	let sender_keychain = ExtKeychain::from_random_seed().unwrap();
-	let receiver_keychain = ExtKeychain::from_random_seed().unwrap();
+	let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+	let receiver_keychain = ExtKeychain::from_random_seed(true).unwrap();
 
 	// This is the kernel offset that we use to split the key
 	// Summing these at the block level prevents the
@@ -250,7 +250,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 		let skey1 = sender_keychain.derive_key(0, &id1).unwrap();
 		let skey2 = receiver_keychain.derive_key(0, &id1).unwrap();
 
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(true).unwrap();
 		let blinding_factor = keychain
 			.blind_sum(
 				&BlindSum::new()
@@ -439,7 +439,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 	// Check we can verify the sig using the kernel excess
 	{
-		let keychain = ExtKeychain::from_random_seed().unwrap();
+		let keychain = ExtKeychain::from_random_seed(true).unwrap();
 		let msg = kernel_sig_msg();
 		let sig_verifies =
 			aggsig::verify_single_from_commit(&keychain.secp(), &final_sig, &msg, &kernel_excess);
@@ -450,7 +450,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 #[test]
 fn test_rewind_range_proof() {
-	let keychain = ExtKeychain::from_random_seed().unwrap();
+	let keychain = ExtKeychain::from_random_seed(true).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let commit = keychain.commit(5, &key_id).unwrap();


### PR DESCRIPTION
For #2207 

Unfortunately needs to be provided as a parameter at keychain init time, since keychain doesn't import core and has no concept of `is_floonet()`

Would appreciate if someone could check/verify the version hex, I actually think the previous value that was supposed to encode to `xpub` may have been incorrect.