### PR TITLE
Fallback to building empty block to mine (if txpool is somehow in invalid state)

### DIFF
--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -111,7 +111,10 @@ fn build_block(
 	// If this fails for *any* reason then fallback to an empty vec of txs.
 	// This will allow us to mine an "empty" block if the txpool is in an
 	// invalid (and unexpected) state.
-	let txs = tx_pool.read().prepare_mineable_transactions().unwrap_or(vec![]);
+	let txs = tx_pool
+		.read()
+		.prepare_mineable_transactions()
+		.unwrap_or(vec![]);
 
 	// build the coinbase and the block itself
 	let fees = txs.iter().map(|tx| tx.fee()).sum();

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -114,7 +114,10 @@ fn build_block(
 	let txs = match tx_pool.read().prepare_mineable_transactions() {
 		Ok(txs) => txs,
 		Err(e) => {
-			error!("build_block: Failed to prepare mineable txs from txpool: {:?}", e);
+			error!(
+				"build_block: Failed to prepare mineable txs from txpool: {:?}",
+				e
+			);
 			warn!("build_block: Falling back to mining empty block.");
 			vec![]
 		}


### PR DESCRIPTION
Beam issue got me paranoid about our txpool...

Adding some error handling and fallback behavior to the `build_block` fn in `mine_block`.
We call `prepare_mineable_transactions()` on the txpool and there exists the possibility of this raising an error and failing to prepare some valid transactions.

This PR handles an error here by falling back to an empty vec of txs which will result in the building of an empty block.

This would be far preferable to jamming a mining node up with an invalid txpool and no way to recover.

Note: The txpool is "reconciled" against chain state every time a new block is accepted, so even if we do end up with an invalid txpool, it should resolve itself against current chain state as soon as the next block is found.

This PR will not change this existing behavior, but should give the mining node a chance to mine an empty block.

