### PR TITLE
Updated default API port.

### DIFF
--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -4,7 +4,7 @@ This document contains the documentation for the 3 Grin REST APIs. These endpoin
 
 ## Node API
 
-This endpoint is used to query a node about various information on the blockchain, networks and peers. By default, this REST API will listen on `localhost:13413`. This API is started as the same time as the Grin node.
+This endpoint is used to query a node about various information on the blockchain, networks and peers. By default, this REST API will listen on `localhost:3413`. This API is started as the same time as the Grin node.
 This endpoint requires, by default, [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). The username is `grin` and the password can be found in the `.api_secret` file.
 To learn about what specific calls can be made read the [node API doc](node_api.md).
 


### PR DESCRIPTION
Grin 1.0.0 uses port as API default.