### PR TITLE
Reduce miner thread sleep to 1 microsecond

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -782,7 +782,7 @@ impl StratumServer {
 			self.handle_rpc_requests(&mut stratum_stats.clone());
 
 			// sleep before restarting loop
-			thread::sleep(Duration::from_millis(50));
+			thread::sleep(Duration::from_micros(1));
 		} // Main Loop
 	} // fn run_loop()
 } // StratumServer


### PR DESCRIPTION
Currently sleeping 50ms which mean the maximum share per second is 20 i.e. 840 gps.
Reducing this to 1 microsecond *theoretically* allows Grin to process 1 000 000 shares per seconds (i.e. 42 000 000 GPS).