### PR TITLE
refactor: get rid of default implementation of Hashed trait for writable things

### DIFF
--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -14,7 +14,7 @@
 
 //! Lightweight readonly view into output MMR for convenience.
 
-use crate::core::core::hash::Hash;
+use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::pmmr::{self, ReadonlyPMMR};
 use crate::core::core::{Block, BlockHeader, Input, Output, Transaction};
 use crate::core::global;

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -73,10 +73,11 @@ impl Tip {
 			total_difficulty: header.total_difficulty(),
 		}
 	}
+}
 
-	/// *Really* easy to accidentally call hash() on a tip (thinking its a header).
-	/// So lets make hash() do the right thing here.
-	pub fn hash(&self) -> Hash {
+impl Hashed for Tip {
+	/// The hash of the underlying block.
+	fn hash(&self) -> Hash {
 		self.last_block_h
 	}
 }

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::consensus::{reward, REWARD};
 use crate::core::committed::{self, Committed};
 use crate::core::compact_block::{CompactBlock, CompactBlockBody};
-use crate::core::hash::{Hash, Hashed, ZERO_HASH};
+use crate::core::hash::{DefaultHashable, Hash, Hashed, ZERO_HASH};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{
 	transaction, Commitment, Input, Output, Transaction, TransactionBody, TxKernel, Weighting,
@@ -160,9 +160,9 @@ impl FixedLength for HeaderEntry {
 	const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
 }
 
-impl HeaderEntry {
+impl Hashed for HeaderEntry {
 	/// The hash of the underlying block.
-	pub fn hash(&self) -> Hash {
+	fn hash(&self) -> Hash {
 		self.hash
 	}
 }
@@ -197,6 +197,7 @@ pub struct BlockHeader {
 	/// Proof of work and related
 	pub pow: ProofOfWork,
 }
+impl DefaultHashable for BlockHeader {}
 
 impl Default for BlockHeader {
 	fn default() -> BlockHeader {
@@ -351,6 +352,13 @@ pub struct Block {
 	pub header: BlockHeader,
 	/// The body - inputs/outputs/kernels
 	body: TransactionBody,
+}
+
+impl Hashed for Block {
+	/// The hash of the underlying block.
+	fn hash(&self) -> Hash {
+		self.header.hash()
+	}
 }
 
 /// Implementation of Writeable for a block, defines how to write the block to a
@@ -568,11 +576,6 @@ impl Block {
 	/// Get kernels mut
 	pub fn kernels_mut(&mut self) -> &mut Vec<TxKernel> {
 		&mut self.body.kernels
-	}
-
-	/// Blockhash, computed using only the POW
-	pub fn hash(&self) -> Hash {
-		self.header.hash()
 	}
 
 	/// Sum of all fees (inputs less outputs) in the block

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -17,7 +17,7 @@
 use rand::{thread_rng, Rng};
 
 use crate::core::block::{Block, BlockHeader, Error};
-use crate::core::hash::Hashed;
+use crate::core::hash::{DefaultHashable, Hashed};
 use crate::core::id::ShortIdentifiable;
 use crate::core::{Output, ShortId, TxKernel};
 use crate::ser::{self, read_multi, Readable, Reader, VerifySortedAndUnique, Writeable, Writer};
@@ -136,6 +136,8 @@ pub struct CompactBlock {
 	/// Container for out_full, kern_full and kern_ids in the compact block.
 	body: CompactBlockBody,
 }
+
+impl DefaultHashable for CompactBlock {}
 
 impl CompactBlock {
 	/// "Lightweight" validation.

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 use byteorder::{ByteOrder, LittleEndian};
 use siphasher::sip::SipHasher24;
 
-use crate::core::hash::{Hash, Hashed};
+use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::ser::{self, Readable, Reader, Writeable, Writer};
 use crate::util;
 
@@ -73,6 +73,7 @@ impl<H: Hashed> ShortIdentifiable for H {
 #[derive(Clone, Serialize, Deserialize, Hash)]
 pub struct ShortId([u8; 6]);
 
+impl DefaultHashable for ShortId {}
 /// We want to sort short_ids in a canonical and consistent manner so we can
 /// verify sort order in the same way we do for full inputs|outputs|kernels
 /// themselves.
@@ -167,6 +168,8 @@ mod test {
 				Ok(())
 			}
 		}
+
+		impl DefaultHashable for Foo {}
 
 		let foo = Foo(0);
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -14,7 +14,7 @@
 
 //! Transactions
 
-use crate::core::hash::Hashed;
+use crate::core::hash::{DefaultHashable, Hashed};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{committed, Committed};
 use crate::keychain::{self, BlindingFactor};
@@ -49,6 +49,8 @@ enum_from_primitive! {
 		HeightLocked = 2,
 	}
 }
+
+impl DefaultHashable for KernelFeatures {}
 
 impl Writeable for KernelFeatures {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
@@ -170,6 +172,7 @@ pub struct TxKernel {
 	pub excess_sig: secp::Signature,
 }
 
+impl DefaultHashable for TxKernel {}
 hashable_ord!(TxKernel);
 
 impl ::std::hash::Hash for TxKernel {
@@ -761,6 +764,8 @@ pub struct Transaction {
 	body: TransactionBody,
 }
 
+impl DefaultHashable for Transaction {}
+
 /// PartialEq
 impl PartialEq for Transaction {
 	fn eq(&self, tx: &Transaction) -> bool {
@@ -1114,6 +1119,7 @@ pub struct Input {
 	pub commit: Commitment,
 }
 
+impl DefaultHashable for Input {}
 hashable_ord!(Input);
 
 impl ::std::hash::Hash for Input {
@@ -1219,6 +1225,7 @@ pub struct Output {
 	pub proof: RangeProof,
 }
 
+impl DefaultHashable for Output {}
 hashable_ord!(Output);
 
 impl ::std::hash::Hash for Output {
@@ -1330,6 +1337,8 @@ pub struct OutputIdentifier {
 	/// Output commitment
 	pub commit: Commitment,
 }
+
+impl DefaultHashable for OutputIdentifier {}
 
 impl OutputIdentifier {
 	/// Build a new output_identifier.

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -22,7 +22,7 @@ use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
-use crate::core::hash::Hashed;
+use crate::core::hash::{DefaultHashable, Hashed};
 use crate::global;
 use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
 
@@ -323,6 +323,8 @@ pub struct Proof {
 	/// The nonces
 	pub nonces: Vec<u64>,
 }
+
+impl DefaultHashable for Proof {}
 
 impl fmt::Debug for Proof {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -19,7 +19,7 @@
 //! To use it simply implement `Writeable` or `Readable` and then use the
 //! `serialize` or `deserialize` functions on them as appropriate.
 
-use crate::core::hash::{Hash, Hashed};
+use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
 use crate::util::read_write::read_exact;
 use crate::util::secp::constants::{
@@ -615,7 +615,7 @@ where
 			match elem {
 				Ok(e) => buf.push(e),
 				Err(Error::IOErr(ref _d, ref kind)) if *kind == io::ErrorKind::UnexpectedEof => {
-					break
+					break;
 				}
 				Err(e) => return Err(e),
 			}
@@ -706,7 +706,7 @@ pub trait FixedLength {
 }
 
 /// Trait for types that can be added to a PMMR.
-pub trait PMMRable: Writeable + Clone + Debug {
+pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	/// The type of element actually stored in the MMR data file.
 	/// This allows us to store Hash elements in the header MMR for variable size BlockHeaders.
 	type E: FixedLength + Readable + Writeable;
@@ -721,7 +721,7 @@ pub trait PMMRIndexHashable {
 	fn hash_with_index(&self, index: u64) -> Hash;
 }
 
-impl<T: Writeable> PMMRIndexHashable for T {
+impl<T: DefaultHashable> PMMRIndexHashable for T {
 	fn hash_with_index(&self, index: u64) -> Hash {
 		(index, self).hash()
 	}

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use self::core::core::hash::Hash;
+use self::core::core::hash::{DefaultHashable, Hash};
 use self::core::core::pmmr::{self, Backend};
 use self::core::core::BlockHeader;
 use self::core::ser;
@@ -24,6 +24,8 @@ use std::path::Path;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TestElem(pub [u32; 4]);
+
+impl DefaultHashable for TestElem {}
 
 impl FixedLength for TestElem {
 	const LEN: usize = 16;

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -29,6 +29,7 @@ use std::{cmp, thread};
 use crate::chain;
 use crate::common::stats::{StratumStats, WorkerStats};
 use crate::common::types::{StratumServerConfig, SyncState};
+use crate::core::core::hash::Hashed;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::Block;
 use crate::core::{pow, ser};

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -21,6 +21,7 @@ use std::fs;
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 
+use crate::core::core::hash::DefaultHashable;
 use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
 	Error, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
@@ -902,6 +903,8 @@ fn load(pos: u64, elems: &[TestElem], backend: &mut store::pmmr::PMMRBackend<Tes
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct TestElem(u32);
+
+impl DefaultHashable for TestElem {}
 
 impl FixedLength for TestElem {
 	const LEN: usize = 4;


### PR DESCRIPTION
This supersedes https://github.com/mimblewimble/grin/pull/2549 as an approach to refactor the Hashed trait. See #2549 for discussion on why this should be done.

For any struct which implements `DefaultHashable`, it automatically derives the Hashed trait.

We no longer have `hash_with` in the Hashed trait as it was only used by Hash, and there was no sane implementation for some implementations.

The only downside is we can no longer put things which are just `Hashed` into a PMMR, as we don't have tuple derivations for `Hashed`. If this becomes a need in the future, something can be figured out.

In future work, I would still like to rename the trait and it's functions, but it is not done here for minimal diff.