### PR TITLE
fix: false positive wallet tests

### DIFF
--- a/wallet/tests/restore.rs
+++ b/wallet/tests/restore.rs
@@ -366,10 +366,10 @@ fn perform_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 fn wallet_restore() {
 	let test_dir = "test_output/wallet_restore";
 	if let Err(e) = setup_restore(test_dir) {
-		println!("Set up restore: Libwallet Error: {}", e);
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
 	if let Err(e) = perform_restore(test_dir) {
-		println!("Perform restore: Libwallet Error: {}", e);
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
 	// let logging finish
 	thread::sleep(Duration::from_millis(200));

--- a/wallet/tests/transaction.rs
+++ b/wallet/tests/transaction.rs
@@ -240,8 +240,8 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			None,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.finalize_tx(&mut slate)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
+		sender_api.finalize_tx(&mut slate)?;
 		Ok(())
 	})?;
 
@@ -337,8 +337,8 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 			None,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.finalize_tx(&mut slate)?;
 		sender_api.tx_lock_outputs(&slate, lock_fn)?;
+		sender_api.finalize_tx(&mut slate)?;
 		Ok(())
 	})?;
 
@@ -458,7 +458,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 fn db_wallet_basic_transaction_api() {
 	let test_dir = "test_output/basic_transaction_api";
 	if let Err(e) = basic_transaction_api(test_dir) {
-		println!("Libwallet Error: {}", e);
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
 }
 
@@ -466,6 +466,6 @@ fn db_wallet_basic_transaction_api() {
 fn db_wallet_tx_rollback() {
 	let test_dir = "test_output/tx_rollback";
 	if let Err(e) = tx_rollback(test_dir) {
-		println!("Libwallet Error: {}", e);
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
 }


### PR DESCRIPTION
Two tests in the wallet were actually failing, we were just ignoring them. This fixes it.