### PR TITLE
new mined block should be broadcasted if a node was synced

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -635,10 +635,6 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			}
 		}
 
-		if !self.sync_state.is_synced_once() {
-			return;
-		}
-
 		// If we mined the block then we want to broadcast the compact block.
 		// If we received the block from another node then broadcast "header first"
 		// to minimize network traffic.
@@ -647,6 +643,9 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			let cb: CompactBlock = b.clone().into();
 			self.peers().broadcast_compact_block(&cb);
 		} else {
+			if !self.sync_state.is_synced_once() {
+				return;
+			}
 			// "header first" propagation if we are not the originator of this block
 			self.peers().broadcast_header(&b.header);
 		}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -635,7 +635,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			}
 		}
 
-		if self.sync_state.is_first_syncing() {
+		if !self.sync_state.is_synced_once() {
 			return;
 		}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -635,7 +635,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			}
 		}
 
-		if self.sync_state.is_syncing() {
+		if self.sync_state.is_first_syncing() {
 			return;
 		}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -643,11 +643,10 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 			let cb: CompactBlock = b.clone().into();
 			self.peers().broadcast_compact_block(&cb);
 		} else {
-			if !self.sync_state.is_synced_once() {
-				return;
+			if self.sync_state.is_synced_once() {
+				// "header first" propagation if we are not the originator of this block
+				self.peers().broadcast_header(&b.header);
 			}
-			// "header first" propagation if we are not the originator of this block
-			self.peers().broadcast_header(&b.header);
 		}
 
 		// Reconcile the txpool against the new block *after* we have broadcast it too our peers.

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -303,9 +303,9 @@ impl SyncState {
 		*self.current.read() != SyncStatus::NoSync
 	}
 
-	/// Same as 'is_syncing' except the flag 'synced_once' is true
-	pub fn is_first_syncing(&self) -> bool {
-		*self.current.read() != SyncStatus::NoSync && *self.synced_once.read() == false
+	/// Whether it was synced once after grin running
+	pub fn is_synced_once(&self) -> bool {
+		*self.synced_once.read() == true
 	}
 
 	/// Current syncing status


### PR DESCRIPTION
Re-pickup #2240 

When a well synced node is mining, the new mined block(s) need broadcast, no matter what pulled this node into a sync state again, possibly because of a connected fraud peer with a fake difficulty and height, and not banned yet.

This will protect the grin network from such kind of attacking. 