### PR TITLE
Build warning sync

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -601,7 +601,6 @@ impl NetToChainAdapter {
 ///  accepted a new block, asking the pool to update its state and
 /// the network to broadcast the block
 pub struct ChainToPoolAndNetAdapter {
-	sync_state: Arc<SyncState>,
 	tx_pool: Arc<RwLock<pool::TransactionPool>>,
 	peers: OneTime<Weak<p2p::Peers>>,
 }
@@ -672,11 +671,9 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 impl ChainToPoolAndNetAdapter {
 	/// Construct a ChainToPoolAndNetAdapter instance.
 	pub fn new(
-		sync_state: Arc<SyncState>,
 		tx_pool: Arc<RwLock<pool::TransactionPool>>,
 	) -> ChainToPoolAndNetAdapter {
 		ChainToPoolAndNetAdapter {
-			sync_state,
 			tx_pool,
 			peers: OneTime::new(),
 		}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -210,7 +210,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 		// pushing the new block header through the header chain pipeline
 		// we will go ask for the block if this is a new header
-		let res = self.chain().process_block_header(&bh, self.chain_opts(false));
+		let res = self
+			.chain()
+			.process_block_header(&bh, self.chain_opts(false));
 
 		if let &Err(ref e) = &res {
 			debug!("Block header {} refused by chain: {:?}", bhash, e.kind());
@@ -434,7 +436,10 @@ impl NetToChainAdapter {
 		let bhash = b.hash();
 		let previous = self.chain().get_previous_header(&b.header);
 
-		match self.chain().process_block(b, self.chain_opts(was_requested)) {
+		match self
+			.chain()
+			.process_block(b, self.chain_opts(was_requested))
+		{
 			Ok(_) => {
 				self.validate_chain(bhash);
 				self.check_compact();
@@ -670,9 +675,7 @@ impl ChainAdapter for ChainToPoolAndNetAdapter {
 
 impl ChainToPoolAndNetAdapter {
 	/// Construct a ChainToPoolAndNetAdapter instance.
-	pub fn new(
-		tx_pool: Arc<RwLock<pool::TransactionPool>>,
-	) -> ChainToPoolAndNetAdapter {
+	pub fn new(tx_pool: Arc<RwLock<pool::TransactionPool>>) -> ChainToPoolAndNetAdapter {
 		ChainToPoolAndNetAdapter {
 			tx_pool,
 			peers: OneTime::new(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -128,9 +128,7 @@ impl Server {
 
 		let sync_state = Arc::new(SyncState::new());
 
-		let chain_adapter = Arc::new(ChainToPoolAndNetAdapter::new(
-			tx_pool.clone(),
-		));
+		let chain_adapter = Arc::new(ChainToPoolAndNetAdapter::new(tx_pool.clone()));
 
 		let genesis = match config.chain_type {
 			global::ChainTypes::AutomatedTesting => genesis::genesis_dev(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -129,7 +129,6 @@ impl Server {
 		let sync_state = Arc::new(SyncState::new());
 
 		let chain_adapter = Arc::new(ChainToPoolAndNetAdapter::new(
-			sync_state.clone(),
 			tx_pool.clone(),
 		));
 


### PR DESCRIPTION
We do not need `sync_state` in adapters any more.
So no need to pass one in either.

Cleans up the following build warning - 

```
   Compiling grin_servers v1.0.0 (/antiochp/grin/servers)                                                                                                                                                
warning: field is never used: `sync_state`                                                                                                                                                               
   --> servers/src/common/adapters.rs:604:2                                                                                                                                                              
    |                                                                                                                                                                                                    
604 |     sync_state: Arc<SyncState>,                                                                                                                                                                    
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                     
    |                                                                                                                                                                                                    
    = note: #[warn(dead_code)] on by default  
```