### PR TITLE
add https as optional for server api

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -86,7 +86,14 @@ pub fn start_rest_apis(
 
 	info!("Starting HTTP API server at {}.", addr);
 	let socket_addr: SocketAddr = addr.parse().expect("unable to parse socket address");
-	apis.start(socket_addr, router, tls_config).is_ok()
+	let res = apis.start(socket_addr, router, tls_config);
+	match res {
+		Ok(_) => true,
+		Err(e) => {
+			error!("HTTP API server failed to start. Err: {}", e);
+			false
+		}
+	}
 }
 
 pub fn build_router(

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -43,6 +43,11 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"api_http_addr".to_string(),
 		"
+#path of TLS certificate file, self-signed certificates are not supported
+#tls_certificate_file = \"\"
+#private key for the TLS certificate
+#tls_certificate_key = \"\"
+
 #the address on which services will listen, e.g. Transaction Pool
 "
 		.to_string(),

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -46,6 +46,8 @@ pub enum Error {
 	Cuckoo(pow::Error),
 	/// Error originating from the transaction pool.
 	Pool(pool::PoolError),
+	/// Invalid Arguments.
+	ArgumentError(String),
 }
 
 impl From<core::block::Error> for Error {
@@ -124,6 +126,11 @@ pub struct ServerConfig {
 	/// Location of secret for basic auth on Rest API HTTP server.
 	pub api_secret_path: Option<String>,
 
+	/// TLS certificate file
+	pub tls_certificate_file: Option<String>,
+	/// TLS certificate private key file
+	pub tls_certificate_key: Option<String>,
+
 	/// Setup the server for tests, testnet or mainnet
 	#[serde(default)]
 	pub chain_type: ChainTypes,
@@ -174,6 +181,8 @@ impl Default for ServerConfig {
 			db_root: "grin_chain".to_string(),
 			api_http_addr: "127.0.0.1:3413".to_string(),
 			api_secret_path: Some(".api_secret".to_string()),
+			tls_certificate_file: None,
+			tls_certificate_key: None,
 			p2p_config: p2p::P2PConfig::default(),
 			dandelion_config: pool::DandelionConfig::default(),
 			stratum_mining_config: Some(StratumServerConfig::default()),


### PR DESCRIPTION
As the optional config, more safe for grin servers with server API exposed on public network.