### PR TITLE
fix: wallet outputs display on white background color scheme

### DIFF
--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -92,6 +92,7 @@ pub fn outputs(
 		} else {
 			table.add_row(row![
 				bFD->commit,
+				bFB->index,
 				bFB->height,
 				bFB->lock_height,
 				bFR->status,


### PR DESCRIPTION
With the wallet config `dark_background_color_scheme = false`, before this fix:

```
$ grin wallet outputs
---------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment      MMR Index  Block Height  Locked Until  Status  Coinbase?  # Confirms    Value 
===================================================================================================================================================
 098a...                7585       0             Unspent       false   1272       1.000000000   0 
---------------------------------------------------------------------------------------------------------------------------------------------------
 0811...                7604       0             Unspent       false   1253       40.978633480  1 
---------------------------------------------------------------------------------------------------------------------------------------------------

```