### PR TITLE
Fix doc dump_stored_tx -> retrieve_stored_tx

### DIFF
--- a/doc/api/wallet_owner_api.md
+++ b/doc/api/wallet_owner_api.md
@@ -7,7 +7,7 @@
     1. [GET Retrieve Summary Info](#get-retrieve-summary-info)
     1. [GET Node Height](#get-node-height)
     1. [GET Retrieve Txs](#get-retrieve-txs)
-    1. [GET Dump Stored Tx](#get-dump-stored-tx)
+    1. [GET Retrieve Stored Tx](#get-retrieve-stored-tx)
     1. [POST Issue Send Tx](#post-issue-send-tx)
     1. [POST Finalize Tx](#post-finalize-tx)
     1. [POST Cancel Tx](#post-cancel-tx)
@@ -253,13 +253,13 @@ Return whether the outputs were validated against a node and an array of TxLogEn
     });
   ```
 
-### GET Dump Stored Tx
+### GET Retrieve Stored Tx
 
 Retrieves a given transaction.
 
 * **URL**
 
-  /v1/wallet/owner/dump_stored_tx?id=x
+  /v1/wallet/owner/retrieve_stored_tx?id=x
 
 * **Method:**
 
@@ -309,7 +309,7 @@ Retrieves a given transaction.
 
   ```javascript
     $.ajax({
-      url: "/v1/wallet/owner/dump_stored_tx?id=13",
+      url: "/v1/wallet/owner/retrieve_stored_tx?id=13",
       dataType: "json",
       type : "GET",
       success : function(r) {


### PR DESCRIPTION
It appears the method call in https://github.com/mimblewimble/grin/blob/master/wallet/src/controller.rs got renamed for consistency and this got missed.