### PR TITLE
wallet config should default to mainnet

### DIFF
--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -69,7 +69,7 @@ pub struct WalletConfig {
 impl Default for WalletConfig {
 	fn default() -> WalletConfig {
 		WalletConfig {
-			chain_type: Some(ChainTypes::Floonet),
+			chain_type: Some(ChainTypes::Mainnet),
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 3415,
 			api_secret_path: Some(".api_secret".to_string()),


### PR DESCRIPTION
Related #2475.

Node defaults to `mainnet`. Wallet should do the same thing.