### PR TITLE
Wallet - only update outputs with unconfirmed transactions outstanding

### DIFF
--- a/servers/tests/framework.rs
+++ b/servers/tests/framework.rs
@@ -349,7 +349,7 @@ impl LocalServerContainer {
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let parent_id = keychain::ExtKeychain::derive_key_id(2, 0, 0, 0, 0);
-		let _ = wallet::libwallet::internal::updater::refresh_outputs(&mut wallet, &parent_id);
+		let _ = wallet::libwallet::internal::updater::refresh_outputs(&mut wallet, &parent_id, false);
 		wallet::libwallet::internal::updater::retrieve_info(&mut wallet, &parent_id, 1).unwrap()
 	}
 

--- a/servers/tests/framework.rs
+++ b/servers/tests/framework.rs
@@ -349,7 +349,8 @@ impl LocalServerContainer {
 			.unwrap_or_else(|e| panic!("Error creating wallet: {:?} Config: {:?}", e, config));
 		wallet.keychain = Some(keychain);
 		let parent_id = keychain::ExtKeychain::derive_key_id(2, 0, 0, 0, 0);
-		let _ = wallet::libwallet::internal::updater::refresh_outputs(&mut wallet, &parent_id, false);
+		let _ =
+			wallet::libwallet::internal::updater::refresh_outputs(&mut wallet, &parent_id, false);
 		wallet::libwallet::internal::updater::retrieve_info(&mut wallet, &parent_id, 1).unwrap()
 	}
 

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -587,7 +587,7 @@ pub fn wallet_command(
 			command::cancel(inst_wallet(), a)
 		}
 		("restore", Some(_)) => command::restore(inst_wallet()),
