### PR TITLE
Set max number of connections for peer db

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -161,7 +161,11 @@ impl Server {
 			config.clone(),
 		));
 
-		let peer_db_env = Arc::new(store::new_named_env(config.db_root.clone(), "peer".into()));
+		let peer_db_env = Arc::new(store::new_named_env(
+			config.db_root.clone(),
+			"peer".into(),
+			config.p2p_config.peer_max_count,
+		));
 		let p2p_server = Arc::new(p2p::Server::new(
 			peer_db_env,
 			config.p2p_config.capabilities,


### PR DESCRIPTION
Use max_peers value for that if set. By default LMDB limit is 126, which is not enough for less than 200 peers on my node.