### PR TITLE
Cleanup compiler warnings

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -140,7 +140,7 @@ impl Handler for BlockHandler {
 				return response(
 					StatusCode::BAD_REQUEST,
 					format!("failed to parse input: {}", e),
-				)
+				);
 			}
 			Ok(h) => h,
 		};

--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -68,7 +68,7 @@ impl HeaderHandler {
 
 impl Handler for HeaderHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let el = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let el = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
 		};
@@ -125,12 +125,12 @@ fn check_block_param(input: &String) -> Result<(), Error> {
 			"Not a valid hash or height.".to_owned(),
 		))?;
 	}
-	return Ok(());
+	Ok(())
 }
 
 impl Handler for BlockHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let el = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let el = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
 		};

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -111,7 +111,7 @@ impl OutputHandler {
 
 		for (k, id) in params {
 			if k == "id" {
-				for id in id.split(",") {
+				for id in id.split(',') {
 					commitments.push(id.to_owned());
 				}
 			}
@@ -178,7 +178,7 @@ impl OutputHandler {
 
 		if let Some(ids) = params.get("id") {
 			for id in ids {
-				for id in id.split(",") {
+				for id in id.split(',') {
 					if let Ok(x) = util::from_hex(String::from(id)) {
 						commitments.push(Commitment::from_vec(x));
 					}
@@ -223,7 +223,7 @@ impl OutputHandler {
 
 impl Handler for OutputHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let command = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let command = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			Some(c) => c,
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 		};

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -56,7 +56,7 @@ pub struct PeerHandler {
 
 impl Handler for PeerHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let command = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let command = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			Some(c) => c,
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 		};
@@ -73,7 +73,7 @@ impl Handler for PeerHandler {
 		}
 	}
 	fn post(&self, req: Request<Body>) -> ResponseFuture {
-		let mut path_elems = req.uri().path().trim_right_matches("/").rsplit("/");
+		let mut path_elems = req.uri().path().trim_right_matches('/').rsplit('/');
 		let command = match path_elems.next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(c) => c,

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -85,7 +85,7 @@ impl Handler for PeerHandler {
 					return response(
 						StatusCode::BAD_REQUEST,
 						format!("invalid peer address: {}", e),
-					)
+					);
 				}
 				Ok(addr) => addr,
 			},

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -22,21 +22,13 @@ use grin_util as util;
 use failure;
 #[macro_use]
 extern crate failure_derive;
-use hyper;
 #[macro_use]
 extern crate lazy_static;
 
-use serde;
 #[macro_use]
 extern crate serde_derive;
-use serde_json;
 #[macro_use]
 extern crate log;
-
-use hyper_rustls;
-use rustls;
-
-use tokio_tcp;
 
 pub mod auth;
 pub mod client;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -990,7 +990,7 @@ impl Chain {
 				Err(e) => {
 					return Err(
 						ErrorKind::StoreErr(e, "retrieving block to compact".to_owned()).into(),
-					)
+					);
 				}
 			}
 			if current.height <= 1 {

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -33,7 +33,6 @@ extern crate log;
 use failure;
 use grin_core as core;
 use grin_keychain as keychain;
-use grin_store;
 use grin_util as util;
 
 mod chain;

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -20,11 +20,8 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-use dirs;
-
 #[macro_use]
 extern crate serde_derive;
-use toml;
 
 use grin_core as core;
 use grin_p2p as p2p;

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -250,7 +250,7 @@ impl HeaderInfo {
 
 /// Move value linearly toward a goal
 pub fn damp(actual: u64, goal: u64, damp_factor: u64) -> u64 {
-	(1 * actual + (damp_factor - 1) * goal) / damp_factor
+	(actual + (damp_factor - 1) * goal) / damp_factor
 }
 
 /// limit value to be within some factor from a goal

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -89,7 +89,7 @@ pub fn to_entropy(mnemonic: &str) -> Result<Vec<u8>, Error> {
 	for index in indexes.iter().rev() {
 		for i in 0..11 {
 			let bit = index & (1 << i) != 0;
-			entropy[datalen - loc / 8] |= (bit as u8) << loc % 8;
+			entropy[datalen - loc / 8] |= (bit as u8) << (loc % 8);
 			loc += 1;
 		}
 	}
@@ -99,7 +99,7 @@ pub fn to_entropy(mnemonic: &str) -> Result<Vec<u8>, Error> {
 	sha2sum.input(&entropy.clone());
 	hash.copy_from_slice(sha2sum.result().as_slice());
 
-	let actual = (hash[0] >> 8 - checksum_bits) & mask;
+	let actual = (hash[0] >> (8 - checksum_bits)) & mask;
 
 	if actual != checksum {
 		return Err(Error::BadChecksum(checksum, actual));
@@ -134,13 +134,13 @@ pub fn from_entropy(entropy: &Vec<u8>) -> Result<String, Error> {
 	for byte in entropy.iter() {
 		for i in (0..8).rev() {
 			let bit = byte & (1 << i) != 0;
-			indexes[loc / 11] |= (bit as u16) << 10 - (loc % 11);
+			indexes[loc / 11] |= (bit as u16) << (10 - (loc % 11));
 			loc += 1;
 		}
 	}
 	for i in (0..checksum_bits).rev() {
 		let bit = checksum & (1 << i) != 0;
-		indexes[loc / 11] |= (bit as u16) << 10 - (loc % 11);
+		indexes[loc / 11] |= (bit as u16) << (10 - (loc % 11));
 		loc += 1;
 	}
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -29,7 +29,6 @@ use lmdb_zero as lmdb;
 
 #[macro_use]
 extern crate grin_core as core;
-use grin_store;
 use grin_util as util;
 
 #[macro_use]

--- a/servers/src/lib.rs
+++ b/servers/src/lib.rs
@@ -21,10 +21,8 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-use serde;
 #[macro_use]
 extern crate serde_derive;
-use serde_json;
 #[macro_use]
 extern crate log;
 

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -16,9 +16,7 @@
 
 #[macro_use]
 extern crate clap;
-use ctrlc;
 
-use serde_json;
 #[macro_use]
 extern crate log;
 use crate::config::config::{SERVER_CONFIG_FILE_NAME, WALLET_CONFIG_FILE_NAME};
@@ -31,9 +29,7 @@ use grin_core as core;
 use grin_p2p as p2p;
 use grin_servers as servers;
 use grin_util as util;
-use grin_wallet;
 use std::process::exit;
-use term;
 
 mod cmd;
 pub mod tui;

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -20,9 +20,6 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-use lmdb_zero;
-use memmap;
-
 #[macro_use]
 extern crate log;
 use failure;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -19,7 +19,6 @@ use blake2_rfc as blake2;
 #[macro_use]
 extern crate prettytable;
 
-use serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -30,7 +29,6 @@ use grin_core as core;
 use grin_keychain as keychain;
 use grin_store as store;
 use grin_util as util;
-use term;
 
 mod adapters;
 pub mod command;

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -21,8 +21,6 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use serde_json;
-
 use failure::ResultExt;
 use uuid::Uuid;
 


### PR DESCRIPTION
Clean away all compiler warnings, including those that have been showing up in pastes in Lobby / support.

I'm also trying to get the cargo-clippy warnings to become manageable. Currently clippy can't even finish its checking, but I'm slowly getting there.

When allowing:

- clippy::style (as in not showin warning for no-idiomatic style, which is otherwise a default)
- and some other things

then there are still a lot of details clippy complains about, but there are also some interesting nags worth to take a longer look t. And if there is some halfway there equilibrium, then periodical clippy checks could help keep code style follow best practice. Some clippy lints will likely also have to be permanently disabled (="allowed") in order to have clippy outputs stay useful over time.

Currently I'm using clippy like this:
`cargo clippy -- -A clippy::precedence -A clippy::match_bool -A clippy::cast_lossless -A clippy::redundant_field_names -A clippy::trivially_copy_pass_by_ref -A clippy:clone_on_copy -A clippy::style` and pipe stderr output to a file.

I think this might be worth merging already anyway, to get a small bit ahead.

Thoughts?