### PR TITLE
[WIP] [wallet] UTXO proof of ownership and verification commands

### DIFF
--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -502,7 +502,7 @@ pub fn parse_sign_utxo_args(args: &ArgMatches) -> Result<command::SignUtxoArgs, 
 
 	Ok(command::SignUtxoArgs {
 		utxo_commitment_string: utxo_commitment_string.to_owned(),
-		message_hash_to_sign: message_hash.to_owned()
+		message_hash_to_sign: message_hash.to_owned(),
 	})
 }
 

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -496,6 +496,31 @@ pub fn parse_cancel_args(args: &ArgMatches) -> Result<command::CancelArgs, Parse
 	})
 }
 
+pub fn parse_sign_utxo_args(args: &ArgMatches) -> Result<command::SignUtxoArgs, ParseError> {
+	let utxo_commitment_string = parse_required(args, "utxo")?;
+	let message_hash = parse_required(args, "msghash")?;
+
+	Ok(command::SignUtxoArgs {
+		utxo_commitment_string: utxo_commitment_string.to_owned(),
+		message_hash_to_sign: message_hash.to_owned()
+	})
+}
+
+pub fn parse_verify_utxo_args(args: &ArgMatches) -> Result<command::VerifyUtxoArgs, ParseError> {
+	let amount = parse_required(args, "amount")?;
+	let amount = parse_u64(amount, "amount")?;
+	let message_hash = parse_required(args, "msghash")?.to_owned();
+	let pubkey = parse_required(args, "pubkey")?.to_owned();
+	let signature = parse_required(args, "signature")?.to_owned();
+
+	Ok(command::VerifyUtxoArgs {
+		amount,
+		message_hash,
+		pubkey,
+		signature,
+	})
+}
+
 pub fn wallet_command(
 	wallet_args: &ArgMatches,
 	mut wallet_config: WalletConfig,
@@ -602,6 +627,14 @@ pub fn wallet_command(
 		("cancel", Some(args)) => {
 			let a = arg_parse!(parse_cancel_args(&args));
 			command::cancel(inst_wallet(), a)
+		}
+		("sign_utxo", Some(args)) => {
+			let a = arg_parse!(parse_sign_utxo_args(&args));
+			command::sign_utxo(inst_wallet(), a)
+		}
+		("verify_utxo", Some(args)) => {
+			let a = arg_parse!(parse_verify_utxo_args(&args));
+			command::verify_utxo(inst_wallet(), a)
 		}
 		("restore", Some(_)) => command::restore(inst_wallet()),
 		("check", Some(_)) => command::check_repair(inst_wallet()),

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -271,6 +271,42 @@ subcommands:
                   long: min_conf
                   default_value: "10"
                   takes_value: true
+        - sign_utxo:
+            about: Sign a specific message with output's associated blinding factor to create proof of ownership
+            args:
+              - utxo:
+                  help: Output's Pedersen Commitment in hex
+                  short: u
+                  long: utxo
+                  takes_value: true
+              - msghash:
+                  help: A message hash which is to be signed with the blinding factor of UTXO
+                  short: m
+                  long: msghash
+                  takes_value: true
+        - verify_utxo:
+            about: Verify proof of output ownership received from another party
+            args:
+              - amount:
+                  help: Output amount
+                  short: a
+                  long: amount
+                  takes_value: true
+              - msghash:
+                  help: A message hash which is comes with the proof
+                  short: m
+                  long: msghash
+                  takes_value: true
+              - pubkey:
+                  help: A public key of the proof (comes from output's blinding factor)
+                  short: p
+                  long: pubkey
+                  takes_value: true
+              - signature:
+                  help: A signature of the proof (signs message hash with blinding factor)
+                  short: s
+                  long: signature
+                  takes_value: true
         - init:
             about: Initialize a new wallet seed file and database
             args:

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -532,8 +532,9 @@ pub struct SignUtxoArgs {
 	pub message_hash_to_sign: String,
 }
 
-pub fn sign_utxo(wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
-				 args: SignUtxoArgs,
+pub fn sign_utxo(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	args: SignUtxoArgs,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
 		let proof = api
@@ -556,8 +557,9 @@ pub struct VerifyUtxoArgs {
 	pub signature: String,
 }
 
-pub fn verify_utxo(wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
-				 args: VerifyUtxoArgs,
+pub fn verify_utxo(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	args: VerifyUtxoArgs,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
 		let proof = api

--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -525,3 +525,49 @@ pub fn check_repair(
 	})?;
 	Ok(())
 }
+
+/// Arguments for `wallet sign_utxo` command.
+pub struct SignUtxoArgs {
+	pub utxo_commitment_string: String,
+	pub message_hash_to_sign: String,
+}
+
+pub fn sign_utxo(wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+				 args: SignUtxoArgs,
+) -> Result<(), Error> {
+	controller::owner_single_use(wallet.clone(), |api| {
+		let proof = api
+			.sign_utxo(&args.utxo_commitment_string, &args.message_hash_to_sign)
+			.unwrap();
+
+		display::output_proof(&proof);
+
+		Ok(())
+	})?;
+
+	Ok(())
+}
+
+/// Arguments for `wallet verify_utxo` command.
+pub struct VerifyUtxoArgs {
+	pub amount: u64,
+	pub message_hash: String,
+	pub pubkey: String,
+	pub signature: String,
+}
+
+pub fn verify_utxo(wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+				 args: VerifyUtxoArgs,
+) -> Result<(), Error> {
+	controller::owner_single_use(wallet.clone(), |api| {
+		let proof = api
+			.verify_utxo(args.amount, &args.message_hash, args.pubkey, args.signature)
+			.unwrap();
+
+		display::output_verification(proof);
+
+		Ok(())
+	})?;
+
+	Ok(())
+}

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -14,7 +14,9 @@
 
 use crate::core::core::{self, amount_to_hr_string};
 use crate::core::global;
-use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, TxLogEntry, WalletInfo, OutputProof};
+use crate::libwallet::types::{
+	AcctPathMapping, OutputData, OutputProof, OutputStatus, TxLogEntry, WalletInfo,
+};
 use crate::libwallet::Error;
 use crate::util;
 use crate::util::secp::pedersen;
@@ -361,10 +363,19 @@ pub fn accounts(acct_mappings: Vec<AcctPathMapping>) {
 pub fn output_proof(utxo_proof: &OutputProof) {
 	println!("\n____ Output Proof of Possession ____\n",);
 
-	println!("Output amount: {}", core::amount_to_hr_string(utxo_proof.amount, false));
+	println!(
+		"Output amount: {}",
+		core::amount_to_hr_string(utxo_proof.amount, false)
+	);
 	println!("Message hash: {}", utxo_proof.msg_hash.to_hex());
-	println!("Public key (compressed): {}", util::to_hex(utxo_proof.public_key.to_vec()));
-	println!("Message signature (compact): {}", util::to_hex(utxo_proof.signature.to_vec()));
+	println!(
+		"Public key (compressed): {}",
+		util::to_hex(utxo_proof.public_key.to_vec())
+	);
+	println!(
+		"Message signature (compact): {}",
+		util::to_hex(utxo_proof.signature.to_vec())
+	);
 
 	println!();
 }

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -14,7 +14,7 @@
 
 use crate::core::core::{self, amount_to_hr_string};
 use crate::core::global;
-use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, TxLogEntry, WalletInfo};
+use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, TxLogEntry, WalletInfo, OutputProof};
 use crate::libwallet::Error;
 use crate::util;
 use crate::util::secp::pedersen;
@@ -354,5 +354,30 @@ pub fn accounts(acct_mappings: Vec<AcctPathMapping>) {
 	}
 	table.set_format(*prettytable::format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
 	table.printstd();
+	println!();
+}
+
+/// Display output's proof of possession (ownership)
+pub fn output_proof(utxo_proof: &OutputProof) {
+	println!("\n____ Output Proof of Possession ____\n",);
+
+	println!("Output amount: {}", core::amount_to_hr_string(utxo_proof.amount, false));
+	println!("Message hash: {}", utxo_proof.msg_hash.to_hex());
+	println!("Public key (compressed): {}", util::to_hex(utxo_proof.public_key.to_vec()));
+	println!("Message signature (compact): {}", util::to_hex(utxo_proof.signature.to_vec()));
+
+	println!();
+}
+
+/// Display output's proof is verified or not
+pub fn output_verification(is_verified: bool) {
+	println!("\n____ Output Proof of Possession ____\n",);
+
+	if is_verified {
+		println!("\tVERIFIED");
+	} else {
+		println!("\tINVALID");
+	}
+
 	println!();
 }

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -41,12 +41,12 @@ use crate::core::ser;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::internal::{keys, tx, updater};
 use crate::libwallet::types::{
-	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputStatus, TxLogEntry, TxLogEntryType,
-	TxWrapper, WalletBackend, WalletInfo, OutputProof,
+	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputProof, OutputStatus,
+	TxLogEntry, TxLogEntryType, TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::libwallet::{Error, ErrorKind};
 use crate::util;
-use crate::util::secp::{pedersen, ContextFlag, Secp256k1, Message, key::PublicKey, Signature};
+use crate::util::secp::{key::PublicKey, pedersen, ContextFlag, Message, Secp256k1, Signature};
 
 /// Functions intended for use by the owner (e.g. master seed holder) of the wallet.
 pub struct APIOwner<W: ?Sized, C, K>
@@ -792,8 +792,12 @@ where
 	}
 
 	/// Signs a user-provided message with UTXO's blinding factor to construct a proof that
-    /// user is indeed in possession of said UTXO.
-	pub fn sign_utxo(&mut self, utxo_commitment: &str, message_hash: &str) -> Result<OutputProof, Error> {
+	/// user is indeed in possession of said UTXO.
+	pub fn sign_utxo(
+		&mut self,
+		utxo_commitment: &str,
+		message_hash: &str,
+	) -> Result<OutputProof, Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 
@@ -831,26 +835,34 @@ where
 						amount: output.value,
 						msg_hash,
 						public_key,
-						signature
+						signature,
 					};
 
 					w.close()?;
 
-					return Ok(proof)
+					return Ok(proof);
 				} else {
-					return Err(ErrorKind::GenericError("Invalid message hash".to_owned()))?
+					return Err(ErrorKind::GenericError("Invalid message hash".to_owned()))?;
 				}
 			}
 		}
 
 		w.close()?;
 
