### PR TITLE
Mainnet enablement

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -62,7 +62,7 @@ pub const COINBASE_MATURITY: u64 = DAY_HEIGHT;
 /// function of block height (time). Starts at 90% losing a percent
 /// approximately every week. Represented as an integer between 0 and 100.
 pub fn secondary_pow_ratio(height: u64) -> u64 {
-	90u64.saturating_sub(height / (2 * YEAR_HEIGHT / 90))
+	90u64.saturating_add(height / (2 * YEAR_HEIGHT / 90))
 }
 
 /// The AR scale damping factor to use. Dependent on block height

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -62,7 +62,7 @@ pub const COINBASE_MATURITY: u64 = DAY_HEIGHT;
 /// function of block height (time). Starts at 90% losing a percent
 /// approximately every week. Represented as an integer between 0 and 100.
 pub fn secondary_pow_ratio(height: u64) -> u64 {
-	90u64.saturating_add(height / (2 * YEAR_HEIGHT / 90))
+	90u64.saturating_sub(height / (2 * YEAR_HEIGHT / 90))
 }
 
 /// The AR scale damping factor to use. Dependent on block height

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -179,7 +179,7 @@ pub fn genesis_main() -> core::Block {
 		output_mmr_size: 1,
 		kernel_mmr_size: 1,
 		pow: ProofOfWork {
-			total_difficulty: Difficulty::from_num(10_u64.pow(8)),
+			total_difficulty: Difficulty::from_num(2_u64.pow(34)),
 			secondary_scaling: 1856,
 			nonce: 1, // REPLACE
 			proof: Proof {

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -87,12 +87,6 @@ fn real_main() -> i32 {
 		global::ChainTypes::Mainnet
 	};
 
-	// TODO remove for mainnet
-	if chain_type == global::ChainTypes::Mainnet {
-		println!("Mainnet not ready yet! In the meantime run 'grin --floonet ...'");
-		exit(1);
-	}
-
 	// Deal with configuration file creation
 	match args.subcommand() {
 		("server", Some(server_args)) => {


### PR DESCRIPTION
1. Remove the exit guarding running a node in mainnet mode.
2. Set initial difficulty in genesis.
