### PR TITLE
fix wallet --data-dir flag

### DIFF
--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -509,7 +509,7 @@ pub fn wallet_command(
 		wallet_config.api_listen_interface = "0.0.0.0".to_string();
 	}
 
-	if let Some(dir) = wallet_args.value_of("dir") {
+	if let Some(dir) = wallet_args.value_of("data_dir") {
 		wallet_config.data_file_dir = dir.to_string().clone();
 	}
 


### PR DESCRIPTION
In the grin.yml  a flag which allows to pass a path to a directory with wallet data defined as 
```
        - data_dir:
            help: Directory in which to store wallet files
            short: dd
            long: data_dir
            takes_value: true
```
However in code we expected this flag to be named `dir`. 