### PR TITLE
Allow to have more than min_peers/2 outbound peers

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -513,7 +513,13 @@ impl Peers {
 	}
 
 	pub fn enough_peers(&self) -> bool {
-		self.connected_peers().len() >= self.config.peer_min_preferred_count() as usize
+		self.peer_count() >= self.config.peer_min_preferred_count()
+	}
+
+	/// We have enough peers, both total connected and outbound connected
+	pub fn healthy_peers_mix(&self) -> bool {
+		self.enough_peers()
+			&& self.peer_outbound_count() >= self.config.peer_min_preferred_count() / 2
 	}
 
 	/// Removes those peers that seem to have expired

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -186,10 +186,7 @@ fn monitor_peers(
 	// maintenance step first, clean up p2p server peers
 	peers.clean_peers(config.peer_max_count() as usize);
 
-	// We have enough peers, both total connected and outbound connected so we are good.
-	if peers.peer_count() >= config.peer_min_preferred_count()
-		&& peers.peer_outbound_count() >= config.peer_min_preferred_count() / 2
-	{
+	if peers.healthy_peers_mix() {
 		return;
 	}
 
@@ -318,9 +315,7 @@ fn listen_for_addrs(
 	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
-	if peers.peer_count() >= p2p.config.peer_min_preferred_count()
-		&& peers.peer_outbound_count() >= p2p.config.peer_max_count() / 2
-	{
+	if peers.healthy_peers_mix() {
 		return;
 	}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -318,7 +318,9 @@ fn listen_for_addrs(
 	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
-	if peers.peer_outbound_count() >= p2p.config.peer_min_preferred_count() / 2 {
+	if peers.peer_count() >= p2p.config.peer_min_preferred_count()
+		&& peers.peer_outbound_count() >= p2p.config.peer_max_count() / 2
+	{
 		return;
 	}
 


### PR DESCRIPTION
Default value is 8, so we allow only 4 outbound peers, unfortunately if a node is behind NAT it can't get inbound peers and it stucks with 4 peers as maximum.
This PR allows a number of outbound peers to be between min_peers and max_peers/2. Node behind NAT will eventually have just min_peers number of peers.