### PR TITLE
Track blocks we requested, always broadcast otherwise

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -554,9 +554,9 @@ impl ChainAdapter for Peers {
 		self.adapter.transaction_received(tx, stem)
 	}
 
-	fn block_received(&self, b: core::Block, peer_addr: SocketAddr) -> bool {
+	fn block_received(&self, b: core::Block, peer_addr: SocketAddr, was_requested: bool) -> bool {
 		let hash = b.hash();
-		if !self.adapter.block_received(b, peer_addr) {
+		if !self.adapter.block_received(b, peer_addr, was_requested) {
 			// if the peer sent us a block that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
 			debug!(

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -154,7 +154,9 @@ impl MessageHandler for Protocol {
 				);
 				let b: core::Block = msg.body()?;
 
-				adapter.block_received(b, self.addr);
+				// we can't know at this level whether we requested the block or not,
+				// the boolean should be properly set in higher level adapter
+				adapter.block_received(b, self.addr, false);
 				Ok(None)
 			}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -242,7 +242,7 @@ impl ChainAdapter for DummyAdapter {
 	fn header_received(&self, _bh: core::BlockHeader, _addr: SocketAddr) -> bool {
 		true
 	}
-	fn block_received(&self, _: core::Block, _: SocketAddr) -> bool {
+	fn block_received(&self, _: core::Block, _: SocketAddr, _: bool) -> bool {
 		true
 	}
 	fn headers_received(&self, _: &[core::BlockHeader], _: SocketAddr) -> bool {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -355,7 +355,7 @@ pub trait ChainAdapter: Sync + Send {
 	/// block could be handled properly and is not deemed defective by the
 	/// chain. Returning false means the block will never be valid and
 	/// may result in the peer being banned.
-	fn block_received(&self, b: core::Block, addr: SocketAddr) -> bool;
+	fn block_received(&self, b: core::Block, addr: SocketAddr, was_requested: bool) -> bool;
 
 	fn compact_block_received(&self, cb: core::CompactBlock, addr: SocketAddr) -> bool;
 


### PR DESCRIPTION
This is an attempt at improving upon #2324. It attempts to fix the following problem:

* Whether we're syncing or not should not impact our ability to relay blocks. Otherwise we open ourselves to an attack where someone could fake a high difficulty to stop all our blocks (including mined ones). This is mitigated with a ban for cheats, but the ban can take a few min.
* We do not want to relay blocks we requested on sync. This would completely flood the network unnecessarily.

This PR adds the tracking of block requests we originate in the `TrackingAdapter` (which was already tracking what we received). We can then check upon receiving a block if it was in the list we requested and propagate this information to decide whether to relay or not. This is a little longer than I'd like but most of the changes are just due to adding a boolean to `block_received`