### PR TITLE
Disable thread local storage for LMDB connection

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -102,7 +102,7 @@ pub enum ErrorKind {
 	#[fail(display = "Invalid TxHashSet: {}", _0)]
 	InvalidTxHashSet(String),
 	/// Internal issue when trying to save or load data from store
-	#[fail(display = "Store Error: {}", _1)]
+	#[fail(display = "Store Error: {}, reason: {}", _1, _0)]
 	StoreErr(store::Error, String),
 	/// Internal issue when trying to save or load data from append only files
 	#[fail(display = "File Read Error: {}", _0)]

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -80,7 +80,7 @@ pub fn new_named_env(path: String, name: String) -> lmdb::Environment {
 		});
 	unsafe {
 		env_builder
-			.open(&full_path, lmdb::open::Flags::empty(), 0o600)
+			.open(&full_path, lmdb::open::NOTLS, 0o600)
 			.unwrap()
 	}
 }


### PR DESCRIPTION
From LMDB docs, fucntion `set_maxreaders`:
> This defines the number of slots in the lock table that is used to track readers in the the environment. The default is 126. Starting a read-only transaction normally ties a lock table slot to the current thread until the environment closes or the thread exits. If NOTLS is in use, starting a transaction instead ties the slot to the transaction object until it or the Environment object is destroyed.

It seems that each thread consumes one reader slot, we run each peer in a separate thread, so we run out of readers pretty quickly if max_peers is high enough. This fix ties the reader to short lived transaction object, so we can reuse.
Tested for a few hours with 150+ peers (250 max), no panics, before was able to reproduce thread crash in minutes. 
Also improves error reporting for db error.
Fixes #2388