### PR TITLE
chain_data/grin.lock to prevent multiple grin processes running from same dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +956,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_api 1.0.1",
  "grin_chain 1.0.1",
@@ -3215,6 +3225,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 hyper = "0.12"
+fs2 = "0.4"
 futures = "0.1"
 http = "0.1"
 hyper-staticfile = "0.3"

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -48,6 +48,8 @@ pub enum Error {
 	Pool(pool::PoolError),
 	/// Invalid Arguments.
 	ArgumentError(String),
+	/// Error originating from some I/O operation (likely a file on disk).
+	IOError(std::io::Error),
 }
 
 impl From<core::block::Error> for Error {
@@ -60,7 +62,11 @@ impl From<chain::Error> for Error {
 		Error::Chain(e)
 	}
 }
-
+impl From<std::io::Error> for Error {
+	fn from(e: std::io::Error) -> Error {
+		Error::IOError(e)
+	}
+}
 impl From<p2p::Error> for Error {
 	fn from(e: p2p::Error) -> Error {
 		Error::P2P(e)


### PR DESCRIPTION
Uses fs2 to take an advisory file lock. Should work across platforms (*nix & windows).

https://docs.rs/fs2/0.4.3/fs2/trait.FileExt.html#tymethod.try_lock_exclusive

```
../target/release/grin server run
Failed to lock "/antiochp/grin/node_mainnet/chain_data/grin.lock" (grin server already running?)
```

This will prevent multiple `grin server` instances from being run (accidentally or otherwise) from the same `chain_data` dir.

This is believed to be one way a node can corrupt the backend files (two grin instances both writing to the same files).

----

This is new to me. I had no idea what a file lock really was... thought it was just creating a file and looking for the existence of said file...

> File locks are implemented with flock(2) on Unix and LockFile on Windows.

http://man7.org/linux/man-pages/man2/flock.2.html

Somewhat related - going down the rabbit hole here - https://gavv.github.io/articles/file-locks/#bsd-locks-flock