### PR TITLE
fix: check_banned must care about ip address only, and ignore the peer port info

### DIFF
--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -162,6 +162,17 @@ impl PeerStore {
 		peers.iter().take(count).cloned().collect()
 	}
 
+	/// Query all peers with same IP address, and ignore the port
+	pub fn find_peers_by_ip(&self, peer_addr: SocketAddr) -> Vec<PeerData> {
+		self.db
+			.iter::<PeerData>(&to_key(
+				PEER_PREFIX,
+				&mut format!("{}", peer_addr.ip()).into_bytes(),
+			))
+			.unwrap()
+			.collect::<Vec<_>>()
+	}
+
 	/// List all known peers
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Vec<PeerData> {


### PR DESCRIPTION
To close https://github.com/mimblewimble/grin/issues/2241 again.

Please refer to https://github.com/mimblewimble/grin/issues/2241#issuecomment-450652666 and https://github.com/mimblewimble/grin/issues/2241#issuecomment-450704362 for the detail info.