### PR TITLE
[DNM] Dandelion Plus Plus

### DIFF
--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -95,7 +95,7 @@ impl PoolPushHandler {
 						.chain_head()
 						.context(ErrorKind::Internal("Failed to get chain head".to_owned()))?;
 					let res = tx_pool
-						.add_to_pool(source, tx, !fluff, &header)
+						.add_to_pool(&source, &tx, !fluff, &header)
 						.context(ErrorKind::Internal("Failed to update pool".to_owned()))?;
 					Ok(res)
 				}),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -525,7 +525,7 @@ impl Chain {
 		let height = self.next_block_height()?;
 		let txhashset = self.txhashset.read();
 		txhashset::utxo_view(&txhashset, |utxo| {
-			utxo.verify_coinbase_maturity(&tx.inputs(), height)?;
+			utxo.verify_coinbase_maturity(tx.inputs(), height)?;
 			Ok(())
 		})
 	}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -100,7 +100,7 @@ impl<'a> UTXOView<'a> {
 
 	/// Verify we are not attempting to spend any coinbase outputs
 	/// that have not sufficiently matured.
-	pub fn verify_coinbase_maturity(&self, inputs: &Vec<Input>, height: u64) -> Result<(), Error> {
+	pub fn verify_coinbase_maturity(&self, inputs: &[Input], height: u64) -> Result<(), Error> {
 		// Find the greatest output pos of any coinbase
 		// outputs we are attempting to spend.
 		let pos = inputs

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -480,7 +480,7 @@ impl Block {
 		let all_kernels = Vec::from_iter(all_kernels);
 
 		// Initialize a tx body and sort everything.
-		let body = TransactionBody::init(all_inputs, all_outputs, all_kernels, false)?;
+		let body = TransactionBody::init(&all_inputs, &all_outputs, &all_kernels, false)?;
 
 		// Finally return the full block.
 		// Note: we have not actually validated the block here,
@@ -509,7 +509,7 @@ impl Block {
 		// A block is just a big transaction, aggregate and add the reward output
 		// and reward kernel. At this point the tx is technically invalid but the
 		// tx body is valid if we account for the reward (i.e. as a block).
-		let agg_tx = transaction::aggregate(txs)?
+		let agg_tx = transaction::aggregate(&txs)?
 			.with_output(reward_out)
 			.with_kernel(reward_kern);
 
@@ -598,7 +598,7 @@ impl Block {
 		let kernels = self.kernels().clone();
 
 		// Initialize tx body and sort everything.
-		let body = TransactionBody::init(inputs, outputs, kernels, false)?;
+		let body = TransactionBody::init(&inputs, &outputs, &kernels, false)?;
 
 		Ok(Block {
 			header: self.header,

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -505,9 +505,9 @@ impl TransactionBody {
 		verify_sorted: bool,
 	) -> Result<TransactionBody, Error> {
 		let mut body = TransactionBody {
-			inputs,
-			outputs,
-			kernels,
+			inputs: inputs.to_vec(),
+			outputs: outputs.to_vec(),
+			kernels: kernels.to_vec(),
 		};
 
 		if verify_sorted {
@@ -1013,7 +1013,7 @@ pub fn aggregate(txs: &[Transaction]) -> Result<Transaction, Error> {
 	// we will sum these together at the end to give us the overall offset for the
 	// transaction
 	let mut kernel_offsets: Vec<BlindingFactor> = Vec::with_capacity(txs.len());
-	for mut tx in txs {
+	for tx in txs {
 		// we will sum these later to give a single aggregate offset
 		kernel_offsets.push(tx.offset);
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1044,7 +1044,7 @@ pub fn aggregate(txs: &[Transaction]) -> Result<Transaction, Error> {
 
 /// Attempt to deaggregate a multi-kernel transaction based on multiple
 /// transactions
-pub fn deaggregate(mk_tx: Transaction, txs: &[Transaction]) -> Result<Transaction, Error> {
+pub fn deaggregate(mk_tx: &Transaction, txs: &[Transaction]) -> Result<Transaction, Error> {
 	let mut inputs: Vec<Input> = vec![];
 	let mut outputs: Vec<Output> = vec![];
 	let mut kernels: Vec<TxKernel> = vec![];
@@ -1055,19 +1055,19 @@ pub fn deaggregate(mk_tx: Transaction, txs: &[Transaction]) -> Result<Transactio
 
 	let tx = aggregate(txs)?;
 
-	for mk_input in mk_tx.body.inputs {
+	for mk_input in mk_tx.inputs() {
 		if !tx.body.inputs.contains(&mk_input) && !inputs.contains(&mk_input) {
-			inputs.push(mk_input);
+			inputs.push(mk_input.clone());
 		}
 	}
-	for mk_output in mk_tx.body.outputs {
+	for mk_output in mk_tx.outputs() {
 		if !tx.body.outputs.contains(&mk_output) && !outputs.contains(&mk_output) {
-			outputs.push(mk_output);
+			outputs.push(mk_output.clone());
 		}
 	}
-	for mk_kernel in mk_tx.body.kernels {
+	for mk_kernel in mk_tx.kernels() {
 		if !tx.body.kernels.contains(&mk_kernel) && !kernels.contains(&mk_kernel) {
-			kernels.push(mk_kernel);
+			kernels.push(mk_kernel.clone());
 		}
 	}
 
@@ -1314,10 +1314,7 @@ impl Output {
 
 	/// Batch validates the range proofs using the commitments.
 	/// TODO - can verify_bullet_proof_multi be reworked to take slices?
-	pub fn batch_verify_proofs(
-		commits: &[Commitment],
-		proofs: &[RangeProof],
-	) -> Result<(), Error> {
+	pub fn batch_verify_proofs(commits: &[Commitment], proofs: &[RangeProof]) -> Result<(), Error> {
 		let secp = static_secp_instance();
 		secp.lock()
 			.verify_bullet_proof_multi(commits.to_vec(), proofs.to_vec(), None)?;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::util::{Mutex, RwLock};
+use std::fmt;
 use std::fs::File;
 use std::net::{Shutdown, TcpStream};
 use std::sync::Arc;
@@ -52,6 +53,12 @@ pub struct Peer {
 	// set of all hashes known to this peer (so no need to send)
 	tracking_adapter: TrackingAdapter,
 	connection: Option<Mutex<conn::Tracker>>,
+}
+
+impl fmt::Debug for Peer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "Peer({:?})", &self.info)
+	}
 }
 
 impl Peer {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -36,7 +36,7 @@ use crate::types::{
 pub struct Peers {
 	pub adapter: Arc<dyn ChainAdapter>,
 	store: PeerStore,
-	peers: RwLock<HashMap<SocketAddr, Arc<Peer>>>,
+	peers: RwLock<HashMap<PeerAddr, Arc<Peer>>>,
 	config: P2PConfig,
 }
 

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -35,6 +35,4 @@ pub mod transaction_pool;
 pub mod types;
 
 pub use crate::transaction_pool::TransactionPool;
-pub use crate::types::{
-	BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolError, TxSource,
-};
+pub use crate::types::{BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolError, TxSource};

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -36,5 +36,5 @@ pub mod types;
 
 pub use crate::transaction_pool::TransactionPool;
 pub use crate::types::{
-	BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolEntryState, PoolError, TxSource,
+	BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolError, TxSource,
 };

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -204,10 +204,7 @@ impl Pool {
 			// Create a single aggregated tx from the existing pool txs and the
 			// new entry
 			txs.push(entry.tx.clone());
-
-			let tx = transaction::aggregate(&txs)?;
-			tx.validate(self.verifier_cache.clone())?;
-			tx
+			transaction::aggregate(&txs)?
 		};
 
 		// Validate aggregated tx (existing pool + new tx), ignoring tx weight limits.
@@ -216,7 +213,7 @@ impl Pool {
 
 		// If we get here successfully then we can safely add the entry to the pool.
 		self.log_pool_add(&entry, header);
-		self.entries.push(entry);
+		self.entries.push(entry.clone());
 
 		Ok(())
 	}
@@ -277,7 +274,7 @@ impl Pool {
 
 			// We know the tx is valid if the entire aggregate tx is valid.
 			if self.validate_raw_tx(&agg_tx, header, weighting).is_ok() {
-				valid_txs.push(tx);
+				valid_txs.push(tx.clone());
 			}
 		}
 
@@ -380,7 +377,7 @@ impl Pool {
 					// if the aggregate tx is a valid tx.
 					// Otherwise discard and let the next block pick this tx up.
 					let current = tx_buckets[pos].clone();
-					if let Ok(agg_tx) = transaction::aggregate(vec![current, entry.tx.clone()]) {
+					if let Ok(agg_tx) = transaction::aggregate(&vec![current, entry.tx.clone()]) {
 						if agg_tx
 							.validate(
 								Weighting::AsLimitedTransaction { max_weight },

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -24,7 +24,7 @@ use self::core::core::{transaction, Block, BlockHeader, Transaction, Weighting};
 use self::util::RwLock;
 use crate::pool::Pool;
 use crate::types::{
-	BlockChain, PoolAdapter, PoolConfig, PoolEntry, PoolEntryState, PoolError, TxSource,
+	BlockChain, PoolAdapter, PoolConfig, PoolEntry, PoolError, TxSource,
 };
 use chrono::prelude::*;
 use grin_core as core;
@@ -79,7 +79,7 @@ impl TransactionPool {
 	fn add_to_stempool(&mut self, entry: PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
 		// Add tx to stempool (passing in all txs from txpool to validate against).
 		self.stempool
-			.add_to_pool(entry.clone(), self.txpool.all_transactions(), header)?;
+			.add_to_pool(&entry, &self.txpool.all_transactions(), header)?;
 		self.adapter.stem_tx_accepted(&entry.tx);
 		Ok(())
 	}
@@ -114,7 +114,7 @@ impl TransactionPool {
 				entry.src.debug_name = "deagg".to_string();
 			}
 		}
-		self.txpool.add_to_pool(entry.clone(), vec![], header)?;
+		self.txpool.add_to_pool(&entry, &vec![], header)?;
 
 		// We now need to reconcile the stempool based on the new state of the txpool.
 		// Some stempool txs may no longer be valid and we need to evict them.
@@ -157,7 +157,6 @@ impl TransactionPool {
 		self.blockchain.verify_coinbase_maturity(&tx)?;
 
 		let entry = PoolEntry {
-			state: PoolEntryState::Fresh,
 			src,
 			tx_at: Utc::now(),
 			tx,

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -98,7 +98,11 @@ impl TransactionPool {
 		debug!("added tx to reorg_cache: size now {}", cache.len());
 	}
 
-	fn add_to_txpool(&mut self, entry: &mut PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
+	fn add_to_txpool(
+		&mut self,
+		entry: &mut PoolEntry,
+		header: &BlockHeader,
+	) -> Result<(), PoolError> {
 		// First deaggregate the tx based on current txpool txs.
 		if entry.tx.kernels().len() > 1 {
 			let txs = self.txpool.find_matching_transactions(entry.tx.kernels());

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -74,7 +74,11 @@ impl TransactionPool {
 		self.blockchain.chain_head()
 	}
 
-	fn add_to_stempool(&mut self, entry: &PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
+	fn add_to_stempool(
+		&mut self,
+		entry: &PoolEntry,
+		header: &BlockHeader,
+	) -> Result<(), PoolError> {
 		// Add tx to stempool (passing in all txs from txpool to validate against).
 		self.stempool
 			.add_to_pool(entry, &self.txpool.all_transactions(), header)?;
@@ -94,11 +98,7 @@ impl TransactionPool {
 		debug!("added tx to reorg_cache: size now {}", cache.len());
 	}
 
-	fn add_to_txpool(
-		&mut self,
-		entry: &PoolEntry,
-		header: &BlockHeader,
-	) -> Result<(), PoolError> {
+	fn add_to_txpool(&mut self, entry: &PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
 		// First deaggregate the tx based on current txpool txs.
 		if entry.tx.kernels().len() > 1 {
 			let txs = self.txpool.find_matching_transactions(entry.tx.kernels());

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -107,7 +107,7 @@ impl TransactionPool {
 		if entry.tx.kernels().len() > 1 {
 			let txs = self.txpool.find_matching_transactions(entry.tx.kernels());
 			if !txs.is_empty() {
-				let tx = transaction::deaggregate(entry.tx, txs)?;
+				let tx = transaction::deaggregate(&entry.tx, &txs)?;
 
 				// Validate this deaggregated tx "as tx", subject to regular tx weight limits.
 				tx.validate(Weighting::AsTransaction, self.verifier_cache.clone())?;
@@ -122,7 +122,7 @@ impl TransactionPool {
 		// Some stempool txs may no longer be valid and we need to evict them.
 		{
 			let txpool_tx = self.txpool.all_transactions_aggregate()?;
-			self.stempool.reconcile(txpool_tx, header)?;
+			self.stempool.reconcile(txpool_tx.as_ref(), header)?;
 		}
 
 		self.adapter.tx_accepted(&entry.tx);
@@ -213,7 +213,7 @@ impl TransactionPool {
 		self.stempool.reconcile_block(block);
 		{
 			let txpool_tx = self.txpool.all_transactions_aggregate()?;
-			self.stempool.reconcile(txpool_tx, &block.header)?;
+			self.stempool.reconcile(txpool_tx.as_ref(), &block.header)?;
 		}
 
 		Ok(())

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -31,7 +31,7 @@ use grin_keychain as keychain;
 const DANDELION_RELAY_SECS: u64 = 600;
 
 /// Dandelion embargo timer
-const DANDELION_EMBARGO_SECS: u64 = 180;
+const DANDELION_EMBARGO_SECS: u64 = 600;
 
 /// Dandelion patience timer
 const DANDELION_PATIENCE_SECS: u64 = 10;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -37,7 +37,7 @@ const DANDELION_EMBARGO_SECS: u64 = 600;
 const DANDELION_PATIENCE_SECS: u64 = 10;
 
 /// Dandelion stem probability (stem 90% of the time, fluff 10%).
-const DANDELION_STEM_PROBABILITY: usize = 90;
+const DANDELION_STEM_PROBABILITY: u64 = 90;
 
 /// Configuration for "Dandelion".
 /// Note: shared between p2p and pool.
@@ -56,7 +56,18 @@ pub struct DandelionConfig {
 	pub patience_secs: Option<u64>,
 	/// Dandelion stem probability (stem 90% of the time, fluff 10% etc.)
 	#[serde = "default_dandelion_stem_probability"]
-	pub stem_probability: Option<usize>,
+	pub stem_probability: Option<u64>,
+}
+
+impl DandelionConfig {
+	pub fn stem_probability(&self) -> u64 {
+		self.stem_probability.unwrap_or(DANDELION_STEM_PROBABILITY)
+	}
+
+	// TODO - Cleanup config for Dandelion++
+	pub fn epoch_secs(&self) -> u64 {
+		self.relay_secs.unwrap_or(DANDELION_RELAY_SECS)
+	}
 }
 
 impl Default for DandelionConfig {
@@ -82,7 +93,7 @@ fn default_dandelion_patience_secs() -> Option<u64> {
 	Some(DANDELION_PATIENCE_SECS)
 }
 
-fn default_dandelion_stem_probability() -> Option<usize> {
+fn default_dandelion_stem_probability() -> Option<u64> {
 	Some(DANDELION_STEM_PROBABILITY)
 }
 

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -267,13 +267,11 @@ pub trait BlockChain: Sync + Send {
 /// downstream processing of valid transactions by the rest of the system, most
 /// importantly the broadcasting of transactions to our peers.
 pub trait PoolAdapter: Send + Sync {
-	/// The transaction pool has accepted this transactions as valid and added
+	/// The transaction pool has accepted this transaction as valid and added
 	/// it to its internal cache.
 	fn tx_accepted(&self, tx: &transaction::Transaction);
-	/// The stem transaction pool has accepted this transactions as valid and
-	/// added it to its internal cache, we have waited for the "patience" timer
-	/// to fire and we now want to propagate the tx to the next Dandelion relay.
-	fn stem_tx_accepted(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;
+
+	fn stem_tx_accepted(&self, tx: &transaction::Transaction);
 }
 
 /// Dummy adapter used as a placeholder for real implementations
@@ -281,9 +279,6 @@ pub trait PoolAdapter: Send + Sync {
 pub struct NoopAdapter {}
 
 impl PoolAdapter for NoopAdapter {
-	fn tx_accepted(&self, _: &transaction::Transaction) {}
-
-	fn stem_tx_accepted(&self, _: &transaction::Transaction) -> Result<(), PoolError> {
-		Ok(())
-	}
+	fn tx_accepted(&self, _tx: &transaction::Transaction) {}
+	fn stem_tx_accepted(&self, _tx: &transaction::Transaction) {}
 }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -138,29 +138,12 @@ fn default_mineable_max_weight() -> usize {
 /// A single (possibly aggregated) transaction.
 #[derive(Clone, Debug)]
 pub struct PoolEntry {
-	/// The state of the pool entry.
-	pub state: PoolEntryState,
 	/// Info on where this tx originated from.
 	pub src: TxSource,
 	/// Timestamp of when this tx was originally added to the pool.
 	pub tx_at: DateTime<Utc>,
 	/// The transaction itself.
 	pub tx: Transaction,
-}
-
-/// The possible states a pool entry can be in.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum PoolEntryState {
-	/// A new entry, not yet processed.
-	Fresh,
-	/// Tx to be included in the next "stem" run.
-	ToStem,
-	/// Tx previously "stemmed" and propagated.
-	Stemmed,
-	/// Tx to be included in the next "fluff" run.
-	ToFluff,
-	/// Tx previously "fluffed" and broadcast.
-	Fluffed,
 }
 
 /// Placeholder: the data representing where we heard about a tx from.

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -22,7 +22,9 @@ use std::thread;
 use std::time::Instant;
 
 use crate::chain::{self, BlockStatus, ChainAdapter, Options};
-use crate::common::types::{self, ChainValidationMode, ServerConfig, SyncState, SyncStatus};
+use crate::common::types::{
+	self, ChainValidationMode, DandelionEpoch, ServerConfig, SyncState, SyncStatus,
+};
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::transaction::Transaction;
 use crate::core::core::verifier_cache::VerifierCache;
@@ -700,18 +702,38 @@ impl ChainToPoolAndNetAdapter {
 /// transactions that have been accepted.
 pub struct PoolToNetAdapter {
 	peers: OneTime<Weak<p2p::Peers>>,
+	dandelion_epoch: Arc<RwLock<DandelionEpoch>>,
 }
 
-impl pool::PoolAdapter for PoolToNetAdapter {
-	fn stem_tx_accepted(&self, tx: &core::Transaction) -> Result<(), pool::PoolError> {
-		self.peers()
-			.relay_stem_transaction(tx)
-			.map_err(|_| pool::PoolError::DandelionError)?;
-		Ok(())
-	}
+pub trait DandelionAdapter {}
 
+impl DandelionAdapter for PoolToNetAdapter {}
+
+impl pool::PoolAdapter for PoolToNetAdapter {
 	fn tx_accepted(&self, tx: &core::Transaction) {
 		self.peers().broadcast_transaction(tx);
+	}
+
+	fn stem_tx_accepted(&self, tx: &core::Transaction) {
+		let mut epoch = self.dandelion_epoch.write();
+		if epoch.is_expired() {
+			warn!("epoch expired, setting up next epoch");
+			epoch.next_epoch(&self.peers());
+		}
+
+		if epoch.is_stem() {
+			if let Some(peer) = epoch.relay_peer() {
+				if peer.is_connected() {
+					peer.send_stem_transaction(tx);
+				} else {
+					error!("what to do here? relay peer is not connected?");
+				}
+			} else {
+				error!("what to do here? We have no relay peer?");
+			}
+		} else {
+			warn!("not forwarding stem tx, we fluff for this epoch");
+		}
 	}
 }
 
@@ -720,6 +742,7 @@ impl PoolToNetAdapter {
 	pub fn new() -> PoolToNetAdapter {
 		PoolToNetAdapter {
 			peers: OneTime::new(),
+			dandelion_epoch: Arc::new(RwLock::new(DandelionEpoch::new())),
 		}
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -101,7 +101,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 		let res = {
 			let mut tx_pool = self.tx_pool.write();
-			tx_pool.add_to_pool(source, tx, stem, &header)
+			tx_pool.add_to_pool(&source, &tx, stem, &header)
 		};
 
 		if let Err(e) = res {

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -397,3 +397,41 @@ impl chain::TxHashsetWriteStatus for SyncState {
 		self.update(SyncStatus::TxHashsetDone);
 	}
 }
+
+pub struct DandelionEpoch {
+	// When did this epoch start?
+	start_time: i64,
+	is_stem: bool,
+	relay_peer: Option<Arc<p2p::Peer>>,
+}
+
+impl DandelionEpoch {
+	pub fn new() -> DandelionEpoch {
+		DandelionEpoch {
+			start_time: Utc::now().timestamp(),
+			is_stem: false,
+			relay_peer: None,
+		}
+	}
+
+	// TODO - config for epoch duration
+	pub fn is_expired(&self) -> bool {
+		Utc::now().timestamp() - self.start_time > 600
+	}
+
+	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
+		self.start_time = Utc::now().timestamp();
+
+		// TODO - select a new relay_peer.
+		self.relay_peer = None;
+	}
+
+	// Are we stemming transactions in this epoch?
+	pub fn is_stem(&self) -> bool {
+		self.is_stem
+	}
+
+	pub fn relay_peer(&self) -> Option<Arc<p2p::Peer>> {
+		self.relay_peer.clone()
+	}
+}

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 //! Server types
-use crate::util::RwLock;
 use std::convert::From;
 use std::sync::Arc;
+
+use chrono::prelude::{DateTime, Utc};
+use rand::prelude::*;
 
 use crate::api;
 use crate::chain;
@@ -23,9 +25,10 @@ use crate::core::global::ChainTypes;
 use crate::core::{core, pow};
 use crate::p2p;
 use crate::pool;
+use crate::pool::types::DandelionConfig;
 use crate::store;
+use crate::util::RwLock;
 use crate::wallet;
-use chrono::prelude::{DateTime, Utc};
 
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]
@@ -400,7 +403,9 @@ impl chain::TxHashsetWriteStatus for SyncState {
 
 /// A node is either "stem" of "fluff" for the duration of a single epoch.
 /// A node also maintains an outbound relay peer for the epoch.
+#[derive(Debug)]
 pub struct DandelionEpoch {
+	config: DandelionConfig,
 	// When did this epoch start?
 	start_time: Option<i64>,
 	// Are we in "stem" mode or "fluff" mode for this epoch?
@@ -410,28 +415,34 @@ pub struct DandelionEpoch {
 }
 
 impl DandelionEpoch {
-	pub fn new() -> DandelionEpoch {
+	pub fn new(config: DandelionConfig) -> DandelionEpoch {
 		DandelionEpoch {
+			config,
 			start_time: None,
 			is_stem: false,
 			relay_peer: None,
 		}
 	}
 
-	// TODO - config for epoch duration
 	pub fn is_expired(&self) -> bool {
-		if let Some(start_time) = self.start_time {
-			Utc::now().timestamp() - start_time > 600
+		let expired = if let Some(start_time) = self.start_time {
+			Utc::now().timestamp().saturating_sub(start_time) > self.config.epoch_secs() as i64
 		} else {
 			true
-		}
+		};
+		error!("DandelionEpoch: is_expired: {}", expired);
+		expired
 	}
 
 	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
 		self.start_time = Some(Utc::now().timestamp());
+		self.relay_peer = peers.outgoing_connected_peers().first().cloned();
 
-		// TODO - select a new relay_peer.
-		self.relay_peer = None;
+		// If stem_probability == 90 then we stem 90% of the time.
+		let mut rng = rand::thread_rng();
+		self.is_stem = rng.gen_range(0, 101) < self.config.stem_probability();
+
+		error!("DandelionEpoch: next_epoch: {:?}", self);
 	}
 
 	// Are we stemming transactions in this epoch?
@@ -439,7 +450,20 @@ impl DandelionEpoch {
 		self.is_stem
 	}
 
-	pub fn relay_peer(&self) -> Option<Arc<p2p::Peer>> {
+	pub fn relay_peer(&mut self, peers: &Arc<p2p::Peers>) -> Option<Arc<p2p::Peer>> {
+		let mut update_relay = false;
+		if let Some(peer) = &self.relay_peer {
+			if !peer.is_connected() {
+				update_relay = true;
+			}
+		} else {
+			update_relay = true;
+		}
+
+		if update_relay {
+			self.relay_peer = peers.outgoing_connected_peers().first().cloned();
+		}
+
 		self.relay_peer.clone()
 	}
 }

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -22,7 +22,7 @@ use crate::common::adapters::DandelionAdapter;
 use crate::core::core::hash::Hashed;
 use crate::core::core::transaction;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::pool::{DandelionConfig, PoolEntryState, PoolError, TransactionPool, TxSource};
+use crate::pool::{DandelionConfig, PoolError, TransactionPool, TxSource};
 use crate::util::{Mutex, RwLock, StopState};
 
 /// A process to monitor transactions in the stempool.
@@ -50,112 +50,43 @@ pub fn monitor_transactions(
 					break;
 				}
 
-				// Our adapter hooks us into the current Dandelion Epoch.
-				// From this we can determine if we should fluff everything currently in the stempool.
-				// TODO - how to handle expired epoch here?
-
+				// TODO - may be preferable to loop more often and check for expired patience time?
 				// This is the patience timer, we loop every n secs.
 				let patience_secs = dandelion_config.patience_secs.unwrap();
 				thread::sleep(Duration::from_secs(patience_secs));
+
+				// Our adapter hooks us into the current Dandelion "epoch".
+				// From this we can determine if we should fluff txs in stempool.
+				if adapter.is_expired() {
+					adapter.next_epoch();
+				}
 
 				// Vastly simplified -
 				// check if we are is_stem() via the adapter (current epoch)
 				// * if we are stem then do nothing (nothing to aggregate here)
 				// * if fluff then aggregate and add to txpool
 
-				if adapter.is_fluff() {}
-
-				// // Step 1: find all "ToStem" entries in stempool from last run.
-				// // Aggregate them up to give a single (valid) aggregated tx and propagate it
-				// // to the next Dandelion relay along the stem.
-				// if process_stem_phase(tx_pool.clone(), verifier_cache.clone()).is_err() {
-				// 	error!("dand_mon: Problem with stem phase.");
-				// }
-				//
-				// // Step 2: find all "ToFluff" entries in stempool from last run.
-				// // Aggregate them up to give a single (valid) aggregated tx and (re)add it
-				// // to our pool with stem=false (which will then broadcast it).
-				// if process_fluff_phase(tx_pool.clone(), verifier_cache.clone()).is_err() {
-				// 	error!("dand_mon: Problem with fluff phase.");
-				// }
-				//
-				// // Step 3: now find all "Fresh" entries in stempool since last run.
-				// // Coin flip for each (90/10) and label them as either "ToStem" or "ToFluff".
-				// // We will process these in the next run (waiting patience secs).
-				// if process_fresh_entries(dandelion_config.clone(), tx_pool.clone()).is_err() {
-				// 	error!("dand_mon: Problem processing fresh pool entries.");
-				// }
+				if !adapter.is_stem() {
+					if process_fluff_phase(&tx_pool, &verifier_cache).is_err() {
+						error!("dand_mon: Problem processing fresh pool entries.");
+					}
+				}
 
 				// Now find all expired entries based on embargo timer.
-				if process_expired_entries(dandelion_config.clone(), tx_pool.clone()).is_err() {
+				if process_expired_entries(&dandelion_config, &tx_pool).is_err() {
 					error!("dand_mon: Problem processing fresh pool entries.");
 				}
 			}
 		});
 }
 
-fn process_stem_phase(
-	tx_pool: Arc<RwLock<TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write();
-
-	let header = tx_pool.chain_head()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.get_transactions_in_state(PoolEntryState::ToStem);
-
-	if stem_txs.is_empty() {
-		return Ok(());
-	}
-
-	// Get the aggregate tx representing the entire txpool.
-	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool
-		.stempool
-		.transition_to_state(&stem_txs, PoolEntryState::Stemmed);
-
-	if stem_txs.len() > 0 {
-		debug!("dand_mon: Found {} txs for stemming.", stem_txs.len());
-
-		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(
-			transaction::Weighting::AsTransaction,
-			verifier_cache.clone(),
-		)?;
-
-		let res = tx_pool.adapter.stem_tx_accepted(&agg_tx);
-		if res.is_err() {
-			debug!("dand_mon: Unable to propagate stem tx. No relay, fluffing instead.");
-
-			let src = TxSource {
-				debug_name: "no_relay".to_string(),
-				identifier: "?.?.?.?".to_string(),
-			};
-
-			tx_pool.add_to_pool(src, agg_tx, false, &header)?;
-		}
-	}
-	Ok(())
-}
-
 fn process_fluff_phase(
-	tx_pool: Arc<RwLock<TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	tx_pool: &Arc<RwLock<TransactionPool>>,
+	verifier_cache: &Arc<RwLock<dyn VerifierCache>>,
 ) -> Result<(), PoolError> {
 	let mut tx_pool = tx_pool.write();
 
-	let header = tx_pool.chain_head()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.get_transactions_in_state(PoolEntryState::ToFluff);
-
+	let stem_txs = tx_pool.stempool.all_transactions();
 	if stem_txs.is_empty() {
 		return Ok(());
 	}
@@ -163,68 +94,32 @@ fn process_fluff_phase(
 	// Get the aggregate tx representing the entire txpool.
 	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
 
+	let header = tx_pool.chain_head()?;
 	let stem_txs = tx_pool
 		.stempool
-		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool
-		.stempool
-		.transition_to_state(&stem_txs, PoolEntryState::Fluffed);
+		.select_valid_transactions(&stem_txs, txpool_tx.as_ref(), &header)?;
 
-	if stem_txs.len() > 0 {
-		debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
-
-		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(
-			transaction::Weighting::AsTransaction,
-			verifier_cache.clone(),
-		)?;
-
-		let src = TxSource {
-			debug_name: "fluff".to_string(),
-			identifier: "?.?.?.?".to_string(),
-		};
-
-		tx_pool.add_to_pool(src, agg_tx, false, &header)?;
+	if stem_txs.is_empty() {
+		return Ok(());
 	}
-	Ok(())
-}
 
-fn process_fresh_entries(
-	dandelion_config: DandelionConfig,
-	tx_pool: Arc<RwLock<TransactionPool>>,
-) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write();
+	debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
 
-	let mut rng = thread_rng();
+	let agg_tx = transaction::aggregate(&stem_txs)?;
+	agg_tx.validate(verifier_cache.clone())?;
 
-	let fresh_entries = &mut tx_pool
-		.stempool
-		.entries
-		.iter_mut()
-		.filter(|x| x.state == PoolEntryState::Fresh)
-		.collect::<Vec<_>>();
+	let src = TxSource {
+		debug_name: "fluff".to_string(),
+		identifier: "?.?.?.?".to_string(),
+	};
 
-	if fresh_entries.len() > 0 {
-		debug!(
-			"dand_mon: Found {} fresh entries in stempool.",
-			fresh_entries.len()
-		);
-
-		for x in &mut fresh_entries.iter_mut() {
-			let random = rng.gen_range(0, 101);
-			if random <= dandelion_config.stem_probability.unwrap() {
-				x.state = PoolEntryState::ToStem;
-			} else {
-				x.state = PoolEntryState::ToFluff;
-			}
-		}
-	}
+	tx_pool.add_to_pool(src, agg_tx, false, &header)?;
 	Ok(())
 }
 
 fn process_expired_entries(
-	dandelion_config: DandelionConfig,
-	tx_pool: Arc<RwLock<TransactionPool>>,
+	dandelion_config: &DandelionConfig,
+	tx_pool: &Arc<RwLock<TransactionPool>>,
 ) -> Result<(), PoolError> {
 	let now = Utc::now().timestamp();
 	let embargo_sec = dandelion_config.embargo_secs.unwrap() + thread_rng().gen_range(0, 31);
@@ -244,24 +139,26 @@ fn process_expired_entries(
 		}
 	}
 
-	if expired_entries.len() > 0 {
-		debug!("dand_mon: Found {} expired txs.", expired_entries.len());
-
-		{
-			let mut tx_pool = tx_pool.write();
-			let header = tx_pool.chain_head()?;
-
-			for entry in expired_entries {
-				let src = TxSource {
-					debug_name: "embargo_expired".to_string(),
-					identifier: "?.?.?.?".to_string(),
-				};
-				match tx_pool.add_to_pool(src, entry.tx, false, &header) {
-					Ok(_) => debug!("dand_mon: embargo expired, fluffed tx successfully."),
-					Err(e) => debug!("dand_mon: Failed to fluff expired tx - {:?}", e),
-				};
-			}
-		}
+	if expired_entries.is_empty() {
+		return Ok(());
 	}
+
+	debug!("dand_mon: Found {} expired txs.", expired_entries.len());
+
+	let mut tx_pool = tx_pool.write();
+	let header = tx_pool.chain_head()?;
+
+	let src = TxSource {
+		debug_name: "embargo_expired".to_string(),
+		identifier: "?.?.?.?".to_string(),
+	};
+
+	for entry in expired_entries {
+		match tx_pool.add_to_pool(src.clone(), entry.tx, false, &header) {
+			Ok(_) => debug!("dand_mon: embargo expired, fluffed tx successfully."),
+			Err(e) => debug!("dand_mon: Failed to fluff expired tx - {:?}", e),
+		};
+	}
+
 	Ok(())
 }

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -107,7 +107,10 @@ fn process_fluff_phase(
 	debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
 
 	let agg_tx = transaction::aggregate(&stem_txs)?;
-	agg_tx.validate(verifier_cache.clone())?;
+	agg_tx.validate(
+		transaction::Weighting::AsTransaction,
+		verifier_cache.clone(),
+	)?;
 
 	let src = TxSource {
 		debug_name: "fluff".to_string(),

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -114,7 +114,7 @@ fn process_fluff_phase(
 		identifier: "?.?.?.?".to_string(),
 	};
 
-	tx_pool.add_to_pool(src, agg_tx, false, &header)?;
+	tx_pool.add_to_pool(&src, &agg_tx, false, &header)?;
 	Ok(())
 }
 
@@ -155,7 +155,7 @@ fn process_expired_entries(
 	};
 
 	for entry in expired_entries {
-		match tx_pool.add_to_pool(src.clone(), entry.tx, false, &header) {
+		match tx_pool.add_to_pool(&src, &entry.tx, false, &header) {
 			Ok(_) => debug!("dand_mon: embargo expired, fluffed tx successfully."),
 			Err(e) => debug!("dand_mon: Failed to fluff expired tx - {:?}", e),
 		};

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -95,9 +95,10 @@ fn process_fluff_phase(
 	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
 
 	let header = tx_pool.chain_head()?;
-	let stem_txs = tx_pool
-		.stempool
-		.select_valid_transactions(&stem_txs, txpool_tx.as_ref(), &header)?;
+	let stem_txs =
+		tx_pool
+			.stempool
+			.select_valid_transactions(&stem_txs, txpool_tx.as_ref(), &header)?;
 
 	if stem_txs.is_empty() {
 		return Ok(());

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -119,8 +119,6 @@ pub fn connect_and_monitor(
 						preferred_peers.clone(),
 					);
 
-					update_dandelion_relay(peers.clone(), dandelion_config.clone());
-
 					prev = Utc::now();
 					start_attempt = cmp::min(6, start_attempt + 1);
 				}
@@ -244,20 +242,22 @@ fn monitor_peers(
 	}
 }
 
-fn update_dandelion_relay(peers: Arc<p2p::Peers>, dandelion_config: DandelionConfig) {
-	// Dandelion Relay Updater
-	let dandelion_relay = peers.get_dandelion_relay();
-	if let Some((last_added, _)) = dandelion_relay {
-		let dandelion_interval = Utc::now().timestamp() - last_added;
-		if dandelion_interval >= dandelion_config.relay_secs.unwrap() as i64 {
-			debug!("monitor_peers: updating expired dandelion relay");
-			peers.update_dandelion_relay();
-		}
-	} else {
-		debug!("monitor_peers: no dandelion relay updating");
-		peers.update_dandelion_relay();
-	}
-}
+// fn update_dandelion_relay(peers: Arc<p2p::Peers>, dandelion_config: DandelionConfig) {
+// 	// Dandelion Relay Updater
+// 	let dandelion_relay = peers.get_dandelion_relay();
+// 	if dandelion_relay.is_empty() {
+// 		debug!("monitor_peers: no dandelion relay updating");
+// 		peers.update_dandelion_relay();
+// 	} else {
+// 		for last_added in dandelion_relay.keys() {
+// 			let dandelion_interval = Utc::now().timestamp() - last_added;
+// 			if dandelion_interval >= dandelion_config.relay_secs.unwrap() as i64 {
+// 				debug!("monitor_peers: updating expired dandelion relay");
+// 				peers.update_dandelion_relay();
+// 			}
+// 		}
+// 	}
+// }
 
 // Check if we have any pre-existing peer in db. If so, start with those,
 // otherwise use the seeds provided.

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -118,7 +118,7 @@ impl Server {
 		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
 
 		let pool_adapter = Arc::new(PoolToChainAdapter::new());
-		let pool_net_adapter = Arc::new(PoolToNetAdapter::new());
+		let pool_net_adapter = Arc::new(PoolToNetAdapter::new(config.dandelion_config.clone()));
 		let tx_pool = Arc::new(RwLock::new(pool::TransactionPool::new(
 			config.pool_config.clone(),
 			pool_adapter.clone(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -174,6 +174,8 @@ impl Server {
 			genesis.hash(),
 			stop_state.clone(),
 		)?);
+
+		// Initialize various adapters with our set of connected peers.
 		chain_adapter.init(p2p_server.peers.clone());
 		pool_net_adapter.init(p2p_server.peers.clone());
 		net_adapter.init(p2p_server.peers.clone());
@@ -248,6 +250,7 @@ impl Server {
 		dandelion_monitor::monitor_transactions(
 			config.dandelion_config.clone(),
 			tx_pool.clone(),
+			pool_net_adapter.clone(),
 			verifier_cache.clone(),
 			stop_state.clone(),
 		);


### PR DESCRIPTION
Still very much a WIP. Do not merge before mainnet...

* rewrite Dandelion logic (WIP) to follow Dandelion++
  * add concept of a node _epoch_
  * relay _immediately_ to next stem relay when in stem mode
  * node in _fluff_ mode for a given epoch will collect and aggregate txs
  * get rid of pool entry states, `ToStem` etc. No longer necessary to track this state.
* less cloning when adding txs to the pool
* pass slices around and not vecs directly
* other assorted cleanup around tx handling
