### PR TITLE
Only create single TXLog entry on restore

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -415,6 +415,15 @@ fn comments() -> HashMap<String, String> {
 		.to_string(),
 	);
 	retval.insert(
+		"no_commit_cache".to_string(),
+		"
+#If true, don't store calculated commits in the database
+#better privacy, but at a performance cost of having to 
+#re-calculate commits every time they're used
+"
+		.to_string(),
+	);
+	retval.insert(
 		"dark_background_color_scheme".to_string(),
 		"
 #Whether to use the black background color scheme for command line

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -465,6 +465,30 @@ mod wallet_tests {
 		let arg_vec = vec!["grin", "wallet", "-p", "password", "check"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
+		// Another file exchange, cancel this time
+		let arg_vec = vec![
+			"grin",
+			"wallet",
+			"-p",
+			"password",
+			"-a",
+			"mining",
+			"send",
+			"-m",
+			"file",
+			"-d",
+			&file_name,
+			"-g",
+			"Ain't sending 2",
+			"10",
+		];
+		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
+		let arg_vec = vec![
+			"grin", "wallet", "-p", "password", "-a", "mining", "cancel", "-i", "26",
+		];
+		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
 		// txs and outputs (mostly spit out for a visual in test logs)
 		let arg_vec = vec!["grin", "wallet", "-p", "password", "-a", "mining", "txs"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -431,7 +431,7 @@ where
 
 		let res = Ok((
 			validated,
-			updater::retrieve_txs(&mut *w, tx_id, tx_slate_id, Some(&parent_key_id))?,
+			updater::retrieve_txs(&mut *w, tx_id, tx_slate_id, Some(&parent_key_id), false)?,
 		));
 
 		w.close()?;
@@ -867,7 +867,7 @@ where
 			None => w.parent_key_id(),
 		};
 		// Don't do this multiple times
-		let tx = updater::retrieve_txs(&mut *w, None, Some(slate.id), Some(&parent_key_id))?;
+		let tx = updater::retrieve_txs(&mut *w, None, Some(slate.id), Some(&parent_key_id), false)?;
 		for t in &tx {
 			if t.tx_type == TxLogEntryType::TxReceived {
 				return Err(ErrorKind::TransactionAlreadyReceived(slate.id.to_string()).into());

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -421,8 +421,6 @@ where
 		)?;
 	}
 
-	println!("RESTORE STATS: {:?}", restore_stats);
-
 	// restore labels, account paths and child derivation indices
 	let label_base = "account";
 	let mut acct_index = 1;

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -142,6 +142,8 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
+	let commit = wallet.cached_commit(output.value, &output.key_id)?;
+	println!("Storing commit : {:?}", commit);
 	let mut batch = wallet.batch()?;
 
 	let parent_key_id = output.key_id.parent_path();
@@ -167,6 +169,7 @@ where
 		key_id: output.key_id,
 		n_child: output.n_child,
 		mmr_index: Some(output.mmr_index),
+		commit: commit,
 		value: output.value,
 		status: OutputStatus::Unspent,
 		height: output.height,

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -45,6 +45,19 @@ struct OutputResult {
 	pub blinding: SecretKey,
 }
 
+#[derive(Debug, Clone)]
+/// Collect stats in case we want to just output a single tx log entry
+/// for restored non-coinbase outputs
+struct RestoredTxStats {
+	///
+	pub log_id: u32,
+	///
+	pub amount_credited: u64,
+	///
+	pub num_outputs: usize,
+}
+
+
 fn identify_utxo_outputs<T, C, K>(
 	wallet: &mut T,
 	outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64, u64)>,
@@ -136,6 +149,7 @@ fn restore_missing_output<T, C, K>(
 	wallet: &mut T,
 	output: OutputResult,
 	found_parents: &mut HashMap<Identifier, u32>,
+	tx_stats: &mut Option<&mut HashMap<Identifier, RestoredTxStats>>,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
@@ -148,20 +162,41 @@ where
 	let parent_key_id = output.key_id.parent_path();
 	if !found_parents.contains_key(&parent_key_id) {
 		found_parents.insert(parent_key_id.clone(), 0);
+		if let Some(ref mut s) = tx_stats {
+			s.insert(parent_key_id.clone(), RestoredTxStats {
+				log_id: batch.next_tx_log_id(&parent_key_id)?,
+				amount_credited: 0,
+				num_outputs: 0,
+			});
+		}
 	}
 
-	let log_id = batch.next_tx_log_id(&parent_key_id)?;
-	let entry_type = match output.is_coinbase {
-		true => TxLogEntryType::ConfirmedCoinbase,
-		false => TxLogEntryType::TxReceived,
+	let log_id = if tx_stats.is_none() || output.is_coinbase {
+		let log_id = batch.next_tx_log_id(&parent_key_id)?;
+		let entry_type = match output.is_coinbase {
+			true => TxLogEntryType::ConfirmedCoinbase,
+			false => TxLogEntryType::TxReceived,
+		};
+		let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
+		t.confirmed = true;
+		t.amount_credited = output.value;
+		t.num_outputs = 1;
+		t.update_confirmation_ts();
+		batch.save_tx_log_entry(t, &parent_key_id)?;
+		log_id
+	} else {
+		if let Some(ref mut s) = tx_stats {
+			let ts =  s.get(&parent_key_id).unwrap().clone();
+			s.insert(parent_key_id.clone(), RestoredTxStats {
+				log_id: ts.log_id,
+				amount_credited: ts.amount_credited + output.value,
+				num_outputs: ts.num_outputs + 1,
+			});
+			ts.log_id
+		} else {
+			0
+		}
 	};
-
-	let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
-	t.confirmed = true;
-	t.amount_credited = output.value;
-	t.num_outputs = 1;
-	t.update_confirmation_ts();
-	batch.save_tx_log_entry(t, &parent_key_id)?;
 
 	let _ = batch.save(OutputData {
 		root_key_id: parent_key_id.clone(),
@@ -292,7 +327,7 @@ where
 			 Restoring.",
 			m.value, m.key_id, m.commit,
 		);
-		restore_missing_output(wallet, m, &mut found_parents)?;
+		restore_missing_output(wallet, m, &mut found_parents, &mut None)?;
 	}
 
 	// Unlock locked outputs
@@ -330,24 +365,18 @@ where
 
 	// restore labels, account paths and child derivation indices
 	let label_base = "account";
-	let mut index = 1;
+	let mut acct_index = 1;
 	for (path, max_child_index) in found_parents.iter() {
-		if *path == ExtKeychain::derive_key_id(2, 0, 0, 0, 0) {
-			//default path already exists
-			continue;
-		}
-		let res = wallet.acct_path_iter().find(|e| e.path == *path);
-		if let None = res {
-			let label = format!("{}_{}", label_base, index);
+		// default path already exists
+		if *path != ExtKeychain::derive_key_id(2, 0, 0, 0, 0) {
+			let label = format!("{}_{}", label_base, acct_index);
 			keys::set_acct_path(wallet, &label, path)?;
-			index = index + 1;
+			acct_index += 1;
 		}
-		{
-			let mut batch = wallet.batch()?;
-			batch.save_child_index(path, max_child_index + 1)?;
-		}
+		let mut batch = wallet.batch()?;
+		batch.save_child_index(path, max_child_index + 1)?;
+		batch.commit()?;
 	}
-
 	Ok(())
 }
 
@@ -375,27 +404,39 @@ where
 	);
 
 	let mut found_parents: HashMap<Identifier, u32> = HashMap::new();
-	// Now save what we have
+	let mut restore_stats = HashMap::new();
 
+	// Now save what we have
 	for output in result_vec {
-		restore_missing_output(wallet, output, &mut found_parents)?;
+		restore_missing_output(wallet, output, &mut found_parents, &mut Some(&mut restore_stats))?;
 	}
+
+	println!("RESTORE STATS: {:?}", restore_stats);
 
 	// restore labels, account paths and child derivation indices
 	let label_base = "account";
-	let mut index = 1;
+	let mut acct_index = 1;
 	for (path, max_child_index) in found_parents.iter() {
-		if *path == ExtKeychain::derive_key_id(2, 0, 0, 0, 0) {
-			//default path already exists
-			continue;
+		// default path already exists
+		if *path != ExtKeychain::derive_key_id(2, 0, 0, 0, 0) {
+			let label = format!("{}_{}", label_base, acct_index);
+			keys::set_acct_path(wallet, &label, path)?;
+			acct_index += 1;
 		}
-		let label = format!("{}_{}", label_base, index);
-		keys::set_acct_path(wallet, &label, path)?;
-		index = index + 1;
-		{
+		// restore tx log entry for non-coinbase outputs
+		if let Some(s) = restore_stats.get(path) {
 			let mut batch = wallet.batch()?;
-			batch.save_child_index(path, max_child_index + 1)?;
+			let mut t = TxLogEntry::new(path.clone(), TxLogEntryType::TxReceived, s.log_id);
+			t.confirmed = true;
+			t.amount_credited = s.amount_credited;
+			t.num_outputs = s.num_outputs;
+			t.update_confirmation_ts();
+			batch.save_tx_log_entry(t, &path)?;
+			batch.commit()?;
 		}
+		let mut batch = wallet.batch()?;
+		batch.save_child_index(path, max_child_index + 1)?;
+		batch.commit()?;
 	}
 	Ok(())
 }

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -143,7 +143,6 @@ where
 	K: Keychain,
 {
 	let commit = wallet.cached_commit(output.value, &output.key_id)?;
-	println!("Storing commit : {:?}", commit);
 	let mut batch = wallet.batch()?;
 
 	let parent_key_id = output.key_id.parent_path();
@@ -201,6 +200,7 @@ where
 			output.tx_log_entry.clone(),
 			None,
 			Some(&parent_key_id),
+			false,
 		)?;
 		if entries.len() > 0 {
 			let mut entry = entries[0].clone();

--- a/wallet/src/libwallet/internal/restore.rs
+++ b/wallet/src/libwallet/internal/restore.rs
@@ -57,7 +57,6 @@ struct RestoredTxStats {
 	pub num_outputs: usize,
 }
 
-
 fn identify_utxo_outputs<T, C, K>(
 	wallet: &mut T,
 	outputs: Vec<(pedersen::Commitment, pedersen::RangeProof, bool, u64, u64)>,
@@ -163,11 +162,14 @@ where
 	if !found_parents.contains_key(&parent_key_id) {
 		found_parents.insert(parent_key_id.clone(), 0);
 		if let Some(ref mut s) = tx_stats {
-			s.insert(parent_key_id.clone(), RestoredTxStats {
-				log_id: batch.next_tx_log_id(&parent_key_id)?,
-				amount_credited: 0,
-				num_outputs: 0,
-			});
+			s.insert(
+				parent_key_id.clone(),
+				RestoredTxStats {
+					log_id: batch.next_tx_log_id(&parent_key_id)?,
+					amount_credited: 0,
+					num_outputs: 0,
+				},
+			);
 		}
 	}
 
@@ -186,12 +188,15 @@ where
 		log_id
 	} else {
 		if let Some(ref mut s) = tx_stats {
-			let ts =  s.get(&parent_key_id).unwrap().clone();
-			s.insert(parent_key_id.clone(), RestoredTxStats {
-				log_id: ts.log_id,
-				amount_credited: ts.amount_credited + output.value,
-				num_outputs: ts.num_outputs + 1,
-			});
+			let ts = s.get(&parent_key_id).unwrap().clone();
+			s.insert(
+				parent_key_id.clone(),
+				RestoredTxStats {
+					log_id: ts.log_id,
+					amount_credited: ts.amount_credited + output.value,
+					num_outputs: ts.num_outputs + 1,
+				},
+			);
 			ts.log_id
 		} else {
 			0
@@ -408,7 +413,12 @@ where
 
 	// Now save what we have
 	for output in result_vec {
-		restore_missing_output(wallet, output, &mut found_parents, &mut Some(&mut restore_stats))?;
+		restore_missing_output(
+			wallet,
+			output,
+			&mut found_parents,
+			&mut Some(&mut restore_stats),
+		)?;
 	}
 
 	println!("RESTORE STATS: {:?}", restore_stats);

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -87,7 +87,7 @@ where
 		context.add_input(&input.key_id, &input.mmr_index);
 	}
 
-	let mut commits:HashMap<Identifier, Option<String>> = HashMap::new();
+	let mut commits: HashMap<Identifier, Option<String>> = HashMap::new();
 
 	// Store change output(s) and cached commits
 	for (change_amount, id, mmr_index) in &change_amounts_derivations {

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -21,6 +21,8 @@ use crate::libwallet::error::{Error, ErrorKind};
 use crate::libwallet::internal::keys;
 use crate::libwallet::types::*;
 
+use std::collections::HashMap;
+
 /// Initialize a transaction on the sender side, returns a corresponding
 /// libwallet transaction slate with the appropriate inputs selected,
 /// and saves the private wallet identifiers of our selected outputs
@@ -85,9 +87,12 @@ where
 		context.add_input(&input.key_id, &input.mmr_index);
 	}
 
-	// Store change output(s)
-	for (_, id, mmr_index) in &change_amounts_derivations {
+	let mut commits:HashMap<Identifier, Option<String>> = HashMap::new();
+
+	// Store change output(s) and cached commits
+	for (change_amount, id, mmr_index) in &change_amounts_derivations {
 		context.add_output(&id, &mmr_index);
+		commits.insert(id.clone(), wallet.cached_commit(*change_amount, &id)?);
 	}
 
 	let lock_inputs = context.get_inputs().clone();
@@ -119,10 +124,12 @@ where
 			for (change_amount, id, _) in &change_amounts_derivations {
 				t.num_outputs += 1;
 				t.amount_credited += change_amount;
+				let commit = commits.get(&id).unwrap().clone();
 				batch.save(OutputData {
 					root_key_id: parent_key_id.clone(),
 					key_id: id.clone(),
 					n_child: id.to_path().last_path_index(),
+					commit: commit,
 					mmr_index: None,
 					value: change_amount.clone(),
 					status: OutputStatus::Unconfirmed,
@@ -189,6 +196,7 @@ where
 	// Create closure that adds the output to recipient's wallet
 	// (up to the caller to decide when to do)
 	let wallet_add_fn = move |wallet: &mut T| {
+		let commit = wallet.cached_commit(amount, &key_id_inner)?;
 		let mut batch = wallet.batch()?;
 		let log_id = batch.next_tx_log_id(&parent_key_id)?;
 		let mut t = TxLogEntry::new(parent_key_id.clone(), TxLogEntryType::TxReceived, log_id);
@@ -200,6 +208,7 @@ where
 			key_id: key_id_inner.clone(),
 			mmr_index: None,
 			n_child: key_id_inner.to_path().last_path_index(),
+			commit: commit,
 			value: amount,
 			status: OutputStatus::Unconfirmed,
 			height: height,

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -161,7 +161,7 @@ where
 	} else if let Some(tx_slate_id) = tx_slate_id {
 		tx_id_string = tx_slate_id.to_string();
 	}
-	let tx_vec = updater::retrieve_txs(wallet, tx_id, tx_slate_id, Some(&parent_key_id))?;
+	let tx_vec = updater::retrieve_txs(wallet, tx_id, tx_slate_id, Some(&parent_key_id), false)?;
 	if tx_vec.len() != 1 {
 		return Err(ErrorKind::TransactionDoesntExist(tx_id_string))?;
 	}
@@ -191,7 +191,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let tx_vec = updater::retrieve_txs(wallet, Some(tx_id), None, Some(parent_key_id))?;
+	let tx_vec = updater::retrieve_txs(wallet, Some(tx_id), None, Some(parent_key_id), false)?;
 	if tx_vec.len() != 1 {
 		return Err(ErrorKind::TransactionDoesntExist(tx_id.to_string()))?;
 	}
@@ -207,7 +207,7 @@ where
 	K: Keychain,
 {
 	// finalize command
-	let tx_vec = updater::retrieve_txs(wallet, None, Some(slate.id), None)?;
+	let tx_vec = updater::retrieve_txs(wallet, None, Some(slate.id), None, false)?;
 	let mut tx = None;
 	// don't want to assume this is the right tx, in case of self-sending
 	for t in tx_vec {

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -202,7 +202,7 @@ where
 			batch.delete(&o.key_id, &o.mmr_index)?;
 		}
 		if o.status == OutputStatus::Locked {
-			o.status = OutputStatus::Unconfirmed;
+			o.status = OutputStatus::Unspent;
 			batch.save(o)?;
 		}
 	}

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -98,29 +98,32 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let mut txs : Vec<TxLogEntry> = wallet.tx_log_iter()
-	.filter(|tx_entry| {
-		let f_pk = match parent_key_id {
-			Some(k) => tx_entry.parent_key_id == *k,
-			None => true,
-		};
-		let f_tx_id = match tx_id {
-			Some(i) => tx_entry.id == i,
-			None => true,
-		};
-		let f_txs = match tx_slate_id {
-			Some(t) => tx_entry.tx_slate_id == Some(t),
-			None => true,
-		};
-		let f_outstanding = match outstanding_only {
-			true => tx_entry.confirmed &&
-				(tx_entry.tx_type == TxLogEntryType::TxReceived
-				|| tx_entry.tx_type == TxLogEntryType::TxSent),
-			false => true,
-		};
-		f_pk && f_tx_id && f_txs && f_outstanding
-	})
-	.collect();
+	let mut txs: Vec<TxLogEntry> = wallet
+		.tx_log_iter()
+		.filter(|tx_entry| {
+			let f_pk = match parent_key_id {
+				Some(k) => tx_entry.parent_key_id == *k,
+				None => true,
+			};
+			let f_tx_id = match tx_id {
+				Some(i) => tx_entry.id == i,
+				None => true,
+			};
+			let f_txs = match tx_slate_id {
+				Some(t) => tx_entry.tx_slate_id == Some(t),
+				None => true,
+			};
+			let f_outstanding = match outstanding_only {
+				true => {
+					tx_entry.confirmed
+						&& (tx_entry.tx_type == TxLogEntryType::TxReceived
+							|| tx_entry.tx_type == TxLogEntryType::TxSent)
+				}
+				false => true,
+			};
+			f_pk && f_tx_id && f_txs && f_outstanding
+		})
+		.collect();
 	txs.sort_by_key(|tx| tx.creation_ts);
 	Ok(txs)
 }

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -115,7 +115,7 @@ where
 			};
 			let f_outstanding = match outstanding_only {
 				true => {
-					tx_entry.confirmed
+					!tx_entry.confirmed
 						&& (tx_entry.tx_type == TxLogEntryType::TxReceived
 							|| tx_entry.tx_type == TxLogEntryType::TxSent)
 				}

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -91,30 +91,36 @@ pub fn retrieve_txs<T: ?Sized, C, K>(
 	tx_id: Option<u32>,
 	tx_slate_id: Option<Uuid>,
 	parent_key_id: Option<&Identifier>,
+	outstanding_only: bool,
 ) -> Result<Vec<TxLogEntry>, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
 	K: Keychain,
 {
-	// just read the wallet here, no need for a write lock
-	let mut txs = if let Some(id) = tx_id {
-		wallet.tx_log_iter().filter(|t| t.id == id).collect()
-	} else if tx_slate_id.is_some() {
-		wallet
-			.tx_log_iter()
-			.filter(|t| t.tx_slate_id == tx_slate_id)
-			.collect()
-	} else {
-		wallet.tx_log_iter().collect::<Vec<_>>()
-	};
-	if let Some(k) = parent_key_id {
-		txs = txs
-			.iter()
-			.filter(|t| t.parent_key_id == *k)
-			.map(|t| t.clone())
-			.collect();
-	}
+	let mut txs : Vec<TxLogEntry> = wallet.tx_log_iter()
+	.filter(|tx_entry| {
+		let f_pk = match parent_key_id {
+			Some(k) => tx_entry.parent_key_id == *k,
+			None => true,
+		};
+		let f_tx_id = match tx_id {
+			Some(i) => tx_entry.id == i,
+			None => true,
+		};
+		let f_txs = match tx_slate_id {
+			Some(t) => tx_entry.tx_slate_id == Some(t),
+			None => true,
+		};
+		let f_outstanding = match outstanding_only {
+			true => tx_entry.confirmed &&
+				(tx_entry.tx_type == TxLogEntryType::TxReceived
+				|| tx_entry.tx_type == TxLogEntryType::TxSent),
+			false => true,
+		};
+		f_pk && f_tx_id && f_txs && f_outstanding
+	})
+	.collect();
 	txs.sort_by_key(|tx| tx.creation_ts);
 	Ok(txs)
 }
@@ -156,20 +162,18 @@ where
 		.filter(|x| x.root_key_id == *parent_key_id && x.status != OutputStatus::Spent)
 		.collect();
 
+	let tx_entries = retrieve_txs(wallet, None, None, Some(&parent_key_id), true)?;
+
 	// Only select outputs that are actually involved in an outstanding transaction
 	let unspents: Vec<OutputData> = match update_all {
 		false => unspents
 			.into_iter()
 			.filter(|x| match x.tx_log_entry.as_ref() {
 				Some(t) => {
-					let entries = retrieve_txs(wallet, Some(*t), None, Some(&parent_key_id));
-					match entries {
-						Err(_) => true,
-						Ok(e) => {
-							e.len() > 0
-								&& !e[0].confirmed && (e[0].tx_type == TxLogEntryType::TxReceived
-								|| e[0].tx_type == TxLogEntryType::TxSent)
-						}
+					if let Some(_) = tx_entries.iter().find(|&te| te.id == *t) {
+						true
+					} else {
+						false
 					}
 				}
 				None => true,

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -67,6 +67,9 @@ where
 	/// Return the client being used to communicate with the node
 	fn w2n_client(&mut self) -> &mut C;
 
+	/// return the commit if allowed, if enabled, None otherwise
+	fn cached_commit(&mut self, amount: u64, id: &Identifier) -> Result<Option<String>, Error>;
+
 	/// Set parent key id by stored account name
 	fn set_parent_key_id_by_name(&mut self, label: &str) -> Result<(), Error>;
 
@@ -241,6 +244,8 @@ pub struct OutputData {
 	pub key_id: Identifier,
 	/// How many derivations down from the root key
 	pub n_child: u32,
+	/// The actual commit, optionally stored
+	pub commit: Option<String>,
 	/// PMMR Index, used on restore in case of duplicate wallets using the same
 	/// key_id (2 wallets using same seed, for instance
 	pub mmr_index: Option<u64>,

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -199,6 +199,15 @@ where
 		&mut self.w2n_client
 	}
 
+	/// return the commit, if enabled, None otherwise
+	fn cached_commit(&mut self, amount: u64, id: &Identifier) -> Result<Option<String>, Error>{
+		if self.config.no_commit_cache == Some(true) {
+			Ok(None)
+		} else {
+			Ok(Some(util::to_hex(self.keychain().commit(amount, &id)?.0.to_vec())))
+		}
+	}
+
 	/// Set parent path by account name
 	fn set_parent_key_id_by_name(&mut self, label: &str) -> Result<(), Error> {
 		let label = label.to_owned();

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -200,11 +200,13 @@ where
 	}
 
 	/// return the commit, if enabled, None otherwise
-	fn cached_commit(&mut self, amount: u64, id: &Identifier) -> Result<Option<String>, Error>{
+	fn cached_commit(&mut self, amount: u64, id: &Identifier) -> Result<Option<String>, Error> {
 		if self.config.no_commit_cache == Some(true) {
 			Ok(None)
 		} else {
-			Ok(Some(util::to_hex(self.keychain().commit(amount, &id)?.0.to_vec())))
+			Ok(Some(util::to_hex(
+				self.keychain().commit(amount, &id)?.0.to_vec(),
+			)))
 		}
 	}
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -52,6 +52,9 @@ pub struct WalletConfig {
 	pub owner_api_include_foreign: Option<bool>,
 	// The directory in which wallet files are stored
 	pub data_file_dir: String,
+	/// If Some(true), don't cache commits alongside output data
+	/// speed improvement, but your commits are in the database
+	pub no_commit_cache: Option<bool>,
 	/// TLS certificate file
 	pub tls_certificate_file: Option<String>,
 	/// TLS certificate private key file
@@ -74,6 +77,7 @@ impl Default for WalletConfig {
 			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
 			owner_api_include_foreign: Some(false),
 			data_file_dir: ".".to_string(),
+			no_commit_cache: Some(false),
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			dark_background_color_scheme: Some(true),


### PR DESCRIPTION
Futher improvement (that shouldn't affect anything other than restore,) on restore, instead of outputting a new transaction log entry for every output, just create one received TX log entry for the entire amount. The new TX only includes non-coinbase transactions; coinbase transactions get their own TX log entry.