### PR TITLE
Maintain min outbound peers (min_preferred_peers / 2)

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -171,12 +171,21 @@ impl Peers {
 		self.peers.read().get(addr).map(|p| p.clone())
 	}
 
-	/// Number of peers we're currently connected to.
+	/// Number of peers currently connected to.
 	pub fn peer_count(&self) -> u32 {
 		self.peers
 			.read()
 			.values()
 			.filter(|x| x.is_connected())
+			.count() as u32
+	}
+
+	/// Number of outbound peers currently connected to.
+	pub fn peer_outbound_count(&self) -> u32 {
+		self.peers
+			.read()
+			.values()
+			.filter(|x| x.is_connected() && x.info.is_outbound())
 			.count() as u32
 	}
 

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -273,6 +273,10 @@ impl PeerInfo {
 		self.live_info.read().total_difficulty
 	}
 
+	pub fn is_outbound(&self) -> bool {
+		self.direction == Direction::Outbound
+	}
+
 	/// The current height of the peer.
 	pub fn height(&self) -> u64 {
 		self.live_info.read().height

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -317,14 +317,14 @@ fn listen_for_addrs(
 	// here to prevent it backing up.
 	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
 
-	warn!("***** listen_for_addrs: addrs count here: {}", addrs.len());
-
 	// If we have a healthy number of outbound peers then we are done here.
-	// Note: We drained the rx queue earlier to keep it under control.
 	if peers.peer_outbound_count() >= p2p.config.peer_min_preferred_count() / 2 {
 		return;
 	}
 
+	// Try to connect to (up to max peers) peer addresses.
+	// Note: We drained the rx queue earlier to keep it under control.
+	// Even if there are many addresses to try we will only try a bounded number of them.
 	let connect_min_interval = 30;
 	for addr in addrs.into_iter().take(p2p.config.peer_max_count() as usize) {
 		// ignore the duplicate connecting to same peer within 30 seconds

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -313,18 +313,20 @@ fn listen_for_addrs(
 ) {
 	// Pull everything currently on the queue off the queue.
 	// Does not block so addrs may be empty.
+	// We will take(max_peers) from this later but we want to drain the rx queue
+	// here to prevent it backing up.
 	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
 
 	warn!("***** listen_for_addrs: addrs count here: {}", addrs.len());
 
-	// if peers.peer_count() >= p2p.config.peer_max_count() {
-	// 	// clean the rx messages to avoid accumulating
-	// 	for _ in rx.try_iter() {}
-	// 	return;
-	// }
+	// If we have a healthy number of outbound peers then we are done here.
+	// Note: We drained the rx queue earlier to keep it under control.
+	if peers.peer_outbound_count() >= p2p.config.peer_min_preferred_count() / 2 {
+		return;
+	}
 
 	let connect_min_interval = 30;
-	for addr in addrs.into_iter().take(config.peer_max_count() as usize) {
+	for addr in addrs.into_iter().take(p2p.config.peer_max_count() as usize) {
 		// ignore the duplicate connecting to same peer within 30 seconds
 		let now = Utc::now();
 		if let Some(last_connect_time) = connecting_history.get(&addr) {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -186,9 +186,10 @@ fn monitor_peers(
 	// maintenance step first, clean up p2p server peers
 	peers.clean_peers(config.peer_max_count() as usize);
 
-	// not enough peers, getting more from db
-	if peers.peer_count() >= config.peer_min_preferred_count() {
-		return;
+	// We have enough peers, both total connected and outbound connected so we are good.
+	if peers.peer_count() >= config.peer_min_preferred_count() 
+		&& peers.peer_outbound_count() >= config.peer_min_preferred_count() / 2 {
+			return;
 	}
 
 	// loop over connected peers

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -187,9 +187,10 @@ fn monitor_peers(
 	peers.clean_peers(config.peer_max_count() as usize);
 
 	// We have enough peers, both total connected and outbound connected so we are good.
-	if peers.peer_count() >= config.peer_min_preferred_count() 
-		&& peers.peer_outbound_count() >= config.peer_min_preferred_count() / 2 {
-			return;
+	if peers.peer_count() >= config.peer_min_preferred_count()
+		&& peers.peer_outbound_count() >= config.peer_min_preferred_count() / 2
+	{
+		return;
 	}
 
 	// loop over connected peers

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -135,7 +135,6 @@ impl TUIStatusListener for TUIPeerView {
 			LinearLayout::new(Orientation::Vertical)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
-						.child(TextView::new("Total Peers: "))
 						.child(TextView::new("  ").with_id("peers_total")),
 				)
 				.child(
@@ -179,7 +178,11 @@ impl TUIStatusListener for TUIPeerView {
 			},
 		);
 		let _ = c.call_on_id("peers_total", |t: &mut TextView| {
-			t.set_content(stats.peer_stats.len().to_string());
+			t.set_content(format!(
+				"Total Peers: {} (Outbound: {})",
+				stats.peer_stats.len(),
+				stats.peer_stats.iter().filter(|x| x.direction == "Outbound").count(),
+			));
 		});
 		let _ = c.call_on_id("longest_work_peer", |t: &mut TextView| {
 			t.set_content(lp_str);

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -181,7 +181,11 @@ impl TUIStatusListener for TUIPeerView {
 			t.set_content(format!(
 				"Total Peers: {} (Outbound: {})",
 				stats.peer_stats.len(),
-				stats.peer_stats.iter().filter(|x| x.direction == "Outbound").count(),
+				stats
+					.peer_stats
+					.iter()
+					.filter(|x| x.direction == "Outbound")
+					.count(),
 			));
 		});
 		let _ = c.call_on_id("longest_work_peer", |t: &mut TextView| {


### PR DESCRIPTION
Resolves: #2394.

Large number of nodes on mainnet and a growing network size means nodes are inundated with `inbound` connections (if they are public nodes, not behind NAT).
This means we are losing outbound connections over time as we do not prioritize these at all.

See #2394 for more context.

This PR changes the "do we need to dial more peers" behavior so it is aware of our `outbound` peer count in addition to the total connected count.

If `peer_min_preferred_count = 8` (default config) we attempt to open more outbound connections if - 
* we have less than 8 connected peers, or
* we have less than 4 connected outbound peers

TODO (in progress) - 
- [x] test against mainnet with node that accepts inbound connections
Edit: Node running happily on mainnet for ~12 hours and connections staying healthy.