### PR TITLE
debug how long it takes to verify the kernel sums for fast sync

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1204,11 +1204,19 @@ impl<'a> Extension<'a> {
 	/// from the respective MMRs.
 	/// For a significantly faster way of validating full kernel sums see BlockSums.
 	pub fn validate_kernel_sums(&self) -> Result<((Commitment, Commitment)), Error> {
+		let now = Instant::now();
+
 		let genesis = self.get_header_by_height(0)?;
 		let (utxo_sum, kernel_sum) = self.verify_kernel_sums(
 			self.header.total_overage(genesis.kernel_mmr_size > 0),
 			self.header.total_kernel_offset(),
 		)?;
+
+		debug!(
+			"txhashset: validated total kernel sums, took {}s",
+			now.elapsed().as_secs(),
+		);
+
 		Ok((utxo_sum, kernel_sum))
 	}
 


### PR DESCRIPTION
Adds some useful logs showing how long it took to perform the `validate_kernel_sums` step during fast sync validation - 
```
20190219 12:33:39.813 DEBUG grin_chain::txhashset::txhashset - Rewind to header 0000040b27ca at 49956
20190219 12:33:39.813 DEBUG grin_chain::txhashset::txhashset - txhashset: rewind_to_pos: header 99907, output 957452, kernel 373415
20190219 12:33:40.261 DEBUG grin_chain::txhashset::txhashset - txhashset: validated the header 99907, output 957452, rproof 957452, kernel 373415 mmrs, took 0s
20190219 12:33:45.913 DEBUG grin_chain::txhashset::txhashset - txhashset: validated total kernel sums, took 5s
```