### PR TITLE
add a new configure item for log_max_files

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -521,7 +521,7 @@ fn comments() -> HashMap<String, String> {
 		"
 #maximum count of the log files to rotate over
 "
-			.to_string(),
+		.to_string(),
 	);
 
 	retval

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -516,6 +516,14 @@ fn comments() -> HashMap<String, String> {
 		.to_string(),
 	);
 
+	retval.insert(
+		"log_max_files".to_string(),
+		"
+#maximum count of the log files to rotate over
+"
+			.to_string(),
+	);
+
 	retval
 }
 

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 use backtrace::Backtrace;
 use std::{panic, thread};
 
-use crate::types::{LogLevel, LoggingConfig};
+use crate::types::{self, LogLevel, LoggingConfig};
 
 use log::{LevelFilter, Record};
 use log4rs;
@@ -124,7 +124,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
-					let count = c.log_max_files.unwrap_or_else(|| 32);
+					let count = c.log_max_files.unwrap_or_else(|| types::DEFAULT_ROTATE_LOG_FILES);
 					let roller = FixedWindowRoller::builder()
 						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
 						.unwrap();

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -124,7 +124,7 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
-					let count = c.log_max_files.unwrap_or_else(||32);
+					let count = c.log_max_files.unwrap_or_else(|| 32);
 					let roller = FixedWindowRoller::builder()
 						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
 						.unwrap();

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -124,7 +124,9 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
-					let count = c.log_max_files.unwrap_or_else(|| types::DEFAULT_ROTATE_LOG_FILES);
+					let count = c
+						.log_max_files
+						.unwrap_or_else(|| types::DEFAULT_ROTATE_LOG_FILES);
 					let roller = FixedWindowRoller::builder()
 						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
 						.unwrap();

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -124,8 +124,9 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
+					let count = c.log_max_files.unwrap_or_else(||32);
 					let roller = FixedWindowRoller::builder()
-						.build(&format!("{}.{{}}.gz", c.log_file_path), 32)
+						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
 						.unwrap();
 					let trigger = SizeTrigger::new(size);
 

--- a/util/src/types.rs
+++ b/util/src/types.rs
@@ -46,6 +46,8 @@ pub struct LoggingConfig {
 	pub log_file_append: bool,
 	/// Size of the log in bytes to rotate over (optional)
 	pub log_max_size: Option<u64>,
+	/// Number of the log files to rotate over (optional)
+	pub log_max_files: Option<u32>,
 	/// Whether the tui is running (optional)
 	pub tui_running: Option<bool>,
 }
@@ -60,6 +62,7 @@ impl Default for LoggingConfig {
 			log_file_path: String::from("grin.log"),
 			log_file_append: true,
 			log_max_size: Some(1024 * 1024 * 16), // 16 megabytes default
+			log_max_files: Some(32), // 32 log files to rotate over by default
 			tui_running: None,
 		}
 	}

--- a/util/src/types.rs
+++ b/util/src/types.rs
@@ -62,7 +62,7 @@ impl Default for LoggingConfig {
 			log_file_path: String::from("grin.log"),
 			log_file_append: true,
 			log_max_size: Some(1024 * 1024 * 16), // 16 megabytes default
-			log_max_files: Some(32), // 32 log files to rotate over by default
+			log_max_files: Some(32),              // 32 log files to rotate over by default
 			tui_running: None,
 		}
 	}

--- a/util/src/types.rs
+++ b/util/src/types.rs
@@ -29,6 +29,9 @@ pub enum LogLevel {
 	Trace,
 }
 
+/// 32 log files to rotate over by default
+pub const DEFAULT_ROTATE_LOG_FILES: u32 = 32 as u32;
+
 /// Logging config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LoggingConfig {
@@ -62,7 +65,7 @@ impl Default for LoggingConfig {
 			log_file_path: String::from("grin.log"),
 			log_file_append: true,
 			log_max_size: Some(1024 * 1024 * 16), // 16 megabytes default
-			log_max_files: Some(32),              // 32 log files to rotate over by default
+			log_max_files: Some(DEFAULT_ROTATE_LOG_FILES),
 			tui_running: None,
 		}
 	}


### PR DESCRIPTION
Currently the log rotation files limitation is hardcoded as 32 log files. That means at maximum we can only keep 512M logs by default (512M here refers to the original file size before gzip), the only way is to change / enlarge `log_max_size` configuration.

This PR add a new config `log_max_files`, default value is still `32`, to replace that hardcoded `count`.
