### PR TITLE
fix: Fix race condition with dandelion_relay peer map and make more semantic

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -38,7 +38,7 @@ pub struct Peers {
 	pub adapter: Arc<dyn ChainAdapter>,
 	store: PeerStore,
 	peers: RwLock<HashMap<SocketAddr, Arc<Peer>>>,
-	dandelion_relay: RwLock<HashMap<i64, Arc<Peer>>>,
+	dandelion_relay: RwLock<Option<(i64, Arc<Peer>)>>,
 	config: P2PConfig,
 }
 
@@ -49,7 +49,7 @@ impl Peers {
 			store,
 			config,
 			peers: RwLock::new(HashMap::new()),
-			dandelion_relay: RwLock::new(HashMap::new()),
+			dandelion_relay: RwLock::new(None),
 		}
 	}
 
@@ -115,10 +115,9 @@ impl Peers {
 	fn set_dandelion_relay(&self, peer: &Arc<Peer>) {
 		// Clear the map and add new relay
 		let dandelion_relay = &self.dandelion_relay;
-		dandelion_relay.write().clear();
 		dandelion_relay
 			.write()
-			.insert(Utc::now().timestamp(), peer.clone());
+			.replace((Utc::now().timestamp(), peer.clone()));
 		debug!(
 			"Successfully updated Dandelion relay to: {}",
 			peer.info.addr
@@ -126,7 +125,7 @@ impl Peers {
 	}
 
 	// Get the dandelion relay
-	pub fn get_dandelion_relay(&self) -> HashMap<i64, Arc<Peer>> {
+	pub fn get_dandelion_relay(&self) -> Option<(i64, Arc<Peer>)> {
 		self.dandelion_relay.read().clone()
 	}
 
@@ -371,23 +370,23 @@ impl Peers {
 	/// Relays the provided stem transaction to our single stem peer.
 	pub fn relay_stem_transaction(&self, tx: &core::Transaction) -> Result<(), Error> {
 		let dandelion_relay = self.get_dandelion_relay();
-		if dandelion_relay.is_empty() {
+		if dandelion_relay.is_none() {
 			debug!("No dandelion relay, updating.");
 			self.update_dandelion_relay();
 		}
 		// If still return an error, let the caller handle this as they see fit.
 		// The caller will "fluff" at this point as the stem phase is finished.
-		if dandelion_relay.is_empty() {
-			return Err(Error::NoDandelionRelay);
-		}
-		for relay in dandelion_relay.values() {
-			if relay.is_connected() {
-				if let Err(e) = relay.send_stem_transaction(tx) {
-					debug!("Error sending stem transaction to peer relay: {:?}", e);
+		match dandelion_relay {
+			Some((ts, relay)) => {
+				if relay.is_connected() {
+					if let Err(e) = relay.send_stem_transaction(tx) {
+						debug!("Error sending stem transaction to peer relay: {:?}", e);
+					}
 				}
+				Ok(())
 			}
+			None => Err(Error::NoDandelionRelay),
 		}
-		Ok(())
 	}
 
 	/// Broadcasts the provided transaction to PEER_PREFERRED_COUNT of our

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -249,17 +249,15 @@ fn monitor_peers(
 fn update_dandelion_relay(peers: Arc<p2p::Peers>, dandelion_config: DandelionConfig) {
 	// Dandelion Relay Updater
 	let dandelion_relay = peers.get_dandelion_relay();
-	if dandelion_relay.is_empty() {
+	if let Some((last_added, _)) = dandelion_relay {
+		let dandelion_interval = Utc::now().timestamp() - last_added;
+		if dandelion_interval >= dandelion_config.relay_secs.unwrap() as i64 {
+			debug!("monitor_peers: updating expired dandelion relay");
+			peers.update_dandelion_relay();
+		}
+	} else {
 		debug!("monitor_peers: no dandelion relay updating");
 		peers.update_dandelion_relay();
-	} else {
-		for last_added in dandelion_relay.keys() {
-			let dandelion_interval = Utc::now().timestamp() - last_added;
-			if dandelion_interval >= dandelion_config.relay_secs.unwrap() as i64 {
-				debug!("monitor_peers: updating expired dandelion relay");
-				peers.update_dandelion_relay();
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
This might be a little controversial.

Currently, we are storing a HashMap of peers by time in the dandelion_relay field inside of the Peers struct.

However, it doesn't seem to be the case that there is an intended code-path where this is ever more than one peer (the only writer is from set_dandelion_relay, which first clears the map).

However, it's possible that two or more calls to set_dandelion_relay happen concurrently. Let's assume two calls. It's then possible for this synchronization to happen:

```
clear();
clear();
insert();
insert();
```

In which case the map would contain two entries. Because this can't be triggered deterministicly, I'm assuming it's unintended and can be safely removed.

edit: there is also a minor race condition caused by the potential for both of the timestamps received to be the same

Because we only want to store one value, I replace the map with an Option.

As a bonus, this should be a small performance improvement as we don't have to copy the hashmap any more and we only need the write lock one time.

Note: Future work could also replace the RwLock<Option<_>> with an AtomicPtr<Arc<(i64, Arc<Peer>)>> and some trivial-ish unsafe code if the read-write-locking burden is an issue.