### PR TITLE
Refactor: hashed trait to disambiguate use cases

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -105,7 +105,7 @@ impl BlockHandler {
 	fn parse_input(&self, input: String) -> Result<Hash, Error> {
 		if let Ok(height) = input.parse() {
 			match w(&self.chain).get_header_by_height(height) {
-				Ok(header) => return Ok(header.hash()),
+				Ok(header) => return Ok(header.crypto_hash()),
 				Err(_) => return Err(ErrorKind::NotFound)?,
 			}
 		}

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -139,7 +139,7 @@ impl OutputHandler {
 		// TODO - possible to compact away blocks we care about
 		// in the period between accepting the block and refreshing the wallet
 		let block = w(&self.chain)
-			.get_block(&header.hash())
+			.get_block(&header.crypto_hash())
 			.map_err(|_| ErrorKind::NotFound)?;
 		let outputs = block
 			.outputs()

--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -91,7 +91,7 @@ impl PoolPushHandler {
 					};
 					info!(
 						"Pushing transaction {} to pool (inputs: {}, outputs: {}, kernels: {})",
-						tx.hash(),
+						tx.crypto_hash(),
 						tx.inputs().len(),
 						tx.outputs().len(),
 						tx.kernels().len(),

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -291,7 +291,7 @@ impl OutputPrintable {
 			commit: output.commit,
 			spent,
 			proof,
-			proof_hash: util::to_hex(output.proof.hash().to_vec()),
+			proof_hash: util::to_hex(output.proof.crypto_hash().to_vec()),
 			block_height,
 			merkle_proof,
 			mmr_index: output_pos,
@@ -489,7 +489,7 @@ pub struct BlockHeaderInfo {
 impl BlockHeaderInfo {
 	pub fn from_header(header: &core::BlockHeader) -> BlockHeaderInfo {
 		BlockHeaderInfo {
-			hash: util::to_hex(header.hash().to_vec()),
+			hash: util::to_hex(header.crypto_hash().to_vec()),
 			height: header.height,
 			previous: util::to_hex(header.prev_hash.to_vec()),
 		}
@@ -533,7 +533,7 @@ pub struct BlockHeaderPrintable {
 impl BlockHeaderPrintable {
 	pub fn from_header(header: &core::BlockHeader) -> BlockHeaderPrintable {
 		BlockHeaderPrintable {
-			hash: util::to_hex(header.hash().to_vec()),
+			hash: util::to_hex(header.crypto_hash().to_vec()),
 			version: header.version,
 			height: header.height,
 			previous: util::to_hex(header.prev_hash.to_vec()),
@@ -621,7 +621,7 @@ impl CompactBlockPrintable {
 		cb: &core::CompactBlock,
 		chain: Arc<chain::Chain>,
 	) -> CompactBlockPrintable {
-		let block = chain.get_block(&cb.hash()).unwrap();
+		let block = chain.get_block(&cb.crypto_hash()).unwrap();
 		let out_full = cb
 			.out_full()
 			.iter()

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -204,7 +204,7 @@ impl<'a> Batch<'a> {
 
 		// Save the block itself to the db.
 		self.db
-			.put_ser(&to_key(BLOCK_PREFIX, &mut b.hash().to_vec())[..], b)?;
+			.put_ser(&to_key(BLOCK_PREFIX, &mut b.header_hash().to_vec())[..], b)?;
 
 		Ok(())
 	}
@@ -226,7 +226,7 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
-		let hash = header.hash();
+		let hash = header.crypto_hash();
 
 		// Store the header itself indexed by hash.
 		self.db
@@ -310,7 +310,7 @@ impl<'a> Batch<'a> {
 		let bitmap = self.build_block_input_bitmap(block)?;
 
 		// Save the bitmap to the db (via the batch).
-		self.save_block_input_bitmap(&block.hash(), &bitmap)?;
+		self.save_block_input_bitmap(&block.header_hash(), &bitmap)?;
 
 		Ok(bitmap)
 	}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -135,7 +135,7 @@ impl<'a> UTXOView<'a> {
 
 	/// Get the header hash for the specified pos from the underlying MMR backend.
 	fn get_header_hash(&self, pos: u64) -> Option<Hash> {
-		self.header_pmmr.get_data(pos).map(|x| x.hash())
+		self.header_pmmr.get_data(pos).map(|x| x.header_hash())
 	}
 
 	/// Get the header at the specified height based on the current state of the extension.

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -68,16 +68,18 @@ impl Tip {
 	pub fn from_header(header: &BlockHeader) -> Tip {
 		Tip {
 			height: header.height,
-			last_block_h: header.hash(),
+			last_block_h: header.crypto_hash(),
 			prev_block_h: header.prev_hash,
 			total_difficulty: header.total_difficulty(),
 		}
 	}
 
 	/// *Really* easy to accidentally call hash() on a tip (thinking its a header).
-	/// So lets make hash() do the right thing here.
-	pub fn hash(&self) -> Hash {
-		self.last_block_h
+	/// So lets make crypto_hash() panic so we can find where we make this error easily
+	/// If you need to call crypto_hash on Tip, use UFCS
+	#[deprecated]
+	pub fn crypto_hash(&self) -> ! {
+		unimplemented!();
 	}
 }
 

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -64,7 +64,7 @@ fn test_various_store_indices() {
 
 	let reward = libtx::reward::output(&keychain, &key_id, 0).unwrap();
 	let block = Block::new(&genesis.header, vec![], Difficulty::min(), reward).unwrap();
-	let block_hash = block.hash();
+	let block_hash = block.header_hash();
 
 	{
 		let batch = chain_store.batch().unwrap();
@@ -74,7 +74,7 @@ fn test_various_store_indices() {
 	}
 
 	let block_header = chain_store.get_block_header(&block_hash).unwrap();
-	assert_eq!(block_header.hash(), block_hash);
+	assert_eq!(block_header.crypto_hash(), block_hash);
 
 	// Test we can retrive the block from the db and that we can safely delete the
 	// block from the db even though the block_sums are missing.

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -162,8 +162,13 @@ impl FixedLength for HeaderEntry {
 
 impl HeaderEntry {
 	/// The hash of the underlying block.
-	pub fn hash(&self) -> Hash {
+	pub fn header_hash(&self) -> Hash {
 		self.hash
+	}
+	/// If you need the crypto_hash, use UFCS
+	#[deprecated]
+	pub fn crypto_hash(&self) -> ! {
+		unimplemented!();
 	}
 }
 
@@ -222,7 +227,7 @@ impl PMMRable for BlockHeader {
 
 	fn as_elmt(&self) -> Self::E {
 		HeaderEntry {
-			hash: self.hash(),
+			hash: self.crypto_hash(),
 			timestamp: self.timestamp.timestamp() as u64,
 			total_difficulty: self.total_difficulty(),
 			secondary_scaling: self.pow.secondary_scaling,
@@ -443,7 +448,11 @@ impl Block {
 	/// Note: caller must validate the block themselves, we do not validate it
 	/// here.
 	pub fn hydrate_from(cb: CompactBlock, txs: Vec<Transaction>) -> Result<Block, Error> {
-		trace!("block: hydrate_from: {}, {} txs", cb.hash(), txs.len(),);
+		trace!(
+			"block: hydrate_from: {}, {} txs",
+			cb.crypto_hash(),
+			txs.len(),
+		);
 
 		let header = cb.header.clone();
 
@@ -519,7 +528,7 @@ impl Block {
 			header: BlockHeader {
 				height: prev.height + 1,
 				timestamp,
-				prev_hash: prev.hash(),
+				prev_hash: prev.crypto_hash(),
 				total_kernel_offset,
 				pow: ProofOfWork {
 					total_difficulty: difficulty + prev.pow.total_difficulty,
@@ -571,8 +580,13 @@ impl Block {
 	}
 
 	/// Blockhash, computed using only the POW
-	pub fn hash(&self) -> Hash {
-		self.header.hash()
+	pub fn header_hash(&self) -> Hash {
+		self.header.crypto_hash()
+	}
+	/// If you need the crypto_hash, use UFCS
+	#[deprecated]
+	pub fn crypto_hash(&self) -> ! {
+		unimplemented!();
 	}
 
 	/// Sum of all fees (inputs less outputs) in the block

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -179,7 +179,7 @@ impl From<Block> for CompactBlock {
 			if k.is_coinbase() {
 				kern_full.push(k.clone());
 			} else {
-				kern_ids.push(k.short_id(&header.hash(), nonce));
+				kern_ids.push(k.short_id(&header.crypto_hash(), nonce));
 			}
 		}
 

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -158,7 +158,7 @@ impl Writeable for Hash {
 impl Add for Hash {
 	type Output = Hash;
 	fn add(self, other: Hash) -> Hash {
-		self.hash_with(other)
+		self.crypto_hash_with(other)
 	}
 }
 
@@ -211,13 +211,13 @@ impl ser::Writer for HashWriter {
 /// A trait for types that have a canonical hash
 pub trait Hashed {
 	/// Obtain the hash of the object
-	fn hash(&self) -> Hash;
+	fn crypto_hash(&self) -> Hash;
 	/// Hash the object together with another writeable object
-	fn hash_with<T: Writeable>(&self, other: T) -> Hash;
+	fn crypto_hash_with<T: Writeable>(&self, other: T) -> Hash;
 }
 
 impl<W: ser::Writeable> Hashed for W {
-	fn hash(&self) -> Hash {
+	fn crypto_hash(&self) -> Hash {
 		let mut hasher = HashWriter::default();
 		ser::Writeable::write(self, &mut hasher).unwrap();
 		let mut ret = [0; 32];
@@ -225,7 +225,7 @@ impl<W: ser::Writeable> Hashed for W {
 		Hash(ret)
 	}
 
-	fn hash_with<T: Writeable>(&self, other: T) -> Hash {
+	fn crypto_hash_with<T: Writeable>(&self, other: T) -> Hash {
 		let mut hasher = HashWriter::default();
 		ser::Writeable::write(self, &mut hasher).unwrap();
 		ser::Writeable::write(&other, &mut hasher).unwrap();

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1430,9 +1430,9 @@ pub fn kernel_sig_msg(
 		return Err(Error::InvalidKernelFeatures);
 	}
 	let hash = match features {
-		KernelFeatures::Coinbase => (features).hash(),
-		KernelFeatures::Plain => (features, fee).hash(),
-		KernelFeatures::HeightLocked => (features, fee, lock_height).hash(),
+		KernelFeatures::Coinbase => (features).crypto_hash(),
+		KernelFeatures::Plain => (features, fee).crypto_hash(),
+		KernelFeatures::HeightLocked => (features, fee, lock_height).crypto_hash(),
 	};
 	Ok(secp::Message::from_slice(&hash.as_bytes())?)
 }

--- a/core/src/core/verifier_cache.rs
+++ b/core/src/core/verifier_cache.rs
@@ -60,7 +60,11 @@ impl VerifierCache for LruVerifierCache {
 	fn filter_kernel_sig_unverified(&mut self, kernels: &[TxKernel]) -> Vec<TxKernel> {
 		let res = kernels
 			.iter()
-			.filter(|x| !self.kernel_sig_verification_cache.contains_key(&x.hash()))
+			.filter(|x| {
+				!self
+					.kernel_sig_verification_cache
+					.contains_key(&x.crypto_hash())
+			})
 			.cloned()
 			.collect::<Vec<_>>();
 		trace!(
@@ -77,7 +81,7 @@ impl VerifierCache for LruVerifierCache {
 			.filter(|x| {
 				!self
 					.rangeproof_verification_cache
-					.contains_key(&x.proof.hash())
+					.contains_key(&x.proof.crypto_hash())
 			})
 			.cloned()
 			.collect::<Vec<_>>();
@@ -91,14 +95,15 @@ impl VerifierCache for LruVerifierCache {
 
 	fn add_kernel_sig_verified(&mut self, kernels: Vec<TxKernel>) {
 		for k in kernels {
-			self.kernel_sig_verification_cache.insert(k.hash(), ());
+			self.kernel_sig_verification_cache
+				.insert(k.crypto_hash(), ());
 		}
 	}
 
 	fn add_rangeproof_verified(&mut self, outputs: Vec<Output>) {
 		for o in outputs {
 			self.rangeproof_verification_cache
-				.insert(o.proof.hash(), ());
+				.insert(o.proof.crypto_hash(), ());
 		}
 	}
 }

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -292,32 +292,38 @@ mod test {
 
 	#[test]
 	fn floonet_genesis_hash() {
-		let gen_hash = genesis_floo().hash();
+		let gen_hash = genesis_floo().header_hash();
 		println!("floonet genesis hash: {}", gen_hash.to_hex());
 		let gen_bin = ser::ser_vec(&genesis_floo()).unwrap();
-		println!("floonet genesis full hash: {}\n", gen_bin.hash().to_hex());
+		println!(
+			"floonet genesis full hash: {}\n",
+			gen_bin.crypto_hash().to_hex()
+		);
 		assert_eq!(
 			gen_hash.to_hex(),
 			"edc758c1370d43e1d733f70f58cf187c3be8242830429b1676b89fd91ccf2dab"
 		);
 		assert_eq!(
-			gen_bin.hash().to_hex(),
+			gen_bin.crypto_hash().to_hex(),
 			"91c638fc019a54e6652bd6bb3d9c5e0c17e889cef34a5c28528e7eb61a884dc4"
 		);
 	}
 
 	#[test]
 	fn mainnet_genesis_hash() {
-		let gen_hash = genesis_main().hash();
+		let gen_hash = genesis_main().header_hash();
 		println!("mainnet genesis hash: {}", gen_hash.to_hex());
 		let gen_bin = ser::ser_vec(&genesis_main()).unwrap();
-		println!("mainnet genesis full hash: {}\n", gen_bin.hash().to_hex());
+		println!(
+			"mainnet genesis full hash: {}\n",
+			gen_bin.crypto_hash().to_hex()
+		);
 		assert_eq!(
 			gen_hash.to_hex(),
 			"40adad0aec27797b48840aa9e00472015c21baea118ce7a2ff1a82c0f8f5bf82"
 		);
 		assert_eq!(
-			gen_bin.hash().to_hex(),
+			gen_bin.crypto_hash().to_hex(),
 			"6be6f34b657b785e558e85cc3b8bdb5bcbe8c10e7e58524c8027da7727e189ef"
 		);
 	}

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -99,7 +99,7 @@ macro_rules! hashable_ord {
 	($hashable:ident) => {
 		impl Ord for $hashable {
 			fn cmp(&self, other: &$hashable) -> Ordering {
-				self.hash().cmp(&other.hash())
+				self.crypto_hash().cmp(&other.crypto_hash())
 			}
 		}
 		impl PartialOrd for $hashable {
@@ -109,7 +109,7 @@ macro_rules! hashable_ord {
 		}
 		impl PartialEq for $hashable {
 			fn eq(&self, other: &$hashable) -> bool {
-				self.hash() == other.hash()
+				self.crypto_hash() == other.crypto_hash()
 			}
 		}
 		impl Eq for $hashable {}

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -383,7 +383,7 @@ impl Proof {
 
 	/// Difficulty achieved by this proof with given scaling factor
 	fn scaled_difficulty(&self, scale: u64) -> u64 {
-		let diff = ((scale as u128) << 64) / (max(1, self.hash().to_u64()) as u128);
+		let diff = ((scale as u128) << 64) / (max(1, self.crypto_hash().to_u64()) as u128);
 		min(diff, <u64>::max_value() as u128) as u64
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -543,7 +543,10 @@ pub trait VerifySortedAndUnique<T> {
 
 impl<T: Hashed> VerifySortedAndUnique<T> for Vec<T> {
 	fn verify_sorted_and_unique(&self) -> Result<(), Error> {
-		let hashes = self.iter().map(|item| item.hash()).collect::<Vec<_>>();
+		let hashes = self
+			.iter()
+			.map(|item| item.crypto_hash())
+			.collect::<Vec<_>>();
 		let pairs = hashes.windows(2);
 		for pair in pairs {
 			if pair[0] > pair[1] {
@@ -615,7 +618,7 @@ where
 			match elem {
 				Ok(e) => buf.push(e),
 				Err(Error::IOErr(ref _d, ref kind)) if *kind == io::ErrorKind::UnexpectedEof => {
-					break
+					break;
 				}
 				Err(e) => return Err(e),
 			}
@@ -723,7 +726,7 @@ pub trait PMMRIndexHashable {
 
 impl<T: Writeable> PMMRIndexHashable for T {
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		(index, self).crypto_hash()
 	}
 }
 

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -210,7 +210,7 @@ fn serialize_deserialize_block_header() {
 	ser::serialize(&mut vec, &header1).expect("serialization failed");
 	let header2: BlockHeader = ser::deserialize(&mut &vec[..]).unwrap();
 
-	assert_eq!(header1.hash(), header2.hash());
+	assert_eq!(header1.crypto_hash(), header2.crypto_hash());
 	assert_eq!(header1, header2);
 }
 
@@ -226,7 +226,7 @@ fn serialize_deserialize_block() {
 	ser::serialize(&mut vec, &b).expect("serialization failed");
 	let b2: Block = ser::deserialize(&mut &vec[..]).unwrap();
 
-	assert_eq!(b.hash(), b2.hash());
+	assert_eq!(b.header_hash(), b2.header_hash());
 	assert_eq!(b.header, b2.header);
 	assert_eq!(b.inputs(), b2.inputs());
 	assert_eq!(b.outputs(), b2.outputs());
@@ -336,8 +336,8 @@ fn compact_block_hash_with_nonce() {
 	// random nonce will not affect the hash of the compact block itself
 	// hash is based on header POW only
 	assert!(cb1.nonce != cb2.nonce);
-	assert_eq!(b.hash(), cb1.hash());
-	assert_eq!(cb1.hash(), cb2.hash());
+	assert_eq!(b.header_hash(), cb1.crypto_hash());
+	assert_eq!(cb1.crypto_hash(), cb2.crypto_hash());
 
 	assert!(cb1.kern_ids()[0] != cb2.kern_ids()[0]);
 
@@ -345,11 +345,11 @@ fn compact_block_hash_with_nonce() {
 	// correctly in both of the compact_blocks
 	assert_eq!(
 		cb1.kern_ids()[0],
-		tx.kernels()[0].short_id(&cb1.hash(), cb1.nonce)
+		tx.kernels()[0].short_id(&cb1.crypto_hash(), cb1.nonce)
 	);
 	assert_eq!(
 		cb2.kern_ids()[0],
-		tx.kernels()[0].short_id(&cb2.hash(), cb2.nonce)
+		tx.kernels()[0].short_id(&cb2.crypto_hash(), cb2.nonce)
 	);
 }
 
@@ -372,7 +372,7 @@ fn convert_block_to_compact_block() {
 			.iter()
 			.find(|x| !x.is_coinbase())
 			.unwrap()
-			.short_id(&cb.hash(), cb.nonce)
+			.short_id(&cb.crypto_hash(), cb.nonce)
 	);
 }
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -52,7 +52,7 @@ fn simple_tx_ser_deser() {
 	assert_eq!(dtx.fee(), 2);
 	assert_eq!(dtx.inputs().len(), 2);
 	assert_eq!(dtx.outputs().len(), 1);
-	assert_eq!(tx.hash(), dtx.hash());
+	assert_eq!(tx.crypto_hash(), dtx.crypto_hash());
 }
 
 #[test]
@@ -68,8 +68,8 @@ fn tx_double_ser_deser() {
 	assert!(ser::serialize(&mut vec2, &btx).is_ok());
 	let dtx2: Transaction = ser::deserialize(&mut &vec2[..]).unwrap();
 
-	assert_eq!(btx.hash(), dtx.hash());
-	assert_eq!(dtx.hash(), dtx2.hash());
+	assert_eq!(btx.crypto_hash(), dtx.crypto_hash());
+	assert_eq!(dtx.crypto_hash(), dtx2.crypto_hash());
 }
 
 #[test]
@@ -364,9 +364,9 @@ fn hash_output() {
 		&keychain,
 	)
 	.unwrap();
-	let h = tx.outputs()[0].hash();
+	let h = tx.outputs()[0].crypto_hash();
 	assert!(h != ZERO_HASH);
-	let h2 = tx.outputs()[1].hash();
+	let h2 = tx.outputs()[1].crypto_hash();
 	assert!(h != h2);
 }
 
@@ -397,7 +397,7 @@ fn tx_hash_diff() {
 	let btx1 = tx2i1o();
 	let btx2 = tx1i1o();
 
-	if btx1.hash() == btx2.hash() {
+	if btx1.crypto_hash() == btx2.crypto_hash() {
 		panic!("diff txs have same hash")
 	}
 }

--- a/etc/gen_gen/src/bin/gen_gen.rs
+++ b/etc/gen_gen/src/bin/gen_gen.rs
@@ -147,9 +147,12 @@ fn main() {
 	)
 	.unwrap();
 
-	println!("\nFinal genesis cyclehash: {}", gen.hash().to_hex());
+	println!("\nFinal genesis cyclehash: {}", gen.crypto_hash().to_hex());
 	let gen_bin = core::ser::ser_vec(&gen).unwrap();
-	println!("Final genesis full hash: {}\n", gen_bin.hash().to_hex());
+	println!(
+		"Final genesis full hash: {}\n",
+		gen_bin.crypto_hash().to_hex()
+	);
 
 	update_genesis_rs(&gen);
 	println!("genesis.rs has been updated, check it and run mainnet_genesis_hash test");

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -344,7 +344,7 @@ impl Peers {
 		let count = self.broadcast("compact block", num_peers, |p| p.send_compact_block(b));
 		debug!(
 			"broadcast_compact_block: {}, {} at {}, to {} peers, done.",
-			b.hash(),
+			b.crypto_hash(),
 			b.header.pow.total_difficulty,
 			b.header.height,
 			count,
@@ -361,7 +361,7 @@ impl Peers {
 		let count = self.broadcast("header", num_peers, |p| p.send_header(bh));
 		debug!(
 			"broadcast_header: {}, {} at {}, to {} peers, done.",
-			bh.hash(),
+			bh.crypto_hash(),
 			bh.pow.total_difficulty,
 			bh.height,
 			count,
@@ -400,7 +400,7 @@ impl Peers {
 		let count = self.broadcast("transaction", num_peers, |p| p.send_transaction(tx));
 		debug!(
 			"broadcast_transaction: {} to {} peers, done.",
-			tx.hash(),
+			tx.crypto_hash(),
 			count,
 		);
 	}
@@ -570,7 +570,7 @@ impl ChainAdapter for Peers {
 	}
 
 	fn block_received(&self, b: core::Block, peer_addr: SocketAddr, was_requested: bool) -> bool {
-		let hash = b.hash();
+		let hash = b.header_hash();
 		if !self.adapter.block_received(b, peer_addr, was_requested) {
 			// if the peer sent us a block that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
@@ -586,7 +586,7 @@ impl ChainAdapter for Peers {
 	}
 
 	fn compact_block_received(&self, cb: core::CompactBlock, peer_addr: SocketAddr) -> bool {
-		let hash = cb.hash();
+		let hash = cb.crypto_hash();
 		if !self.adapter.compact_block_received(cb, peer_addr) {
 			// if the peer sent us a block that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -54,13 +54,13 @@ impl Pool {
 
 	/// Does the transaction pool contain an entry for the given transaction?
 	pub fn contains_tx(&self, hash: Hash) -> bool {
-		self.entries.iter().any(|x| x.tx.hash() == hash)
+		self.entries.iter().any(|x| x.tx.crypto_hash() == hash)
 	}
 
 	pub fn get_tx(&self, hash: Hash) -> Option<Transaction> {
 		self.entries
 			.iter()
-			.find(|x| x.tx.hash() == hash)
+			.find(|x| x.tx.crypto_hash() == hash)
 			.map(|x| x.tx.clone())
 	}
 
@@ -68,7 +68,7 @@ impl Pool {
 	pub fn retrieve_tx_by_kernel_hash(&self, hash: Hash) -> Option<Transaction> {
 		for x in &self.entries {
 			for k in x.tx.kernels() {
-				if k.hash() == hash {
+				if k.crypto_hash() == hash {
 					return Some(x.tx.clone());
 				}
 			}
@@ -238,13 +238,13 @@ impl Pool {
 		debug!(
 			"add_to_pool [{}]: {} ({}) [in/out/kern: {}/{}/{}] pool: {} (at block {})",
 			self.name,
-			entry.tx.hash(),
+			entry.tx.crypto_hash(),
 			entry.src.debug_name,
 			entry.tx.inputs().len(),
 			entry.tx.outputs().len(),
 			entry.tx.kernels().len(),
 			self.size(),
-			header.hash(),
+			header.crypto_hash(),
 		);
 	}
 
@@ -304,7 +304,7 @@ impl Pool {
 		let overage = tx.overage();
 		let offset = (header.total_kernel_offset() + tx.offset)?;
 
-		let block_sums = self.blockchain.get_block_sums(&header.hash())?;
+		let block_sums = self.blockchain.get_block_sums(&header.crypto_hash())?;
 
 		// Verify the kernel sums for the block_sums with the new tx applied,
 		// accounting for overage and offset.

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -140,7 +140,7 @@ impl TransactionPool {
 	) -> Result<(), PoolError> {
 		// Quick check to deal with common case of seeing the *same* tx
 		// broadcast from multiple peers simultaneously.
-		if !stem && self.txpool.contains_tx(tx.hash()) {
+		if !stem && self.txpool.contains_tx(tx.crypto_hash()) {
 			return Err(PoolError::DuplicateTx);
 		}
 
@@ -200,14 +200,14 @@ impl TransactionPool {
 		debug!(
 			"reconcile_reorg_cache: size: {}, block: {:?} ...",
 			entries.len(),
-			header.hash(),
+			header.crypto_hash(),
 		);
 		for entry in entries {
 			let _ = &self.add_to_txpool(entry.clone(), header);
 		}
 		debug!(
 			"reconcile_reorg_cache: block: {:?} ... done.",
-			header.hash()
+			header.crypto_hash()
 		);
 		Ok(())
 	}

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -48,7 +48,7 @@ fn test_transaction_pool_block_building() {
 		let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
-		block.header.prev_root = prev_header.hash();
+		block.header.prev_root = prev_header.crypto_hash();
 
 		chain.update_db_for_block(&block);
 		block

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -53,7 +53,7 @@ fn test_block_building_max_weight() {
 		let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
-		block.header.prev_root = prev_header.hash();
+		block.header.prev_root = prev_header.crypto_hash();
 
 		chain.update_db_for_block(&block);
 		block

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -49,7 +49,7 @@ fn test_transaction_pool_block_reconciliation() {
 		let mut block = Block::new(&genesis, vec![], Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
-		block.header.prev_root = genesis.hash();
+		block.header.prev_root = genesis.crypto_hash();
 
 		chain.update_db_for_block(&block);
 
@@ -67,7 +67,7 @@ fn test_transaction_pool_block_reconciliation() {
 		let mut block = Block::new(&header, vec![initial_tx], Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
-		block.header.prev_root = header.hash();
+		block.header.prev_root = header.crypto_hash();
 
 		chain.update_db_for_block(&block);
 
@@ -160,7 +160,7 @@ fn test_transaction_pool_block_reconciliation() {
 		let mut block = Block::new(&header, block_txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
-		block.header.prev_root = header.hash();
+		block.header.prev_root = header.crypto_hash();
 
 		chain.update_db_for_block(&block);
 		block

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -84,7 +84,9 @@ impl ChainAdapter {
 			utxo_sum,
 			kernel_sum,
 		};
-		batch.save_block_sums(&header.hash(), &block_sums).unwrap();
+		batch
+			.save_block_sums(&header.crypto_hash(), &block_sums)
+			.unwrap();
 
 		batch.commit().unwrap();
 

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -226,7 +226,10 @@ fn process_expired_entries(
 			.iter()
 			.filter(|x| x.tx_at.timestamp() < cutoff)
 		{
-			debug!("dand_mon: Embargo timer expired for {:?}", entry.tx.hash());
+			debug!(
+				"dand_mon: Embargo timer expired for {:?}",
+				entry.tx.crypto_hash()
+			);
 			expired_entries.push(entry.clone());
 		}
 	}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -137,7 +137,7 @@ impl Server {
 			global::ChainTypes::Mainnet => genesis::genesis_main(),
 		};
 
-		info!("Starting server, genesis block: {}", genesis.hash());
+		info!("Starting server, genesis block: {}", genesis.header_hash());
 
 		let db_env = Arc::new(store::new_env(config.db_root.clone()));
 		let shared_chain = Arc::new(chain::Chain::init(
@@ -171,7 +171,7 @@ impl Server {
 			config.p2p_config.capabilities,
 			config.p2p_config.clone(),
 			net_adapter.clone(),
-			genesis.hash(),
+			genesis.header_hash(),
 			stop_state.clone(),
 		)?);
 		chain_adapter.init(p2p_server.peers.clone());
@@ -403,7 +403,7 @@ impl Server {
 					// Default to "zero" hash if synthetic header_info.
 					let hash = if height >= 0 {
 						if let Ok(header) = txhashset.get_header_by_height(height as u64) {
-							header.hash()
+							header.crypto_hash()
 						} else {
 							ZERO_HASH
 						}

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -63,9 +63,9 @@ impl HeaderSync {
 				let sync_head = self.chain.get_sync_head().unwrap();
 				debug!(
 					"sync: initial transition to HeaderSync. sync_head: {} at {}, resetting to: {} at {}",
-					sync_head.hash(),
+					sync_head.last_block_h,
 					sync_head.height,
-					header_head.hash(),
+					header_head.last_block_h,
 					header_head.height,
 				);
 
@@ -210,7 +210,9 @@ impl HeaderSync {
 
 		// for security, clear history_locator[] in any case of header chain rollback,
 		// the easiest way is to check whether the sync head and the header head are identical.
-		if self.history_locator.len() > 0 && tip.hash() != self.chain.header_head()?.hash() {
+		if self.history_locator.len() > 0
+			&& tip.last_block_h != self.chain.header_head()?.last_block_h
+		{
 			self.history_locator.retain(|&x| x.0 == 0);
 		}
 
@@ -227,7 +229,7 @@ impl HeaderSync {
 				while let Ok(header) = header_cursor {
 					if header.height == h {
 						if header.height != last_loc.0 {
-							locator.push((header.height, header.hash()));
+							locator.push((header.height, header.crypto_hash()));
 						}
 						break;
 					}

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -167,7 +167,7 @@ impl StateSync {
 			for _ in 0..threshold {
 				txhashset_head = self.chain.get_previous_header(&txhashset_head).unwrap();
 			}
-			let bhash = txhashset_head.hash();
+			let bhash = txhashset_head.crypto_hash();
 			debug!(
 				"state_sync: before txhashset request, header head: {} / {}, txhashset_head: {} / {}",
 				header_head.height,

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -490,7 +490,7 @@ impl StratumServer {
 			// Return error status
 			error!(
 				"(Server ID: {}) Failed to validate solution at height {}, hash {}, edge_bits {}, nonce {}, job_id {}: cuckoo size too small",
-				self.id, params.height, b.hash(), params.edge_bits, params.nonce, params.job_id,
+				self.id, params.height, b.header_hash(), params.edge_bits, params.nonce, params.job_id,
 			);
 			worker_stats.num_rejected += 1;
 			let e = RpcError {
@@ -507,7 +507,7 @@ impl StratumServer {
 			// Return error status
 			error!(
 				"(Server ID: {}) Share at height {}, hash {}, edge_bits {}, nonce {}, job_id {} rejected due to low difficulty: {}/{}",
-				self.id, params.height, b.hash(), params.edge_bits, params.nonce, params.job_id, share_difficulty, self.minimum_share_difficulty,
+				self.id, params.height, b.header_hash(), params.edge_bits, params.nonce, params.job_id, share_difficulty, self.minimum_share_difficulty,
 			);
 			worker_stats.num_rejected += 1;
 			let e = RpcError {
@@ -526,7 +526,7 @@ impl StratumServer {
 					"(Server ID: {}) Failed to validate solution at height {}, hash {}, edge_bits {}, nonce {}, job_id {}, {}: {}",
 					self.id,
 					params.height,
-					b.hash(),
+					b.header_hash(),
 					params.edge_bits,
 					params.nonce,
 					params.job_id,
@@ -546,7 +546,7 @@ impl StratumServer {
 			warn!(
 				"(Server ID: {}) Solution Found for block {}, hash {} - Yay!!! Worker ID: {}, blocks found: {}, shares: {}",
 				self.id, params.height,
-				b.hash(),
+				b.header_hash(),
 				worker_stats.id,
 				worker_stats.num_blocks_found,
 				worker_stats.num_accepted,
@@ -560,7 +560,7 @@ impl StratumServer {
 					"(Server ID: {}) Failed to validate share at height {}, hash {}, edge_bits {}, nonce {}, job_id {}. {:?}",
 					self.id,
 					params.height,
-					b.hash(),
+					b.header_hash(),
 					params.edge_bits,
 					b.header.pow.nonce,
 					params.job_id,
@@ -583,7 +583,7 @@ impl StratumServer {
 			"(Server ID: {}) Got share at height {}, hash {}, edge_bits {}, nonce {}, job_id {}, difficulty {}/{}, submitted by {}",
 			self.id,
 			b.header.height,
-			b.hash(),
+			b.header_hash(),
 			b.header.pow.proof.edge_bits,
 			b.header.pow.nonce,
 			params.job_id,
@@ -594,7 +594,7 @@ impl StratumServer {
 		worker_stats.num_accepted += 1;
 		let submit_response;
 		if share_is_block {
-			submit_response = format!("blockfound - {}", b.hash().to_hex());
+			submit_response = format!("blockfound - {}", b.header_hash().to_hex());
 		} else {
 			submit_response = "ok".to_string();
 		}

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -93,7 +93,7 @@ impl Miner {
 		);
 		let mut iter_count = 0;
 
-		while head.hash() == *latest_hash && Utc::now().timestamp() < deadline {
+		while head.crypto_hash() == *latest_hash && Utc::now().timestamp() < deadline {
 			let mut ctx = global::create_pow_context::<u32>(
 				head.height,
 				global::min_edge_bits(),
@@ -166,7 +166,7 @@ impl Miner {
 				info!(
 					"(Server ID: {}) Found valid proof of work, adding block {} (prev_root {}).",
 					self.debug_output_id,
-					b.hash(),
+					b.header_hash(),
 					b.header.prev_root,
 				);
 				let res = self.chain.process_block(b, chain::Options::MINE);

--- a/servers/tests/simulnet.rs
+++ b/servers/tests/simulnet.rs
@@ -282,7 +282,7 @@ fn simulate_full_sync() {
 	let s1_header = s1.chain.head_header().unwrap();
 	info!(
 		"simulate_full_sync - s1 header head: {} at {}",
-		s1_header.hash(),
+		s1_header.crypto_hash(),
 		s1_header.height
 	);
 
@@ -302,7 +302,7 @@ fn simulate_full_sync() {
 	}
 
 	// Confirm both s1 and s2 see a consistent header at that height.
-	let s2_header = s2.chain.get_block_header(&s1_header.hash()).unwrap();
+	let s2_header = s2.chain.get_block_header(&s1_header.crypto_hash()).unwrap();
 	assert_eq!(s1_header, s2_header);
 
 	// Stop our servers cleanly.
@@ -359,7 +359,7 @@ fn simulate_fast_sync() {
 	}
 
 	// Confirm both s1 and s2 see a consistent header at that height.
-	let s2_header = s2.chain.get_block_header(&s1_header.hash()).unwrap();
+	let s2_header = s2.chain.get_block_header(&s1_header.crypto_hash()).unwrap();
 	assert_eq!(s1_header, s2_header);
 
 	// Stop our servers cleanly.
@@ -651,7 +651,7 @@ fn long_fork_test_case_2(s: &Vec<servers::Server>) {
 	}
 	let s0_tail_new = s[0].chain.tail().unwrap();
 	assert_eq!(s0_tail_new.height, s0_tail.height);
-	assert_eq!(s[0].head().hash(), s3_header.hash());
+	assert_eq!(s[0].head().last_block_h, s3_header.last_block_h);
 
 	let _ = s[0].chain.compact();
 	let s0_header = s[0].chain.head().unwrap();
@@ -700,7 +700,7 @@ fn long_fork_test_case_3(s: &Vec<servers::Server>) {
 			exit(1);
 		}
 	}
-	assert_eq!(s[0].head().hash(), s4_header.hash());
+	assert_eq!(s[0].head().last_block_h, s4_header.last_block_h);
 
 	s[0].stop();
 	s[1].resume();
@@ -725,7 +725,7 @@ fn long_fork_test_case_3(s: &Vec<servers::Server>) {
 		s1_tail_new.height, s1_tail.height
 	);
 	assert_ne!(s1_tail_new.height, s1_tail.height);
-	assert_eq!(s[1].head().hash(), s4_header.hash());
+	assert_eq!(s[1].head().last_block_h, s4_header.last_block_h);
 
 	s[1].pause();
 	s[4].pause();
@@ -771,7 +771,7 @@ fn long_fork_test_case_4(s: &Vec<servers::Server>) {
 		s1_tail_new.height, s1_tail.height
 	);
 	assert_ne!(s1_tail_new.height, s1_tail.height);
-	assert_eq!(s[1].head().hash(), s5_header.hash());
+	assert_eq!(s[1].head().last_block_h, s5_header.last_block_h);
 
 	s[1].pause();
 	s[5].pause();
@@ -818,7 +818,7 @@ fn long_fork_test_case_5(s: &Vec<servers::Server>) {
 		s1_tail_new.height, s1_tail.height
 	);
 	assert_eq!(s1_tail_new.height, s1_tail.height);
-	assert_eq!(s[1].head().hash(), s5_header.hash());
+	assert_eq!(s[1].head().last_block_h, s5_header.last_block_h);
 
 	s[1].pause();
 	s[5].pause();
@@ -866,7 +866,7 @@ fn long_fork_test_case_6(s: &Vec<servers::Server>) {
 		s1_tail_new.height, s1_tail.height
 	);
 	assert_eq!(s1_tail_new.height, s1_tail.height);
-	assert_eq!(s[1].head().hash(), s5_header.hash());
+	assert_eq!(s[1].head().last_block_h, s5_header.last_block_h);
 
 	s[1].pause();
 	s[5].pause();

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -155,7 +155,7 @@ impl LeafSet {
 		let mut cp_bitmap = self.bitmap.clone();
 		cp_bitmap.run_optimize();
 
-		let cp_path = format!("{}.{}", self.path.to_str().unwrap(), header.hash());
+		let cp_path = format!("{}.{}", self.path.to_str().unwrap(), header.crypto_hash());
 		let mut file = BufWriter::new(File::create(cp_path)?);
 		file.write_all(&cp_bitmap.serialize())?;
 		file.flush()?;

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -153,9 +153,12 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	}
 
 	fn snapshot(&self, header: &BlockHeader) -> Result<(), String> {
-		self.leaf_set
-			.snapshot(header)
-			.map_err(|_| format!("Failed to save copy of leaf_set for {}", header.hash()))?;
+		self.leaf_set.snapshot(header).map_err(|_| {
+			format!(
+				"Failed to save copy of leaf_set for {}",
+				header.crypto_hash()
+			)
+		})?;
 		Ok(())
 	}
 
@@ -191,7 +194,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			let leaf_snapshot_path = format!(
 				"{}.{}",
 				data_dir.join(PMMR_LEAF_FILE).to_str().unwrap(),
-				header.hash()
+				header.crypto_hash()
 			);
 			// Check for a ... (3 dot) ending version of the file - could probably be removed after mainnet
 			let compatible_snapshot_path = PathBuf::from(leaf_snapshot_path.clone() + "...");

--- a/wallet/src/libwallet/api.rs
+++ b/wallet/src/libwallet/api.rs
@@ -746,7 +746,7 @@ where
 		} else {
 			debug!(
 				"api: post_tx: successfully posted tx: {}, fluff? {}",
-				tx.hash(),
+				tx.crypto_hash(),
 				fluff
 			);
 			Ok(())

--- a/wallet/src/libwallet/types.rs
+++ b/wallet/src/libwallet/types.rs
@@ -459,7 +459,7 @@ pub struct BlockIdentifier(pub Hash);
 
 impl BlockIdentifier {
 	/// return hash
-	pub fn hash(&self) -> Hash {
+	pub fn crypto_hash(&self) -> Hash {
 		self.0
 	}
 


### PR DESCRIPTION
This PR aims to disambiguate the cryptographic hash used in consensus critical applications from the rust implementation-defined std::hash trait.

Problematically, there are couple user defined functions called 'hash', in addition to the standard one, which might be accidentally called.

To remedy this, I changed the cryptographic hash trait fn to be called `crypto_hash`.

Where we were previously worried about accidentally getting the hash of a container struct rather than the inner item, rather than shadow it with the correct result, I shadowed it with an deprecated function that calls `unimplemented!` and returns `!`. The three instances of this are Block, HeaderEntry, Tip. Thus, using the result of a call should trigger unreachable expression warnings/errors, and should cause linter errors for deprecated function use, and if we somehow did manage to call the wrong version, tests should cause panics if the wrong method is somehow used,

If the crypto_hash of such a container is actually needed, UFCS can resolve it explicitly.

This PR is a bit noisy and large, and careful review is required to ensure it is consistent. I think the noise is a large improvement in readability long term.