### PR TITLE
Allow to peers behind NAT to get up to preferred_max connections

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -518,12 +518,8 @@ impl Peers {
 
 	/// We have enough peers, both total connected and outbound connected
 	pub fn healthy_peers_mix(&self) -> bool {
-		let peer_count = self.peer_count();
-		let outbound_count = self.peer_outbound_count();
-
-		peer_count > outbound_count
-			&& peer_count >= self.config.peer_min_preferred_count()
-			&& outbound_count >= self.config.peer_min_preferred_count() / 2
+		self.enough_peers()
+			&& self.peer_outbound_count() >= self.config.peer_min_preferred_count() / 2
 	}
 
 	/// Removes those peers that seem to have expired

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -518,8 +518,12 @@ impl Peers {
 
 	/// We have enough peers, both total connected and outbound connected
 	pub fn healthy_peers_mix(&self) -> bool {
-		self.enough_peers()
-			&& self.peer_outbound_count() >= self.config.peer_min_preferred_count() / 2
+		let peer_count = self.peer_count();
+		let outbound_count = self.peer_outbound_count();
+
+		peer_count > outbound_count
+			&& peer_count >= self.config.peer_min_preferred_count()
+			&& outbound_count >= self.config.peer_min_preferred_count() / 2
 	}
 
 	/// Removes those peers that seem to have expired

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -186,7 +186,7 @@ fn monitor_peers(
 	// maintenance step first, clean up p2p server peers
 	peers.clean_peers(config.peer_max_count() as usize);
 
-	if peers.peer_count() > peers.peer_outbound_count() && peers.healthy_peers_mix() {
+	if peers.healthy_peers_mix() {
 		return;
 	}
 
@@ -315,7 +315,7 @@ fn listen_for_addrs(
 	let addrs: Vec<SocketAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
-	if peers.healthy_peers_mix() {
+	if peers.peer_count() > peers.peer_outbound_count() && peers.healthy_peers_mix() {
 		return;
 	}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -186,7 +186,7 @@ fn monitor_peers(
 	// maintenance step first, clean up p2p server peers
 	peers.clean_peers(config.peer_max_count() as usize);
 
-	if peers.healthy_peers_mix() {
+	if peers.peer_count() > peers.peer_outbound_count() && peers.healthy_peers_mix() {
 		return;
 	}
 


### PR DESCRIPTION
If peer has only outbound connections it's most likely behind NAT and we should not stop it from getting more outbound connections.

With that change a node with a public IP eventually still has 4 outbounds peers, but node behind the NAT jumps higher than 8 from time to time.