### PR TITLE
Don't clean unconfirmed outputs > 500 blocks old

### DIFF
--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -309,14 +309,14 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	if height < 500 {
+	if height < 50 {
 		return Ok(());
 	}
 	let mut ids_to_del = vec![];
 	for out in wallet.iter() {
 		if out.status == OutputStatus::Unconfirmed
 			&& out.height > 0
-			&& out.height < height - 500
+			&& out.height < height - 50
 			&& out.is_coinbase
 		{
 			ids_to_del.push(out.key_id.clone())


### PR DESCRIPTION
This is the obvious cause of https://github.com/mimblewimble/grin/issues/2228, and the cleaning is a holdover from when we didn't have a transaction log or async transactions or any other ways to clean up unconfirmed outputs. Obviously this is too restrictive now.

I think we may want to think about TTLs (that are just enforced by the default wallet code, at least), but for now I think cleaning up mining outputs from the past 50 blocks is a sufficient fix.