### PR TITLE
fix: shutdown the tcpstream when we initiate to close a peer connection

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -22,7 +22,7 @@
 
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::net::TcpStream;
+use std::net::{Shutdown, TcpStream};
 use std::sync::{mpsc, Arc};
 use std::{cmp, thread, time};
 
@@ -291,6 +291,7 @@ fn poll<H>(
 							.map(|a| a.to_string())
 							.unwrap_or("?".to_owned())
 					);
+					let _ = conn.shutdown(Shutdown::Both);
 					break;
 				}
 


### PR DESCRIPTION
Based on https://github.com/mimblewimble/grin/pull/2287 's a test log, perhaps I find one leaking point for peer connections:
```
20190104 05:15:29.510 DEBUG grin_p2p::peer - Send tx kernel hash 133cc0ab to 47.99.92.164:13414
20190104 05:15:33.058 DEBUG grin_p2p::peer - Client 47.99.92.164:13414 connection lost: Connection(Custom { kind: ConnectionAborted, error: StringError("read_exact") })
20190104 05:15:50.546 DEBUG grin_p2p::peers - clean_peers V4(47.99.92.164:13414), not connected
20190104 05:22:28.466 DEBUG grin_p2p::serv - clean_lost_sockets - close a lost open socket: 47.99.92.164:58462, not in peers list
```
that means when we quit the peer polling thread, we forgot to close the socket:
```
	// check the close channel
	if let Ok(_) = close_rx.try_recv() {
		debug!(
			"Connection close with {} initiated by us",
			...
		);
		break;    <<<< problem here!  we just quit without a real close!
	}
```
