### PR TITLE
Clean existing sockets when accept new p2p connection with same address

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -118,6 +118,16 @@ impl Peers {
 		self.peers.read().contains_key(addr)
 	}
 
+	/// Check whether peer's ip address is in the active peers list, ignore the port
+	pub fn is_known_ip(&self, addr: &SocketAddr) -> bool {
+		for socket in self.peers.read().keys() {
+			if addr.ip() == socket.ip() {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	/// Get vec of peers we are currently connected to.
 	pub fn connected_peers(&self) -> Vec<Arc<Peer>> {
 		let mut res = self

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -247,8 +247,7 @@ fn check_existing_socket(peer_addr: SocketAddr, sockets: &mut HashMap<SocketAddr
 			if let Ok(_) = stream.shutdown(Shutdown::Both) {
 				debug!(
 					"check_existing_socket - close an old open socket: {}, before accept new: {}",
-					socket,
-					peer_addr,
+					socket, peer_addr,
 				);
 			}
 			existing_sockets.push(socket.clone());


### PR DESCRIPTION
Still suffering on the full connection problem on seed servers, which force me restart grin server several times every day (I don't want to schedule a periodic auto-restart).

Examples:
```
tcp        0      0 10.142.0.2:13414        40.114.250.29:2944      SYN_RECV   
tcp        0      0 10.142.0.2:13414        40.114.250.29:2946      SYN_RECV   
tcp        0      0 10.142.0.2:13414        40.114.250.29:2947      SYN_RECV   
tcp        0      0 10.142.0.2:13414        40.114.250.29:2948      SYN_RECV   
```
```
tcp        0      0 10.142.0.2:13414        35.185.101.157:39166    SYN_RECV   
tcp        0      0 10.142.0.2:13414        35.185.101.157:39182    SYN_RECV   
tcp        0      0 10.142.0.2:13414        35.185.101.157:39246    SYN_RECV   
```
```
tcp        0      0 10.142.0.2:13414        117.50.56.131:45802     SYN_RECV   
tcp        0      0 10.142.0.2:13414        117.50.56.131:45922     SYN_RECV   
tcp        0      0 10.142.0.2:13414        117.50.56.131:45992     SYN_RECV   
... 
tcp        0      0 10.142.0.2:13414        117.50.56.131:46136     SYN_RECV   
```
Or even in 'ESTABLISHED` state:
```
tcp        0    102 45.118.135.254:51034    45.76.0.106:13414       ESTABLISHED
tcp        0    102 45.118.135.254:51182    45.76.0.106:13414       ESTABLISHED
tcp        0    102 45.118.135.254:53060    45.32.188.238:13414     ESTABLISHED
tcp        0    102 45.118.135.254:53110    45.32.188.238:13414     ESTABLISHED
```

I test with this PR, and finally it's clean, no more wasted tcp connections, the `13414` port connections number is always same (or very close) as the peers number.

The basic idea is putting a clean-up function on every peer connection accept, if same IP address is found in the saved list, then we close the old stream before accept new connection.

And another clean-up for the saved socket addresses: if it's not in the peers list, we clean it also to close tcp connection, since it will never be used. Somehow, we leaked some connections, but I still don't know where.
