### PR TITLE
bump for v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,16 +675,16 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.0",
- "grin_chain 1.0.0",
- "grin_config 1.0.0",
- "grin_core 1.0.0",
- "grin_keychain 1.0.0",
- "grin_p2p 1.0.0",
- "grin_servers 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
- "grin_wallet 1.0.0",
+ "grin_api 1.0.1",
+ "grin_chain 1.0.1",
+ "grin_config 1.0.1",
+ "grin_core 1.0.1",
+ "grin_keychain 1.0.1",
+ "grin_p2p 1.0.1",
+ "grin_servers 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
+ "grin_wallet 1.0.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -698,17 +698,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.0.0",
- "grin_core 1.0.0",
- "grin_p2p 1.0.0",
- "grin_pool 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
+ "grin_chain 1.0.1",
+ "grin_core 1.0.1",
+ "grin_p2p 1.0.1",
+ "grin_pool 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,10 +738,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.0",
- "grin_keychain 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
+ "grin_core 1.0.1",
+ "grin_keychain 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,14 +752,14 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.0",
- "grin_p2p 1.0.0",
- "grin_servers 1.0.0",
- "grin_util 1.0.0",
- "grin_wallet 1.0.0",
+ "grin_core 1.0.1",
+ "grin_p2p 1.0.1",
+ "grin_servers 1.0.1",
+ "grin_util 1.0.1",
+ "grin_wallet 1.0.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -778,8 +778,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.0.0",
- "grin_util 1.0.0",
+ "grin_keychain 1.0.1",
+ "grin_util 1.0.1",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,12 +795,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.0.0",
+ "grin_util 1.0.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,16 +816,16 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.0",
- "grin_pool 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
+ "grin_core 1.0.1",
+ "grin_pool 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -837,15 +837,15 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.0.0",
- "grin_core 1.0.0",
- "grin_keychain 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
+ "grin_chain 1.0.1",
+ "grin_core 1.0.1",
+ "grin_keychain 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -868,21 +868,21 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.0",
- "grin_chain 1.0.0",
- "grin_core 1.0.0",
- "grin_keychain 1.0.0",
- "grin_p2p 1.0.0",
- "grin_pool 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
- "grin_wallet 1.0.0",
+ "grin_api 1.0.1",
+ "grin_chain 1.0.1",
+ "grin_core 1.0.1",
+ "grin_keychain 1.0.1",
+ "grin_p2p 1.0.1",
+ "grin_pool 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
+ "grin_wallet 1.0.1",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -907,8 +907,8 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.0",
- "grin_util 1.0.0",
+ "grin_core 1.0.1",
+ "grin_util 1.0.1",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,12 +948,12 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.0",
- "grin_chain 1.0.0",
- "grin_core 1.0.0",
- "grin_keychain 1.0.0",
- "grin_store 1.0.0",
- "grin_util 1.0.0",
+ "grin_api 1.0.1",
+ "grin_chain 1.0.1",
+ "grin_core 1.0.1",
+ "grin_keychain 1.0.1",
+ "grin_store 1.0.1",
+ "grin_util 1.0.1",
  "hyper 0.12.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -36,14 +36,14 @@ linefeed = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "1.0.0" }
-grin_config = { path = "./config", version = "1.0.0" }
-grin_core = { path = "./core", version = "1.0.0" }
-grin_keychain = { path = "./keychain", version = "1.0.0" }
-grin_p2p = { path = "./p2p", version = "1.0.0" }
-grin_servers = { path = "./servers", version = "1.0.0" }
-grin_util = { path = "./util", version = "1.0.0" }
-grin_wallet = { path = "./wallet", version = "1.0.0" }
+grin_api = { path = "./api", version = "1.0.1" }
+grin_config = { path = "./config", version = "1.0.1" }
+grin_core = { path = "./core", version = "1.0.1" }
+grin_keychain = { path = "./keychain", version = "1.0.1" }
+grin_p2p = { path = "./p2p", version = "1.0.1" }
+grin_servers = { path = "./servers", version = "1.0.1" }
+grin_util = { path = "./util", version = "1.0.1" }
+grin_wallet = { path = "./wallet", version = "1.0.1" }
 
 [build-dependencies]
 built = "0.3"
@@ -52,5 +52,5 @@ flate2 = "1.0"
 tar = "0.4"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "1.0.0" }
