### PR TITLE
Grin wallet check/repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "grin_secp256k1zkp"
 version = "0.7.3"
-source = "git+https://github.com/mimblewimble/rust-secp256k1-zkp#60fe4c3e106b923170eca7b2a01d04f03f606abf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -918,7 +918,7 @@ dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_secp256k1zkp 0.7.3 (git+https://github.com/mimblewimble/rust-secp256k1-zkp)",
+ "grin_secp256k1zkp 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2969,7 +2969,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_secp256k1zkp 0.7.3 (git+https://github.com/mimblewimble/rust-secp256k1-zkp)" = "<none>"
+"checksum grin_secp256k1zkp 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d551d7c26f0a4b997440133e7b770576b8672e2193196bcf362c79175eb078f7"
 "checksum h2 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1ac030ae20dee464c5d0f36544d8b914a6bc606da44a57e052d2b0f5dae129e0"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab"

--- a/doc/wallet/usage.md
+++ b/doc/wallet/usage.md
@@ -403,9 +403,33 @@ grin wallet repost -i 3 -m tx_3.json
 
 This will create a file called tx_3.json containing your raw transaction data. Note that this formatting in the file isn't yet very user-readable.
 
+##### check_repair
+
+If for some reason the wallet cancel commands above don't work and you believe your outputs are in an inconsistent state, you have two options:
+
+First, you can try the `check_repair` command. This will scan the entire UTXO set from the node, identify which outputs are yours and update your wallet state to
+be consistent with what's currently in the UTXO set. This command will unlock all outputs, restore any missing outputs, and mark any outputs that have been marked
+'Spent' but are still in the UTXO set as 'Unspent' (as can happen during a fork). It will also attempt to cancel any transaction log entries associated with any locked 
+or outputs incorrectly marked 'Spent' 
+
+For these reasons, you should be fairly sure that nobody will attempt to post any unconfirmed transactions involving your wallet before trying this command,
+(but even it someone does, it should be possible to re-run this command to fix any resulting issues.
+
+To attempt a repair, ensure a wallet listener isn't running, and enter:
+
+```sh
+grin wallet check_repair
+```
+
+The operation may take some time (it's advised to only perform this operation using a release build,) and it will report any inconsistencies it finds and repairs it makes.
+Once it's done, the state of your wallet outputs should match the contents of the UTXO set.
+
 ##### restore
 
-If for some reason the wallet cancel commands above don't work, you need to restore from a backed up `wallet.seed` file and password, or have recovered the wallet seed from a recovery phrase, you can perform a full wallet restore.
+If check_repair isn't working, or you need to restore your wallet from a backed up `wallet.seed` file and password, or have recovered the wallet seed from a recovery phrase,
+you can perform a full wallet restore.
+
+This command acts similarly to the check_repair command in that it scans the UTXO set for your outputs, however it restores all found UTXOs from scratch into an empty wallet.
 
 To do this, generate an empty wallet somewhere with:
 

--- a/doc/wallet/usage.md
+++ b/doc/wallet/usage.md
@@ -409,8 +409,8 @@ If for some reason the wallet cancel commands above don't work and you believe y
 
 First, you can try the `check_repair` command. This will scan the entire UTXO set from the node, identify which outputs are yours and update your wallet state to
 be consistent with what's currently in the UTXO set. This command will unlock all outputs, restore any missing outputs, and mark any outputs that have been marked
-'Spent' but are still in the UTXO set as 'Unspent' (as can happen during a fork). It will also attempt to cancel any transaction log entries associated with any locked 
-or outputs incorrectly marked 'Spent' 
+'Spent' but are still in the UTXO set as 'Unspent' (as can happen during a fork). It will also attempt to cancel any transaction log entries associated with any locked outputs
+or outputs incorrectly marked 'Spent'
 
 For these reasons, you should be fairly sure that nobody will attempt to post any unconfirmed transactions involving your wallet before trying this command,
 (but even it someone does, it should be possible to re-run this command to fix any resulting issues.
@@ -429,9 +429,10 @@ Once it's done, the state of your wallet outputs should match the contents of th
 If check_repair isn't working, or you need to restore your wallet from a backed up `wallet.seed` file and password, or have recovered the wallet seed from a recovery phrase,
 you can perform a full wallet restore.
 
-This command acts similarly to the check_repair command in that it scans the UTXO set for your outputs, however it restores all found UTXOs from scratch into an empty wallet.
+This command acts similarly to the check_repair command in that it scans the UTXO set for your outputs, however it will only restore found UTXOs into an empty wallet, 
+refusing to run if the wallet isn't empty.
 
-To do this, generate an empty wallet somewhere with:
+To restore a wallet, generate an empty wallet somewhere with:
 
 ```sh
 grin wallet init -h

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -504,6 +504,7 @@ pub fn wallet_command(
 			command::cancel(inst_wallet(), a)
 		}
 		("restore", Some(_)) => command::restore(inst_wallet()),
+		("check_repair", Some(_)) => command::check_repair(inst_wallet()),
 		_ => {
 			let msg = format!("Unknown wallet command, use 'grin help wallet' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -443,6 +443,30 @@ mod wallet_tests {
 			Ok(())
 		})?;
 
+		// Another file exchange, don't send, but unlock with repair command
+		let arg_vec = vec![
+			"grin",
+			"wallet",
+			"-p",
+			"password",
+			"-a",
+			"mining",
+			"send",
+			"-m",
+			"file",
+			"-d",
+			&file_name,
+			"-g",
+			"Ain't sending",
+			"10",
+		];
+		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
+		let arg_vec = vec![
+			"grin", "wallet", "-p", "password", "check_repair",
+		];
+		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
 		// txs and outputs (mostly spit out for a visual in test logs)
 		let arg_vec = vec!["grin", "wallet", "-p", "password", "-a", "mining", "txs"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
@@ -452,6 +476,7 @@ mod wallet_tests {
 			"grin", "wallet", "-p", "password", "-a", "mining", "outputs",
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
 
 		// let logging finish
 		thread::sleep(Duration::from_millis(200));

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -462,9 +462,7 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		let arg_vec = vec![
-			"grin", "wallet", "-p", "password", "check_repair",
-		];
+		let arg_vec = vec!["grin", "wallet", "-p", "password", "check_repair"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
 		// txs and outputs (mostly spit out for a visual in test logs)
@@ -476,7 +474,6 @@ mod wallet_tests {
 			"grin", "wallet", "-p", "password", "-a", "mining", "outputs",
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
-
 
 		// let logging finish
 		thread::sleep(Duration::from_millis(200));

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -292,5 +292,7 @@ subcommands:
                   long: recovery_phrase
                   takes_value: true
         - restore:
-            about: Initialize a new wallet seed file and database
+            about: Restores a wallet contents from a seed file
+        - check_repair:
+            about: Checks a wallet's outputs against a live node, repairing and restoring missing outputs if required
  

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -480,11 +480,31 @@ pub fn restore(
 		let result = api.restore();
 		match result {
 			Ok(_) => {
-				info!("Wallet restore complete",);
+				warn!("Wallet restore complete",);
 				Ok(())
 			}
 			Err(e) => {
 				error!("Wallet restore failed: {}", e);
+				error!("Backtrace: {}", e.backtrace().unwrap());
+				Err(e)
+			}
+		}
+	})?;
+	Ok(())
+}
+
+pub fn check_repair(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+) -> Result<(), Error> {
+	controller::owner_single_use(wallet.clone(), |api| {
+		let result = api.check_repair();
+		match result {
+			Ok(_) => {
+				warn!("Wallet check/repair complete",);
+				Ok(())
+			}
+			Err(e) => {
+				error!("Wallet check/repair failed: {}", e);
 				error!("Backtrace: {}", e.backtrace().unwrap());
 				Err(e)
 			}

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -353,7 +353,7 @@ where
 
 		let res = Ok((
 			validated,
-			updater::retrieve_outputs(&mut *w, include_spent, tx_id, &parent_key_id)?,
+			updater::retrieve_outputs(&mut *w, include_spent, tx_id, Some(&parent_key_id))?,
 		));
 
 		w.close()?;
@@ -756,9 +756,19 @@ where
 	pub fn restore(&mut self) -> Result<(), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		let res = w.restore();
+		w.restore()?;
 		w.close()?;
-		res
+		Ok(())
+	}
+
+	/// Attempt to check and fix the contents of the wallet
+	pub fn check(&mut self) -> Result<(), Error> {
+		let mut w = self.wallet.lock();
+		w.open_with_credentials()?;
+		self.update_outputs(&mut w);
+		w.check()?;
+		w.close()?;
+		Ok(())
 	}
 
 	/// Retrieve current height from node

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -762,11 +762,11 @@ where
 	}
 
 	/// Attempt to check and fix the contents of the wallet
-	pub fn check(&mut self) -> Result<(), Error> {
+	pub fn check_repair(&mut self) -> Result<(), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 		self.update_outputs(&mut w);
-		w.check()?;
+		w.check_repair()?;
 		w.close()?;
 		Ok(())
 	}

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -50,25 +50,33 @@ pub enum ErrorKind {
 	/// Fee dispute
 	#[fail(
 		display = "Fee dispute: sender fee {}, recipient fee {}",
-		sender_fee, recipient_fee
+		sender_fee_disp, recipient_fee_disp
 	)]
 	FeeDispute {
 		/// sender fee
 		sender_fee: u64,
+		/// display friendly
+		sender_fee_disp: String,
 		/// recipient fee
 		recipient_fee: u64,
+		/// display friendly
+		recipient_fee_disp: String,
 	},
 
 	/// Fee Exceeds amount
 	#[fail(
 		display = "Fee exceeds amount: sender amount {}, recipient fee {}",
-		sender_amount, recipient_fee
+		sender_amount_disp, recipient_fee
 	)]
 	FeeExceedsAmount {
 		/// sender amount
 		sender_amount: u64,
+		/// display friendly
+		sender_amount_disp: String,
 		/// recipient fee
 		recipient_fee: u64,
+		/// display friendly
+		recipient_fee_disp: String,
 	},
 
 	/// LibTX Error

--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -34,13 +34,17 @@ pub enum ErrorKind {
 	/// Not enough funds
 	#[fail(
 		display = "Not enough funds. Required: {}, Available: {}",
-		needed, available
+		needed_disp, available_disp
 	)]
 	NotEnoughFunds {
 		/// available funds
 		available: u64,
+		/// Display friendly
+		available_disp: String,
 		/// Needed funds
 		needed: u64,
+		/// Display friendly
+		needed_disp: String,
 	},
 
 	/// Fee dispute

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -234,7 +234,6 @@ where
 		chain_outs.len(),
 	);
 
-
 	// Now, get all outputs owned by this wallet (regardless of account)
 	let wallet_outputs = {
 		let res = updater::retrieve_outputs(&mut *wallet, true, None, None)?;

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -220,7 +220,7 @@ where
 /// Check / repair wallet contents
 /// assume wallet contents have been freshly updated with contents
 /// of latest block
-pub fn check<T, C, K>(wallet: &mut T) -> Result<(), Error>
+pub fn check_repair<T, C, K>(wallet: &mut T) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
@@ -234,7 +234,6 @@ where
 		chain_outs.len(),
 	);
 
-	wallet.open_with_credentials()?;
 
 	// Now, get all outputs owned by this wallet (regardless of account)
 	let wallet_outputs = {
@@ -302,8 +301,6 @@ where
 		batch.save(o)?;
 		batch.commit()?;
 	}
-
-	wallet.close()?;
 
 	Ok(())
 }

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -79,7 +79,7 @@ where
 		// through to find the right path if required later
 		let key_id = Identifier::from_serialized_path(3u8, &info.message.as_bytes());
 
-		warn!(
+		info!(
 			"Output found: {:?}, amount: {:?}, parent_key_id: {:?}",
 			commit, info.value, key_id
 		);
@@ -112,7 +112,7 @@ where
 			.w2n_client()
 			.get_outputs_by_pmmr_index(start_index, batch_size)?;
 		warn!(
-			"Retrieved {} outputs, up to index {}. (Highest index: {})",
+			"Checking {} outputs, up to index {}. (Highest index: {})",
 			outputs.len(),
 			highest_index,
 			last_retrieved_index,

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -152,14 +152,13 @@ where
 		let res = updater::retrieve_outputs(&mut *wallet, true, None, None)?;
 		res
 	};
-	
+
 	// check all definitive outputs exist in the wallet outputs
 	let mut missing_outs = vec![];
 	let mut accidental_spend_outs = vec![];
 	let mut locked_outs = vec![];
 	for deffo in chain_outs.into_iter() {
-		let matched_out = wallet_outputs.iter()
-			.find(|wo| wo.0.key_id == deffo.key_id);
+		let matched_out = wallet_outputs.iter().find(|wo| wo.0.key_id == deffo.key_id);
 		match matched_out {
 			Some(s) => {
 				if s.0.status == OutputStatus::Spent {
@@ -168,7 +167,7 @@ where
 				if s.0.status == OutputStatus::Locked {
 					locked_outs.push((s.0.clone(), deffo));
 				}
-			},
+			}
 			None => missing_outs.push(deffo),
 		}
 	}

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -14,7 +14,7 @@
 
 //! Selection of inputs for building transactions
 
-use crate::core::core::Transaction;
+use crate::core::core::{amount_to_hr_string, Transaction};
 use crate::core::libtx::{build, slate::Slate, tx_fee};
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::error::{Error, ErrorKind};
@@ -266,7 +266,9 @@ where
 	if total == 0 {
 		return Err(ErrorKind::NotEnoughFunds {
 			available: 0,
+			available_disp: amount_to_hr_string(0, false),
 			needed: amount_with_fee as u64,
+			needed_disp: amount_to_hr_string(amount_with_fee as u64, false),
 		})?;
 	}
 
@@ -274,7 +276,9 @@ where
 	if total < amount_with_fee && coins.len() == max_outputs {
 		return Err(ErrorKind::NotEnoughFunds {
 			available: total,
+			available_disp: amount_to_hr_string(total, false),
 			needed: amount_with_fee as u64,
+			needed_disp: amount_to_hr_string(amount_with_fee as u64, false),
 		})?;
 	}
 
@@ -292,7 +296,9 @@ where
 			if coins.len() == max_outputs {
 				return Err(ErrorKind::NotEnoughFunds {
 					available: total as u64,
+					available_disp: amount_to_hr_string(total, false),
 					needed: amount_with_fee as u64,
+					needed_disp: amount_to_hr_string(amount_with_fee as u64, false),
 				})?;
 			}
 

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -173,7 +173,7 @@ where
 		return Err(ErrorKind::TransactionNotCancellable(tx_id_string))?;
 	}
 	// get outputs associated with tx
-	let res = updater::retrieve_outputs(wallet, false, Some(tx.id), &parent_key_id)?;
+	let res = updater::retrieve_outputs(wallet, false, Some(tx.id), Some(&parent_key_id))?;
 	let outputs = res.iter().map(|(out, _)| out).cloned().collect();
 	updater::cancel_tx_and_outputs(wallet, tx, outputs, parent_key_id)?;
 	Ok(())

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -118,6 +118,9 @@ where
 
 	/// Attempt to restore the contents of a wallet from seed
 	fn restore(&mut self) -> Result<(), Error>;
+
+	/// Attempt to check and fix wallet state
+	fn check(&mut self) -> Result<(), Error>;
 }
 
 /// Batch trait to update the output data backend atomically. Trying to use a
@@ -635,6 +638,16 @@ impl TxLogEntry {
 			fee: None,
 			stored_tx: None,
 		}
+	}
+
+	/// Given a vec of TX log entries, return credited + debited sums
+	pub fn sum_confirmed(txs: &Vec<TxLogEntry>) -> (u64, u64) {
+		txs.iter().fold((0, 0), |acc, tx| {
+			match tx.confirmed {
+				true => (acc.0 + tx.amount_credited, acc.1 + tx.amount_debited),
+				false => acc
+			}
+		})
 	}
 
 	/// Update confirmation TS with now

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -565,7 +565,7 @@ impl fmt::Display for TxLogEntryType {
 			TxLogEntryType::TxReceived => write!(f, "Received Tx"),
 			TxLogEntryType::TxSent => write!(f, "Sent Tx"),
 			TxLogEntryType::TxReceivedCancelled => write!(f, "Received Tx\n- Cancelled"),
-			TxLogEntryType::TxSentCancelled => write!(f, "Send Tx\n- Cancelled"),
+			TxLogEntryType::TxSentCancelled => write!(f, "Sent Tx\n- Cancelled"),
 		}
 	}
 }

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -120,7 +120,7 @@ where
 	fn restore(&mut self) -> Result<(), Error>;
 
 	/// Attempt to check and fix wallet state
-	fn check(&mut self) -> Result<(), Error>;
+	fn check_repair(&mut self) -> Result<(), Error>;
 }
 
 /// Batch trait to update the output data backend atomically. Trying to use a

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -642,11 +642,9 @@ impl TxLogEntry {
 
 	/// Given a vec of TX log entries, return credited + debited sums
 	pub fn sum_confirmed(txs: &Vec<TxLogEntry>) -> (u64, u64) {
-		txs.iter().fold((0, 0), |acc, tx| {
-			match tx.confirmed {
-				true => (acc.0 + tx.amount_credited, acc.1 + tx.amount_debited),
-				false => acc
-			}
+		txs.iter().fold((0, 0), |acc, tx| match tx.confirmed {
+			true => (acc.0 + tx.amount_credited, acc.1 + tx.amount_debited),
+			false => acc,
 		})
 	}
 

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -369,6 +369,11 @@ where
 		internal::restore::restore(self).context(ErrorKind::Restore)?;
 		Ok(())
 	}
+
+	fn check(&mut self) -> Result<(), Error> {
+		internal::restore::check(self).context(ErrorKind::Restore)?;
+		Ok(())
+	}
 }
 
 /// An atomic batch in which all changes can be committed all at once or

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -370,8 +370,8 @@ where
 		Ok(())
 	}
 
-	fn check(&mut self) -> Result<(), Error> {
-		internal::restore::check(self).context(ErrorKind::Restore)?;
+	fn check_repair(&mut self) -> Result<(), Error> {
+		internal::restore::check_repair(self).context(ErrorKind::Restore)?;
 		Ok(())
 	}
 }

--- a/wallet/tests/check.rs
+++ b/wallet/tests/check.rs
@@ -108,9 +108,8 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		w1_outputs_commits = api.retrieve_outputs(false, true, None)?.1;
 		Ok(())
 	})?;
-	let w1_outputs: Vec<libwallet::types::OutputData> = w1_outputs_commits.into_iter()
-		.map(|o| o.0)
-		.collect();
+	let w1_outputs: Vec<libwallet::types::OutputData> =
+		w1_outputs_commits.into_iter().map(|o| o.0).collect();
 	{
 		let mut w = wallet1.lock();
 		w.open_with_credentials()?;
@@ -148,7 +147,6 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(wallet1_info.total, bh * reward);
 		Ok(())
 	})?;
-
 
 	// let logging finish
 	thread::sleep(Duration::from_millis(200));

--- a/wallet/tests/check.rs
+++ b/wallet/tests/check.rs
@@ -84,7 +84,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	// Do some mining
-	let mut bh = 20u64;
+	let bh = 20u64;
 	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), bh as usize);
 
 	// Sanity check contents
@@ -136,7 +136,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// this should restore our missing outputs
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check()?;
+		api.check_repair()?;
 		Ok(())
 	})?;
 
@@ -177,7 +177,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// unlock/restore
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check()?;
+		api.check_repair()?;
 		Ok(())
 	})?;
 

--- a/wallet/tests/check.rs
+++ b/wallet/tests/check.rs
@@ -18,8 +18,8 @@ extern crate log;
 use self::core::global;
 use self::core::global::ChainTypes;
 use self::keychain::ExtKeychain;
-use self::wallet::{libwallet, FileWalletCommAdapter};
 use self::wallet::test_framework::{self, LocalWalletClient, WalletProxy};
+use self::wallet::{libwallet, FileWalletCommAdapter};
 use grin_core as core;
 use grin_keychain as keychain;
 use grin_util as util;
@@ -153,12 +153,12 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		// send to send
 		let (mut slate, lock_fn) = api.initiate_tx(
 			None,
-			reward * 2,               // amount
-			cm,                       // minimum confirmations
-			500,                      // max outputs
-			1,                        // num change outputs
-			true,                     // select all outputs
-			None, // optional message
+			reward * 2, // amount
+			cm,         // minimum confirmations
+			500,        // max outputs
+			1,          // num change outputs
+			true,       // select all outputs
+			None,       // optional message
 		)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();

--- a/wallet/tests/check.rs
+++ b/wallet/tests/check.rs
@@ -1,0 +1,164 @@
+// Copyright 2018 The Grin Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! tests differing accounts in the same wallet
+#[macro_use]
+extern crate log;
+
+use self::core::global;
+use self::core::global::ChainTypes;
+use self::keychain::ExtKeychain;
+use self::wallet::libwallet;
+use self::wallet::test_framework::{self, LocalWalletClient, WalletProxy};
+use grin_core as core;
+use grin_keychain as keychain;
+use grin_util as util;
+use grin_wallet as wallet;
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+fn clean_output_dir(test_dir: &str) {
+	let _ = fs::remove_dir_all(test_dir);
+}
+
+fn setup(test_dir: &str) {
+	util::init_test_logger();
+	clean_output_dir(test_dir);
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
+}
+
+/// Various tests on accounts within the same wallet
+fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
+	setup(test_dir);
+	// Create a new proxy to simulate server and wallet responses
+	let mut wallet_proxy: WalletProxy<LocalWalletClient, ExtKeychain> = WalletProxy::new(test_dir);
+	let chain = wallet_proxy.chain.clone();
+
+	// Create a new wallet test client, and set its queues to communicate with the
+	// proxy
+	let client1 = LocalWalletClient::new("wallet1", wallet_proxy.tx.clone());
+	let wallet1 = test_framework::create_wallet(&format!("{}/wallet1", test_dir), client1.clone());
+	wallet_proxy.add_wallet("wallet1", client1.get_send_instance(), wallet1.clone());
+
+	let client2 = LocalWalletClient::new("wallet2", wallet_proxy.tx.clone());
+	// define recipient wallet, add to proxy
+	let wallet2 = test_framework::create_wallet(&format!("{}/wallet2", test_dir), client2.clone());
+	wallet_proxy.add_wallet("wallet2", client2.get_send_instance(), wallet2.clone());
+
+	// Set the wallet proxy listener running
+	thread::spawn(move || {
+		if let Err(e) = wallet_proxy.run() {
+			error!("Wallet Proxy error: {}", e);
+		}
+	});
+
+	// few values to keep things shorter
+	let reward = core::consensus::REWARD;
+	let cm = global::coinbase_maturity(); // assume all testing precedes soft fork height
+
+	// add some accounts
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		api.create_account_path("account_1")?;
+		api.create_account_path("account_2")?;
+		api.create_account_path("account_3")?;
+		api.set_active_account("account_1")?;
+		Ok(())
+	})?;
+
+	// add account to wallet 2
+	wallet::controller::owner_single_use(wallet2.clone(), |api| {
+		api.create_account_path("account_1")?;
+		api.set_active_account("account_1")?;
+		Ok(())
+	})?;
+
+	// Do some mining
+	let mut bh = 20u64;
+	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), bh as usize);
+
+	// Sanity check contents
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
+		assert!(wallet1_refreshed);
+		assert_eq!(wallet1_info.last_confirmed_height, bh);
+		assert_eq!(wallet1_info.total, bh * reward);
+		assert_eq!(wallet1_info.amount_currently_spendable, (bh - cm) * reward);
+		// check tx log as well
+		let (_, txs) = api.retrieve_txs(true, None, None)?;
+		let (c, _) = libwallet::types::TxLogEntry::sum_confirmed(&txs);
+		assert_eq!(wallet1_info.total, c);
+		assert_eq!(txs.len(), bh as usize);
+		Ok(())
+	})?;
+
+	// Accidentally delete some outputs
+	let mut w1_outputs_commits = vec![];
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		w1_outputs_commits = api.retrieve_outputs(false, true, None)?.1;
+		Ok(())
+	})?;
+	let w1_outputs: Vec<libwallet::types::OutputData> = w1_outputs_commits.into_iter()
+		.map(|o| o.0)
+		.collect();
+	{
+		let mut w = wallet1.lock();
+		w.open_with_credentials()?;
+		{
+			let mut batch = w.batch()?;
+			batch.delete(&w1_outputs[4].key_id)?;
+			batch.delete(&w1_outputs[10].key_id)?;
+			let mut accidental_spent = w1_outputs[13].clone();
+			accidental_spent.status = libwallet::types::OutputStatus::Spent;
+			batch.save(accidental_spent)?;
+			batch.commit()?;
+		}
+		w.close()?;
+	}
+
+	// check we have a problem now
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		let (_, wallet1_info) = api.retrieve_summary_info(true, 1)?;
+		let (_, txs) = api.retrieve_txs(true, None, None)?;
+		let (c, _) = libwallet::types::TxLogEntry::sum_confirmed(&txs);
+		assert!(wallet1_info.total != c);
+		Ok(())
+	})?;
+
+	// this should restore our missing outputs
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		api.check()?;
+		Ok(())
+	})?;
+
+	// check our outputs match again
+	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(true, 1)?;
+		assert!(wallet1_refreshed);
+		assert_eq!(wallet1_info.total, bh * reward);
+		Ok(())
+	})?;
+
+
+	// let logging finish
+	thread::sleep(Duration::from_millis(200));
+	Ok(())
+}
+
+#[test]
+fn check_repair() {
+	let test_dir = "test_output/check_repair";
+	if let Err(e) = check_repair_impl(test_dir) {
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
+	}
+}


### PR DESCRIPTION
Creates a `wallet check_repair` process as described in https://github.com/mimblewimble/grin/issues/2242

Should work identically to the restore (as a matter of fact, you should be able to run it against an empty wallet and achieve the same effect). However, `check_repair` scans the UTXO set from the node and:

* Restores any missing outputs, creating a transaction log entry for them (identical to the restore process)
* Changes the state of any outputs that may have been marked as 'Spent' but are still in the UTXO set back to 'Unspent', and cancels any associated transactions.
* Unlocks any Locked outputs that are still in the UTXO set, and cancels the associated locking transaction.

Can't guarantee this process will 100% repair the transaction log (it does its best), however the output state should always match the UTXO set after running this command.




