### PR TITLE
[docs] Add more details to wallet TLS setup instruction

### DIFF
--- a/doc/wallet/tls-setup.md
+++ b/doc/wallet/tls-setup.md
@@ -17,6 +17,18 @@ tls_certificate_file = "/path/to/my/cerificate/fullchain.pem"
 tls_certificate_key =  "/path/to/my/cerificate/privkey.pem"
 ```
 
+And update `api_listen_interface` to your static IP if you want to lock your wallet only to external interface
+
+```toml
+api_listen_interface = "3.3.3.3"
+```
+
+Or, in case you are using DynDNS or `localhost` in order to comunicate with your wallet, just put `0.0.0.0` as mentioned in the inline instruction.
+
+```toml
+api_listen_interface = "0.0.0.0"
+```
+
 If you have Stratum server enabled (you run a miner) make sure that wallet listener URL starts with `https` in node config (by default `~/.grin/grin-server.toml`):
 
 ```toml
@@ -57,12 +69,14 @@ Now you have the certificate files but only root user can read it. We run grin a
 ```sh
 sudo groupadd tls-cert
 sudo usermod -a -G tls-cert ubuntu
-chgrp -R tls-cert /etc/letsencrypt
-chmod -R g=rX /etc/letsencrypt
+sudo chgrp -R tls-cert /etc/letsencrypt
+sudo chmod -R g=rX /etc/letsencrypt
 sudo chmod 2755 /etc/letsencrypt
 ```
 
 The last step is needed for renewal, it makes sure that all new files will have the same group ownership.
+
+Now you need to logout so the user's group membership modification can take place.
 
 ### Update wallet config
 Refer to `I have a TLS certificate already` because you have it now. Use the folowing values:


### PR DESCRIPTION
While setting up TLS for the wallet found out that instruction is missing a couple of details.