### PR TITLE
Catching clippy

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -60,8 +60,8 @@ impl HeaderHandler {
 	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {
 		let oid = get_output(&self.chain, &commit_id)?.1;
 		match w(&self.chain).get_header_for_output(&oid) {
-			Ok(header) => return Ok(BlockHeaderPrintable::from_header(&header)),
-			Err(_) => return Err(ErrorKind::NotFound)?,
+			Ok(header) => Ok(BlockHeaderPrintable::from_header(&header)),
+			Err(_) => Err(ErrorKind::NotFound)?,
 		}
 	}
 }

--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -68,7 +68,7 @@ impl HeaderHandler {
 
 impl Handler for HeaderHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let el = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let el = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
 		};
@@ -125,12 +125,12 @@ fn check_block_param(input: &String) -> Result<(), Error> {
 			"Not a valid hash or height.".to_owned(),
 		))?;
 	}
-	return Ok(());
+	Ok(())
 }
 
 impl Handler for BlockHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let el = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let el = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
 		};

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -111,7 +111,7 @@ impl OutputHandler {
 
 		for (k, id) in params {
 			if k == "id" {
-				for id in id.split(",") {
+				for id in id.split(',') {
 					commitments.push(id.to_owned());
 				}
 			}
@@ -178,7 +178,7 @@ impl OutputHandler {
 
 		if let Some(ids) = params.get("id") {
 			for id in ids {
-				for id in id.split(",") {
+				for id in id.split(',') {
 					if let Ok(x) = util::from_hex(String::from(id)) {
 						commitments.push(Commitment::from_vec(x));
 					}
@@ -223,7 +223,7 @@ impl OutputHandler {
 
 impl Handler for OutputHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let command = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let command = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			Some(c) => c,
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 		};

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -56,7 +56,7 @@ pub struct PeerHandler {
 
 impl Handler for PeerHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
-		let command = match req.uri().path().trim_right_matches("/").rsplit("/").next() {
+		let command = match req.uri().path().trim_right_matches('/').rsplit('/').next() {
 			Some(c) => c,
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 		};
@@ -73,7 +73,7 @@ impl Handler for PeerHandler {
 		}
 	}
 	fn post(&self, req: Request<Body>) -> ResponseFuture {
-		let mut path_elems = req.uri().path().trim_right_matches("/").rsplit("/");
+		let mut path_elems = req.uri().path().trim_right_matches('/').rsplit('/');
 		let command = match path_elems.next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(c) => c,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -250,7 +250,7 @@ impl HeaderInfo {
 
 /// Move value linearly toward a goal
 pub fn damp(actual: u64, goal: u64, damp_factor: u64) -> u64 {
-	(1 * actual + (damp_factor - 1) * goal) / damp_factor
+	(actual + (damp_factor - 1) * goal) / damp_factor
 }
 
 /// limit value to be within some factor from a goal

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -418,6 +418,7 @@ impl Block {
 	/// TODO - Move this somewhere where only tests will use it.
 	/// *** Only used in tests. ***
 	///
+	#[warn(clippy::new_ret_no_self)]
 	pub fn new(
 		prev: &BlockHeader,
 		txs: Vec<Transaction>,

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -17,6 +17,8 @@
 // required for genesis replacement
 //! #![allow(unused_imports)]
 
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+
 use chrono::prelude::{TimeZone, Utc};
 
 use crate::core;

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -89,7 +89,7 @@ pub fn to_entropy(mnemonic: &str) -> Result<Vec<u8>, Error> {
 	for index in indexes.iter().rev() {
 		for i in 0..11 {
 			let bit = index & (1 << i) != 0;
-			entropy[datalen - loc / 8] |= (bit as u8) << loc % 8;
+			entropy[datalen - loc / 8] |= (bit as u8) << (loc % 8);
 			loc += 1;
 		}
 	}
@@ -99,7 +99,7 @@ pub fn to_entropy(mnemonic: &str) -> Result<Vec<u8>, Error> {
 	sha2sum.input(&entropy.clone());
 	hash.copy_from_slice(sha2sum.result().as_slice());
 
-	let actual = (hash[0] >> 8 - checksum_bits) & mask;
+	let actual = (hash[0] >> (8 - checksum_bits)) & mask;
 
 	if actual != checksum {
 		return Err(Error::BadChecksum(checksum, actual));
@@ -134,13 +134,13 @@ pub fn from_entropy(entropy: &Vec<u8>) -> Result<String, Error> {
 	for byte in entropy.iter() {
 		for i in (0..8).rev() {
 			let bit = byte & (1 << i) != 0;
-			indexes[loc / 11] |= (bit as u16) << 10 - (loc % 11);
+			indexes[loc / 11] |= (bit as u16) << (10 - (loc % 11));
 			loc += 1;
 		}
 	}
 	for i in (0..checksum_bits).rev() {
 		let bit = checksum & (1 << i) != 0;
-		indexes[loc / 11] |= (bit as u16) << 10 - (loc % 11);
+		indexes[loc / 11] |= (bit as u16) << (10 - (loc % 11));
 		loc += 1;
 	}
 


### PR DESCRIPTION
(This is the second, and extended, part of now superceded https://github.com/mimblewimble/grin/pull/2437)

Initial cleanups with the goal of making `cargo clippy` usable.

Currently I'm using clippy like this:
cargo clippy -- -A clippy::precedence -A clippy::match_bool -A clippy::cast_lossless -A clippy::redundant_field_names -A clippy::trivially_copy_pass_by_ref -A clippy:clone_on_copy -A clippy::style and pipe stderr output to a file.

With this command, I get a few interesting warnings. Also there might be more interesting warnings that clippy due to an error can't yet reveal, since clippy functions by extending the rustc compiler.

(The flag -A means Allow and makes clippy ignore a linting rule. The last -A clippy:style makes clippy ignore _all_ style linting rules, and a future goal of mine is to not need to be so drastic. There also exists a clippy::pedantic which I didn't yet dare to try.)

Cue debate which clippy complaints are relevant or not?
I think this might be worth merging to get a small bit ahead.