### PR TITLE
Fix: Recovering from phrase gives IO Error

### DIFF
--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -191,6 +191,9 @@ impl WalletSeed {
 		word_list: &str,
 		password: &str,
 	) -> Result<(), Error> {
+		// create directory if it doesn't exist
+		fs::create_dir_all(&wallet_config.data_file_dir).context(ErrorKind::IO)?;
+		
 		let seed_file_path = &format!(
 			"{}{}{}",
 			wallet_config.data_file_dir, MAIN_SEPARATOR, SEED_FILE,


### PR DESCRIPTION
If you try to recover your wallet from the phrase on a fresh "install" of the grin it will always fail with IO Error. This happens because the directory for the seed file to be generated doesn't exist. 

If you check the functions init_file and from_file in this same file, you can see that these exact lines can be found there.

My first lines of rust and grin. Very exiting project. 