-		("check_repair", Some(_)) => command::check_repair(inst_wallet()),
+		("check", Some(_)) => command::check_repair(inst_wallet()),
 		_ => {
 			let msg = format!("Unknown wallet command, use 'grin help wallet' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -462,7 +462,7 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		let arg_vec = vec!["grin", "wallet", "-p", "password", "check_repair"];
+		let arg_vec = vec!["grin", "wallet", "-p", "password", "check"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
 		// txs and outputs (mostly spit out for a visual in test logs)

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -294,6 +294,6 @@ subcommands:
                   takes_value: false
         - restore:
             about: Restores a wallet contents from a seed file
-        - check_repair:
+        - check:
             about: Checks a wallet's outputs against a live node, repairing and restoring missing outputs if required
  

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -501,14 +501,16 @@ pub fn check_repair(
 	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
+		warn!("Starting wallet check...",);
+		warn!("Updating all wallet outputs, please wait ...",);
 		let result = api.check_repair();
 		match result {
 			Ok(_) => {
-				warn!("Wallet check/repair complete",);
+				warn!("Wallet checkr complete",);
 				Ok(())
 			}
 			Err(e) => {
-				error!("Wallet check/repair failed: {}", e);
+				error!("Wallet check failed: {}", e);
 				error!("Backtrace: {}", e.backtrace().unwrap());
 				Err(e)
 			}

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -506,7 +506,7 @@ pub fn check_repair(
 		let result = api.check_repair();
 		match result {
 			Ok(_) => {
-				warn!("Wallet checkr complete",);
+				warn!("Wallet check complete",);
 				Ok(())
 			}
 			Err(e) => {

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -348,7 +348,7 @@ where
 
 		let mut validated = false;
 		if refresh_from_node {
-			validated = self.update_outputs(&mut w);
+			validated = self.update_outputs(&mut w, false);
 		}
 
 		let res = Ok((
@@ -426,7 +426,7 @@ where
 
 		let mut validated = false;
 		if refresh_from_node {
-			validated = self.update_outputs(&mut w);
+			validated = self.update_outputs(&mut w, false);
 		}
 
 		let res = Ok((
@@ -498,7 +498,7 @@ where
 
 		let mut validated = false;
 		if refresh_from_node {
-			validated = self.update_outputs(&mut w);
+			validated = self.update_outputs(&mut w, false);
 		}
 
 		let wallet_info = updater::retrieve_info(&mut *w, &parent_key_id, minimum_confirmations)?;
@@ -708,7 +708,7 @@ where
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 		let parent_key_id = w.parent_key_id();
-		if !self.update_outputs(&mut w) {
+		if !self.update_outputs(&mut w, false) {
 			return Err(ErrorKind::TransactionCancellationError(
 				"Can't contact running Grin node. Not Cancelling.",
 			))?;
@@ -765,7 +765,7 @@ where
 	pub fn check_repair(&mut self) -> Result<(), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		self.update_outputs(&mut w);
+		self.update_outputs(&mut w, true);
 		w.check_repair()?;
 		w.close()?;
 		Ok(())
@@ -792,9 +792,9 @@ where
 	}
 
 	/// Attempt to update outputs in wallet, return whether it was successful
-	fn update_outputs(&self, w: &mut W) -> bool {
+	fn update_outputs(&self, w: &mut W, update_all: bool) -> bool {
 		let parent_key_id = w.parent_key_id();
-		match updater::refresh_outputs(&mut *w, &parent_key_id) {
+		match updater::refresh_outputs(&mut *w, &parent_key_id, update_all) {
 			Ok(_) => true,
 			Err(_) => false,
 		}

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -217,6 +217,44 @@ where
 	Ok(())
 }
 
+///
+fn confirm_tx_log_entry<T, C, K>(wallet: &mut T, output: &OutputData) -> Result<(), Error>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
+	let parent_key_id = output.key_id.parent_path();
+	let updated_tx_entry = if output.tx_log_entry.is_some() {
+		let entries = updater::retrieve_txs(
+			wallet,
+			output.tx_log_entry.clone(),
+			None,
+			Some(&parent_key_id),
+		)?;
+		if entries.len() > 0 {
+			let mut entry = entries[0].clone();
+			entry.confirmed = true;
+			entry.update_confirmation_ts();
+			match entry.tx_type {
+				TxLogEntryType::TxSentCancelled => entry.tx_type = TxLogEntryType::TxSent,
+				TxLogEntryType::TxReceivedCancelled => entry.tx_type = TxLogEntryType::TxReceived,
+				_ => {}
+			}
+			Some(entry)
+		} else {
+			None
+		}
+	} else {
+		None
+	};
+	let mut batch = wallet.batch()?;
+	if let Some(t) = updated_tx_entry {
+		batch.save_tx_log_entry(t, &parent_key_id)?;
+	}
+	batch.commit()?;
+	Ok(())
+}
 /// Check / repair wallet contents
 /// assume wallet contents have been freshly updated with contents
 /// of latest block
@@ -240,10 +278,25 @@ where
 		res
 	};
 
-	// check all definitive outputs exist in the wallet outputs
 	let mut missing_outs = vec![];
 	let mut accidental_spend_outs = vec![];
 	let mut locked_outs = vec![];
+	let mut spent_outs = vec![];
+
+	// check for outputs that have been spent but not marked as such
+	// small chance this can happen if a user cancels a transaction but then
+	// posts it anyhow
+	for o in wallet_outputs.iter() {
+		if o.0.status == OutputStatus::Locked || o.0.status == OutputStatus::Unspent {
+			let matched_out = chain_outs.iter().find(|wo| wo.key_id == o.0.key_id);
+			match matched_out {
+				Some(_) => {}
+				None => spent_outs.push(o.0.clone()),
+			}
+		}
+	}
+
+	// check all definitive outputs exist in the wallet outputs
 	for deffo in chain_outs.into_iter() {
 		let matched_out = wallet_outputs.iter().find(|wo| wo.0.key_id == deffo.key_id);
 		match matched_out {
@@ -270,6 +323,21 @@ where
 		o.status = OutputStatus::Unspent;
 		// any transactions associated with this should be cancelled
 		cancel_tx_log_entry(wallet, &o)?;
+		let mut batch = wallet.batch()?;
+		batch.save(o)?;
+		batch.commit()?;
+	}
+
+	// Remove any spent outputs that shouldn't exist
+	for mut o in spent_outs.into_iter() {
+		warn!(
+			"Output for {} with ID {} marked as Unspent but doesn't exist in UTXO set. \
+			 Marking as spent and marking associated transaction confirmed.",
+			o.value, o.key_id,
+		);
+		o.status = OutputStatus::Spent;
+		// any transactions associated with this should be cancelled
+		confirm_tx_log_entry(wallet, &o)?;
 		let mut batch = wallet.batch()?;
 		batch.save(o)?;
 		batch.commit()?;

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -85,7 +85,7 @@ where
 	// Get lock height
 	let current_height = wallet.w2n_client().get_chain_height()?;
 	// ensure outputs we're selecting are up to date
-	updater::refresh_outputs(wallet, parent_key_id)?;
+	updater::refresh_outputs(wallet, parent_key_id, false)?;
 
 	let lock_height = current_height;
 

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -153,8 +153,7 @@ where
 
 	// Only select outputs that are actually involved in an outstanding transaction
 	let unspents: Vec<OutputData> = match update_all {
-		false => {
-			unspents
+		false => unspents
 			.into_iter()
 			.filter(|x| match x.tx_log_entry.as_ref() {
 				Some(t) => {
@@ -170,11 +169,8 @@ where
 				}
 				None => true,
 			})
-			.collect()
-		},
-		true => {
-			unspents
-		}
+			.collect(),
+		true => unspents,
 	};
 
 	for out in unspents {

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -120,6 +120,7 @@ where
 pub fn refresh_outputs<T: ?Sized, C, K>(
 	wallet: &mut T,
 	parent_key_id: &Identifier,
+	update_all: bool,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
@@ -127,7 +128,7 @@ where
 	K: Keychain,
 {
 	let height = wallet.w2n_client().get_chain_height()?;
-	refresh_output_state(wallet, height, parent_key_id)?;
+	refresh_output_state(wallet, height, parent_key_id, update_all)?;
 	Ok(())
 }
 
@@ -136,6 +137,7 @@ where
 pub fn map_wallet_outputs<T: ?Sized, C, K>(
 	wallet: &mut T,
 	parent_key_id: &Identifier,
+	update_all: bool,
 ) -> Result<HashMap<pedersen::Commitment, Identifier>, Error>
 where
 	T: WalletBackend<C, K>,
@@ -150,23 +152,30 @@ where
 		.collect();
 
 	// Only select outputs that are actually involved in an outstanding transaction
-	let unspents: Vec<OutputData> = unspents
-		.into_iter()
-		.filter(|x| match x.tx_log_entry.as_ref() {
-			Some(t) => {
-				let entries = retrieve_txs(wallet, Some(*t), None, Some(&parent_key_id));
-				match entries {
-					Err(_) => true,
-					Ok(e) => {
-						e.len() > 0
-							&& !e[0].confirmed && (e[0].tx_type == TxLogEntryType::TxReceived
-							|| e[0].tx_type == TxLogEntryType::TxSent)
+	let unspents: Vec<OutputData> = match update_all {
+		false => {
+			unspents
+			.into_iter()
+			.filter(|x| match x.tx_log_entry.as_ref() {
+				Some(t) => {
+					let entries = retrieve_txs(wallet, Some(*t), None, Some(&parent_key_id));
+					match entries {
+						Err(_) => true,
+						Ok(e) => {
+							e.len() > 0
+								&& !e[0].confirmed && (e[0].tx_type == TxLogEntryType::TxReceived
+								|| e[0].tx_type == TxLogEntryType::TxSent)
+						}
 					}
 				}
-			}
-			None => true,
-		})
-		.collect();
+				None => true,
+			})
+			.collect()
+		},
+		true => {
+			unspents
+		}
+	};
 
 	for out in unspents {
 		let commit = keychain.commit(out.value, &out.key_id)?;
@@ -296,6 +305,7 @@ fn refresh_output_state<T: ?Sized, C, K>(
 	wallet: &mut T,
 	height: u64,
 	parent_key_id: &Identifier,
+	update_all: bool,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
@@ -306,7 +316,7 @@ where
 
 	// build a local map of wallet outputs keyed by commit
 	// and a list of outputs we want to query the node for
-	let wallet_outputs = map_wallet_outputs(wallet, parent_key_id)?;
+	let wallet_outputs = map_wallet_outputs(wallet, parent_key_id, update_all)?;
 
 	let wallet_output_keys = wallet_outputs.keys().map(|commit| commit.clone()).collect();
 


### PR DESCRIPTION
This should go _some_ (not all) the way towards improving wallet performance. Instead of blindly querying the server with all outputs in the wallet to see if they're spent, only query outputs that are involved in outstanding unconfirmed transactions.

Thinking through the use cases, I don't think this will cause any problems. Perhaps in the case where you cancel a send transaction, then post it anyhow? In this case, you'll have outputs showing up in your wallet as unspent, and a check_repair won't currently catch them as it assumes the output refresh already took care of that (though that's a quick enough case to add to check_repair). Would appreciate if everyone could think a bit about this before we merge this.