### PR TITLE
fix: foreign_api to handle OPTIONS call on POSTs

### DIFF
--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -627,6 +627,10 @@ where
 			ok(create_error_response(e))
 		}))
 	}
+
+	fn options(&self, _req: Request<Body>) -> ResponseFuture {
+		Box::new(ok(create_ok_response("{}")))
+	}
 }
 
 // Utility to serialize a struct into JSON and produce a sensible Response


### PR DESCRIPTION
This PR enables the `foreign_api` to handle the pre-flight `OPTIONS` call that is made on authenticated POST requests from the browser. As it stands today, HTTP clients cannot make authenticated post requests to the `foreign_api` (e.g.: `receive_tx`).

Related changes were originally made to the API for the `owner_api` by @quentinlesceller. Initial dialogue for context to this change can be found in [this PR](https://github.com/mimblewimble/grin/pull/2184) and [this one](https://github.com/mimblewimble/grin/pull/2131/files).

