### PR TITLE
refactor/fix: use sort_unstable instead of sort, more efficient with_* methods for TransactionBody

### DIFF
--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -62,9 +62,9 @@ impl CompactBlockBody {
 
 	/// Sort everything.
 	fn sort(&mut self) {
-		self.out_full.sort();
-		self.kern_full.sort();
-		self.kern_ids.sort();
+		self.out_full.sort_unstable();
+		self.kern_full.sort_unstable();
+		self.kern_ids.sort_unstable();
 	}
 
 	/// "Lightweight" validation.

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -487,9 +487,9 @@ impl TransactionBody {
 
 	/// Sort the inputs|outputs|kernels.
 	pub fn sort(&mut self) {
-		self.inputs.sort();
-		self.outputs.sort();
-		self.kernels.sort();
+		self.inputs.sort_unstable();
+		self.outputs.sort_unstable();
+		self.kernels.sort_unstable();
 	}
 
 	/// Creates a new transaction body initialized with
@@ -501,7 +501,7 @@ impl TransactionBody {
 		kernels: Vec<TxKernel>,
 		verify_sorted: bool,
 	) -> Result<TransactionBody, Error> {
-		let body = TransactionBody {
+		let mut body = TransactionBody {
 			inputs,
 			outputs,
 			kernels,
@@ -511,52 +511,44 @@ impl TransactionBody {
 			// If we are verifying sort order then verify and
 			// return an error if not sorted lexicographically.
 			body.verify_sorted()?;
-			Ok(body)
 		} else {
 			// If we are not verifying sort order then sort in place and return.
-			let mut body = body;
 			body.sort();
-			Ok(body)
 		}
+		Ok(body)
 	}
 
 	/// Builds a new body with the provided inputs added. Existing
 	/// inputs, if any, are kept intact.
 	/// Sort order is maintained.
-	pub fn with_input(self, input: Input) -> TransactionBody {
-		let mut new_ins = self.inputs;
-		new_ins.push(input);
-		new_ins.sort();
-		TransactionBody {
-			inputs: new_ins,
-			..self
-		}
+	pub fn with_input(mut self, input: Input) -> TransactionBody {
+		self.inputs
+			.binary_search(&input)
+			.err()
+			.map(|e| self.inputs.insert(e, input));
+		self
 	}
 
 	/// Builds a new TransactionBody with the provided output added. Existing
 	/// outputs, if any, are kept intact.
 	/// Sort order is maintained.
-	pub fn with_output(self, output: Output) -> TransactionBody {
-		let mut new_outs = self.outputs;
-		new_outs.push(output);
-		new_outs.sort();
-		TransactionBody {
-			outputs: new_outs,
-			..self
-		}
+	pub fn with_output(mut self, output: Output) -> TransactionBody {
+		self.outputs
+			.binary_search(&output)
+			.err()
+			.map(|e| self.outputs.insert(e, output));
+		self
 	}
 
 	/// Builds a new TransactionBody with the provided kernel added. Existing
 	/// kernels, if any, are kept intact.
 	/// Sort order is maintained.
-	pub fn with_kernel(self, kernel: TxKernel) -> TransactionBody {
-		let mut new_kerns = self.kernels;
-		new_kerns.push(kernel);
-		new_kerns.sort();
-		TransactionBody {
-			kernels: new_kerns,
-			..self
-		}
+	pub fn with_kernel(mut self, kernel: TxKernel) -> TransactionBody {
+		self.kernels
+			.binary_search(&kernel)
+			.err()
+			.map(|e| self.kernels.insert(e, kernel));
+		self
 	}
 
 	/// Total fee for a TransactionBody is the sum of fees of all kernels.
@@ -987,8 +979,8 @@ pub fn cut_through(inputs: &mut Vec<Input>, outputs: &mut Vec<Output>) -> Result
 	// filter and sort
 	inputs.retain(|inp| !to_cut_through.contains(&inp.commitment()));
 	outputs.retain(|out| !to_cut_through.contains(&out.commitment()));
-	inputs.sort();
-	outputs.sort();
+	inputs.sort_unstable();
+	outputs.sort_unstable();
 	Ok(())
 }
 
@@ -1022,7 +1014,7 @@ pub fn aggregate(mut txs: Vec<Transaction>) -> Result<Transaction, Error> {
 	cut_through(&mut inputs, &mut outputs)?;
 
 	// Now sort kernels.
-	kernels.sort();
+	kernels.sort_unstable();
 
 	// now sum the kernel_offsets up to give us an aggregate offset for the
 	// transaction
@@ -1093,9 +1085,9 @@ pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transact
 	};
 
 	// Sorting them lexicographically
-	inputs.sort();
-	outputs.sort();
-	kernels.sort();
+	inputs.sort_unstable();
+	outputs.sort_unstable();
+	kernels.sort_unstable();
 
 	// Build a new tx from the above data.
 	let tx = Transaction::new(inputs, outputs, kernels).with_offset(total_kernel_offset);

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -265,7 +265,7 @@ where
 		self.graph.solutions.pop();
 		for s in &mut self.graph.solutions {
 			s.nonces = map_vec!(s.nonces, |n| val[*n as usize]);
-			s.nonces.sort();
+			s.nonces.sort_unstable();
 		}
 		for s in &self.graph.solutions {
 			self.verify_impl(&s)?;

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -342,7 +342,7 @@ impl Eq for Proof {}
 impl Proof {
 	/// Builds a proof with provided nonces at default edge_bits
 	pub fn new(mut in_nonces: Vec<u64>) -> Proof {
-		in_nonces.sort();
+		in_nonces.sort_unstable();
 		Proof {
 			edge_bits: global::min_edge_bits(),
 			nonces: in_nonces,
@@ -369,7 +369,7 @@ impl Proof {
 			.map(|()| (rng.gen::<u32>() & nonce_mask) as u64)
 			.take(proof_size)
 			.collect();
-		v.sort();
+		v.sort_unstable();
 		Proof {
 			edge_bits: global::min_edge_bits(),
 			nonces: v,


### PR DESCRIPTION
Previously, the codebase uses sort. In rust, sort performs a stable sort, which is slow and allocates memory. On the other hand, sort_unstable is supposedly faster and does not require the allocation of memory, so I switch to using unstable sort as we don't need sort stability (our vecs should already be or will be made unique).

According to [RFC documentation](https://github.com/rust-lang/rfcs/blob/master/text/1884-unstable-sort.md), the ordinary sort may be faster in the following case:

```markdown
A: Yes, there are a few cases where it is faster.
For example, if the slice consists of several pre-sorted sequences concatenated one after another, then slice::sort will most probably be faster. 
Another case is when using costly comparison functions, e.g. when sorting strings. slice::sort optimizes the number of comparisons very well, while pdqsort optimizes for fewer writes to memory at expense of slightly larger number of comparisons.
But other than that, slice::sort should be generally slower than pdqsort.
```

As we're generally not sorting inputs from remote peers (we usually are validating they sent it sorted) this should be ok -- and in the worst case, it's not much slower.


I also switch the with_* functions to insert after a failed binary search for the kernel, input, or output rather than unconditionally insert. This has a improved runtime of O(n + log(n)) v.s. O(n log n), but I don't think we use it in any performance sensitive context, so the major change is the behavioral change. This is a **minor breaking change** -- previously, adding two of the same output, input, or kernel would result in two of that item being inserted. I think this is almost always a bug, so it may be worth handling this case differently (e.g., not returning anything on duplicate add). In theory, this is also a little bit less safe if a user passes in a TransactionBody with an unsorted vec, the `with_*` will do something unspecified. We'll get an error at `verify_sorted_and_unique` in such a case.




