### PR TITLE
Improve error output in cases when db_root / logfile is inaccesible 

### DIFF
--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -66,7 +66,8 @@ pub fn new_env(path: String) -> lmdb::Environment {
 /// Create a new LMDB env under the provided directory with the provided name.
 pub fn new_named_env(path: String, name: String) -> lmdb::Environment {
 	let full_path = [path, name].join("/");
-	fs::create_dir_all(&full_path).unwrap();
+	fs::create_dir_all(&full_path)
+		.expect("Unable to create directory 'db_root' to store chain_data");
 
 	let mut env_builder = lmdb::EnvBuilder::new().unwrap();
 	env_builder.set_maxdbs(8).unwrap();

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -136,7 +136,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 							.append(c.log_file_append)
 							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
 							.build(c.log_file_path, Box::new(policy))
-							.unwrap(),
+							.expect("Failed to create logfile"),
 					)
 				} else {
 					Box::new(
@@ -144,7 +144,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 							.append(c.log_file_append)
 							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
 							.build(c.log_file_path)
-							.unwrap(),
+							.expect("Failed to create logfile"),
 					)
 				}
 			};


### PR DESCRIPTION
I hit this situation earlier today when the server had been previously run as root and now the same db_root is being used. Instead of a silent failure, this makes it simpler to fix the issue and move on for the person running the node.

The same situation applies to the logfile, so addressed that in a second commit.

Minor things like this seem to go a long way in giving it polish. Next I am thinking of looking into implementing the `grin server stop` command however the `/tmp/grin.pid` is empty because potentially Daemonize crate isn't flushing the data written to the file.