### PR TITLE
Feature/slate version

### DIFF
--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -92,6 +92,8 @@ pub struct Slate {
 	/// insert their public data here. For now, 0 is sender and 1
 	/// is receiver, though this will change for multi-party
 	pub participant_data: Vec<ParticipantData>,
+	/// Slate format version
+	pub version: Option<u64>,
 }
 
 impl Slate {
@@ -106,6 +108,7 @@ impl Slate {
 			height: 0,
 			lock_height: 0,
 			participant_data: vec![],
+			version:Some(1)
 		}
 	}
 

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -122,7 +122,12 @@ pub struct Slate {
 	/// is receiver, though this will change for multi-party
 	pub participant_data: Vec<ParticipantData>,
 	/// Slate format version
-	pub version: Option<u64>,
+	#[serde(default = "no_version")]
+	pub version: u64,
+}
+
+fn no_version() -> u64 {
+	0
 }
 
 /// Helper just to facilitate serialization
@@ -144,7 +149,7 @@ impl Slate {
 			height: 0,
 			lock_height: 0,
 			participant_data: vec![],
-			version: Some(CURRENT_SLATE_VERSION),
+			version: CURRENT_SLATE_VERSION,
 		}
 	}
 

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -108,7 +108,7 @@ impl Slate {
 			height: 0,
 			lock_height: 0,
 			participant_data: vec![],
-			version:Some(1)
+			version: Some(1),
 		}
 	}
 

--- a/core/src/libtx/slate.rs
+++ b/core/src/libtx/slate.rs
@@ -31,6 +31,8 @@ use rand::thread_rng;
 use std::sync::Arc;
 use uuid::Uuid;
 
+const CURRENT_SLATE_VERSION: u64 = 1;
+
 /// Public data for each participant in the slate
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -108,7 +110,7 @@ impl Slate {
 			height: 0,
 			lock_height: 0,
 			participant_data: vec![],
-			version: Some(1),
+			version: Some(CURRENT_SLATE_VERSION),
 		}
 	}
 


### PR DESCRIPTION
Add a version field for slate to symbolize slate format.
Doesn't do much yet but seems to be backwards compatible.

Part of addressing https://github.com/mimblewimble/grin/issues/2134