-grin_store = { path = "./store", version = "1.0.0" }
+grin_chain = { path = "./chain", version = "1.0.1" }
+grin_store = { path = "./store", version = "1.0.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_chain = { path = "../chain", version = "1.0.0" }
-grin_p2p = { path = "../p2p", version = "1.0.0" }
-grin_pool = { path = "../pool", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_chain = { path = "../chain", version = "1.0.1" }
+grin_p2p = { path = "../p2p", version = "1.0.1" }
+grin_pool = { path = "../pool", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ serde_derive = "1"
 chrono = "0.4.4"
 lru-cache = "0.1"
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_keychain = { path = "../keychain", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_keychain = { path = "../keychain", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,11 +16,11 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_servers = { path = "../servers", version = "1.0.0" }
-grin_p2p = { path = "../p2p", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
-grin_wallet = { path = "../wallet", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_servers = { path = "../servers", version = "1.0.1" }
+grin_p2p = { path = "../p2p", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
+grin_wallet = { path = "../wallet", version = "1.0.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -28,8 +28,8 @@ uuid = { version = "0.6", features = ["serde", "v4"] }
 log = "0.4"
 chrono = "0.4.4"
 
-grin_keychain = { path = "../keychain", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_keychain = { path = "../keychain", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ sha2 = "0.7"
 pbkdf2 = "0.2"
 
 
-grin_util = { path = "../util", version = "1.0.0" }
+grin_util = { path = "../util", version = "1.0.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,9 +22,9 @@ serde_derive = "1"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "1.0.0" }
+grin_pool = { path = "../pool", version = "1.0.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -17,10 +17,10 @@ serde_derive = "1"
 log = "0.4"
 chrono = "0.4.4"
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_keychain = { path = "../keychain", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_keychain = { path = "../keychain", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "1.0.0" }
+grin_chain = { path = "../chain", version = "1.0.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,15 +25,15 @@ chrono = "0.4.4"
 bufstream = "~0.1"
 jsonrpc-core = "~8.0"
 
-grin_api = { path = "../api", version = "1.0.0" }
-grin_chain = { path = "../chain", version = "1.0.0" }
-grin_core = { path = "../core", version = "1.0.0" }
-grin_keychain = { path = "../keychain", version = "1.0.0" }
-grin_p2p = { path = "../p2p", version = "1.0.0" }
-grin_pool = { path = "../pool", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
-grin_wallet = { path = "../wallet", version = "1.0.0" }
+grin_api = { path = "../api", version = "1.0.1" }
+grin_chain = { path = "../chain", version = "1.0.1" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_keychain = { path = "../keychain", version = "1.0.1" }
+grin_p2p = { path = "../p2p", version = "1.0.1" }
+grin_pool = { path = "../pool", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
+grin_wallet = { path = "../wallet", version = "1.0.1" }
 
 [dev-dependencies]
 blake2-rfc = "0.2"

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -1,5 +1,5 @@
 name: grin
-version: "1.0.0"
+version: "1.0.1"
 about: Lightweight implementation of the MimbleWimble protocol.
 author: The Grin Team
 
@@ -301,4 +301,3 @@ subcommands:
             about: Restores a wallet contents from a seed file
         - check:
             about: Checks a wallet's outputs against a live node, repairing and restoring missing outputs if required
- 

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,8 +22,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,13 +31,12 @@ uuid = { version = "0.6", features = ["serde", "v4"] }
 url = "1.7.0"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_api = { path = "../api", version = "1.0.0" }
-grin_core = { path = "../core", version = "1.0.0" }
-grin_keychain = { path = "../keychain", version = "1.0.0" }
-grin_store = { path = "../store", version = "1.0.0" }
-grin_util = { path = "../util", version = "1.0.0" }
-grin_chain = { path = "../chain", version = "1.0.0" }
+grin_api = { path = "../api", version = "1.0.1" }
+grin_core = { path = "../core", version = "1.0.1" }
+grin_keychain = { path = "../keychain", version = "1.0.1" }
+grin_store = { path = "../store", version = "1.0.1" }
+grin_util = { path = "../util", version = "1.0.1" }
+grin_chain = { path = "../chain", version = "1.0.1" }
 
 [dev-dependencies]
-grin_store = { path = "../store", version = "1.0.0" }
-#grin_config = { path = "../config", version = "1.0.0" }
+grin_store = { path = "../store", version = "1.0.1" }


### PR DESCRIPTION
Bump our crate version numbers in preparation for cutting the `v1.0.1` release.
