### PR TITLE
Refactor tx lib to be more Sender-Recipient agnostic

### DIFF
--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -616,6 +616,7 @@ where
 
 	pub fn initiate_tx(
 		&mut self,
+		as_recipient: bool,
 		src_acct_name: Option<&str>,
 		amount: u64,
 		minimum_confirmations: u64,
@@ -653,17 +654,30 @@ where
 
 		let mut slate = tx::new_tx_slate(&mut *w, amount, 2)?;
 
-		let (context, lock_fn) = tx::add_inputs_to_slate(
-			&mut *w,
-			&mut slate,
-			minimum_confirmations,
-			max_outputs,
-			num_change_outputs,
-			selection_strategy_is_use_all,
-			&parent_key_id,
-			0,
-			message,
-		)?;
+		let (context, lock_fn) = match as_recipient {
+			false => {
+				tx::add_inputs_to_slate(
+					&mut *w,
+					&mut slate,
+					minimum_confirmations,
+					max_outputs,
+					num_change_outputs,
+					selection_strategy_is_use_all,
+					&parent_key_id,
+					0,
+					message,
+				)?
+			},
+			true => {
+				tx::add_output_to_slate(
+					&mut *w,
+					&mut slate,
+					&parent_key_id,
+					1,
+					message,
+				)?
+			}
+		};
 
 		// Save the aggsig context in our DB for when we
 		// recieve the transaction back

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -41,8 +41,8 @@ use crate::core::ser;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::internal::{keys, tx, updater};
 use crate::libwallet::types::{
-	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputLockFn, TxLogEntry, TxLogEntryType,
-	TxWrapper, WalletBackend, WalletInfo,
+	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputLockFn, TxLogEntry,
+	TxLogEntryType, TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::libwallet::{Error, ErrorKind};
 use crate::util;
@@ -623,13 +623,7 @@ where
 		num_change_outputs: usize,
 		selection_strategy_is_use_all: bool,
 		message: Option<String>,
-	) -> Result<
-		(
-			Slate,
-			OutputLockFn<W, C, K>,
-		),
-		Error,
-	> {
+	) -> Result<(Slate, OutputLockFn<W, C, K>), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 		let parent_key_id = match src_acct_name {
@@ -896,7 +890,8 @@ where
 			None => None,
 		};
 
-		let (_, mut create_fn) = tx::add_output_to_slate(&mut *w, slate, &parent_key_id, 1, message)?;
+		let (_, mut create_fn) =
+			tx::add_output_to_slate(&mut *w, slate, &parent_key_id, 1, message)?;
 		create_fn(&mut *w, &slate.tx, PhantomData, PhantomData)?;
 		tx::update_message(&mut *w, slate)?;
 		w.close()?;

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -655,28 +655,18 @@ where
 		let mut slate = tx::new_tx_slate(&mut *w, amount, 2)?;
 
 		let (context, lock_fn) = match as_recipient {
-			false => {
-				tx::add_inputs_to_slate(
-					&mut *w,
-					&mut slate,
-					minimum_confirmations,
-					max_outputs,
-					num_change_outputs,
-					selection_strategy_is_use_all,
-					&parent_key_id,
-					0,
-					message,
-				)?
-			},
-			true => {
-				tx::add_output_to_slate(
-					&mut *w,
-					&mut slate,
-					&parent_key_id,
-					1,
-					message,
-				)?
-			}
+			false => tx::add_inputs_to_slate(
+				&mut *w,
+				&mut slate,
+				minimum_confirmations,
+				max_outputs,
+				num_change_outputs,
+				selection_strategy_is_use_all,
+				&parent_key_id,
+				0,
+				message,
+			)?,
+			true => tx::add_output_to_slate(&mut *w, &mut slate, &parent_key_id, 1, message)?,
 		};
 
 		// Save the aggsig context in our DB for when we

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -158,7 +158,7 @@ pub fn build_recipient_output<T: ?Sized, C, K>(
 	(
 		Identifier,
 		Context,
-		impl FnOnce(&mut T) -> Result<(), Error>,
+		impl FnOnce(&mut T, &Transaction) -> Result<(), Error>,
 	),
 	Error,
 >
@@ -192,7 +192,7 @@ where
 
 	// Create closure that adds the output to recipient's wallet
 	// (up to the caller to decide when to do)
-	let wallet_add_fn = move |wallet: &mut T| {
+	let wallet_add_fn = move |wallet: &mut T, tx: &Transaction| {
 		let commit = wallet.calc_commit_for_cache(amount, &key_id_inner)?;
 		let mut batch = wallet.batch()?;
 		let log_id = batch.next_tx_log_id(&parent_key_id)?;
@@ -215,6 +215,7 @@ where
 			tx_log_entry: Some(log_id),
 		})?;
 		batch.save_tx_log_entry(t, &parent_key_id)?;
+		wallet.store_tx(&format!("{}", t.tx_slate_id.unwrap()), tx)?;
 		batch.commit()?;
 		Ok(())
 	};

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -92,6 +92,7 @@ where
 	let update_sender_wallet_fn =
 		move |wallet: &mut T, tx: &Transaction, _: PhantomData<C>, _: PhantomData<K>| {
 			let tx_entry = {
+				// These ensure the closure remains FnMut
 				let lock_inputs = lock_inputs_in.clone();
 				let messages = messages_in.clone();
 				let slate_id = slate_id_in.clone();
@@ -186,6 +187,7 @@ where
 	// (up to the caller to decide when to do)
 	let wallet_add_fn =
 		move |wallet: &mut T, _tx: &Transaction, _: PhantomData<C>, _: PhantomData<K>| {
+			// Ensure closure remains FnMut
 			let messages = messages_in.clone();
 			let commit = wallet.calc_commit_for_cache(amount, &key_id_inner)?;
 			let mut batch = wallet.batch()?;

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -107,7 +107,7 @@ pub fn add_output_to_slate<T: ?Sized, C, K>(
 	parent_key_id: &Identifier,
 	participant_id: usize,
 	message: Option<String>,
-) -> Result<impl FnOnce(&mut T) -> Result<(), Error>, Error>
+) -> Result<(Context, impl FnOnce(&mut T, &Transaction) -> Result<(), Error>), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
@@ -134,7 +134,7 @@ where
 		participant_id,
 	)?;
 
-	Ok(create_fn)
+	Ok((context, create_fn))
 }
 
 /// Complete a transaction as the sender

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -53,13 +53,7 @@ pub fn add_inputs_to_slate<T: ?Sized, C, K>(
 	parent_key_id: &Identifier,
 	participant_id: usize,
 	message: Option<String>,
-) -> Result<
-	(
-		Context,
-		OutputLockFn<T, C, K>,
-	),
-	Error,
->
+) -> Result<(Context, OutputLockFn<T, C, K>), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
@@ -106,13 +100,7 @@ pub fn add_output_to_slate<T: ?Sized, C, K>(
 	parent_key_id: &Identifier,
 	participant_id: usize,
 	message: Option<String>,
-) -> Result<
-	(
-		Context,
-		OutputLockFn<T, C, K>,
-	),
-	Error,
->
+) -> Result<(Context, OutputLockFn<T, C, K>), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -90,6 +90,12 @@ where
 
 	let lock_height = current_height;
 
