### PR TITLE
Update dependencies

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -25,7 +25,7 @@ What's working so far?
 For Debian-based distributions (Debian, Ubuntu, Mint, etc), all in one line (except Rust):
 
 ```sh
-apt install build-essential cmake git libgit2-dev clang libncurses5-dev libncursesw5-dev zlib1g-dev pkg-config libssl-dev llvm
+apt install build-essential cmake git libgit2-dev clang libncurses5-dev libncursesw5-dev zlib1g-dev pkg-config libssl-dev llvm cargo
 ```
 
 ## Build steps


### PR DESCRIPTION
Include cargo for Debian-based systems, required for building.