### PR TITLE
More useful store_error output

### DIFF
--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -53,7 +53,7 @@ const ACCOUNT_PATH_MAPPING_PREFIX: u8 = 'a' as u8;
 
 impl From<store::Error> for Error {
 	fn from(error: store::Error) -> Error {
-		Error::from(ErrorKind::Backend(format!("{:?}", error)))
+		Error::from(ErrorKind::Backend(format!("{}", error)))
 	}
 }
 


### PR DESCRIPTION
Store errors are being swallowed in the log as they're outputting Debug {:?} formatters as opposed to the more useful custom display formatter.