### PR TITLE
Add comment for Mainnet chain type

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -78,7 +78,8 @@ fn comments() -> HashMap<String, String> {
 #parameters used for mining as well as wallet output coinbase maturity. Can be:
 #AutomatedTesting - For CI builds and instant blockchain creation
 #UserTesting - For regular user testing (cuckoo 16)
-#Floonet - For the long term Floonet test network
+#Floonet - For the long term floonet test network
+#Mainnet - For mainnet
 "
 		.to_string(),
 	);
@@ -418,7 +419,7 @@ fn comments() -> HashMap<String, String> {
 		"no_commit_cache".to_string(),
 		"
 #If true, don't store calculated commits in the database
-#better privacy, but at a performance cost of having to 
+#better privacy, but at a performance cost of having to
 #re-calculate commits every time they're used
 "
 		.to_string(),


### PR DESCRIPTION
Produce the following stanza in the config file(s), both `grin-server.toml` and `grin-wallet.toml` - 


```
#The chain type, which defines the genesis block and the set of cuckoo
#parameters used for mining as well as wallet output coinbase maturity. Can be:
#AutomatedTesting - For CI builds and instant blockchain creation
#UserTesting - For regular user testing (cuckoo 16)
#Floonet - For the long term floonet test network
#Mainnet - For mainnet
chain_type = "Mainnet"
```

