### PR TITLE
Pool tx weight verification

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -603,7 +603,8 @@ impl TransactionBody {
 			.unwrap_or(0)
 	}
 
-	// Verify the body is not too big in terms of number of inputs|outputs|kernels.
+	/// Verify the body is not too big in terms of number of inputs|outputs|kernels.
+	/// Weight rules vary depending on the "weight type" (block or tx or pool).
 	fn verify_weight(&self, weight_type: WeightVerificationType) -> Result<(), Error> {
 		// If "tx" body then remember to reduce the max_block_weight for block requirements.
 		// If "block" body then verify weight based on full set of inputs|outputs|kernels.
@@ -616,6 +617,7 @@ impl TransactionBody {
 			WeightVerificationType::AsTransaction => 1,
 			WeightVerificationType::AsBlock => 0,
 			WeightVerificationType::AsPool => {
+				// We do not verify "tx as pool" weight so we are done here.
 				return Ok(());
 			}
 		};
@@ -624,7 +626,7 @@ impl TransactionBody {
 		// allowed in the body itself.
 		// A block is allowed to be slightly weightier than a tx to account for
 		// the additional coinbase reward output and kernel.
-		//
+		// i.e. We need to reserve space for coinbase reward when verifying tx weight.
 		// max_block = max_tx + coinbase
 		//
 		let tx_block_weight = TransactionBody::weight_as_block(

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -18,7 +18,9 @@
 use crate::blake2::blake2b::blake2b;
 use crate::core::amount_to_hr_string;
 use crate::core::committed::Committed;
-use crate::core::transaction::{kernel_features, kernel_sig_msg, Transaction};
+use crate::core::transaction::{
+	kernel_features, kernel_sig_msg, Transaction, WeightVerificationType,
+};
 use crate::core::verifier_cache::LruVerifierCache;
 use crate::keychain::{BlindSum, BlindingFactor, Keychain};
 use crate::libtx::error::{Error, ErrorKind};
@@ -472,8 +474,9 @@ impl Slate {
 		final_tx.kernels()[0].verify()?;
 
 		// confirm the overall transaction is valid (including the updated kernel)
+		// accounting for tx weight limits
 		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
-		let _ = final_tx.validate(verifier_cache)?;
+		let _ = final_tx.validate(WeightVerificationType::AsTransaction, verifier_cache)?;
 
 		self.tx = final_tx;
 		Ok(())

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -19,7 +19,9 @@ use self::core::core::hash::{Hash, Hashed};
 use self::core::core::id::{ShortId, ShortIdentifiable};
 use self::core::core::transaction;
 use self::core::core::verifier_cache::VerifierCache;
-use self::core::core::{Block, BlockHeader, BlockSums, Committed, Transaction, TxKernel};
+use self::core::core::{
+	Block, BlockHeader, BlockSums, Committed, Transaction, TxKernel, WeightVerificationType,
+};
 use self::util::RwLock;
 use crate::types::{BlockChain, PoolEntry, PoolEntryState, PoolError};
 use grin_core as core;
@@ -127,7 +129,14 @@ impl Pool {
 		let mut flat_txs: Vec<Transaction> = tx_buckets
 			.into_iter()
 			.filter_map(|bucket| transaction::aggregate(bucket).ok())
-			.filter(|x| x.validate(self.verifier_cache.clone()).is_ok())
+			.filter(|x| {
+				// Here we validate the tx, subject to regular tx weight limits.
+				x.validate(
+					WeightVerificationType::AsTransaction,
+					self.verifier_cache.clone(),
+				)
+				.is_ok()
+			})
 			.collect();
 
 		// sort by fees over weight, multiplying by 1000 to keep some precision
@@ -143,8 +152,14 @@ impl Pool {
 
 		// Iteratively apply the txs to the current chain state,
 		// rejecting any that do not result in a valid state.
+		// Verify these txs produce an aggregated tx below max tx weight.
 		// Return a vec of all the valid txs.
-		let txs = self.validate_raw_txs(flat_txs, None, &header)?;
+		let txs = self.validate_raw_txs(
+			flat_txs,
+			None,
+			&header,
+			WeightVerificationType::AsTransaction,
+		)?;
 		Ok(txs)
 	}
 
@@ -152,14 +167,19 @@ impl Pool {
 		self.entries.iter().map(|x| x.tx.clone()).collect()
 	}
 
-	pub fn aggregate_transaction(&self) -> Result<Option<Transaction>, PoolError> {
+	/// Return a single aggregate tx representing all txs in the txpool.
+	/// Returns None if the txpool is empty.
+	pub fn all_transactions_aggregate(&self) -> Result<Option<Transaction>, PoolError> {
 		let txs = self.all_transactions();
 		if txs.is_empty() {
 			return Ok(None);
 		}
 
 		let tx = transaction::aggregate(txs)?;
-		tx.validate(self.verifier_cache.clone())?;
+
+		// Validate the single aggregate transaction "as pool", not subject to tx weight limits.
+		tx.validate(WeightVerificationType::AsPool, self.verifier_cache.clone())?;
+
 		Ok(Some(tx))
 	}
 
@@ -169,7 +189,8 @@ impl Pool {
 		extra_tx: Option<Transaction>,
 		header: &BlockHeader,
 	) -> Result<Vec<Transaction>, PoolError> {
-		let valid_txs = self.validate_raw_txs(txs, extra_tx, header)?;
+		let valid_txs =
+			self.validate_raw_txs(txs, extra_tx, header, WeightVerificationType::AsPool)?;
 		Ok(valid_txs)
 	}
 
@@ -218,12 +239,18 @@ impl Pool {
 			txs.push(entry.tx.clone());
 
 			let tx = transaction::aggregate(txs)?;
-			tx.validate(self.verifier_cache.clone())?;
+
+			// TODO - Is this necessary? We validate_raw_tx below.
+			// Validate this single aggregated tx (existing pool + new tx),
+			// not subject to tx weight limits.
+			// tx.validate(WeightVerificationType::AsPool, self.verifier_cache.clone())?;
+
 			tx
 		};
 
-		// Validate aggregated tx against a known chain state.
-		self.validate_raw_tx(&agg_tx, header)?;
+		// Validate aggregated tx (existing pool + new tx), ignoring tx weight limits.
+		// Validate against known chain state at the provided header.
+		self.validate_raw_tx(&agg_tx, header, WeightVerificationType::AsPool)?;
 
 		debug!(
 			"add_to_pool [{}]: {} ({}) [in/out/kern: {}/{}/{}] pool: {} (at block {})",
@@ -246,8 +273,11 @@ impl Pool {
 		&self,
 		tx: &Transaction,
 		header: &BlockHeader,
+		weight_type: WeightVerificationType,
 	) -> Result<BlockSums, PoolError> {
-		tx.validate(self.verifier_cache.clone())?;
+		// Validate the tx, conditionally checking against weight limits,
+		// based on weight verification type.
+		tx.validate(weight_type, self.verifier_cache.clone())?;
 
 		// Validate the tx against current chain state.
 		// Check all inputs are in the current UTXO set.
@@ -263,6 +293,7 @@ impl Pool {
 		txs: Vec<Transaction>,
 		extra_tx: Option<Transaction>,
 		header: &BlockHeader,
+		weight_type: WeightVerificationType,
 	) -> Result<Vec<Transaction>, PoolError> {
 		let mut valid_txs = vec![];
 
@@ -278,7 +309,7 @@ impl Pool {
 			let agg_tx = transaction::aggregate(candidate_txs)?;
 
 			// We know the tx is valid if the entire aggregate tx is valid.
-			if self.validate_raw_tx(&agg_tx, header).is_ok() {
+			if self.validate_raw_tx(&agg_tx, header, weight_type).is_ok() {
 				valid_txs.push(tx);
 			}
 		}

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -20,7 +20,7 @@
 use self::core::core::hash::{Hash, Hashed};
 use self::core::core::id::ShortId;
 use self::core::core::verifier_cache::VerifierCache;
-use self::core::core::{transaction, Block, BlockHeader, Transaction};
+use self::core::core::{transaction, Block, BlockHeader, Transaction, WeightVerificationType};
 use self::util::RwLock;
 use crate::pool::Pool;
 use crate::types::{
@@ -108,7 +108,13 @@ impl TransactionPool {
 			let txs = self.txpool.find_matching_transactions(entry.tx.kernels());
 			if !txs.is_empty() {
 				let tx = transaction::deaggregate(entry.tx, txs)?;
-				tx.validate(self.verifier_cache.clone())?;
+
+				// Validate this deaggregated tx "as tx", subject to regulat tx weight limits.
+				tx.validate(
+					WeightVerificationType::AsTransaction,
+					self.verifier_cache.clone(),
+				)?;
+
 				entry.tx = tx;
 				entry.src.debug_name = "deagg".to_string();
 			}
@@ -118,7 +124,7 @@ impl TransactionPool {
 		// We now need to reconcile the stempool based on the new state of the txpool.
 		// Some stempool txs may no longer be valid and we need to evict them.
 		{
-			let txpool_tx = self.txpool.aggregate_transaction()?;
+			let txpool_tx = self.txpool.all_transactions_aggregate()?;
 			self.stempool.reconcile(txpool_tx, header)?;
 		}
 
@@ -145,8 +151,12 @@ impl TransactionPool {
 		self.is_acceptable(&tx, stem)?;
 
 		// Make sure the transaction is valid before anything else.
-		tx.validate(self.verifier_cache.clone())
-			.map_err(PoolError::InvalidTx)?;
+		// Validate tx accounting for max tx weight.
+		tx.validate(
+			WeightVerificationType::AsTransaction,
+			self.verifier_cache.clone(),
+		)
+		.map_err(PoolError::InvalidTx)?;
 
 		// Check the tx lock_time is valid based on current chain state.
 		self.blockchain.verify_tx_lock_height(&tx)?;
@@ -218,7 +228,7 @@ impl TransactionPool {
 		// Now reconcile our stempool, accounting for the updated txpool txs.
 		self.stempool.reconcile_block(block);
 		{
-			let txpool_tx = self.txpool.aggregate_transaction()?;
+			let txpool_tx = self.txpool.all_transactions_aggregate()?;
 			self.stempool.reconcile(txpool_tx, &block.header)?;
 		}
 

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -219,7 +219,12 @@ fn test_the_transaction_pool() {
 		// tx4 is the "new" part of this aggregated tx that we care about
 		let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
-		agg_tx.validate(WeightVerificationType::AsTransaction, verifier_cache.clone()).unwrap();
+		agg_tx
+			.validate(
+				WeightVerificationType::AsTransaction,
+				verifier_cache.clone(),
+			)
+			.unwrap();
 
 		write_pool
 			.add_to_pool(test_source(), agg_tx, false, &header)

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -15,7 +15,7 @@
 pub mod common;
 
 use self::core::core::verifier_cache::LruVerifierCache;
-use self::core::core::{transaction, Block, BlockHeader};
+use self::core::core::{transaction, Block, BlockHeader, WeightVerificationType};
 use self::core::libtx;
 use self::core::pow::Difficulty;
 use self::keychain::{ExtKeychain, Keychain};
@@ -177,7 +177,7 @@ fn test_the_transaction_pool() {
 		let mut write_pool = pool.write();
 		let agg_tx = write_pool
 			.stempool
-			.aggregate_transaction()
+			.all_transactions_aggregate()
 			.unwrap()
 			.unwrap();
 		assert_eq!(agg_tx.kernels().len(), 2);
@@ -219,7 +219,7 @@ fn test_the_transaction_pool() {
 		// tx4 is the "new" part of this aggregated tx that we care about
 		let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
-		agg_tx.validate(verifier_cache.clone()).unwrap();
+		agg_tx.validate(WeightVerificationType::AsTransaction, verifier_cache.clone()).unwrap();
 
 		write_pool
 			.add_to_pool(test_source(), agg_tx, false, &header)

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -97,7 +97,8 @@ fn process_stem_phase(
 		return Ok(());
 	}
 
-	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
+	// Get the aggregate tx representing the entire txpool.
+	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
 
 	let stem_txs = tx_pool
 		.stempool
@@ -110,7 +111,10 @@ fn process_stem_phase(
 		debug!("dand_mon: Found {} txs for stemming.", stem_txs.len());
 
 		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(verifier_cache.clone())?;
+		agg_tx.validate(
+			transaction::WeightVerificationType::AsTransaction,
+			verifier_cache.clone(),
+		)?;
 
 		let res = tx_pool.adapter.stem_tx_accepted(&agg_tx);
 		if res.is_err() {
@@ -143,7 +147,8 @@ fn process_fluff_phase(
 		return Ok(());
 	}
 
-	let txpool_tx = tx_pool.txpool.aggregate_transaction()?;
+	// Get the aggregate tx representing the entire txpool.
+	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
 
 	let stem_txs = tx_pool
 		.stempool
@@ -156,7 +161,10 @@ fn process_fluff_phase(
 		debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
 
 		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(verifier_cache.clone())?;
+		agg_tx.validate(
+			transaction::WeightVerificationType::AsTransaction,
+			verifier_cache.clone(),
+		)?;
 
 		let src = TxSource {
 			debug_name: "fluff".to_string(),


### PR DESCRIPTION
So it turns out treating the txpool as "one big tx" for validation purposes meant we were verifying the max weight of the whole _transaction pool_ and checking it did not exceed `MAX_BLOCK_WEIGHT`...

This is clearly sub-optimal for a bunch of reasons.

Existing `verify_weight()` logic takes a `with_reward` bool flag to allow txs and blocks to both be weight verified. A block will have an additional output and kernel to cover the coinbase reward, so txs have to be slightly less weighty to account for this.

```
max tx weight + coinbase reward = max block weight
```

This PR introduces a `WeightVerificationType` enum and replaces the `with_reward` bool flag with the enum.

```
pub enum WeightVerificationType {
	/// Tx represents a tx (max weight).
	AsTransaction,
	/// Tx represents a block (max weight + additional coinbase reward).
	AsBlock,
	/// Tx represents the txpool (no max weight).
	AsPool,
}
```

So now we can robustly validate the contents of the txpool by treating it as "one big tx" after aggregation, but skipping the weight verification step.


This is all slightly confusing because we - 
* validate blocks (and the txpool) as if they were txs
* but then we verify weight against MAX_BLOCK_WEIGHT (as if they were blocks)

So in the context of weight we validate txs as if they were pretending to be blocks.
And blocks as if they were pretending to be txs pretending to be blocks.

We validate the txpool as if it was "one big tx", but for weight purposes we treat it as having no weight limit.

