### PR TITLE
Add secondary scaling in JobTemplate

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -85,6 +85,7 @@ pub struct JobTemplate {
 	height: u64,
 	job_id: u64,
 	difficulty: u64,
+	secondary_scaling: u32,
 	pre_pow: String,
 }
 
@@ -275,6 +276,7 @@ impl StratumServer {
 			height: bh.height,
 			job_id: (self.current_block_versions.len() - 1) as u64,
 			difficulty: self.minimum_share_difficulty,
+			secondary_scaling: bh.pow.secondary_scaling,
 			pre_pow,
 		};
 		return job_template;


### PR DESCRIPTION
WARNING: might break mining pools and grin-miner.
I recognised that it might be a little bit late to add this in Grin Stratum server.
This allows miners to compute their share difficulty so they don't send low diff shares.

