### PR TITLE
feat: Configuration option to include foreign API endpoints in the owner API

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -394,6 +394,15 @@ fn comments() -> HashMap<String, String> {
 		.to_string(),
 	);
 	retval.insert(
+		"owner_api_include_foreign".to_string(),
+		"
+#include the foreign API endpoints on the same port as the owner
+#API. Useful for networking environments like AWS ECS that make
+#it difficult to access multiple ports on a single service.
+"
+		.to_string(),
+	);
+	retval.insert(
 		"data_file_dir".to_string(),
 		"
 #where to find wallet files (seed, data, etc)

--- a/doc/api/wallet_owner_api.md
+++ b/doc/api/wallet_owner_api.md
@@ -13,6 +13,7 @@
     1. [POST Cancel Tx](#post-cancel-tx)
     1. [POST Post Tx](#post-post-tx)
     1. [POST Issue Burn Tx](#post-issue-burn-tx)
+    1. [Adding Foreign API Endpoints](#add-foreign-api-endpoints)
 
 ## Wallet Owner Endpoint
 
@@ -681,3 +682,7 @@ Issue a burn TX.
       }
     });
   ```
+
+### Add Foreign API Endpoints
+
+For some environments it may be convenient to have the [wallet foreign API](wallet_foreign_api.md) available on the same port as the owner API.  You can do so by setting the `owner_api_include_foreign` configuration setting to `true`.

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -494,9 +494,9 @@ pub fn wallet_command(
 		("owner_api", Some(_)) => {
 			let mut g = global_wallet_args.clone();
 			g.tls_conf = None;
-			command::owner_api(inst_wallet(), &g)
+			command::owner_api(inst_wallet(), &wallet_config, &g)
 		}
-		("web", Some(_)) => command::owner_api(inst_wallet(), &global_wallet_args),
+		("web", Some(_)) => command::owner_api(inst_wallet(), &wallet_config, &global_wallet_args),
 		("account", Some(args)) => {
 			let a = arg_parse!(parse_account_args(&args));
 			command::account(inst_wallet(), a)

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -127,6 +127,7 @@ pub fn listen(config: &WalletConfig, args: &ListenArgs, g_args: &GlobalArgs) -> 
 
 pub fn owner_api(
 	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	config: &WalletConfig,
 	g_args: &GlobalArgs,
 ) -> Result<(), Error> {
 	let res = controller::owner_listener(
@@ -134,6 +135,7 @@ pub fn owner_api(
 		"127.0.0.1:13420",
 		g_args.node_api_secret.clone(),
 		g_args.tls_conf.clone(),
+		config.owner_api_include_foreign.clone(),
 	);
 	if let Err(e) = res {
 		return Err(ErrorKind::LibWallet(e.kind(), e.cause_string()).into());

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -48,6 +48,8 @@ pub struct WalletConfig {
 	// The api address of a running server node against which transaction inputs
 	// will be checked during send
 	pub check_node_api_http_addr: String,
+	// Whether to include foreign API endpoints on the Owner API
+	pub owner_api_include_foreign: Option<bool>,
 	// The directory in which wallet files are stored
 	pub data_file_dir: String,
 	/// TLS certificate file
@@ -70,6 +72,7 @@ impl Default for WalletConfig {
 			api_secret_path: Some(".api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
+			owner_api_include_foreign: Some(false),
 			data_file_dir: ".".to_string(),
 			tls_certificate_file: None,
 			tls_certificate_key: None,


### PR DESCRIPTION
This pull request adds an `owner_api_include_foreign` wallet configuration option to make endpoints from the [Foreign API](https://github.com/mimblewimble/grin/blob/master/doc/api/wallet_foreign_api.md) available over the same port as the [Owner API](https://github.com/mimblewimble/grin/blob/master/doc/api/wallet_owner_api.md).

A few notes on the actual change:
- This feature is useful when running the wallet in environments that make it difficult to access multiple ports on the same container.  In particular, Amazon's ECS and the various Amazon load balancers make it very difficult to have multiple ports open on the same container.
- The feature defaults to false.
- There shouldn't be any overlapping paths because the Foreign API endpoints start with `/v1/wallet/foreign` and the Owner API endpoints start with `/v1/wallet/owner/`.
- I do not believe there are any security concerns about setting the configuration option, because presumably anyone trusted to access the Owner API (which can perform arbitrary sends) is trusted to access the Foreign API.

I have added a basic integration test to make sure setting the configuration option on/off works as expected.  This involved making some changes to the test harness, so I've separated the changes for the tests into a separate commit in case those changes are problematic.

This is my first PR to this repository, so as usual please let me know if I'm missing anything major from the PR or description.  Thanks!