### PR TITLE
use travis-ci to update a release instead of creating new release

### DIFF
--- a/.auto-release.sh
+++ b/.auto-release.sh
@@ -2,6 +2,7 @@
 
 repo_slug="mimblewimble/grin"
 token="$GITHUB_TOKEN"
+export CHANGELOG_GITHUB_TOKEN="$token"
 
 tagname=`git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD`
 
@@ -42,7 +43,6 @@ LAST_RELEASE_TAG=$(git describe --abbrev=0 --tags ${LAST_REVISION})
 github_changelog_generator \
   -u $(cut -d "/" -f1 <<< $repo_slug) \
   -p $(cut -d "/" -f2 <<< $repo_slug) \
-  --token $token \
   --since-tag ${LAST_RELEASE_TAG}
 
 body="$(cat CHANGELOG.md)"
@@ -62,7 +62,8 @@ jq -n \
     prerelease: false
   }' > CHANGELOG.md
 
-echo "Create release $version for repo: $repo_slug, branch: $branch"
-curl -H "Authorization: token $token" --data @CHANGELOG.md "https://api.github.com/repos/$repo_slug/releases"
+release_id="$(curl -0 -XGET -H "Authorization: token $token" https://api.github.com/repos/garyyu/grin/releases/tags/$tagname 2>/dev/null | grep id | head -n 1 | sed 's/ *"id": *\(.*\),/\1/')"
+echo "Updating release $version for repo: $repo_slug, branch: $branch. release id: $release_id"
+curl -H "Authorization: token $token" --request PATCH  --data @CHANGELOG.md "https://api.github.com/repos/$repo_slug/releases/$release_id"
 echo "auto changelog uploaded.\n"
 


### PR DESCRIPTION
This PR solve the problem in https://github.com/mimblewimble/grin/issues/2251:  "released by" is wrong.

According to Github staff's feedback:
> Please note, the person who creates the release can be different to the user who originally created the tag.

And after reading Github API docs: https://developer.github.com/v3/repos/releases/#edit-a-release
We can use `edit a release` instead of `create a release`, then we will never have such kind of problem, the member who created a release in github will never be touched and correctly tagged with "released by".

So, we just need add `--request PATCH ` on our request, and put the `release id` as a request parameter.

