### PR TITLE
Update api.md to use correct port

### DIFF
--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -17,6 +17,6 @@ To learn about what specific calls can be made read the [wallet foreign API doc]
 
 ### Wallet Owner API
 
-The wallet owner API is an endpoint to manage the user wallet: broadcast transaction, sign transaction, see the current balance... This REST API can be started with the `grin wallet owner_api` command and will listen on `localhost:3420`. This endpoint must **never** be exposed to the outside world.
+The wallet owner API is an endpoint to manage the user wallet: broadcast transaction, sign transaction, see the current balance... This REST API can be started with the `grin wallet owner_api` command and will listen on `localhost:13420`. This endpoint must **never** be exposed to the outside world.
 This endpoint requires, by default, Basic Authentication. The username is `grin` and the password can be found in the `.api_secret` file.
 To learn about what specific calls can be made read the [wallet owner API doc](wallet_owner_api.md).


### PR DESCRIPTION
It appears that Grin uses 13420 for the owner_api port, not 3420. This is for both floonet and mainet.
`20190122 10:22:12.140 INFO grin_wallet::controller - Starting HTTP Owner API server at 127.0.0.1:13420.`