### PR TITLE
Added support for saving message

### DIFF
--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -581,7 +581,8 @@ where
 					error!("Error validating participant messages: {}", e);
 					err(e)
 				} else {
-					match api.receive_tx(&mut slate, None, None) {
+					let msg = slate.participant_data[0].message.clone();
+					match api.receive_tx(&mut slate, None, msg) {
 						Ok(_) => ok(slate.clone()),
 						Err(e) => {
 							error!("receive_tx: failed with error: {}", e);

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -71,6 +71,15 @@ where
 	slate.lock_height = lock_height;
 	slate.fee = fee;
 	let slate_id = slate.id.clone();
+	let mut message = "".to_string();
+	if slate.participant_data.len() > 0 {
+		for data in slate.participant_data.iter() {
+			if message.len() > 0 {
+				message.push_str(&"|".to_string());
+			}
+			message.push_str(&data.message.clone().unwrap_or("".to_string()));
+		}
+	}
 
 	let keychain = wallet.keychain().clone();
 
@@ -109,6 +118,7 @@ where
 			let log_id = batch.next_tx_log_id(&parent_key_id)?;
 			let mut t = TxLogEntry::new(parent_key_id.clone(), TxLogEntryType::TxSent, log_id);
 			t.tx_slate_id = Some(slate_id);
+			t.message = Some(message);
 			let filename = format!("{}.grintx", slate_id);
 			t.stored_tx = Some(filename);
 			t.fee = Some(fee);
@@ -183,6 +193,16 @@ where
 	let height = slate.height;
 
 	let slate_id = slate.id.clone();
+	let mut message = "".to_string();
+	if slate.participant_data.len() > 0 {
+		for data in slate.participant_data.iter() {
+			if message.len() > 0 {
+				message.push_str(&"|".to_string());
+			}
+			message.push_str(&data.message.clone().unwrap_or("".to_string()));
+		}
+	}
+
 	let blinding =
 		slate.add_transaction_elements(&keychain, vec![build::output(amount, key_id.clone())])?;
 
@@ -205,6 +225,7 @@ where
 		let mut t = TxLogEntry::new(parent_key_id.clone(), TxLogEntryType::TxReceived, log_id);
 		t.tx_slate_id = Some(slate_id);
 		t.amount_credited = amount;
+		t.message = Some(message);
 		t.num_outputs = 1;
 		batch.save(OutputData {
 			root_key_id: parent_key_id.clone(),

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -612,6 +612,8 @@ pub struct TxLogEntry {
 	pub fee: Option<u64>,
 	/// Location of the store transaction, (reference or resending)
 	pub stored_tx: Option<String>,
+	/// Message
+	pub message: Option<String>,
 }
 
 impl ser::Writeable for TxLogEntry {
@@ -644,6 +646,7 @@ impl TxLogEntry {
 			num_outputs: 0,
 			fee: None,
 			stored_tx: None,
+			message: None,
 		}
 	}
 


### PR DESCRIPTION
This PR intends to add support for saving messages that are sent with Grin transactions. In Grin's current state it is possible to store messages but nothing is done with them. In order to be able to use messages and streamline implementation into 3rd party services (merchant or exchange) the team at ChainRift exchange has come up with these basic changes.

What the PR does is save all messages from participants and stores them into the local database, separated by pipe, only extending existing features.

The messages are currently only shown when fetching transactions through owner API. If necessary the txs command can be extended to show messages as well.

Since Grin designers may have intended to save/show messages in a different way I welcome any and all comments in order to meet their intent. Since this was my first touch with Rust feel free to make code suggestions if necessary.