+	// Create slate
+	let num_participants = 2;
+	let mut slate = Slate::blank(num_participants);
+	slate.height = current_height;
+	slate.lock_height = lock_height;
+
 	// Sender selects outputs into a new slate and save our corresponding keys in
 	// a transaction context. The secret key in our transaction context will be
 	// randomly selected. This returns the public slate, and a closure that locks
@@ -97,9 +103,9 @@ where
 	// according to plan
 	// This function is just a big helper to do all of that, in theory
 	// this process can be split up in any way
-	let (mut slate, mut context, sender_lock_fn) = selection::build_send_tx_slate(
+	let (mut context, sender_lock_fn) = selection::build_send_tx(
 		wallet,
-		2,
+		&mut slate,
 		amount,
 		current_height,
 		minimum_confirmations,

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -16,11 +16,10 @@
 
 use uuid::Uuid;
 
-use crate::core::core::Transaction;
 use crate::core::libtx::slate::Slate;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::internal::{selection, updater};
-use crate::libwallet::types::{Context, NodeClient, TxLogEntryType, WalletBackend};
+use crate::libwallet::types::{Context, NodeClient, OutputLockFn, TxLogEntryType, WalletBackend};
 use crate::libwallet::{Error, ErrorKind};
 
 /// Creates a new slate for a transaction, can be called by anyone involved in
@@ -57,7 +56,7 @@ pub fn add_inputs_to_slate<T: ?Sized, C, K>(
 ) -> Result<
 	(
 		Context,
-		impl FnOnce(&mut T, &Transaction) -> Result<(), Error>,
+		OutputLockFn<T, C, K>,
 	),
 	Error,
 >
@@ -110,7 +109,7 @@ pub fn add_output_to_slate<T: ?Sized, C, K>(
 ) -> Result<
 	(
 		Context,
-		impl FnOnce(&mut T, &Transaction) -> Result<(), Error>,
+		OutputLockFn<T, C, K>,
 	),
 	Error,
 >

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -25,7 +25,11 @@ use crate::libwallet::{Error, ErrorKind};
 
 /// Creates a new slate for a transaction, can be called by anyone involved in
 /// the transaction (sender(s), receiver(s))
-pub fn new_tx_slate<T: ?Sized, C, K>(wallet: &mut T, amount: u64, num_participants: usize) -> Result<Slate, Error>
+pub fn new_tx_slate<T: ?Sized, C, K>(
+	wallet: &mut T,
+	amount: u64,
+	num_participants: usize,
+) -> Result<Slate, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
@@ -123,7 +127,12 @@ where
 	)?;
 
 	// perform partial sig
-	let _ = slate.fill_round_2(wallet.keychain(), &context.sec_key, &context.sec_nonce, participant_id)?;
+	let _ = slate.fill_round_2(
+		wallet.keychain(),
+		&context.sec_key,
+		&context.sec_nonce,
+		participant_id,
+	)?;
 
 	Ok(create_fn)
 }
