### PR TITLE
[DNM] clean-up the txhashset zip file and temp folder

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -37,7 +37,7 @@ use crate::util::{Mutex, RwLock, StopState};
 use chrono::prelude::{DateTime, Utc};
 use grin_store::Error::NotFoundErr;
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -155,6 +155,27 @@ pub struct Chain {
 	stop_state: Arc<Mutex<StopState>>,
 	genesis: BlockHeader,
 	txhashset_snapshot_zips: Arc<RwLock<Vec<(PathBuf, DateTime<Utc>)>>>,
+}
+
+/// Clean-up all the remaining txhashset zip files when process exit
+impl Drop for Chain {
+	fn drop(&mut self) {
+		let zip_paths = self.txhashset_snapshot_zips.read();
+		for (zip_path, _) in zip_paths.iter() {
+			if let Err(e) = fs::remove_file(&zip_path) {
+				warn!(
+					"txhashset zip file: {:?} fail to remove, err: {}",
+					zip_path.to_str(),
+					e
+				);
+			} else {
+				debug!(
+					"clean-up txhashset zip file: {:?} on exit",
+					zip_path.to_str()
+				);
+			}
+		}
+	}
 }
 
 impl Chain {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -14,7 +14,7 @@
 
 use std::cmp;
 use std::env;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -330,7 +330,7 @@ impl MessageHandler for Protocol {
 					tmp,
 				);
 
-				let tmp_zip = File::open(tmp)?;
+				let tmp_zip = File::open(tmp.clone())?;
 				let res = self
 					.adapter
 					.txhashset_write(sm_arch.hash, tmp_zip, self.addr);
@@ -339,6 +339,7 @@ impl MessageHandler for Protocol {
 					"handle_payload: txhashset archive for {} at {}, DONE. Data Ok: {}",
 					sm_arch.hash, sm_arch.height, res
 				);
+				let _ = fs::remove_file(&tmp);
 
 				Ok(None)
 			}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -455,6 +455,7 @@ impl Server {
 	pub fn stop(&self) {
 		self.p2p.stop();
 		self.stop_state.lock().stop();
+		self.chain.drop_txhashset_zips();
 	}
 
 	/// Pause the p2p server.


### PR DESCRIPTION
My `floo/chain_data` folder becomes more and more bigger, 4.6G for 6 days:
```
$ du -s chain_data
4601608	chain_data

$ ls -l chain_data | grep txhashset
drwxrwxr-x 5 garyyu garyyu     4096 Dec 30 03:02 txhashset
-rw-r--r-- 1 garyyu garyyu 39838686 Jan  7 23:57 txhashset_snapshot_102503.zip
-rw-r--r-- 1 garyyu garyyu 45923180 Jan  9 18:23 txhashset_snapshot_14035.zip
...
-rw-r--r-- 1 garyyu garyyu 41937198 Jan  8 14:22 txhashset_snapshot_988669.zip
drwxr-xr-x 5 garyyu garyyu     4096 Jan  7 23:57 txhashset_zip_102503
drwxr-xr-x 5 garyyu garyyu     4096 Jan  9 18:23 txhashset_zip_14035
...
drwxr-xr-x 5 garyyu garyyu     4096 Jan  8 14:22 txhashset_zip_988669
```
There are a lot of temporary files there! Let's clean-up these garbage. 

