### PR TITLE
fix: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,6 +913,8 @@ version = "1.0.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_chain 1.0.1",
  "grin_core 1.0.1",
  "grin_keychain 1.0.1",


### PR DESCRIPTION
It seems a recent patch modified something but Cargo.lock didn't get committed.

This prevents a clean rebase on master.