### PR TITLE
feature: Enable setting a node address for a dandelion peer

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -230,6 +230,10 @@ fn comments() -> HashMap<String, String> {
 
 # 15 = Bit flags for FULL_NODE
 #This structure needs to be changed internally, to make it more configurable
+
+# A prefered dandelion_peer, mainly used for testing dandelion
+# dandelion_peer = \"10.0.0.1:13144\"
+
 "
 		.to_string(),
 	);

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -124,6 +124,8 @@ pub struct P2PConfig {
 	pub peer_max_count: Option<u32>,
 
 	pub peer_min_preferred_count: Option<u32>,
+
+	pub dandelion_peer: Option<SocketAddr>,
 }
 
 /// Default address for peer-to-peer connections.
@@ -142,6 +144,7 @@ impl Default for P2PConfig {
 			ban_window: None,
 			peer_max_count: None,
 			peer_min_preferred_count: None,
+			dandelion_peer: None
 		}
 	}
 }


### PR DESCRIPTION
So this should address https://github.com/mimblewimble/grin/issues/1250
I don't have too much experience with rust so not sure if this is the right way to do it.
I also don't have much idea as to the best way to test this, what's the best way to go about it?