### PR TITLE
default to sane value for missing owner_api_listen_port

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -365,13 +365,20 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"api_listen_port".to_string(),
 		"
-#port for wallet listener
-
 #path of TLS certificate file, self-signed certificates are not supported
 #tls_certificate_file = \"\"
 #private key for the TLS certificate
 #tls_certificate_key = \"\"
 
+#port for wallet listener
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"owner_api_listen_port".to_string(),
+		"
+#port for wallet owner api
 "
 		.to_string(),
 	);
@@ -418,7 +425,7 @@ fn comments() -> HashMap<String, String> {
 		"no_commit_cache".to_string(),
 		"
 #If true, don't store calculated commits in the database
-#better privacy, but at a performance cost of having to 
+#better privacy, but at a performance cost of having to
 #re-calculate commits every time they're used
 "
 		.to_string(),

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -42,7 +42,7 @@ pub struct WalletConfig {
 	// The port this wallet will run on
 	pub api_listen_port: u16,
 	// The port this wallet's owner API will run on
-	pub owner_api_listen_port: u16,
+	pub owner_api_listen_port: Option<u16>,
 	/// Location of the secret for basic auth on the Owner API
 	pub api_secret_path: Option<String>,
 	/// Location of the node api secret for basic auth on the Grin API
@@ -74,7 +74,7 @@ impl Default for WalletConfig {
 			chain_type: Some(ChainTypes::Mainnet),
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 3415,
-			owner_api_listen_port: 3420,
+			owner_api_listen_port: Some(WalletConfig::default_owner_api_listen_port()),
 			api_secret_path: Some(".api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
@@ -94,8 +94,19 @@ impl WalletConfig {
 		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
 	}
 
+	// TODO - This should default to 3420 for mainnent and 13420 for floonet.
+	pub fn default_owner_api_listen_port() -> u16 {
+		3420
+	}
+
+	/// Use value from config file, defaulting to sensible value if missing.
+	pub fn owner_api_listen_port(&self) -> u16 {
+		self.owner_api_listen_port
+			.unwrap_or(WalletConfig::default_owner_api_listen_port())
+	}
+
 	pub fn owner_api_listen_addr(&self) -> String {
-		format!("127.0.0.1:{}", self.owner_api_listen_port)
+		format!("127.0.0.1:{}", self.owner_api_listen_port())
 	}
 }
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -94,7 +94,6 @@ impl WalletConfig {
 		format!("{}:{}", self.api_listen_interface, self.api_listen_port)
 	}
 
-	// TODO - This should default to 3420 for mainnent and 13420 for floonet.
 	pub fn default_owner_api_listen_port() -> u16 {
 		3420
 	}


### PR DESCRIPTION
Resolves #2482.

Safely default to `3420` if `owner_api_listen_port` is not explicitly set in `grin-wallet.toml`

- [x] Tested `grin wallet info` with and without `owner_api_listen_port` set.
- [x] Tested `grin wallet init` generates a new grin-wallet.toml successfully (confirmed default is set correctly).

