### PR TITLE
default log level DEBUG -> INFO

### DIFF
--- a/util/src/types.rs
+++ b/util/src/types.rs
@@ -56,7 +56,7 @@ impl Default for LoggingConfig {
 			log_to_stdout: true,
 			stdout_log_level: LogLevel::Warning,
 			log_to_file: true,
-			file_log_level: LogLevel::Debug,
+			file_log_level: LogLevel::Info,
 			log_file_path: String::from("grin.log"),
 			log_file_append: true,
 			log_max_size: Some(1024 * 1024 * 16), // 16 megabytes default


### PR DESCRIPTION
Resolves #2419.

We may want to keep it at DEBUG for a bit but its filling everyones disks up, mainly with peer connection messages as the network grows and hopefully stabilizes.

Thoughts?



