### PR TITLE
default our chain type to mainnet (already doing this via config file)

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -107,7 +107,7 @@ impl ChainTypes {
 
 impl Default for ChainTypes {
 	fn default() -> ChainTypes {
-		ChainTypes::Floonet
+		ChainTypes::Mainnet
 	}
 }
 


### PR DESCRIPTION
We default to `mainnet` when generating config file. 

We should default to `mainnet` in the code as well.

