### PR TITLE
Handle rpc requests unwrap crash in stratumserver.rs

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -354,29 +354,23 @@ impl StratumServer {
 					};
 
 					// Package the reply as RpcResponse json
-					let rpc_response: String;
-					match response {
-						Err(response) => {
-							let resp = RpcResponse {
-								id: request.id,
-								jsonrpc: String::from("2.0"),
-								method: request.method,
-								result: None,
-								error: Some(response),
-							};
-							rpc_response = serde_json::to_string(&resp).unwrap();
-						}
-						Ok(response) => {
-							let resp = RpcResponse {
-								id: request.id,
-								jsonrpc: String::from("2.0"),
-								method: request.method,
-								result: Some(response),
-								error: None,
-							};
-							rpc_response = serde_json::to_string(&resp).unwrap();
-						}
-					}
+					let resp = match response {
+						Err(response) => RpcResponse {
+							id: request.id,
+							jsonrpc: String::from("2.0"),
+							method: request.method,
+							result: None,
+							error: Some(response),
+						},
+						Ok(response) => RpcResponse {
+							id: request.id,
+							jsonrpc: String::from("2.0"),
+							method: request.method,
+							result: Some(response),
+							error: None,
+						},
+					};
+					let rpc_response = serde_json::to_string(&resp).unwrap(); //
 
 					// Send the reply
 					workers_l[num].write_message(rpc_response);

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -353,27 +353,30 @@ impl StratumServer {
 						}
 					};
 
+					let id = request.id.clone();
 					// Package the reply as RpcResponse json
 					let resp = match response {
 						Err(response) => RpcResponse {
-							id: request.id,
+							id: id,
 							jsonrpc: String::from("2.0"),
 							method: request.method,
 							result: None,
 							error: Some(response),
 						},
 						Ok(response) => RpcResponse {
-							id: request.id,
+							id: id,
 							jsonrpc: String::from("2.0"),
 							method: request.method,
 							result: Some(response),
 							error: None,
 						},
 					};
-					let rpc_response = serde_json::to_string(&resp).unwrap(); //
-
-					// Send the reply
-					workers_l[num].write_message(rpc_response);
+					if let Ok(rpc_response) = serde_json::to_string(&resp) {
+						// Send the reply
+						workers_l[num].write_message(rpc_response);
+					} else {
+						warn!("handle_rpc_requests: failed responding to {:?}", request.id);
+					};
 				}
 				None => {} // No message for us from this worker
 			}

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -312,6 +312,9 @@ impl StratumServer {
 					// Call the handler function for requested method
 					let response = match request.method.as_str() {
 						"login" => {
+							if self.current_block_versions.is_empty() {
+								continue;
+							}
 							stratum_stats.worker_stats[worker_stats_id].initial_block_height =
 								self.current_block_versions.last().unwrap().header.height;
 							self.handle_login(request.params, &mut workers_l[num])

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -302,11 +302,14 @@ impl StratumServer {
 					};
 
 					let mut stratum_stats = stratum_stats.write();
-					let worker_stats_id = stratum_stats
+					let worker_stats_id = match stratum_stats
 						.worker_stats
 						.iter()
 						.position(|r| r.id == workers_l[num].id)
-						.unwrap();
+					{
+						Some(id) => id,
+						None => continue,
+					};
 					stratum_stats.worker_stats[worker_stats_id].last_seen = SystemTime::now();
 
 					// Call the handler function for requested method


### PR DESCRIPTION
Merge after https://github.com/mimblewimble/grin/pull/2468/files

Fixes #2421 
Together with hashmaps the_message.clear fix, this solves the catastrophic https://github.com/mimblewimble/grin/issues/2421 that made stratum servers to become unreachable in a hard to detect manner.

We need additional issues about testing that should be added.