### PR TITLE
chore/docs: eliminate warnings

### DIFF
--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -142,7 +142,7 @@ impl From<Request<Body>> for QueryParams {
 #[macro_export]
 macro_rules! right_path_element(
 	($req: expr) =>(
-		match $req.uri().path().trim_right_matches('/').rsplit('/').next() {
+		match $req.uri().path().trim_end_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
 		};

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -102,7 +102,7 @@ pub fn create_siphash_keys(header: &[u8]) -> Result<[u64; 4], Error> {
 	])
 }
 
-/// Macros to clean up integer unwrapping
+/// Macro to clean up u64 unwrapping
 #[macro_export]
 macro_rules! to_u64 {
 	($n:expr) => {
@@ -110,6 +110,7 @@ macro_rules! to_u64 {
 	};
 }
 
+/// Macro to clean up u64 unwrapping as u32
 #[macro_export]
 macro_rules! to_u32 {
 	($n:expr) => {
@@ -117,6 +118,7 @@ macro_rules! to_u32 {
 	};
 }
 
+/// Macro to clean up u64 unwrapping as usize
 #[macro_export]
 macro_rules! to_usize {
 	($n:expr) => {
@@ -124,6 +126,8 @@ macro_rules! to_usize {
 	};
 }
 
+/// Macro to clean up casting to edge type
+/// TODO: this macro uses unhygenic data T
 #[macro_export]
 macro_rules! to_edge {
 	($n:expr) => {

--- a/util/src/macros.rs
+++ b/util/src/macros.rs
@@ -28,6 +28,7 @@
 
 //! Macros to support Rust BIP-32 code (though could conceivably be used for other things)
 
+/// gives a newtype array wrapper standard array traits
 #[macro_export]
 macro_rules! impl_array_newtype {
 	($thing:ident, $ty:ty, $len:expr) => {
@@ -83,16 +84,6 @@ macro_rules! impl_array_newtype {
 				let mut ret = [0; $len];
 				ret.copy_from_slice(&data[..]);
 				$thing(ret)
-			}
-		}
-
-		impl ::std::ops::Index<usize> for $thing {
-			type Output = $ty;
-
-			#[inline]
-			fn index(&self, index: usize) -> &$ty {
-				let &$thing(ref dat) = self;
-				&dat[index]
 			}
 		}
 
@@ -164,6 +155,7 @@ macro_rules! impl_array_newtype {
 	};
 }
 
+/// gives a newtype array wrapper serialization and deserialization methods
 #[macro_export]
 macro_rules! impl_array_newtype_encodable {
 	($thing:ident, $ty:ty, $len:expr) => {
@@ -193,7 +185,7 @@ macro_rules! impl_array_newtype_encodable {
 							*item = match seq.next_element()? {
 								Some(c) => c,
 								None => {
-									return Err($crate::serde::de::Error::custom("end of stream"))
+									return Err($crate::serde::de::Error::custom("end of stream"));
 								}
 							};
 						}
@@ -218,6 +210,7 @@ macro_rules! impl_array_newtype_encodable {
 	};
 }
 
+/// gives a newtype array wrapper the Debug trait
 #[macro_export]
 macro_rules! impl_array_newtype_show {
 	($thing:ident) => {
@@ -229,9 +222,19 @@ macro_rules! impl_array_newtype_show {
 	};
 }
 
+/// gives a newtype array wrapper Index traits
 #[macro_export]
 macro_rules! impl_index_newtype {
 	($thing:ident, $ty:ty) => {
+		impl ::std::ops::Index<usize> for $thing {
+			type Output = $ty;
+
+			#[inline]
+			fn index(&self, index: usize) -> &$ty {
+				let &$thing(ref dat) = self;
+				&dat[index]
+			}
+		}
 		impl ::std::ops::Index<::std::ops::Range<usize>> for $thing {
 			type Output = [$ty];
 


### PR DESCRIPTION
Eliminates a few more documentation compiler warnings.

Replaces trim_right with trim_end (trim_right deprecates at 1.33.0, trim_end introduced at 1.30.0, we ask for 1.31+ in the build.md.

Moves the macro newtype array indexing trait impl into the right spot.

edit: documents an unhygenic macro use in to_edge