### PR TITLE
use weight_as_block for quick weight check

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -409,9 +409,13 @@ impl Readable for TransactionBody {
 		let (input_len, output_len, kernel_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 
-		// quick block weight check before proceeding
-		let tx_block_weight =
-			TransactionBody::weight(input_len as usize, output_len as usize, kernel_len as usize);
+		// Quick block weight check before proceeding.
+		// Note: We use weight_as_block here (inputs have weight).
+		let tx_block_weight = TransactionBody::weight_as_block(
+			input_len as usize,
+			output_len as usize,
+			kernel_len as usize,
+		);
 
 		if tx_block_weight > consensus::MAX_BLOCK_WEIGHT {
 			return Err(ser::Error::TooLargeReadErr);


### PR DESCRIPTION
During tx deserialization we do a quick check against weight of the tx based on input|output|kernel counts.

We should use `weight_as_block` here and not `weight` when comparing against `MAX_BLOCK_WEIGHT`.

This quick weight check is done during `read` before we have fully deserialized the tx.
We do a more exhaustive weight check when validating the tx later, but this makes the quick weight check when deserializing consistent with this later check.

Note: This is not a consensus change as the more exhaustive check performed during tx validation is unchanged. This PR only affects the "quick check" during deserialization.

