### PR TITLE
Windows TUI Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ grin_wallet = { path = "./wallet", version = "1.0.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.10.0", default-features = false, features = ["pancurses-backend"] }
+[target.'cfg(windows)'.dependencies.pancurses]
+version = "0.16.0"
+features = ["win32"]
 [target.'cfg(unix)'.dependencies]
 cursive = "0.9.0"
 

--- a/wallet/tests/restore.rs
+++ b/wallet/tests/restore.rs
@@ -45,6 +45,7 @@ fn restore_wallet(base_dir: &str, wallet_dir: &str) -> Result<(), libwallet::Err
 	let dest_dir = format!("{}/{}_restore", base_dir, wallet_dir);
 	fs::create_dir_all(dest_dir.clone())?;
 	let dest_seed = format!("{}/wallet.seed", dest_dir);
+	println!("Source: {}, Dest: {}", source_seed, dest_seed);
 	fs::copy(source_seed, dest_seed)?;
 
 	let mut wallet_proxy: WalletProxy<LocalWalletClient, ExtKeychain> = WalletProxy::new(base_dir);
@@ -343,13 +344,13 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 }
 
 fn perform_restore(test_dir: &str) -> Result<(), libwallet::Error> {
-	restore_wallet(&format!("{}_r1", test_dir), "wallet1")?;
+	restore_wallet(test_dir, "wallet1")?;
 	compare_wallet_restore(
 		test_dir,
 		"wallet1",
 		&ExtKeychain::derive_key_id(2, 0, 0, 0, 0),
 	)?;
-	restore_wallet(&format!("{}_r2", test_dir), "wallet2")?;
+	restore_wallet(test_dir, "wallet2")?;
 	compare_wallet_restore(
 		test_dir,
 		"wallet2",
@@ -365,7 +366,7 @@ fn perform_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 		"wallet2",
 		&ExtKeychain::derive_key_id(2, 2, 0, 0, 0),
 	)?;
-	restore_wallet(&format!("{}_r3", test_dir), "wallet3")?;
+	restore_wallet(test_dir, "wallet3")?;
 	compare_wallet_restore(
 		test_dir,
 		"wallet3",


### PR DESCRIPTION
Switches pancurses (windows tui backend) to use win32 (console) instead of win32a (gdi) mode, allowing it to function and look similar to the linux offering.