### PR TITLE
support floonet, separate entrypoint from cmd, add docker volume

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -96,15 +96,15 @@ grin client help
 ```sh
 docker build -t grin -f etc/Dockerfile .
 ```
-for floonet, use `etc/Dockerfile.floonet` instead
+For floonet, use `etc/Dockerfile.floonet` instead
 
 You can bind-mount your grin cache to run inside the container.
 
 ```sh
 docker run -it -d -v $HOME/.grin:/root/.grin grin
 ```
-if you prefer to use a docker named volume, you can pass `-v dotgrin:/root/.grin` instead.
-Using a named volume copies a default grin-server.toml
+If you prefer to use a docker named volume, you can pass `-v dotgrin:/root/.grin` instead.
+Using a named volume copies default configurations upon volume creation
 
 ## Cross-platform builds
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -96,12 +96,15 @@ grin client help
 ```sh
 docker build -t grin -f etc/Dockerfile .
 ```
+for floonet, use `etc/Dockerfile.floonet` instead
 
 You can bind-mount your grin cache to run inside the container.
 
 ```sh
 docker run -it -d -v $HOME/.grin:/root/.grin grin
 ```
+if you prefer to use a docker named volume, you can pass `-v dotgrin:/root/.grin` instead.
+Using a named volume copies a default grin-server.toml
 
 ## Cross-platform builds
 

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -36,9 +36,18 @@ ENV LANG en_US.UTF-8
 COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 
 WORKDIR /root/.grin
-RUN grin server config && \
+
+ARG grinnet=""
+
+RUN grin ${grinnet} server config && \
     sed -i -e 's/run_tui = true/run_tui = false/' grin-server.toml
+
+VOLUME ["/root/.grin"]
 
 EXPOSE 13413 13414 13415 13416
 
-ENTRYPOINT ["grin", "server", "run"]
+EXPOSE 3413 3414 3415 3416
+
+ENTRYPOINT ["grin"]
+
+CMD ["server", "run"]

--- a/etc/Dockerfile.floonet
+++ b/etc/Dockerfile.floonet
@@ -37,13 +37,13 @@ COPY --from=builder /usr/src/grin/target/release/grin /usr/local/bin/grin
 
 WORKDIR /root/.grin
 
-RUN grin server config && \
+RUN grin --floonet server config && \
     sed -i -e 's/run_tui = true/run_tui = false/' grin-server.toml
 
 VOLUME ["/root/.grin"]
 
-EXPOSE 3413 3414 3415 3416
+EXPOSE 13413 13414 13415 13416
 
-ENTRYPOINT ["grin"]
+ENTRYPOINT ["grin", "--floonet"]
 
 CMD ["server", "run"]


### PR DESCRIPTION
* Support floonet as a buildtime ARG
* Separate entrypoint from cmd, allowing the use of different grin sub-commands on `docker run`
* Adding a docker volume to hold state