### PR TITLE
fix: wait peers stage should not wait when all peers are same work

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -183,6 +183,22 @@ impl Peers {
 		max_peers
 	}
 
+	// Return number of connected peers that currently advertise more/same work
+	// (total_difficulty) than/as we do.
+	pub fn more_or_same_work_peers(&self) -> usize {
+		let peers = self.connected_peers();
+		if peers.len() == 0 {
+			return 0;
+		}
+
+		let total_difficulty = self.total_difficulty();
+
+		peers
+			.iter()
+			.filter(|x| x.info.total_difficulty() >= total_difficulty)
+			.count()
+	}
+
 	/// Returns single random peer with more work than us.
 	pub fn more_work_peer(&self) -> Option<Arc<Peer>> {
 		self.more_work_peers().pop()

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -77,18 +77,18 @@ impl SyncRunner {
 		let mut n = 0;
 		const MIN_PEERS: usize = 3;
 		loop {
-			let wp = self.peers.more_work_peers();
+			let wp = self.peers.more_or_same_work_peers();
 			// exit loop when:
-			// * we have more than MIN_PEERS more_work peers
+			// * we have more than MIN_PEERS more_or_same_work peers
 			// * we are synced already, e.g. grin was quickly restarted
 			// * timeout
-			if wp.len() > MIN_PEERS
-				|| (wp.len() == 0
+			if wp > MIN_PEERS
+				|| (wp == 0
 					&& self.peers.enough_peers()
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{
-				if wp.len() > 0 || !global::is_production_mode() {
+				if wp > 0 || !global::is_production_mode() {
 					break;
 				}
 			}


### PR DESCRIPTION
1. In case of mainnet launching practice (`Fake mainnet` test), even set `skip_sync_wait=true`, when the seed node only have genesis block, all connected nodes will wait forever on `waiting more peers...`, and nobody can enter `running` state to mine 1st block. This can be thought as a regression of PR https://github.com/mimblewimble/grin/pull/2326.

2. Actually, the original logic here doesn't make sense, say a well synced grin node is restarted by admin, before this PR the node need wait until get enough `more_work` peers, but actually all connected peers could be in same work same height at this time, then the new restarted node have to wait till next block time (or 30s timeout) to pass this `waiting peers` stage, that's obviously not necessary.

