### PR TITLE
fix: peer connect panic on log

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -97,14 +97,14 @@ impl Peer {
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
-		debug!("connect: handshaking with {:?}", conn.peer_addr().unwrap());
+		debug!("connect: handshaking with {:?}", conn.peer_addr());
 		let info = hs.initiate(capab, total_difficulty, self_addr, conn);
 		match info {
 			Ok(peer_info) => Ok(Peer::new(peer_info, na)),
 			Err(e) => {
 				debug!(
 					"connect: handshaking with {:?} failed with error: {:?}",
-					conn.peer_addr().unwrap(),
+					conn.peer_addr(),
 					e
 				);
 				if let Err(e) = conn.shutdown(Shutdown::Both) {


### PR DESCRIPTION
Two reports in Gitter lobby on this panic error:
```
thread 'peer_connect' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }': libcore/result.rs:1009stack backtrace:
```
I got the log file and find 97 such panic errors in 24 hours.

I guess the related code is:
```
		debug!("connect: handshaking with {:?}", conn.peer_addr().unwrap());
```
which is just imported in a recent PR.

So, let's remove that `unwrap()`.