### PR TITLE
Add ability to compare selection strategies

### DIFF
--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -349,6 +349,9 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 	// selection_strategy
 	let selection_strategy = parse_required(args, "selection_strategy")?;
 
+	// estimate_selection_strategies
+	let estimate_selection_strategies = args.is_present("estimate_selection_strategies");
+
 	// method
 	let method = parse_required(args, "method")?;
 
@@ -360,10 +363,18 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 				None => "default",
 			}
 		} else {
-			parse_required(args, "dest")?
+			if !estimate_selection_strategies {
+				parse_required(args, "dest")?
+			} else {
+				""
+			}
 		}
 	};
-	if method == "http" && !dest.starts_with("http://") && !dest.starts_with("https://") {
+	if !estimate_selection_strategies
+		&& method == "http"
+		&& !dest.starts_with("http://")
+		&& !dest.starts_with("https://")
+	{
 		let msg = format!(
 			"HTTP Destination should start with http://: or https://: {}",
 			dest,
@@ -386,6 +397,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		message: message,
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
+		estimate_selection_strategies,
 		method: method.to_owned(),
 		dest: dest.to_owned(),
 		change_outputs: change_outputs,
@@ -562,7 +574,11 @@ pub fn wallet_command(
 		}
 		("send", Some(args)) => {
 			let a = arg_parse!(parse_send_args(&args));
-			command::send(inst_wallet(), a)
+			command::send(
+				inst_wallet(),
+				a,
+				wallet_config.dark_background_color_scheme.unwrap_or(true),
+			)
 		}
 		("receive", Some(args)) => {
 			let a = arg_parse!(parse_receive_args(&args));

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -161,6 +161,10 @@ subcommands:
                     - smallest
                   default_value: all
                   takes_value: true
+              - estimate_selection_strategies:
+                  help: Estimates all possible Coin/Output selection strategies.
+                  short: e
+                  long: estimate-selection
               - change_outputs:
                   help: Number of change outputs to generate (mainly for testing)
                   short: o

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -338,6 +338,49 @@ pub fn info(
 		);
 	}
 }
+
+/// Display summary info in a pretty way
+pub fn estimate(
+	amount: u64,
+	strategies: Vec<(
+		&str, // strategy
+		u64,  // total amount to be locked
+		u64,  // fee
+	)>,
+	dark_background_color_scheme: bool,
+) {
+	println!(
+		"\nEstimation for sending {}:\n",
+		amount_to_hr_string(amount, false)
+	);
+
+	let mut table = table!();
+
+	table.set_titles(row![
+		bMG->"Selection strategy",
+		bMG->"Fee",
+		bMG->"Will be locked",
+	]);
+
+	for (strategy, total, fee) in strategies {
+		if dark_background_color_scheme {
+			table.add_row(row![
+				bFC->strategy,
+				FR->amount_to_hr_string(fee, false),
+				FY->amount_to_hr_string(total, false),
+			]);
+		} else {
+			table.add_row(row![
+				bFD->strategy,
+				FR->amount_to_hr_string(fee, false),
+				FY->amount_to_hr_string(total, false),
+			]);
+		}
+	}
+	table.printstd();
+	println!();
+}
+
 /// Display list of wallet accounts in a pretty way
 pub fn accounts(acct_mappings: Vec<AcctPathMapping>) {
 	println!("\n____ Wallet Accounts ____\n",);

--- a/wallet/src/libwallet/internal/selection.rs
+++ b/wallet/src/libwallet/internal/selection.rs
@@ -246,6 +246,52 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
+	let (coins, _total, amount, fee) = select_coins_and_fee(
+		wallet,
+		amount,
+		current_height,
+		minimum_confirmations,
+		max_outputs,
+		change_outputs,
+		selection_strategy_is_use_all,
+		&parent_key_id,
+	)?;
+
+	// build transaction skeleton with inputs and change
+	let (mut parts, change_amounts_derivations) =
+		inputs_and_change(&coins, wallet, amount, fee, change_outputs)?;
+
+	// This is more proof of concept than anything but here we set lock_height
+	// on tx being sent (based on current chain height via api).
+	parts.push(build::with_lock_height(lock_height));
+
+	Ok((parts, coins, change_amounts_derivations, fee))
+}
+
+/// Select outputs and calculating fee.
+pub fn select_coins_and_fee<T: ?Sized, C, K>(
+	wallet: &mut T,
+	amount: u64,
+	current_height: u64,
+	minimum_confirmations: u64,
+	max_outputs: usize,
+	change_outputs: usize,
+	selection_strategy_is_use_all: bool,
+	parent_key_id: &Identifier,
+) -> Result<
+	(
+		Vec<OutputData>,
+		u64, // total
+		u64, // amount
+		u64, // fee
+	),
+	Error,
+>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
 	// select some spendable coins from the wallet
 	let (max_outputs, mut coins) = select_coins(
 		wallet,
@@ -324,16 +370,7 @@ where
 			amount_with_fee = amount + fee;
 		}
 	}
-
-	// build transaction skeleton with inputs and change
-	let (mut parts, change_amounts_derivations) =
-		inputs_and_change(&coins, wallet, amount, fee, change_outputs)?;
-
-	// This is more proof of concept than anything but here we set lock_height
-	// on tx being sent (based on current chain height via api).
-	parts.push(build::with_lock_height(lock_height));
-
-	Ok((parts, coins, change_amounts_derivations, fee))
+	Ok((coins, total, amount, fee))
 }
 
 /// Selects inputs and change for a transaction

--- a/wallet/tests/transaction.rs
+++ b/wallet/tests/transaction.rs
@@ -226,6 +226,33 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 		Ok(())
 	})?;
 
+	// Estimate fee and locked amount for a transaction
+	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
+		let (total, fee) = sender_api.estimate_initiate_tx(
+			None,
+			amount * 2, // amount
+			2,          // minimum confirmations
+			500,        // max outputs
+			1,          // num change outputs
+			true,       // select all outputs
+		)?;
+		assert_eq!(total, 600_000_000_000);
+		assert_eq!(fee, 4_000_000);
+
+		let (total, fee) = sender_api.estimate_initiate_tx(
+			None,
+			amount * 2, // amount
+			2,          // minimum confirmations
+			500,        // max outputs
+			1,          // num change outputs
+			false,      // select the smallest amount of outputs
+		)?;
+		assert_eq!(total, 180_000_000_000);
+		assert_eq!(fee, 6_000_000);
+
+		Ok(())
+	})?;
+
 	// Send another transaction, but don't post to chain immediately and use
 	// the stored transaction instead
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {


### PR DESCRIPTION
Before tx creation user can estimate fee and locked amount
with different selection strategies by providing `-e` flag for
`wallet send` command.