### PR TITLE
[WIP] problem identified with clean_output_index callback

### DIFF
--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -333,6 +333,13 @@ impl AppendOnlyFile {
 					if prune_at != buf_start {
 						writer.write_all(&buf[buf_start..prune_at])?;
 					} else {
+						// TODO - Two issues here, turning this into a no-op -
+						//
+						// 1) buf_start == prune_at (see above) so slice is "empty"
+						// 2) even if slice was not empty, its an output_identifier not a commitment
+						//
+						// The problem with passing raw slices of bytes around is we have no type safety.
+						// We are attempting to cleanup the output_pos index by commitment here.
 						prune_cb(&buf[buf_start..prune_at]);
 					}
 					buf_start = prune_at + (prune_len as usize);


### PR DESCRIPTION
We do not allow duplicate outputs in the UTXO set.

But we _do_ allow duplicates in the full TXO set.

The `compact` pruning logic does not correctly account for this when removing entries from the `output_pos` index and assumes they are unique across the entire TXO set.

I _think_ we can fix this by simply having the `clean_output_index` callback check for `is_unspent()` based on the actual entry in `output_pos` index not just blindly removing entries from the index.

----

Edit: Turns out the above _is_ a problem but not one we are actually encountering because we are hitting another issue prior to this - 

The `save_prune` logic is attempting to call `delete_output_pos` with an empty byte slice. So we never actually reconstruct the `output_pos` keys correctly (they are indexed by commitment).

We never actually delete _any_ entries from the `output_pos` index.

