### PR TITLE
wallet/owner_api: allow owner API port to be configurable

### DIFF
--- a/wallet/src/command.rs
+++ b/wallet/src/command.rs
@@ -26,7 +26,6 @@ use uuid::Uuid;
 
 use crate::api::TLSConfig;
 use crate::core::core;
-use crate::core::global;
 use crate::keychain;
 
 use crate::error::{Error, ErrorKind};
@@ -146,7 +145,7 @@ pub fn owner_api(
 ) -> Result<(), Error> {
 	let res = controller::owner_listener(
 		wallet,
-		&format!("127.0.0.1:{}", (if global::is_floonet() { "13420" } else { "3420" })),
+		config.owner_api_listen_addr().as_str(),
 		g_args.node_api_secret.clone(),
 		g_args.tls_conf.clone(),
 		config.owner_api_include_foreign.clone(),

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -41,6 +41,8 @@ pub struct WalletConfig {
 	pub api_listen_interface: String,
 	// The port this wallet will run on
 	pub api_listen_port: u16,
+	// The port this wallet's owner API will run on
+	pub owner_api_listen_port: u16,
 	/// Location of the secret for basic auth on the Owner API
 	pub api_secret_path: Option<String>,
 	/// Location of the node api secret for basic auth on the Grin API
@@ -72,6 +74,7 @@ impl Default for WalletConfig {
 			chain_type: Some(ChainTypes::Floonet),
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 3415,
+			owner_api_listen_port: 3420,
 			api_secret_path: Some(".api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
@@ -89,6 +92,10 @@ impl Default for WalletConfig {
 impl WalletConfig {
 	pub fn api_listen_addr(&self) -> String {
 		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
+	}
+
+	pub fn owner_api_listen_addr(&self) -> String {
+		format!("127.0.0.1:{}", self.owner_api_listen_port)
 	}
 }
 


### PR DESCRIPTION
Adds an `owner_api_listen_port` to the grin-wallet.toml config to allow the port for the owner API to be changed on a per-wallet basis.

Related issues/PRs:

#2328, #2405 