### PR TITLE
Fix regression in reading stratum messages

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -301,6 +301,8 @@ impl StratumServer {
 						}
 					};
 
+					the_message.clear();
+
 					let mut stratum_stats = stratum_stats.write();
 					let worker_stats_id = stratum_stats
 						.worker_stats


### PR DESCRIPTION
It was introduced in #2418, it turns out std read_line always appends to
the string, not writes from the beginning, so when we have multiple
workers to read from all messages are concatenated