### PR TITLE
Map peers by ip only (ignoring port unless on loopback ip)

### DIFF
--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -14,7 +14,7 @@
 
 use super::utils::w;
 use crate::p2p;
-use crate::p2p::types::{PeerInfoDisplay, ReasonForBan};
+use crate::p2p::types::{PeerAddr, PeerInfoDisplay, ReasonForBan};
 use crate::router::{Handler, ResponseFuture};
 use crate::web::*;
 use hyper::{Body, Request, StatusCode};
@@ -58,7 +58,8 @@ impl Handler for PeerHandler {
 	fn get(&self, req: Request<Body>) -> ResponseFuture {
 		let command = right_path_element!(req);
 		if let Ok(addr) = command.parse() {
-			match w(&self.peers).get_peer(addr) {
+			let peer_addr = PeerAddr(addr);
+			match w(&self.peers).get_peer(peer_addr) {
 				Ok(peer) => json_response(&peer),
 				Err(_) => response(StatusCode::NOT_FOUND, "peer not found"),
 			}
@@ -84,13 +85,13 @@ impl Handler for PeerHandler {
 						format!("invalid peer address: {}", e),
 					);
 				}
-				Ok(addr) => addr,
+				Ok(addr) => PeerAddr(addr),
 			},
 		};
 
 		match command {
-			"ban" => w(&self.peers).ban_peer(&addr, ReasonForBan::ManualBan),
-			"unban" => w(&self.peers).unban_peer(&addr),
+			"ban" => w(&self.peers).ban_peer(addr, ReasonForBan::ManualBan),
+			"unban" => w(&self.peers).unban_peer(addr),
 			_ => return response(StatusCode::BAD_REQUEST, "invalid command"),
 		};
 

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -86,15 +86,18 @@ impl Handler for PeerHandler {
 		};
 		let addr = match path_elems.next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
-			Some(a) => match a.parse() {
-				Err(e) => {
+			Some(a) => {
+				if let Ok(ip_addr) = a.parse() {
+					PeerAddr::from_ip(ip_addr)
+				} else if let Ok(addr) = a.parse() {
+					PeerAddr(addr)
+				} else {
 					return response(
 						StatusCode::BAD_REQUEST,
-						format!("invalid peer address: {}", e),
+						format!("invalid peer address: {}", req.uri().path()),
 					);
 				}
-				Ok(addr) => PeerAddr(addr),
-			},
+			}
 		};
 
 		match command {

--- a/p2p/fuzz/fuzz_targets/read_peer_addr.rs
+++ b/p2p/fuzz/fuzz_targets/read_peer_addr.rs
@@ -5,9 +5,9 @@ extern crate grin_core;
 extern crate grin_p2p;
 
 use grin_core::ser;
-use grin_p2p::msg::SockAddr;
+use grin_p2p::types::PeerAddr;
 
 fuzz_target!(|data: &[u8]| {
 	let mut d = data.clone();
-	let _t: Result<SockAddr, ser::Error> = ser::deserialize(&mut d);
+	let _t: Result<PeerAddr, ser::Error> = ser::deserialize(&mut d);
 });

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -52,6 +52,6 @@ pub use crate::peers::Peers;
 pub use crate::serv::{DummyAdapter, Server};
 pub use crate::store::{PeerData, State};
 pub use crate::types::{
-	Capabilities, ChainAdapter, Direction, Error, P2PConfig, PeerInfo, ReasonForBan, Seeding,
-	TxHashSetRead, MAX_BLOCK_HEADERS, MAX_LOCATORS, MAX_PEER_ADDRS,
+	Capabilities, ChainAdapter, Direction, Error, P2PConfig, PeerAddr, PeerInfo, ReasonForBan,
+	Seeding, TxHashSetRead, MAX_BLOCK_HEADERS, MAX_LOCATORS, MAX_PEER_ADDRS,
 };

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -14,7 +14,7 @@
 
 use crate::util::{Mutex, RwLock};
 use std::fs::File;
-use std::net::{Shutdown, SocketAddr, TcpStream};
+use std::net::{Shutdown, TcpStream};
 use std::sync::Arc;
 
 use crate::conn;
@@ -25,7 +25,8 @@ use crate::handshake::Handshake;
 use crate::msg::{self, BanReason, GetPeerAddrs, Locator, Ping, TxHashSetRequest};
 use crate::protocol::Protocol;
 use crate::types::{
-	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerInfo, ReasonForBan, TxHashSetRead,
+	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerAddr, PeerInfo, ReasonForBan,
+	TxHashSetRead,
 };
 use chrono::prelude::{DateTime, Utc};
 
@@ -93,7 +94,7 @@ impl Peer {
 		conn: &mut TcpStream,
 		capab: Capabilities,
 		total_difficulty: Difficulty,
-		self_addr: SocketAddr,
+		self_addr: PeerAddr,
 		hs: &Handshake,
 		na: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
@@ -124,10 +125,10 @@ impl Peer {
 		self.connection = Some(Mutex::new(conn::listen(conn, handler)));
 	}
 
-	pub fn is_denied(config: &P2PConfig, peer_addr: &SocketAddr) -> bool {
-		let peer = format!("{}:{}", peer_addr.ip(), peer_addr.port());
+	pub fn is_denied(config: &P2PConfig, peer_addr: PeerAddr) -> bool {
+		// let peer = format!("{}:{}", peer_addr.0.ip(), peer_addr.0.port());
 		if let Some(ref denied) = config.peers_deny {
-			if denied.contains(&peer) {
+			if denied.contains(&peer_addr) {
 				debug!(
 					"checking peer allowed/denied: {:?} explicitly denied",
 					peer_addr
@@ -136,7 +137,7 @@ impl Peer {
 			}
 		}
 		if let Some(ref allowed) = config.peers_allow {
-			if allowed.contains(&peer) {
+			if allowed.contains(&peer_addr) {
 				debug!(
 					"checking peer allowed/denied: {:?} explicitly allowed",
 					peer_addr
@@ -566,7 +567,7 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.get_transaction(kernel_hash)
 	}
 
-	fn tx_kernel_received(&self, kernel_hash: Hash, addr: SocketAddr) {
+	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr) {
 		self.push_recv(kernel_hash);
 		self.adapter.tx_kernel_received(kernel_hash, addr)
 	}
@@ -582,23 +583,23 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.transaction_received(tx, stem)
 	}
 
-	fn block_received(&self, b: core::Block, addr: SocketAddr, _was_requested: bool) -> bool {
+	fn block_received(&self, b: core::Block, addr: PeerAddr, _was_requested: bool) -> bool {
 		let bh = b.hash();
 		self.push_recv(bh);
 		self.adapter.block_received(b, addr, self.has_req(bh))
 	}
 
-	fn compact_block_received(&self, cb: core::CompactBlock, addr: SocketAddr) -> bool {
+	fn compact_block_received(&self, cb: core::CompactBlock, addr: PeerAddr) -> bool {
 		self.push_recv(cb.hash());
 		self.adapter.compact_block_received(cb, addr)
 	}
 
-	fn header_received(&self, bh: core::BlockHeader, addr: SocketAddr) -> bool {
+	fn header_received(&self, bh: core::BlockHeader, addr: PeerAddr) -> bool {
 		self.push_recv(bh.hash());
 		self.adapter.header_received(bh, addr)
 	}
 
-	fn headers_received(&self, bh: &[core::BlockHeader], addr: SocketAddr) -> bool {
+	fn headers_received(&self, bh: &[core::BlockHeader], addr: PeerAddr) -> bool {
 		self.adapter.headers_received(bh, addr)
 	}
 
@@ -618,7 +619,7 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.txhashset_receive_ready()
 	}
 
-	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: SocketAddr) -> bool {
+	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: PeerAddr) -> bool {
 		self.adapter.txhashset_write(h, txhashset_data, peer_addr)
 	}
 
@@ -634,19 +635,19 @@ impl ChainAdapter for TrackingAdapter {
 }
 
 impl NetAdapter for TrackingAdapter {
-	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {
+	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<PeerAddr> {
 		self.adapter.find_peer_addrs(capab)
 	}
 
-	fn peer_addrs_received(&self, addrs: Vec<SocketAddr>) {
+	fn peer_addrs_received(&self, addrs: Vec<PeerAddr>) {
 		self.adapter.peer_addrs_received(addrs)
 	}
 
-	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
+	fn peer_difficulty(&self, addr: PeerAddr, diff: Difficulty, height: u64) {
 		self.adapter.peer_difficulty(addr, diff, height)
 	}
 
-	fn is_banned(&self, addr: SocketAddr) -> bool {
+	fn is_banned(&self, addr: PeerAddr) -> bool {
 		self.adapter.is_banned(addr)
 	}
 }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -126,7 +126,6 @@ impl Peer {
 	}
 
 	pub fn is_denied(config: &P2PConfig, peer_addr: PeerAddr) -> bool {
-		// let peer = format!("{}:{}", peer_addr.0.ip(), peer_addr.0.port());
 		if let Some(ref denied) = config.peers_deny {
 			if denied.contains(&peer_addr) {
 				debug!(

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -15,7 +15,6 @@
 use crate::util::RwLock;
 use std::collections::HashMap;
 use std::fs::File;
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use rand::{thread_rng, Rng};
@@ -30,14 +29,14 @@ use chrono::Duration;
 use crate::peer::Peer;
 use crate::store::{PeerData, PeerStore, State};
 use crate::types::{
-	Capabilities, ChainAdapter, Direction, Error, NetAdapter, P2PConfig, ReasonForBan,
+	Capabilities, ChainAdapter, Direction, Error, NetAdapter, P2PConfig, PeerAddr, ReasonForBan,
 	TxHashSetRead, MAX_PEER_ADDRS,
 };
 
 pub struct Peers {
 	pub adapter: Arc<dyn ChainAdapter>,
 	store: PeerStore,
-	peers: RwLock<HashMap<String, Arc<Peer>>>,
+	peers: RwLock<HashMap<PeerAddr, Arc<Peer>>>,
 	dandelion_relay: RwLock<HashMap<i64, Arc<Peer>>>,
 	config: P2PConfig,
 }
@@ -56,30 +55,25 @@ impl Peers {
 	/// Adds the peer to our internal peer mapping. Note that the peer is still
 	/// returned so the server can run it.
 	pub fn add_connected(&self, peer: Arc<Peer>) -> Result<(), Error> {
-		let peer_data: PeerData;
-		let addr: SocketAddr;
-		{
-			peer_data = PeerData {
-				addr: peer.info.addr,
-				capabilities: peer.info.capabilities,
-				user_agent: peer.info.user_agent.clone(),
-				flags: State::Healthy,
-				last_banned: 0,
-				ban_reason: ReasonForBan::None,
-				last_connected: Utc::now().timestamp(),
-			};
-			addr = peer.info.addr.clone();
-		}
-		debug!("Saving newly connected peer {}.", addr);
+		let peer_data = PeerData {
+			addr: peer.info.addr,
+			capabilities: peer.info.capabilities,
+			user_agent: peer.info.user_agent.clone(),
+			flags: State::Healthy,
+			last_banned: 0,
+			ban_reason: ReasonForBan::None,
+			last_connected: Utc::now().timestamp(),
+		};
+		debug!("Saving newly connected peer {}.", peer_data.addr);
 		self.save_peer(&peer_data)?;
-		self.peers.write().insert(peer_key(&addr), peer.clone());
+		self.peers.write().insert(peer_data.addr, peer.clone());
 
 		Ok(())
 	}
 
 	/// Add a peer as banned to block future connections, usually due to failed
 	/// handshake
-	pub fn add_banned(&self, addr: SocketAddr, ban_reason: ReasonForBan) -> Result<(), Error> {
+	pub fn add_banned(&self, addr: PeerAddr, ban_reason: ReasonForBan) -> Result<(), Error> {
 		let peer_data = PeerData {
 			addr,
 			capabilities: Capabilities::UNKNOWN,
@@ -126,8 +120,8 @@ impl Peers {
 		self.dandelion_relay.read().clone()
 	}
 
-	pub fn is_known(&self, addr: &SocketAddr) -> bool {
-		self.peers.read().contains_key(&peer_key(addr))
+	pub fn is_known(&self, addr: PeerAddr) -> bool {
+		self.peers.read().contains_key(&addr)
 	}
 
 	/// Get vec of peers we are currently connected to.
@@ -153,8 +147,8 @@ impl Peers {
 	}
 
 	/// Get a peer we're connected to by address.
-	pub fn get_connected_peer(&self, addr: &SocketAddr) -> Option<Arc<Peer>> {
-		self.peers.read().get(&peer_key(addr)).map(|p| p.clone())
+	pub fn get_connected_peer(&self, addr: PeerAddr) -> Option<Arc<Peer>> {
+		self.peers.read().get(&addr).map(|p| p.clone())
 	}
 
 	/// Number of peers currently connected to.
@@ -244,7 +238,7 @@ impl Peers {
 		self.most_work_peers().pop()
 	}
 
-	pub fn is_banned(&self, peer_addr: SocketAddr) -> bool {
+	pub fn is_banned(&self, peer_addr: PeerAddr) -> bool {
 		if let Ok(peer) = self.store.get_peer(peer_addr) {
 			if peer.flags == State::Banned {
 				return true;
@@ -254,8 +248,8 @@ impl Peers {
 	}
 
 	/// Ban a peer, disconnecting it if we're currently connected
-	pub fn ban_peer(&self, peer_addr: &SocketAddr, ban_reason: ReasonForBan) {
-		if let Err(e) = self.update_state(*peer_addr, State::Banned) {
+	pub fn ban_peer(&self, peer_addr: PeerAddr, ban_reason: ReasonForBan) {
+		if let Err(e) = self.update_state(peer_addr, State::Banned) {
 			error!("Couldn't ban {}: {:?}", peer_addr, e);
 		}
 
@@ -269,12 +263,12 @@ impl Peers {
 	}
 
 	/// Unban a peer, checks if it exists and banned then unban
-	pub fn unban_peer(&self, peer_addr: &SocketAddr) {
+	pub fn unban_peer(&self, peer_addr: PeerAddr) {
 		debug!("unban_peer: peer {}", peer_addr);
-		match self.get_peer(*peer_addr) {
+		match self.get_peer(peer_addr) {
 			Ok(_) => {
-				if self.is_banned(*peer_addr) {
-					if let Err(e) = self.update_state(*peer_addr, State::Healthy) {
+				if self.is_banned(peer_addr) {
+					if let Err(e) = self.update_state(peer_addr, State::Healthy) {
 						error!("Couldn't unban {}: {:?}", peer_addr, e);
 					}
 				} else {
@@ -398,12 +392,12 @@ impl Peers {
 	}
 
 	/// Get peer in store by address
-	pub fn get_peer(&self, peer_addr: SocketAddr) -> Result<PeerData, Error> {
+	pub fn get_peer(&self, peer_addr: PeerAddr) -> Result<PeerData, Error> {
 		self.store.get_peer(peer_addr).map_err(From::from)
 	}
 
 	/// Whether we've already seen a peer with the provided address
-	pub fn exists_peer(&self, peer_addr: SocketAddr) -> Result<bool, Error> {
+	pub fn exists_peer(&self, peer_addr: PeerAddr) -> Result<bool, Error> {
 		self.store.exists_peer(peer_addr).map_err(From::from)
 	}
 
@@ -413,7 +407,7 @@ impl Peers {
 	}
 
 	/// Updates the state of a peer in store
-	pub fn update_state(&self, peer_addr: SocketAddr, new_state: State) -> Result<(), Error> {
+	pub fn update_state(&self, peer_addr: PeerAddr, new_state: State) -> Result<(), Error> {
 		self.store
 			.update_state(peer_addr, new_state)
 			.map_err(From::from)
@@ -469,10 +463,9 @@ impl Peers {
 		// now clean up peer map based on the list to remove
 		{
 			let mut peers = self.peers.write();
-			for ref p in rm {
-				let key = peer_key(p);
-				let _ = peers.get(&key).map(|peer| peer.stop());
-				peers.remove(&key);
+			for addr in rm {
+				let _ = peers.get(&addr).map(|peer| peer.stop());
+				peers.remove(&addr);
 			}
 		}
 	}
@@ -533,7 +526,7 @@ impl ChainAdapter for Peers {
 		self.adapter.get_transaction(kernel_hash)
 	}
 
-	fn tx_kernel_received(&self, kernel_hash: Hash, addr: SocketAddr) {
+	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr) {
 		self.adapter.tx_kernel_received(kernel_hash, addr)
 	}
 
@@ -541,7 +534,7 @@ impl ChainAdapter for Peers {
 		self.adapter.transaction_received(tx, stem)
 	}
 
-	fn block_received(&self, b: core::Block, peer_addr: SocketAddr, was_requested: bool) -> bool {
+	fn block_received(&self, b: core::Block, peer_addr: PeerAddr, was_requested: bool) -> bool {
 		let hash = b.hash();
 		if !self.adapter.block_received(b, peer_addr, was_requested) {
 			// if the peer sent us a block that's intrinsically bad
@@ -550,45 +543,45 @@ impl ChainAdapter for Peers {
 				"Received a bad block {} from  {}, the peer will be banned",
 				hash, peer_addr
 			);
-			self.ban_peer(&peer_addr, ReasonForBan::BadBlock);
+			self.ban_peer(peer_addr, ReasonForBan::BadBlock);
 			false
 		} else {
 			true
 		}
 	}
 
-	fn compact_block_received(&self, cb: core::CompactBlock, peer_addr: SocketAddr) -> bool {
+	fn compact_block_received(&self, cb: core::CompactBlock, peer_addr: PeerAddr) -> bool {
 		let hash = cb.hash();
 		if !self.adapter.compact_block_received(cb, peer_addr) {
 			// if the peer sent us a block that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
 			debug!(
 				"Received a bad compact block {} from  {}, the peer will be banned",
-				hash, &peer_addr
+				hash, peer_addr
 			);
-			self.ban_peer(&peer_addr, ReasonForBan::BadCompactBlock);
+			self.ban_peer(peer_addr, ReasonForBan::BadCompactBlock);
 			false
 		} else {
 			true
 		}
 	}
 
-	fn header_received(&self, bh: core::BlockHeader, peer_addr: SocketAddr) -> bool {
+	fn header_received(&self, bh: core::BlockHeader, peer_addr: PeerAddr) -> bool {
 		if !self.adapter.header_received(bh, peer_addr) {
 			// if the peer sent us a block header that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
-			self.ban_peer(&peer_addr, ReasonForBan::BadBlockHeader);
+			self.ban_peer(peer_addr, ReasonForBan::BadBlockHeader);
 			false
 		} else {
 			true
 		}
 	}
 
-	fn headers_received(&self, headers: &[core::BlockHeader], peer_addr: SocketAddr) -> bool {
+	fn headers_received(&self, headers: &[core::BlockHeader], peer_addr: PeerAddr) -> bool {
 		if !self.adapter.headers_received(headers, peer_addr) {
 			// if the peer sent us a block header that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
-			self.ban_peer(&peer_addr, ReasonForBan::BadBlockHeader);
+			self.ban_peer(peer_addr, ReasonForBan::BadBlockHeader);
 			false
 		} else {
 			true
@@ -611,13 +604,13 @@ impl ChainAdapter for Peers {
 		self.adapter.txhashset_receive_ready()
 	}
 
-	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: SocketAddr) -> bool {
+	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: PeerAddr) -> bool {
 		if !self.adapter.txhashset_write(h, txhashset_data, peer_addr) {
 			debug!(
 				"Received a bad txhashset data from {}, the peer will be banned",
 				&peer_addr
 			);
-			self.ban_peer(&peer_addr, ReasonForBan::BadTxHashSet);
+			self.ban_peer(peer_addr, ReasonForBan::BadTxHashSet);
 			false
 		} else {
 			true
@@ -638,14 +631,14 @@ impl ChainAdapter for Peers {
 impl NetAdapter for Peers {
 	/// Find good peers we know with the provided capability and return their
 	/// addresses.
-	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {
+	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<PeerAddr> {
 		let peers = self.find_peers(State::Healthy, capab, MAX_PEER_ADDRS as usize);
 		trace!("find_peer_addrs: {} healthy peers picked", peers.len());
 		map_vec!(peers, |p| p.addr)
 	}
 
 	/// A list of peers has been received from one of our peers.
-	fn peer_addrs_received(&self, peer_addrs: Vec<SocketAddr>) {
+	fn peer_addrs_received(&self, peer_addrs: Vec<PeerAddr>) {
 		trace!("Received {} peer addrs, saving.", peer_addrs.len());
 		for pa in peer_addrs {
 			if let Ok(e) = self.exists_peer(pa) {
@@ -668,28 +661,17 @@ impl NetAdapter for Peers {
 		}
 	}
 
-	fn peer_difficulty(&self, addr: SocketAddr, diff: Difficulty, height: u64) {
-		if let Some(peer) = self.get_connected_peer(&addr) {
+	fn peer_difficulty(&self, addr: PeerAddr, diff: Difficulty, height: u64) {
+		if let Some(peer) = self.get_connected_peer(addr) {
 			peer.info.update(height, diff);
 		}
 	}
 
-	fn is_banned(&self, addr: SocketAddr) -> bool {
+	fn is_banned(&self, addr: PeerAddr) -> bool {
 		if let Ok(peer) = self.get_peer(addr) {
 			peer.flags == State::Banned
 		} else {
 			false
 		}
-	}
-}
-
-// TODO - PeerAddr struct for encapsulation and reuse here and in the store.
-// If this is a "loopback" address then we care about the port and construct the key "ip:port".
-// Otherwise we *only* care about the ip and we ignore the port.
-fn peer_key(addr: &SocketAddr) -> String {
-	if addr.ip().is_loopback() {
-		format!("{}:{}", addr.ip(), addr.port())
-	} else {
-		format!("{}", addr.ip())
 	}
 }

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -37,7 +37,7 @@ pub struct Peers {
 	pub adapter: Arc<dyn ChainAdapter>,
 	store: PeerStore,
 	peers: RwLock<HashMap<PeerAddr, Arc<Peer>>>,
-	dandelion_relay: RwLock<HashMap<i64, Arc<Peer>>>,
+	dandelion_relay: RwLock<Option<(i64, Arc<Peer>)>>,
 	config: P2PConfig,
 }
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -29,7 +29,7 @@ use crate::peer::Peer;
 use crate::peers::Peers;
 use crate::store::PeerStore;
 use crate::types::{
-	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, ReasonForBan, TxHashSetRead,
+	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerAddr, ReasonForBan, TxHashSetRead,
 };
 use crate::util::{Mutex, StopState};
 use chrono::prelude::{DateTime, Utc};
@@ -82,6 +82,8 @@ impl Server {
 
 			match listener.accept() {
 				Ok((stream, peer_addr)) => {
+					let peer_addr = PeerAddr(peer_addr);
+
 					if self.check_undesirable(&stream) {
 						continue;
 					}
@@ -107,8 +109,8 @@ impl Server {
 
 	/// Asks the server to connect to a new peer. Directly returns the peer if
 	/// we're already connected to the provided address.
-	pub fn connect(&self, addr: &SocketAddr) -> Result<Arc<Peer>, Error> {
-		if Peer::is_denied(&self.config, &addr) {
+	pub fn connect(&self, addr: PeerAddr) -> Result<Arc<Peer>, Error> {
+		if Peer::is_denied(&self.config, addr) {
 			debug!("connect_peer: peer {} denied, not connecting.", addr);
 			return Err(Error::ConnectionClose);
 		}
@@ -134,7 +136,7 @@ impl Server {
 			self.config.port,
 			addr
 		);
-		match TcpStream::connect_timeout(addr, Duration::from_secs(10)) {
+		match TcpStream::connect_timeout(&addr.0, Duration::from_secs(10)) {
 			Ok(mut stream) => {
 				let addr = SocketAddr::new(self.config.host, self.config.port);
 				let total_diff = self.peers.total_difficulty();
@@ -143,7 +145,7 @@ impl Server {
 					&mut stream,
 					self.capabilities,
 					total_diff,
-					addr,
+					PeerAddr(addr),
 					&self.handshake,
 					self.peers.clone(),
 				)?;
@@ -192,6 +194,7 @@ impl Server {
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
 		if let Ok(peer_addr) = stream.peer_addr() {
+			let peer_addr = PeerAddr(peer_addr);
 			if self.peers.is_banned(peer_addr) {
 				debug!("Peer {} banned, refusing connection.", peer_addr);
 				if let Err(e) = stream.shutdown(Shutdown::Both) {
@@ -199,7 +202,7 @@ impl Server {
 				}
 				return true;
 			}
-			if self.peers.is_known(&peer_addr) {
+			if self.peers.is_known(peer_addr) {
 				debug!("Peer {} already known, refusing connection.", peer_addr);
 				if let Err(e) = stream.shutdown(Shutdown::Both) {
 					debug!("Error shutting down conn: {:?}", e);
@@ -237,18 +240,18 @@ impl ChainAdapter for DummyAdapter {
 	fn get_transaction(&self, _h: Hash) -> Option<core::Transaction> {
 		None
 	}
-	fn tx_kernel_received(&self, _h: Hash, _addr: SocketAddr) {}
+	fn tx_kernel_received(&self, _h: Hash, _addr: PeerAddr) {}
 	fn transaction_received(&self, _: core::Transaction, _stem: bool) {}
-	fn compact_block_received(&self, _cb: core::CompactBlock, _addr: SocketAddr) -> bool {
+	fn compact_block_received(&self, _cb: core::CompactBlock, _addr: PeerAddr) -> bool {
 		true
 	}
-	fn header_received(&self, _bh: core::BlockHeader, _addr: SocketAddr) -> bool {
+	fn header_received(&self, _bh: core::BlockHeader, _addr: PeerAddr) -> bool {
 		true
 	}
-	fn block_received(&self, _: core::Block, _: SocketAddr, _: bool) -> bool {
+	fn block_received(&self, _: core::Block, _: PeerAddr, _: bool) -> bool {
 		true
 	}
-	fn headers_received(&self, _: &[core::BlockHeader], _: SocketAddr) -> bool {
+	fn headers_received(&self, _: &[core::BlockHeader], _: PeerAddr) -> bool {
 		true
 	}
 	fn locate_headers(&self, _: &[Hash]) -> Vec<core::BlockHeader> {
@@ -265,7 +268,7 @@ impl ChainAdapter for DummyAdapter {
 		false
 	}
 
-	fn txhashset_write(&self, _h: Hash, _txhashset_data: File, _peer_addr: SocketAddr) -> bool {
+	fn txhashset_write(&self, _h: Hash, _txhashset_data: File, _peer_addr: PeerAddr) -> bool {
 		false
 	}
 
@@ -280,12 +283,12 @@ impl ChainAdapter for DummyAdapter {
 }
 
 impl NetAdapter for DummyAdapter {
-	fn find_peer_addrs(&self, _: Capabilities) -> Vec<SocketAddr> {
+	fn find_peer_addrs(&self, _: Capabilities) -> Vec<PeerAddr> {
 		vec![]
 	}
-	fn peer_addrs_received(&self, _: Vec<SocketAddr>) {}
-	fn peer_difficulty(&self, _: SocketAddr, _: Difficulty, _: u64) {}
-	fn is_banned(&self, _: SocketAddr) -> bool {
+	fn peer_addrs_received(&self, _: Vec<PeerAddr>) {}
+	fn peer_difficulty(&self, _: PeerAddr, _: Difficulty, _: u64) {}
+	fn is_banned(&self, _: PeerAddr) -> bool {
 		false
 	}
 }

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -213,20 +213,7 @@ impl PeerStore {
 	}
 }
 
-// TODO - Put this on PeerAddr itself.
-//
-// If this is a "loopback" address then we care about the port and construct the key "ip:port".
-// Otherwise we *only* care about the ip and we ignore the port.
+// Ignore the port unless ip is loopback address.
 fn peer_key(peer_addr: PeerAddr) -> Vec<u8> {
-	if peer_addr.0.ip().is_loopback() {
-		to_key(
-			PEER_PREFIX,
-			&mut format!("{}:{}", peer_addr.0.ip(), peer_addr.0.port()).into_bytes(),
-		)
-	} else {
-		to_key(
-			PEER_PREFIX,
-			&mut format!("{}", peer_addr.0.ip()).into_bytes(),
-		)
-	}
+	to_key(PEER_PREFIX, &mut peer_addr.as_key().into_bytes())
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -16,15 +16,17 @@ use crate::util::RwLock;
 use std::convert::From;
 use std::fs::File;
 use std::io;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
 use std::sync::mpsc;
 use std::sync::Arc;
 
 use chrono::prelude::*;
 
+use crate::core::core;
 use crate::core::core::hash::Hash;
 use crate::core::pow::Difficulty;
-use crate::core::{core, ser};
+use crate::core::ser::{self, Readable, Reader, Writeable, Writer};
 use grin_store;
 
 /// Maximum number of block headers a peer should ever send
@@ -95,6 +97,87 @@ impl<T> From<mpsc::TrySendError<T>> for Error {
 	}
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PeerAddr(pub SocketAddr);
+
+impl Writeable for PeerAddr {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		match self.0 {
+			SocketAddr::V4(sav4) => {
+				ser_multiwrite!(
+					writer,
+					[write_u8, 0],
+					[write_fixed_bytes, &sav4.ip().octets().to_vec()],
+					[write_u16, sav4.port()]
+				);
+			}
+			SocketAddr::V6(sav6) => {
+				writer.write_u8(1)?;
+				for seg in &sav6.ip().segments() {
+					writer.write_u16(*seg)?;
+				}
+				writer.write_u16(sav6.port())?;
+			}
+		}
+		Ok(())
+	}
+}
+
+impl Readable for PeerAddr {
+	fn read(reader: &mut dyn Reader) -> Result<PeerAddr, ser::Error> {
+		let v4_or_v6 = reader.read_u8()?;
+		if v4_or_v6 == 0 {
+			let ip = reader.read_fixed_bytes(4)?;
+			let port = reader.read_u16()?;
+			Ok(PeerAddr(SocketAddr::V4(SocketAddrV4::new(
+				Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]),
+				port,
+			))))
+		} else {
+			let ip = try_iter_map_vec!(0..8, |_| reader.read_u16());
+			let port = reader.read_u16()?;
+			Ok(PeerAddr(SocketAddr::V6(SocketAddrV6::new(
+				Ipv6Addr::new(ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7]),
+				port,
+				0,
+				0,
+			))))
+		}
+	}
+}
+
+impl std::hash::Hash for PeerAddr {
+	/// If loopback address then we care about ip and port.
+	/// If regular address then we only care about the ip and ignore the port.
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		if self.0.ip().is_loopback() {
+			self.0.hash(state);
+		} else {
+			self.0.ip().hash(state);
+		}
+	}
+}
+
+impl PartialEq for PeerAddr {
+	/// If loopback address then we care about ip and port.
+	/// If regular address then we only care about the ip and ignore the port.
+	fn eq(&self, other: &PeerAddr) -> bool {
+		if self.0.ip().is_loopback() {
+			self.0 == other.0
+		} else {
+			self.0.ip() == other.0.ip()
+		}
+	}
+}
+
+impl Eq for PeerAddr {}
+
+impl std::fmt::Display for PeerAddr {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "PeerAddr({})", self.0)
+	}
+}
+
 /// Configuration for the peer-to-peer server.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct P2PConfig {
@@ -106,18 +189,18 @@ pub struct P2PConfig {
 	pub seeding_type: Seeding,
 
 	/// The list of seed nodes, if using Seeding as a seed type
-	pub seeds: Option<Vec<String>>,
+	pub seeds: Option<Vec<PeerAddr>>,
 
 	/// Capabilities expose by this node, also conditions which other peers this
 	/// node will have an affinity toward when connection.
 	pub capabilities: Capabilities,
 
-	pub peers_allow: Option<Vec<String>>,
+	pub peers_allow: Option<Vec<PeerAddr>>,
 
-	pub peers_deny: Option<Vec<String>>,
+	pub peers_deny: Option<Vec<PeerAddr>>,
 
 	/// The list of preferred peers that we will try to connect to
-	pub peers_preferred: Option<Vec<String>>,
+	pub peers_preferred: Option<Vec<PeerAddr>>,
 
 	pub ban_window: Option<i64>,
 
@@ -125,7 +208,7 @@ pub struct P2PConfig {
 
 	pub peer_min_preferred_count: Option<u32>,
 
-	pub dandelion_peer: Option<SocketAddr>,
+	pub dandelion_peer: Option<PeerAddr>,
 }
 
 /// Default address for peer-to-peer connections.
@@ -178,7 +261,7 @@ impl P2PConfig {
 }
 
 /// Type of seeding the server will use to find other peers on the network.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum Seeding {
 	/// No seeding, mostly for tests that programmatically connect
 	None,
@@ -262,7 +345,7 @@ pub struct PeerInfo {
 	pub capabilities: Capabilities,
 	pub user_agent: String,
 	pub version: u32,
-	pub addr: SocketAddr,
+	pub addr: PeerAddr,
 	pub direction: Direction,
 	pub live_info: Arc<RwLock<PeerLiveInfo>>,
 }
@@ -307,7 +390,7 @@ pub struct PeerInfoDisplay {
 	pub capabilities: Capabilities,
 	pub user_agent: String,
 	pub version: u32,
-	pub addr: SocketAddr,
+	pub addr: PeerAddr,
 	pub direction: Direction,
 	pub total_difficulty: Difficulty,
 	pub height: u64,
@@ -353,22 +436,22 @@ pub trait ChainAdapter: Sync + Send {
 
 	fn get_transaction(&self, kernel_hash: Hash) -> Option<core::Transaction>;
 
-	fn tx_kernel_received(&self, kernel_hash: Hash, addr: SocketAddr);
+	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr);
 
 	/// A block has been received from one of our peers. Returns true if the
 	/// block could be handled properly and is not deemed defective by the
 	/// chain. Returning false means the block will never be valid and
 	/// may result in the peer being banned.
-	fn block_received(&self, b: core::Block, addr: SocketAddr, was_requested: bool) -> bool;
+	fn block_received(&self, b: core::Block, addr: PeerAddr, was_requested: bool) -> bool;
 
-	fn compact_block_received(&self, cb: core::CompactBlock, addr: SocketAddr) -> bool;
+	fn compact_block_received(&self, cb: core::CompactBlock, addr: PeerAddr) -> bool;
 
-	fn header_received(&self, bh: core::BlockHeader, addr: SocketAddr) -> bool;
+	fn header_received(&self, bh: core::BlockHeader, addr: PeerAddr) -> bool;
 
 	/// A set of block header has been received, typically in response to a
 	/// block
 	/// header request.
-	fn headers_received(&self, bh: &[core::BlockHeader], addr: SocketAddr) -> bool;
+	fn headers_received(&self, bh: &[core::BlockHeader], addr: PeerAddr) -> bool;
 
 	/// Finds a list of block headers based on the provided locator. Tries to
 	/// identify the common chain and gets the headers that follow it
@@ -401,7 +484,7 @@ pub trait ChainAdapter: Sync + Send {
 	/// If we're willing to accept that new state, the data stream will be
 	/// read as a zip file, unzipped and the resulting state files should be
 	/// rewound to the provided indexes.
-	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: SocketAddr) -> bool;
+	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: PeerAddr) -> bool;
 }
 
 /// Additional methods required by the protocol that don't need to be
@@ -409,14 +492,14 @@ pub trait ChainAdapter: Sync + Send {
 pub trait NetAdapter: ChainAdapter {
 	/// Find good peers we know with the provided capability and return their
 	/// addresses.
-	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr>;
+	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<PeerAddr>;
 
 	/// A list of peers has been received from one of our peers.
-	fn peer_addrs_received(&self, _: Vec<SocketAddr>);
+	fn peer_addrs_received(&self, _: Vec<PeerAddr>);
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
-	fn peer_difficulty(&self, _: SocketAddr, _: Difficulty, _: u64);
+	fn peer_difficulty(&self, _: PeerAddr, _: Difficulty, _: u64);
 
 	/// Is this peer currently banned?
-	fn is_banned(&self, addr: SocketAddr) -> bool;
+	fn is_banned(&self, addr: PeerAddr) -> bool;
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -25,6 +25,7 @@ use chrono::prelude::*;
 
 use crate::core::core;
 use crate::core::core::hash::Hash;
+use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::core::ser::{self, Readable, Reader, Writeable, Writer};
 use grin_store;
@@ -179,6 +180,13 @@ impl std::fmt::Display for PeerAddr {
 }
 
 impl PeerAddr {
+	/// Convenient way of constructing a new peer_addr from an ip_addr
+	/// defaults to port 3414 on mainnet and 13414 on floonet.
+	pub fn from_ip(addr: IpAddr) -> PeerAddr {
+		let port = if global::is_floonet() { 13414 } else { 3414 };
+		PeerAddr(SocketAddr::new(addr, port))
+	}
+
 	/// If the ip is loopback then our key is "ip:port" (mainly for local usernet testing).
 	/// Otherwise we only care about the ip (we disallow multiple peers on the same ip address).
 	pub fn as_key(&self) -> String {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -174,7 +174,7 @@ impl Eq for PeerAddr {}
 
 impl std::fmt::Display for PeerAddr {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		write!(f, "PeerAddr({})", self.0)
+		write!(f, "{}", self.0)
 	}
 }
 

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -178,6 +178,18 @@ impl std::fmt::Display for PeerAddr {
 	}
 }
 
+impl PeerAddr {
+	/// If the ip is loopback then our key is "ip:port" (mainly for local usernet testing).
+	/// Otherwise we only care about the ip (we disallow multiple peers on the same ip address).
+	pub fn as_key(&self) -> String {
+		if self.0.ip().is_loopback() {
+			format!("{}:{}", self.0.ip(), self.0.port())
+		} else {
+			format!("{}", self.0.ip())
+		}
+	}
+}
+
 /// Configuration for the peer-to-peer server.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct P2PConfig {

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -25,6 +25,7 @@ use std::{thread, time};
 
 use crate::core::core::hash::Hash;
 use crate::core::pow::Difficulty;
+use crate::p2p::types::PeerAddr;
 use crate::p2p::Peer;
 
 fn open_port() -> u16 {
@@ -70,7 +71,7 @@ fn peer_handshake() {
 	let addr = SocketAddr::new(p2p_config.host, p2p_config.port);
 	let mut socket = TcpStream::connect_timeout(&addr, time::Duration::from_secs(10)).unwrap();
 
-	let my_addr = "127.0.0.1:5000".parse().unwrap();
+	let my_addr = PeerAddr("127.0.0.1:5000".parse().unwrap());
 	let mut peer = Peer::connect(
 		&mut socket,
 		p2p::Capabilities::UNKNOWN,
@@ -89,7 +90,7 @@ fn peer_handshake() {
 	peer.send_ping(Difficulty::min(), 0).unwrap();
 	thread::sleep(time::Duration::from_secs(1));
 
-	let server_peer = server.peers.get_connected_peer(&my_addr).unwrap();
+	let server_peer = server.peers.get_connected_peer(my_addr).unwrap();
 	assert_eq!(server_peer.info.total_difficulty(), Difficulty::min());
 	assert!(server.peers.peer_count() > 0);
 }

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -21,7 +21,7 @@ use chrono::prelude::{DateTime, Utc};
 use chrono::{Duration, MIN_DATE};
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::ToSocketAddrs;
 use std::sync::{mpsc, Arc};
 use std::{cmp, str, thread, time};
 
@@ -395,17 +395,12 @@ pub fn dns_seeds() -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
 	})
 }
 
-// /// Convenience function when the seed list is immediately known. Mostly used
-// /// for tests.
-// pub fn predefined_seeds(addrs_str: Vec<PeerAddr>) -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
-// 	Box::new(move || {
-// 		addrs_str
-// 			.iter()
-// 			.map(|s| PeerAddr(s.parse().unwrap()))
-// 			.collect::<Vec<_>>()
-// 	})
-// }
-//
+/// Convenience function when the seed list is immediately known. Mostly used
+/// for tests.
+pub fn predefined_seeds(addrs: Vec<PeerAddr>) -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
+	Box::new(move || addrs.clone())
+}
+
 // /// Convenience function when the seed list is immediately known. Mostly used
 // /// for tests.
 // pub fn preferred_peers(addrs_str: Vec<PeerAddr>) -> Option<Vec<PeerAddr>> {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -400,18 +400,3 @@ pub fn dns_seeds() -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
 pub fn predefined_seeds(addrs: Vec<PeerAddr>) -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
 	Box::new(move || addrs.clone())
 }
-
-// /// Convenience function when the seed list is immediately known. Mostly used
-// /// for tests.
-// pub fn preferred_peers(addrs_str: Vec<PeerAddr>) -> Option<Vec<PeerAddr>> {
-// 	if addrs_str.is_empty() {
-// 		None
-// 	} else {
-// 		Some(
-// 			addrs_str
-// 				.iter()
-// 				.map(|s| PeerAddr(s.parse().unwrap()))
-// 				.collect::<Vec<_>>(),
-// 		)
-// 	}
-// }

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -27,6 +27,7 @@ use std::{cmp, str, thread, time};
 
 use crate::core::global;
 use crate::p2p;
+use crate::p2p::types::PeerAddr;
 use crate::p2p::ChainAdapter;
 use crate::pool::DandelionConfig;
 use crate::util::{Mutex, StopState};
@@ -52,8 +53,8 @@ pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,
 	capabilities: p2p::Capabilities,
 	dandelion_config: DandelionConfig,
-	seed_list: Box<dyn Fn() -> Vec<SocketAddr> + Send>,
-	preferred_peers: Option<Vec<SocketAddr>>,
+	seed_list: Box<dyn Fn() -> Vec<PeerAddr> + Send>,
+	preferred_peers: Option<Vec<PeerAddr>>,
 	stop_state: Arc<Mutex<StopState>>,
 ) {
 	let _ = thread::Builder::new()
@@ -78,7 +79,7 @@ pub fn connect_and_monitor(
 			let mut prev_ping = Utc::now();
 			let mut start_attempt = 0;
 
-			let mut connecting_history: HashMap<SocketAddr, DateTime<Utc>> = HashMap::new();
+			let mut connecting_history: HashMap<PeerAddr, DateTime<Utc>> = HashMap::new();
 
 			loop {
 				if stop_state.lock().is_stopped() {
@@ -140,8 +141,8 @@ pub fn connect_and_monitor(
 fn monitor_peers(
 	peers: Arc<p2p::Peers>,
 	config: p2p::P2PConfig,
-	tx: mpsc::Sender<SocketAddr>,
-	preferred_peers_list: Option<Vec<SocketAddr>>,
+	tx: mpsc::Sender<PeerAddr>,
+	preferred_peers_list: Option<Vec<PeerAddr>>,
 ) {
 	// regularly check if we need to acquire more peers  and if so, gets
 	// them from db
@@ -156,7 +157,7 @@ fn monitor_peers(
 				let interval = Utc::now().timestamp() - x.last_banned;
 				// Unban peer
 				if interval >= config.ban_window() {
-					peers.unban_peer(&x.addr);
+					peers.unban_peer(x.addr);
 					debug!(
 						"monitor_peers: unbanned {} after {} seconds",
 						x.addr, interval
@@ -192,7 +193,7 @@ fn monitor_peers(
 
 	// loop over connected peers
 	// ask them for their list of peers
-	let mut connected_peers: Vec<SocketAddr> = vec![];
+	let mut connected_peers: Vec<PeerAddr> = vec![];
 	for p in peers.connected_peers() {
 		trace!(
 			"monitor_peers: {}:{} ask {} for more peers",
@@ -205,19 +206,16 @@ fn monitor_peers(
 	}
 
 	// Attempt to connect to preferred peers if there is some
-	match preferred_peers_list {
-		Some(preferred_peers) => {
-			for p in preferred_peers {
-				if !connected_peers.is_empty() {
-					if !connected_peers.contains(&p) {
-						tx.send(p).unwrap();
-					}
-				} else {
+	if let Some(preferred_peers) = preferred_peers_list {
+		for p in preferred_peers {
+			if !connected_peers.is_empty() {
+				if !connected_peers.contains(&p) {
 					tx.send(p).unwrap();
 				}
+			} else {
+				tx.send(p).unwrap();
 			}
 		}
-		None => debug!("monitor_peers: no preferred peers"),
 	}
 
 	// take a random defunct peer and mark it healthy: over a long period any
@@ -235,7 +233,7 @@ fn monitor_peers(
 		config.peer_max_count() as usize,
 	);
 
-	for p in new_peers.iter().filter(|p| !peers.is_known(&p.addr)) {
+	for p in new_peers.iter().filter(|p| !peers.is_known(p.addr)) {
 		trace!(
 			"monitor_peers: on {}:{}, queue to soon try {}",
 			config.host,
@@ -265,9 +263,9 @@ fn update_dandelion_relay(peers: Arc<p2p::Peers>, dandelion_config: DandelionCon
 // otherwise use the seeds provided.
 fn connect_to_seeds_and_preferred_peers(
 	peers: Arc<p2p::Peers>,
-	tx: mpsc::Sender<SocketAddr>,
-	seed_list: Box<dyn Fn() -> Vec<SocketAddr>>,
-	peers_preferred_list: Option<Vec<SocketAddr>>,
+	tx: mpsc::Sender<PeerAddr>,
+	seed_list: Box<dyn Fn() -> Vec<PeerAddr>>,
+	peers_preferred_list: Option<Vec<PeerAddr>>,
 ) {
 	// check if we have some peers in db
 	// look for peers that are able to give us other peers (via PEER_LIST capability)
@@ -303,14 +301,14 @@ fn listen_for_addrs(
 	peers: Arc<p2p::Peers>,
 	p2p: Arc<p2p::Server>,
 	capab: p2p::Capabilities,
-	rx: &mpsc::Receiver<SocketAddr>,
-	connecting_history: &mut HashMap<SocketAddr, DateTime<Utc>>,
+	rx: &mpsc::Receiver<PeerAddr>,
+	connecting_history: &mut HashMap<PeerAddr, DateTime<Utc>>,
 ) {
 	// Pull everything currently on the queue off the queue.
 	// Does not block so addrs may be empty.
 	// We will take(max_peers) from this later but we want to drain the rx queue
 	// here to prevent it backing up.
-	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
+	let addrs: Vec<PeerAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
 	if peers.healthy_peers_mix() {
@@ -342,7 +340,7 @@ fn listen_for_addrs(
 		let p2p_c = p2p.clone();
 		let _ = thread::Builder::new()
 			.name("peer_connect".to_string())
-			.spawn(move || match p2p_c.connect(&addr) {
+			.spawn(move || match p2p_c.connect(addr) {
 				Ok(p) => {
 					let _ = p.send_peer_request(capab);
 					let _ = peers_c.update_state(addr, p2p::State::Healthy);
@@ -368,9 +366,9 @@ fn listen_for_addrs(
 	}
 }
 
-pub fn dns_seeds() -> Box<dyn Fn() -> Vec<SocketAddr> + Send> {
+pub fn dns_seeds() -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
 	Box::new(|| {
-		let mut addresses: Vec<SocketAddr> = vec![];
+		let mut addresses: Vec<PeerAddr> = vec![];
 		let net_seeds = if global::is_floonet() {
 			FLOONET_DNS_SEEDS
 		} else {
@@ -384,7 +382,7 @@ pub fn dns_seeds() -> Box<dyn Fn() -> Vec<SocketAddr> + Send> {
 					&mut (addrs
 						.map(|mut addr| {
 							addr.set_port(if global::is_floonet() { 13414 } else { 3414 });
-							addr
+							PeerAddr(addr)
 						})
 						.filter(|addr| !temp_addresses.contains(addr))
 						.collect()),
@@ -397,28 +395,28 @@ pub fn dns_seeds() -> Box<dyn Fn() -> Vec<SocketAddr> + Send> {
 	})
 }
 
-/// Convenience function when the seed list is immediately known. Mostly used
-/// for tests.
-pub fn predefined_seeds(addrs_str: Vec<String>) -> Box<dyn Fn() -> Vec<SocketAddr> + Send> {
-	Box::new(move || {
-		addrs_str
-			.iter()
-			.map(|s| s.parse().unwrap())
-			.collect::<Vec<_>>()
-	})
-}
-
-/// Convenience function when the seed list is immediately known. Mostly used
-/// for tests.
-pub fn preferred_peers(addrs_str: Vec<String>) -> Option<Vec<SocketAddr>> {
-	if addrs_str.is_empty() {
-		None
-	} else {
-		Some(
-			addrs_str
-				.iter()
-				.map(|s| s.parse().unwrap())
-				.collect::<Vec<_>>(),
-		)
-	}
-}
+// /// Convenience function when the seed list is immediately known. Mostly used
+// /// for tests.
+// pub fn predefined_seeds(addrs_str: Vec<PeerAddr>) -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
+// 	Box::new(move || {
+// 		addrs_str
+// 			.iter()
+// 			.map(|s| PeerAddr(s.parse().unwrap()))
+// 			.collect::<Vec<_>>()
+// 	})
+// }
+//
+// /// Convenience function when the seed list is immediately known. Mostly used
+// /// for tests.
+// pub fn preferred_peers(addrs_str: Vec<PeerAddr>) -> Option<Vec<PeerAddr>> {
+// 	if addrs_str.is_empty() {
+// 		None
+// 	} else {
+// 		Some(
+// 			addrs_str
+// 				.iter()
+// 				.map(|s| PeerAddr(s.parse().unwrap()))
+// 				.collect::<Vec<_>>(),
+// 		)
+// 	}
+// }

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -148,7 +148,7 @@ impl HeaderSync {
 									&& highest_height == peer.info.height()
 								{
 									self.peers
-										.ban_peer(&peer.info.addr, ReasonForBan::FraudHeight);
+										.ban_peer(peer.info.addr, ReasonForBan::FraudHeight);
 									info!(
 										"sync: ban a fraud peer: {}, claimed height: {}, total difficulty: {}",
 										peer.info.addr,

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -19,6 +19,7 @@ mod framework;
 
 use self::core::core::hash::Hashed;
 use self::core::global::{self, ChainTypes};
+use self::p2p::PeerAddr;
 use self::util::{Mutex, StopState};
 use self::wallet::controller;
 use self::wallet::libwallet::types::{WalletBackend, WalletInst};
@@ -933,7 +934,9 @@ fn replicate_tx_fluff_failure() {
 
 	// Server 2 (another node)
 	let mut s2_config = framework::config(3001, "tx_fluff", 3001);
-	s2_config.p2p_config.seeds = Some(vec!["127.0.0.1:13000".to_owned()]);
+	s2_config.p2p_config.seeds = Some(vec![PeerAddr(
+		"127.0.0.1:13000".to_owned().parse().unwrap(),
+	)]);
 	s2_config.dandelion_config.embargo_secs = Some(10);
 	s2_config.dandelion_config.patience_secs = Some(1);
 	s2_config.dandelion_config.relay_secs = Some(1);
@@ -944,7 +947,9 @@ fn replicate_tx_fluff_failure() {
 	for i in 0..dl_nodes {
 		// (create some stem nodes)
 		let mut s_config = framework::config(3002 + i, "tx_fluff", 3002 + i);
-		s_config.p2p_config.seeds = Some(vec!["127.0.0.1:13000".to_owned()]);
+		s_config.p2p_config.seeds = Some(vec![PeerAddr(
+			"127.0.0.1:13000".to_owned().parse().unwrap(),
+		)]);
 		s_config.dandelion_config.embargo_secs = Some(10);
 		s_config.dandelion_config.patience_secs = Some(1);
 		s_config.dandelion_config.relay_secs = Some(1);

--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -24,7 +24,7 @@ use ctrlc;
 
 use crate::config::GlobalConfig;
 use crate::core::global;
-use crate::p2p::Seeding;
+use crate::p2p::{PeerAddr, Seeding};
 use crate::servers;
 use crate::tui::ui;
 
@@ -116,44 +116,14 @@ pub fn server_command(
 		}
 
 		if let Some(seeds) = a.values_of("seed") {
+			let seed_addrs = seeds
+				.filter_map(|x| x.parse().ok())
+				.map(|x| PeerAddr(x))
+				.collect();
 			server_config.p2p_config.seeding_type = Seeding::List;
-			server_config.p2p_config.seeds = Some(seeds.map(|s| s.to_string()).collect());
+			server_config.p2p_config.seeds = Some(seed_addrs);
 		}
 	}
-
-	/*if let Some(true) = server_config.run_wallet_listener {
-		let mut wallet_config = global_config.members.as_ref().unwrap().wallet.clone();
-		wallet::init_wallet_seed(wallet_config.clone());
-		let wallet = wallet::instantiate_wallet(wallet_config.clone(), "");
-
-		let _ = thread::Builder::new()
-			.name("wallet_listener".to_string())
-			.spawn(move || {
-				controller::foreign_listener(wallet, &wallet_config.api_listen_addr())
-					.unwrap_or_else(|e| {
-						panic!(
-							"Error creating wallet listener: {:?} Config: {:?}",
-							e, wallet_config
-						)
-					});
-			});
-	}
-	if let Some(true) = server_config.run_wallet_owner_api {
-		let mut wallet_config = global_config.members.unwrap().wallet;
-		let wallet = wallet::instantiate_wallet(wallet_config.clone(), "");
-		wallet::init_wallet_seed(wallet_config.clone());
-
-		let _ = thread::Builder::new()
-			.name("wallet_owner_listener".to_string())
-			.spawn(move || {
-				controller::owner_listener(wallet, "127.0.0.1:13420").unwrap_or_else(|e| {
-					panic!(
-						"Error creating wallet api listener: {:?} Config: {:?}",
-						e, wallet_config
-					)
-				});
-			});
-	}*/
 
 	if let Some(a) = server_args {
 		match a.subcommand() {


### PR DESCRIPTION
We have chunks of logic in our peering code that explicitly ignores the port when looking at peer addresses.
But we still store peers, both in the db and in our connected peers map based on `ip:port`.
This appears to cause some unnecessary complexity as we sometimes iterate over them all, comparing the ip and ignoring the port.

This PR attempts to clean this up and consolidate the "do we include the port or ignore the port?" logic based on whether our peer is on the "loopback" address or not.
i.e. If we are running tests or running a usernet locally then we care about the port.
But in all other cases we ignore the port and just treat each ip as having a single node on a single port.

Note we still store the peer ip and port, we just don't take the port into account when creating the key for it in the db or the connected peers map.

Thoughts on this?
It runs locally with tests fine. It also appears to run happily against `mainnet`.

TODO - 
- [x] discuss if this makes sense and is worth spending more time on
- [x] introduce a `PeerAddr` struct so we can encapsulate the key creation logic in one place (currently duplicated in both `peers.rs` and `store.rs`)
- [x] leverage the existing internal `SockAddr` and rename it `PeerAddr` (turning into a big can of worms)
- [x] investigate our api endpoints that take peer addresses (see below)

> http://127.0.0.1:3413/v1/ shows "get peers/a.b.c.d” in the list, but http://127.0.0.1:3413/v1/a.b.c.d doesn’t work. It has to include the port to get results: http://127.0.0.1:3413/v1/a.b.c.d:port. @antiochp Is this fixed with the changes you recently made around peers/ip addresses/etc?