### PR TITLE
fix: one peer occupy multiple tcp connections

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -71,12 +71,13 @@ impl Peer {
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!("p2p::peer::accept: connection from {:?}", conn.peer_addr());
+		debug!("accept: connection from {:?}", conn.peer_addr());
 		let info = hs.accept(capab, total_difficulty, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, adapter)),
 			Err(e) => {
-				debug!("p2p::peer::accept: fail with error: {:?}", e);
+				debug!("accept: connection from {:?} failed with error: {:?}",
+					   conn.peer_addr(), e);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {
 					debug!("Error shutting down conn: {:?}", e);
 				}
@@ -93,12 +94,13 @@ impl Peer {
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!("p2p::peer::connect: connecting to {:?}", conn.peer_addr());
+		debug!("connect: connecting to {:?}", conn.peer_addr());
 		let info = hs.initiate(capab, total_difficulty, self_addr, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, na)),
 			Err(e) => {
-				debug!("p2p::peer::connect: fail with error: {:?}", e);
+				debug!("connect: connecting to {:?} failed with error: {:?}",
+					   conn.peer_addr(), e);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {
 					debug!("Error shutting down conn: {:?}", e);
 				}

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -71,10 +71,7 @@ impl Peer {
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!(
-			"p2p::peer::accept: connection from {:?}",
-			conn.peer_addr()
-		);
+		debug!("p2p::peer::accept: connection from {:?}", conn.peer_addr());
 		let info = hs.accept(capab, total_difficulty, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, adapter)),
@@ -96,10 +93,7 @@ impl Peer {
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!(
-			"p2p::peer::connect: connecting to {:?}",
-			conn.peer_addr()
-		);
+		debug!("p2p::peer::connect: connecting to {:?}", conn.peer_addr());
 		let info = hs.initiate(capab, total_difficulty, self_addr, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, na)),

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -71,13 +71,13 @@ impl Peer {
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!("accept: connection from {:?}", conn.peer_addr());
+		debug!("accept: handshaking from {:?}", conn.peer_addr());
 		let info = hs.accept(capab, total_difficulty, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, adapter)),
 			Err(e) => {
 				debug!(
-					"accept: connection from {:?} failed with error: {:?}",
+					"accept: handshaking from {:?} failed with error: {:?}",
 					conn.peer_addr(),
 					e
 				);
@@ -97,14 +97,14 @@ impl Peer {
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!("connect: connecting to {:?}", conn.peer_addr());
+		debug!("connect: handshaking with {:?}", conn.peer_addr().unwrap());
 		let info = hs.initiate(capab, total_difficulty, self_addr, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, na)),
 			Err(e) => {
 				debug!(
-					"connect: connecting to {:?} failed with error: {:?}",
-					conn.peer_addr(),
+					"connect: handshaking with {:?} failed with error: {:?}",
+					conn.peer_addr().unwrap(),
 					e
 				);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -14,7 +14,7 @@
 
 use crate::util::{Mutex, RwLock};
 use std::fs::File;
-use std::net::{SocketAddr, TcpStream};
+use std::net::{Shutdown, SocketAddr, TcpStream};
 use std::sync::Arc;
 
 use crate::conn;
@@ -71,8 +71,21 @@ impl Peer {
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		let info = hs.accept(capab, total_difficulty, conn)?;
-		Ok(Peer::new(info, adapter))
+		debug!(
+			"p2p::peer::accept: connection from {:?}",
+			conn.peer_addr()
+		);
+		let info = hs.accept(capab, total_difficulty, conn);
+		match info {
+			Ok(peer_info) => Ok(Peer::new(peer_info, adapter)),
+			Err(e) => {
+				debug!("p2p::peer::accept: fail with error: {:?}", e);
+				if let Err(e) = conn.shutdown(Shutdown::Both) {
+					debug!("Error shutting down conn: {:?}", e);
+				}
+				Err(e)
+			}
+		}
 	}
 
 	pub fn connect(
@@ -83,8 +96,21 @@ impl Peer {
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		let info = hs.initiate(capab, total_difficulty, self_addr, conn)?;
-		Ok(Peer::new(info, na))
+		debug!(
+			"p2p::peer::connect: connecting to {:?}",
+			conn.peer_addr()
+		);
+		let info = hs.initiate(capab, total_difficulty, self_addr, conn);
+		match info {
+			Ok(peer_info) => Ok(Peer::new(peer_info, na)),
+			Err(e) => {
+				debug!("p2p::peer::connect: fail with error: {:?}", e);
+				if let Err(e) = conn.shutdown(Shutdown::Both) {
+					debug!("Error shutting down conn: {:?}", e);
+				}
+				Err(e)
+			}
+		}
 	}
 
 	/// Main peer loop listening for messages and forwarding to the rest of the

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -76,8 +76,11 @@ impl Peer {
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, adapter)),
 			Err(e) => {
-				debug!("accept: connection from {:?} failed with error: {:?}",
-					   conn.peer_addr(), e);
+				debug!(
+					"accept: connection from {:?} failed with error: {:?}",
+					conn.peer_addr(),
+					e
+				);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {
 					debug!("Error shutting down conn: {:?}", e);
 				}
@@ -99,8 +102,11 @@ impl Peer {
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, na)),
 			Err(e) => {
-				debug!("connect: connecting to {:?} failed with error: {:?}",
-					   conn.peer_addr(), e);
+				debug!(
+					"connect: connecting to {:?} failed with error: {:?}",
+					conn.peer_addr(),
+					e
+				);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {
 					debug!("Error shutting down conn: {:?}", e);
 				}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -126,7 +126,9 @@ impl Server {
 
 		trace!(
 			"connect_peer: on {}:{}. connecting to {}",
-			self.config.host, self.config.port, addr
+			self.config.host,
+			self.config.port,
+			addr
 		);
 		match TcpStream::connect_timeout(addr, Duration::from_secs(10)) {
 			Ok(mut stream) => {

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -113,10 +113,7 @@ impl Server {
 			let hs = self.handshake.clone();
 			let addrs = hs.addrs.read();
 			if addrs.contains(&addr) {
-				debug!(
-					"connect: ignore connecting to PeerWithSelf, addr: {}",
-					addr
-				);
+				debug!("connect: ignore connecting to PeerWithSelf, addr: {}", addr);
 				return Err(Error::PeerWithSelf);
 			}
 		}
@@ -129,9 +126,7 @@ impl Server {
 
 		debug!(
 			"p2p::serv::connect_peer: on {}:{}. connecting to {}",
-			self.config.host,
-			self.config.port,
-			addr
+			self.config.host, self.config.port, addr
 		);
 		match TcpStream::connect_timeout(addr, Duration::from_secs(10)) {
 			Ok(mut stream) => {

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -114,7 +114,7 @@ impl Server {
 			let addrs = hs.addrs.read();
 			if addrs.contains(&addr) {
 				debug!(
-					"connect: ignore the connecting to PeerWithSelf, addr: {}",
+					"connect: ignore connecting to PeerWithSelf, addr: {}",
 					addr
 				);
 				return Err(Error::PeerWithSelf);
@@ -127,8 +127,8 @@ impl Server {
 			return Ok(p);
 		}
 
-		trace!(
-			"connect_peer: on {}:{}. connecting to {}",
+		debug!(
+			"p2p::serv::connect_peer: on {}:{}. connecting to {}",
 			self.config.host,
 			self.config.port,
 			addr

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -124,8 +124,8 @@ impl Server {
 			return Ok(p);
 		}
 
-		debug!(
-			"p2p::serv::connect_peer: on {}:{}. connecting to {}",
+		trace!(
+			"connect_peer: on {}:{}. connecting to {}",
 			self.config.host, self.config.port, addr
 		);
 		match TcpStream::connect_timeout(addr, Duration::from_secs(10)) {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -303,15 +303,13 @@ fn listen_for_addrs(
 		let p2p_c = p2p.clone();
 		let _ = thread::Builder::new()
 			.name("peer_connect".to_string())
-			.spawn(move || {
-				match p2p_c.connect(&addr) {
-					Ok(p) => {
-						let _ = p.send_peer_request(capab);
-						let _ = peers_c.update_state(addr, p2p::State::Healthy);
-					}
-					Err(_) => {
-						let _ = peers_c.update_state(addr, p2p::State::Defunct);
-					}
+			.spawn(move || match p2p_c.connect(&addr) {
+				Ok(p) => {
+					let _ = p.send_peer_request(capab);
+					let _ = peers_c.update_state(addr, p2p::State::Healthy);
+				}
+				Err(_) => {
+					let _ = peers_c.update_state(addr, p2p::State::Defunct);
 				}
 			});
 	}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -305,7 +305,12 @@ fn listen_for_addrs(
 			.name("peer_connect".to_string())
 			.spawn(move || {
 				// connect and retry on fail, but for 3 times at most
-				for _ in 0..3 {
+				for i in 0..3 {
+					debug!(
+						"seed::listen_for_addrs: connecting to {}. trying no.{}",
+						addr, i
+					);
+
 					match p2p_c.connect(&addr) {
 						Ok(p) => {
 							let _ = p.send_peer_request(capab);


### PR DESCRIPTION
To close #2258 

- The ***main improvement*** is closing TCP stream on fail of peer connect / accept
- Another correction, (not directly related to this issue), is removing the unnecessary 3 times retry for peer connection request, which was imported by me before, but I think I was over worried on the connection request, since we have 10s timeout for a TCP connecting request:
```
TcpStream::connect_timeout(addr, Duration::from_secs(10))
```
And it doesn't make sense to retry in 1 second on any error, and we already have a resurrection mechanism for those `p2p::State::Defunct` peers. 