### PR TITLE
wallet: avoid display the long file name on txs

### DIFF
--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -184,7 +184,7 @@ pub fn txs(
 			)
 		};
 		let tx_data = match t.stored_tx {
-			Some(t) => format!("{}", t),
+			Some(_) => "Yes".to_owned(),
 			None => "None".to_owned(),
 		};
 		if dark_background_color_scheme {


### PR DESCRIPTION
Minor improvement on wallet txs display.

Before this PR:
```
$ grin wallet txs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Id  Type        Shared Transaction Id                 Creation Time        Confirmed?  Confirmation Time    Num.    Num.     Amount    Amount   Fee    Net         Tx  
                                                                                                             Inputs  Outputs  Credited  Debited         Difference  Data 
================================================================================================================================================================================================================
 0   Confirmed   None                                  2019-01-19 13:38:50  true        2019-01-19 13:38:50  0       1        60.018    0.0      None   60.018      None 
     Coinbase                                                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1   Sent Tx     43955493-2648-488b-a4fd-1a4e775d1c54  2019-01-21 03:21:43  true        2019-01-21 03:26:24  1       1        59.01     60.018   0.008  -1.008      43955493-2648-488b-a4fd-1a4e775d1c54.grintx 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

The `TxData` filename is using the `Shared Transaction Id` as the name and with fixed extension `.grintx`. So, perhaps we can just display `Yes/None` for the `TxData` status instead of a long filename, to avoid the wrapped lines on laptop screen.

After this PR:
```
$ grin wallet txs
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Id  Type        Shared Transaction Id                 Creation Time        Confirmed?  Confirmation Time    Num.    Num.     Amount    Amount   Fee    Net         Tx  
                                                                                                             Inputs  Outputs  Credited  Debited         Difference  Data 
=========================================================================================================================================================================
 0   Confirmed   None                                  2019-01-19 13:38:50  true        2019-01-19 13:38:50  0       1        60.018    0.0      None   60.018      None 
     Coinbase                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1   Sent Tx     43955493-2648-488b-a4fd-1a4e775d1c54  2019-01-21 03:21:43  true        2019-01-21 03:26:24  1       1        59.01     60.018   0.008  -1.008      Yes 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```