### PR TITLE
Refresh coinbase key if the existing one was removed

### DIFF
--- a/wallet/src/libwallet/error.rs
+++ b/wallet/src/libwallet/error.rs
@@ -104,7 +104,7 @@ pub enum ErrorKind {
 	CallbackImpl(&'static str),
 
 	/// Wallet backend error
-	#[fail(display = "Wallet store error")]
+	#[fail(display = "Wallet store error: {}", _0)]
 	Backend(String),
 
 	/// Callback implementation error conversion

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -471,7 +471,6 @@ where
 	let lock_height = height + global::coinbase_maturity();
 	let key_id = block_fees.key_id();
 	let parent_key_id = wallet.parent_key_id();
-	println!("HEYHO key id {:?}", key_id);
 
 	let key_id = match key_id {
 		Some(key_id) => match keys::retrieve_existing_key(wallet, key_id, None) {

--- a/wallet/src/libwallet/internal/updater.rs
+++ b/wallet/src/libwallet/internal/updater.rs
@@ -471,9 +471,13 @@ where
 	let lock_height = height + global::coinbase_maturity();
 	let key_id = block_fees.key_id();
 	let parent_key_id = wallet.parent_key_id();
+	println!("HEYHO key id {:?}", key_id);
 
 	let key_id = match key_id {
-		Some(key_id) => keys::retrieve_existing_key(wallet, key_id, None)?.0,
+		Some(key_id) => match keys::retrieve_existing_key(wallet, key_id, None) {
+			Ok(k) => k.0,
+			Err(_) => keys::next_available_key(wallet)?,
+		},
 		None => keys::next_available_key(wallet)?,
 	};
 


### PR DESCRIPTION
It happens if `wallet check` runs in parallel.
Alternative solution is not to remove it during the check.
Fixes #2412