### PR TITLE
Skip connecting PeerWithSelf by checking ip address

### DIFF
--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -39,7 +39,7 @@ pub struct Handshake {
 	/// a node id.
 	nonces: Arc<RwLock<VecDeque<u64>>>,
 	/// Ring buffer of self addr(s) collected from PeerWithSelf detection (by nonce).
-	addrs: Arc<RwLock<VecDeque<SocketAddr>>>,
+	pub addrs: Arc<RwLock<VecDeque<SocketAddr>>>,
 	/// The genesis block header of the chain seen by this node.
 	/// We only want to connect to other nodes seeing the same chain (forks are
 	/// ok).

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -21,7 +21,6 @@ use chrono::prelude::*;
 use rand::{thread_rng, Rng};
 
 use crate::core::core::hash::Hash;
-use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::msg::{
 	read_message, write_message, Hand, Shake, SockAddr, Type, PROTOCOL_VERSION, USER_AGENT,
@@ -162,17 +161,6 @@ impl Handshake {
 					debug!("Error shutting down conn: {:?}", e);
 				}
 				return Err(Error::PeerWithSelf);
-			}
-
-			// double check the ip address except for the travis-ci test
-			if global::is_production_mode() {
-				let addrs = self.addrs.read();
-				if addrs.contains(&addr) {
-					if let Err(e) = conn.shutdown(Shutdown::Both) {
-						debug!("Error shutting down conn: {:?}", e);
-					}
-					return Err(Error::PeerWithSelf);
-				}
 			}
 		}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -113,7 +113,10 @@ impl Server {
 			let hs = self.handshake.clone();
 			let addrs = hs.addrs.read();
 			if addrs.contains(&addr) {
-				debug!("connect: ignore the connecting to PeerWithSelf, addr: {}", addr);
+				debug!(
+					"connect: ignore the connecting to PeerWithSelf, addr: {}",
+					addr
+				);
 				return Err(Error::PeerWithSelf);
 			}
 		}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -22,6 +22,7 @@ use crate::lmdb;
 
 use crate::core::core;
 use crate::core::core::hash::Hash;
+use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::handshake::Handshake;
 use crate::peer::Peer;
@@ -108,13 +109,13 @@ impl Server {
 			return Err(Error::ConnectionClose);
 		}
 
-		// check ip and port to see if we are trying to connect to ourselves
-		// todo: this can't detect all cases of PeerWithSelf, for example config.host is '0.0.0.0'
-		//
-		if self.config.port == addr.port()
-			&& (addr.ip().is_loopback() || addr.ip() == self.config.host)
-		{
-			return Err(Error::PeerWithSelf);
+		if global::is_production_mode() {
+			let hs = self.handshake.clone();
+			let addrs = hs.addrs.read();
+			if addrs.contains(&addr) {
+				debug!("connect: ignore the connecting to PeerWithSelf, addr: {}", addr);
+				return Err(Error::PeerWithSelf);
+			}
 		}
 
 		if let Some(p) = self.peers.get_connected_peer(addr) {


### PR DESCRIPTION
My server can't be connected any more but the total connected peers is far below the configured `peer_max_count`,  less than 30 peers, check by netstat:
```
$ netstat -tlna | grep -c 13414
235

in 2nd server:
$ netstat -tlna | grep -c 13414
213

in 3rd server:
$ netstat -tlna | grep 13414 | grep -c ESTABLISHED
200

$ netstat -tlna | grep 13414 | grep -c CLOSE_WAIT
40

My grin-server config:
peer_max_count = 256
```

And check detail on one server, I find 160 TCP connections by itself.  I don't know how but it do connect to itself and keep these connections.

This PR give an improvement on current PeerWithSelf detection solution (by nonce which store 100 recent nonces it generated/sent in Hand).

And add one more step for PeerWithSelf:  `shutdown` the TcpStream.

**[Updated]**
I find it's more clean to skip self connecting (on requester side), compared to double check nonce and ip address (on listener side).