### PR TITLE
Use failure for Pool and Committed erros

### DIFF
--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -20,17 +20,22 @@ use crate::keychain::BlindingFactor;
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen::Commitment;
 use crate::util::{secp, secp_static, static_secp_instance};
+use failure::Fail;
 
 /// Errors from summing and verifying kernel excesses via committed trait.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Fail)]
 pub enum Error {
 	/// Keychain related error.
+	#[fail(display = "Keychain error {}", _0)]
 	Keychain(keychain::Error),
 	/// Secp related error.
+	#[fail(display = "Secp error {}", _0)]
 	Secp(secp::Error),
 	/// Kernel sums do not equal output sums.
+	#[fail(display = "Kernel sum mismatch")]
 	KernelSumMismatch,
 	/// Committed overage (fee or reward) is invalid
+	#[fail(display = "Invalid value")]
 	InvalidValue,
 }
 

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -16,6 +16,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 chrono = "0.4.4"
+failure = "0.1"
+failure_derive = "0.1"
 
 grin_core = { path = "../core", version = "1.0.1" }
 grin_keychain = { path = "../keychain", version = "1.0.1" }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -23,6 +23,7 @@ use self::core::core::hash::Hash;
 use self::core::core::transaction::{self, Transaction};
 use self::core::core::{BlockHeader, BlockSums};
 use self::core::{consensus, global};
+use failure::Fail;
 use grin_core as core;
 use grin_keychain as keychain;
 
@@ -179,32 +180,44 @@ pub struct TxSource {
 }
 
 /// Possible errors when interacting with the transaction pool.
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum PoolError {
 	/// An invalid pool entry caused by underlying tx validation error
+	#[fail(display = "Invalid Tx {}", _0)]
 	InvalidTx(transaction::Error),
 	/// An invalid pool entry caused by underlying block validation error
+	#[fail(display = "Invalid Block {}", _0)]
 	InvalidBlock(block::Error),
 	/// Underlying keychain error.
+	#[fail(display = "Keychain error {}", _0)]
 	Keychain(keychain::Error),
 	/// Underlying "committed" error.
+	#[fail(display = "Committed error {}", _0)]
 	Committed(committed::Error),
 	/// Attempt to add a transaction to the pool with lock_height
 	/// greater than height of current block
+	#[fail(display = "Immature transaction")]
 	ImmatureTransaction,
 	/// Attempt to spend a coinbase output before it has sufficiently matured.
+	#[fail(display = "Immature coinbase")]
 	ImmatureCoinbase,
 	/// Problem propagating a stem tx to the next Dandelion relay node.
+	#[fail(display = "Dandelion error")]
 	DandelionError,
 	/// Transaction pool is over capacity, can't accept more transactions
+	#[fail(display = "Over capacity")]
 	OverCapacity,
 	/// Transaction fee is too low given its weight
+	#[fail(display = "Low fee transaction {}", _0)]
 	LowFeeTransaction(u64),
 	/// Attempt to add a duplicate output to the pool.
+	#[fail(display = "Duplicate commitment")]
 	DuplicateCommitment,
 	/// Attempt to add a duplicate tx to the pool.
+	#[fail(display = "Duplicate tx")]
 	DuplicateTx,
 	/// Other kinds of error (not yet pulled out into meaningful errors).
+	#[fail(display = "General pool error {}", _0)]
 	Other(String),
 }
 


### PR DESCRIPTION
It doesn't play nice with failure-based error management, we have to
throw away an exisiting error and create a new one (failure-based)