-		Err(ErrorKind::GenericError(format!("UTXO with commitment {} is not found", utxo_commitment)))?
+		Err(ErrorKind::GenericError(format!(
+			"UTXO with commitment {} is not found",
+			utxo_commitment
+		)))?
 	}
 
-	pub fn verify_utxo(&mut self, amount: u64, msg_hash: &str, pubkey: String, signature: String) -> Result<bool, Error> {
+	pub fn verify_utxo(
+		&mut self,
+		amount: u64,
+		msg_hash: &str,
+		pubkey: String,
+		signature: String,
+	) -> Result<bool, Error> {
 		if let Ok(msg_hash) = Hash::from_hex(&msg_hash) {
-
 			let secp = Secp256k1::with_caps(ContextFlag::VerifyOnly);
 			let pk = util::from_hex(pubkey).unwrap();
 			let pk = PublicKey::from_slice(&secp, &pk).unwrap();
@@ -861,9 +873,8 @@ where
 			let is_verified = secp.verify(&msg, &signature, &pk).is_ok();
 
 			Ok(is_verified)
-
 		} else {
-			return Err(ErrorKind::GenericError("Invalid message hash".to_owned()))?
+			return Err(ErrorKind::GenericError("Invalid message hash".to_owned()))?;
 		}
 	}
 

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -702,7 +702,6 @@ pub struct SendTXArgs {
 	pub message: Option<String>,
 }
 
-
 /// Output's proof-of-possession
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutputProof {
@@ -716,5 +715,5 @@ pub struct OutputProof {
 	pub public_key: Vec<u8>,
 
 	/// Signature (compact)
-	pub signature: Vec<u8>
+	pub signature: Vec<u8>,
 }

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -701,3 +701,20 @@ pub struct SendTXArgs {
 	/// Optional message, that will be signed
 	pub message: Option<String>,
 }
+
+
+/// Output's proof-of-possession
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputProof {
+	/// Amount held in the output
+	pub amount: u64,
+
+	/// Signed message hash
+	pub msg_hash: Hash,
+
+	/// Signature's public key (compressed)
+	pub public_key: Vec<u8>,
+
+	/// Signature (compact)
+	pub signature: Vec<u8>
+}


### PR DESCRIPTION
As discussed in #2336, this PR provides basic means of signing and verifying output's ownership based on digital signatures with keys derived from blinding factors of outputs.

## Example of UTXO proof generation:
```bash
$ grin --usernet wallet outputs

--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   MMR Index  Block Height  Locked Until  Status   Coinbase?  # Confirms  Value         Tx 
==============================================================================================================================================================
 081a14f7e693ac74a9741d3297b101f5862fb28eadd7506f250fef7fc9b026f2cf  None       49            52            Unspent  true       409         60.000000000  2 
```

Take `081a14f7e693ac74a9741d3297b101f5862fb28eadd7506f250fef7fc9b026f2cf` UTXO's Pedersen Commitment and use it to identify output that we're willing to create proof of ownership for.

Create a hash for message:
```
Blake2b("eupn") = 065294beaa22c6a8c399adaa2388f813425e774da1d14160e48da6b923bcdb15
```

The message hash should be provided by the verifying party to ensure that no signature reuse from proving party is possible.

Generate a proof using commitment and hash:

```bash
$ grin --usernet wallet sign_utxo --utxo 081a14f7e693ac74a9741d3297b101f5862fb28eadd7506f250fef7fc9b026f2cf --msghash 065294beaa22c6a8c399adaa2388f813425e774da1d14160e48da6b923bcdb15

____ Output Proof of Possession ____

Output amount: 60.000000000
Message hash: 065294beaa22c6a8c399adaa2388f813425e774da1d14160e48da6b923bcdb15
Public key (compressed): 03f6ed0a25d5c3f701034cb05a458d06b0312604e6d443de123e962591fe4d14d1
Message signature (compact): 3666059884f673e14aae4e8c79ee26afdd007122aa42b83b0fbe899e8a75f35019fb25bb79b059832a6f171c79bd13c7a4e2ececd533a603140654ceb5c3821a

Command 'sign_utxo' completed successfully
```

Now proving party can send this proof to verifying party and they will be able to check it with `verify_utxo` command.

Furthermore, by having exact amount and a public key, it's possible to check whether there is a commitment to that amount in the blockchain.

## Example of UTXO ownership proof verification:

```bash
$ grin --usernet wallet verify_utxo --amount 60000000000 --msghash 065294beaa22c6a8c399adaa2388f813425e774da1d14160e48da6b923bcdb15 --pubkey 03f6ed0a25d5c3f701034cb05a458d06b0312604e6d443de123e962591fe4d14d1 --signature 3666059884f673e14aae4e8c79ee26afdd007122aa42b83b0fbe899e8a75f35019fb25bb79b059832a6f171c79bd13c7a4e2ececd533a603140654ceb5c3821a

____ Output Proof of Possession ____

        VERIFIED

Command 'verify_utxo' completed successfully
```

## To Do

- [ ] Implement unit tests in `src/bin/cmd/wallet_tests.rs` and `wallet/tests`
- [ ] Determine scope of use cases

Feedback is highly appreciated, hopefully I didn't totally missed the point.