### PR TITLE
fix: connection close should stay outside the poll loop

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -291,11 +291,11 @@ fn poll<H>(
 							.map(|a| a.to_string())
 							.unwrap_or("?".to_owned())
 					);
-					let _ = conn.shutdown(Shutdown::Both);
 					break;
 				}
 
 				thread::sleep(sleep_time);
 			}
+			let _ = conn.shutdown(Shutdown::Both);
 		});
 }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -526,7 +526,9 @@ impl TrackingAdapter {
 		if known.len() > MAX_TRACK_SIZE {
 			known.truncate(MAX_TRACK_SIZE);
 		}
-		known.insert(0, hash);
+		if !known.contains(&hash) {
+			known.insert(0, hash);
+		}
 	}
 }
 


### PR DESCRIPTION
Really don't like the macro!  I just realize that `try_break` macro will break the poll loop, that means in case of error, we send error message to `error_tx`, and rely on `peer::check_connection` to get this error and then call `stop_with_connection`, and then send a message in `close_channel`, but at this time, unfortunately the `close_channel` (i.e. `close_rx` in `conn::poll`) will never be read, because poll thread already exit!

So, let's move that `conn.shutdown` to the outside of poll loop, to make sure an error connection is cleaned.

Another modification in this PR for peer is a small improvement to not cache the ***duplicated*** hash (for received header/block/compact_block/tx) from a peer.