@@ -140,7 +149,12 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let _ = slate.fill_round_2(wallet.keychain(), &context.sec_key, &context.sec_nonce, participant_id)?;
+	let _ = slate.fill_round_2(
+		wallet.keychain(),
+		&context.sec_key,
+		&context.sec_nonce,
+		participant_id,
+	)?;
 	// Final transaction can be built by anyone at this stage
 	let res = slate.finalize(wallet.keychain());
 	if let Err(e) = res {

--- a/wallet/src/libwallet/internal/tx.rs
+++ b/wallet/src/libwallet/internal/tx.rs
@@ -107,7 +107,13 @@ pub fn add_output_to_slate<T: ?Sized, C, K>(
 	parent_key_id: &Identifier,
 	participant_id: usize,
 	message: Option<String>,
-) -> Result<(Context, impl FnOnce(&mut T, &Transaction) -> Result<(), Error>), Error>
+) -> Result<
+	(
+		Context,
+		impl FnOnce(&mut T, &Transaction) -> Result<(), Error>,
+	),
+	Error,
+>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -30,12 +30,12 @@ use serde;
 use serde_json;
 use std::collections::HashMap;
 use std::fmt;
-use uuid::Uuid;
 use std::marker::PhantomData;
+use uuid::Uuid;
 
 /// Lock function type
-pub type OutputLockFn<T, C, K>
-= Box<dyn FnMut(&mut T, &Transaction, PhantomData<C>, PhantomData<K>) -> Result<(), Error>>;
+pub type OutputLockFn<T, C, K> =
+	Box<dyn FnMut(&mut T, &Transaction, PhantomData<C>, PhantomData<K>) -> Result<(), Error>>;
 
 /// Combined trait to allow dynamic wallet dispatch
 pub trait WalletInst<C, K>: WalletBackend<C, K> + Send + Sync + 'static

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -31,6 +31,11 @@ use serde_json;
 use std::collections::HashMap;
 use std::fmt;
 use uuid::Uuid;
+use std::marker::PhantomData;
+
+/// Lock function type
+pub type OutputLockFn<T, C, K>
+= Box<dyn FnMut(&mut T, &Transaction, PhantomData<C>, PhantomData<K>) -> Result<(), Error>>;
 
 /// Combined trait to allow dynamic wallet dispatch
 pub trait WalletInst<C, K>: WalletBackend<C, K> + Send + Sync + 'static


### PR DESCRIPTION
As a prelude to allowing transactions to be created by the recipient, some changes to make the underlying libs less dependent on who the sender is and who the receiver is. From an API perspective the process should become more granular, something like:

To create a slate as sender:

create_new_slate()
add_inputs()
send()
receive()
finalize()

And to create a slate as recipient
create_new_slate()
add_outputs()
send()

In either case the other party is simply calling the same `add_inputs` or `add_outputs` function depending on the order in which the transaction is being sent around.

This just rejigs internals for now without actually changing the API. While doing this, I realized that I think we want to do the grin/wallet split first, to make it easier to manage wallet API changes and additions without having to worry about grin versioning.