### PR TITLE
wait_for_min_peers should continue waiting if none connected

### DIFF
--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -87,7 +87,9 @@ impl SyncRunner {
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{
-				break;
+				if wp.len() > 0 {
+					break;
+				}
 			}
 			thread::sleep(time::Duration::from_secs(1));
 			n += 1;

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -18,6 +18,7 @@ use std::time;
 
 use crate::chain;
 use crate::common::types::{SyncState, SyncStatus};
+use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::grin::sync::body_sync::BodySync;
 use crate::grin::sync::header_sync::HeaderSync;
@@ -87,7 +88,7 @@ impl SyncRunner {
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{
-				if wp.len() > 0 {
+				if wp.len() > 0 || !global::is_production_mode() {
 					break;
 				}
 			}


### PR DESCRIPTION
It doesn't make sense to allow grin enter `running` state with `0` connected peers, better to let it wait forever here to connect peers.