### PR TITLE
[DNM] fix: new mined block need broadcast

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -635,9 +635,9 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			}
 		}
 
-		if self.sync_state.is_syncing() {
-			return;
-		}
+//		if self.sync_state.is_syncing() {
+//			return;
+//		}
 
 		// If we mined the block then we want to broadcast the compact block.
 		// If we received the block from another node then broadcast "header first"


### PR DESCRIPTION
Regarding to fraud peer issue https://github.com/mimblewimble/grin/issues/2233#issuecomment-450005782

@ignopeverell 
> And I think the check on the miner's block submission has been removed.


I believe the block submission on node syncing state do have been removed, but without broadcasting 😸 

I'm not sure removing the check here (in this PR) is a good idea, because this check is absolutely needed for the real initial syncing stage of a new node.

Want some suggestions on this PR.  @ignopeverell   @antiochp  