### PR TITLE
fix minor build warning and one log

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -18,7 +18,6 @@ use crate::consensus;
 use crate::core::hash::Hashed;
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{committed, Committed};
-use crate::global;
 use crate::keychain::{self, BlindingFactor};
 use crate::ser::{
 	self, read_multi, FixedLength, PMMRable, Readable, Reader, VerifySortedAndUnique, Writeable,
@@ -29,7 +28,6 @@ use crate::util::secp;
 use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::util::static_secp_instance;
 use crate::util::RwLock;
-use byteorder::{BigEndian, ByteOrder};
 use std::cmp::max;
 use std::cmp::Ordering;
 use std::collections::HashSet;

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -246,7 +246,7 @@ impl StratumServer {
 		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
 	) -> StratumServer {
 		StratumServer {
-			id: String::from("StratumServer"),
+			id: String::from("0"),
 			minimum_share_difficulty: config.minimum_share_difficulty,
 			config,
 			chain,
@@ -535,8 +535,9 @@ impl StratumServer {
 			worker_stats.num_blocks_found += 1;
 			// Log message to make it obvious we found a block
 			warn!(
-				"(Server ID: {}) Solution Found for block {} - Yay!!! Worker ID: {}, blocks found: {}, shares: {}",
+				"(Server ID: {}) Solution Found for block {}, hash {} - Yay!!! Worker ID: {}, blocks found: {}, shares: {}",
 				self.id, params.height,
+				b.hash(),
 				worker_stats.id,
 				worker_stats.num_blocks_found,
 				worker_stats.num_accepted,


### PR DESCRIPTION
A few warning and log clean up:
- fix 2 build warning which is new imported
- change the boring repeat string `StratumServer` to `0`, the `id` here is reserved for the case of multiple stratum server threads, and in Grin we only start one stratum server thread.
> WARN grin_servers::mining::stratumserver - (Server ID: ***StratumServer***) Solution Found for block 

Now it's:
> WARN grin_servers::mining::stratumserver - (Server ID: 0) Solution Found for block

- Add block hash in the solution found log, like `Solution Found for block 2035, hash 08321e6c`.


