### PR TITLE
Simplify (and fix) output_pos cleanup during chain compaction

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -955,7 +955,7 @@ impl Chain {
 	/// Cleanup old blocks from the db.
 	/// Determine the cutoff height from the horizon and the current block height.
 	/// *Only* runs if we are not in archive mode.
-	fn compact_blocks_db(&self) -> Result<(), Error> {
+	fn remove_historical_blocks(&self) -> Result<(), Error> {
 		if self.archive_mode {
 			return Ok(());
 		}
@@ -971,7 +971,7 @@ impl Chain {
 		let cutoff = head.height.saturating_sub(horizon);
 
 		debug!(
-			"compact_blocks_db: head height: {}, tail height: {}, horizon: {}, cutoff: {}",
+			"remove_historical_blocks: head height: {}, tail height: {}, horizon: {}, cutoff: {}",
 			head.height, tail.height, horizon, cutoff,
 		);
 
@@ -1013,7 +1013,7 @@ impl Chain {
 		batch.save_body_tail(&Tip::from_header(&tail))?;
 		batch.commit()?;
 		debug!(
-			"compact_blocks_db: removed {} blocks. tail height: {}",
+			"remove_historical_blocks: removed {} blocks. tail height: {}",
 			count, tail.height
 		);
 		Ok(())
@@ -1028,7 +1028,7 @@ impl Chain {
 		self.compact_txhashset()?;
 
 		if !self.archive_mode {
-			self.compact_blocks_db()?;
+			self.remove_historical_blocks()?;
 		}
 
 		Ok(())

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -89,9 +89,15 @@ pub enum ErrorKind {
 	/// Error validating a Merkle proof (coinbase output)
 	#[fail(display = "Error validating merkle proof")]
 	MerkleProof,
-	/// output not found
+	/// Output not found
 	#[fail(display = "Output not found")]
 	OutputNotFound,
+	/// Rangeproof not found
+	#[fail(display = "Rangeproof not found")]
+	RangeproofNotFound,
+	/// Tx kernel not found
+	#[fail(display = "Tx kernel not found")]
+	TxKernelNotFound,
 	/// output spent
 	#[fail(display = "Output is spent")]
 	OutputSpent,

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -250,10 +250,10 @@ impl<'a> Batch<'a> {
 		)
 	}
 
-	pub fn delete_output_pos(&self, commit: &[u8]) -> Result<(), Error> {
-		self.db
-			.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
-	}
+	// pub fn delete_output_pos(&self, commit: &[u8]) -> Result<(), Error> {
+	// 	self.db
+	// 		.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
+	// }
 
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		self.get_block_header(&header.prev_hash)

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -51,12 +51,13 @@ impl ChainStore {
 	}
 }
 
-#[allow(missing_docs)]
 impl ChainStore {
+	/// The current chain head.
 	pub fn head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![HEAD_PREFIX]), "HEAD")
 	}
 
+	/// The current chain "tail" (earliest block in the store).
 	pub fn tail(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![TAIL_PREFIX]), "TAIL")
 	}
@@ -71,10 +72,12 @@ impl ChainStore {
 		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), "HEADER_HEAD")
 	}
 
+	/// The "sync" head.
 	pub fn get_sync_head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]), "SYNC_HEAD")
 	}
 
+	/// Get full block.
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_PREFIX, &mut h.to_vec())),
@@ -82,10 +85,12 @@ impl ChainStore {
 		)
 	}
 
+	/// Does this full block exist?
 	pub fn block_exists(&self, h: &Hash) -> Result<bool, Error> {
 		self.db.exists(&to_key(BLOCK_PREFIX, &mut h.to_vec()))
 	}
 
+	/// Get block_sums for the block hash.
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
@@ -93,10 +98,12 @@ impl ChainStore {
 		)
 	}
 
+	/// Get previous header.
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		self.get_block_header(&header.prev_hash)
 	}
 
+	/// Get block header.
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
 			self.db
@@ -105,6 +112,7 @@ impl ChainStore {
 		)
 	}
 
+	/// Get PMMR pos for the given output commitment.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		option_to_not_found(
 			self.db
@@ -127,12 +135,13 @@ pub struct Batch<'a> {
 	db: store::Batch<'a>,
 }
 
-#[allow(missing_docs)]
 impl<'a> Batch<'a> {
+	/// The head.
 	pub fn head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![HEAD_PREFIX]), "HEAD")
 	}
 
+	/// The tail.
 	pub fn tail(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![TAIL_PREFIX]), "TAIL")
 	}
@@ -147,27 +156,33 @@ impl<'a> Batch<'a> {
 		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), "HEADER_HEAD")
 	}
 
+	/// Get "sync" head.
 	pub fn get_sync_head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]), "SYNC_HEAD")
 	}
 
+	/// Save head to db.
 	pub fn save_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![HEAD_PREFIX], t)?;
 		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)
 	}
 
+	/// Save body head to db.
 	pub fn save_body_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![HEAD_PREFIX], t)
 	}
 
+	/// Save body "tail" to db.
 	pub fn save_body_tail(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![TAIL_PREFIX], t)
 	}
 
+	/// Save header_head to db.
 	pub fn save_header_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)
 	}
 
+	/// Save "sync" head to db.
 	pub fn save_sync_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
@@ -192,6 +207,7 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	/// Does the block exist?
 	pub fn block_exists(&self, h: &Hash) -> Result<bool, Error> {
 		self.db.exists(&to_key(BLOCK_PREFIX, &mut h.to_vec()))
 	}
@@ -225,6 +241,7 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Save block header to db.
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
 		let hash = header.hash();
 
@@ -235,6 +252,7 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Save output_pos to index.
 	pub fn save_output_pos(&self, commit: &Commitment, pos: u64) -> Result<(), Error> {
 		self.db.put_ser(
 			&to_key(COMMIT_POS_PREFIX, &mut commit.as_ref().to_vec())[..],
@@ -242,6 +260,7 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	/// Get output_pos from index.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		option_to_not_found(
 			self.db
@@ -250,15 +269,21 @@ impl<'a> Batch<'a> {
 		)
 	}
 
-	// pub fn delete_output_pos(&self, commit: &[u8]) -> Result<(), Error> {
-	// 	self.db
-	// 		.delete(&to_key(COMMIT_POS_PREFIX, &mut commit.to_vec()))
-	// }
+	/// Clear all entries from the output_pos index (must be rebuilt after).
+	pub fn clear_output_pos(&self) -> Result<(), Error> {
+		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
+		for (k, _) in self.db.iter::<u64>(&key).unwrap() {
+			self.db.delete(&k)?;
+		}
+		Ok(())
+	}
 
+	/// Get the previous header.
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		self.get_block_header(&header.prev_hash)
 	}
 
+	/// Get block header.
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
 			self.db
@@ -267,6 +292,7 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	/// Save the input bitmap for the block.
 	fn save_block_input_bitmap(&self, bh: &Hash, bm: &Bitmap) -> Result<(), Error> {
 		self.db.put(
 			&to_key(BLOCK_INPUT_BITMAP_PREFIX, &mut bh.to_vec())[..],
@@ -274,16 +300,19 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	/// Delete the block input bitmap.
 	fn delete_block_input_bitmap(&self, bh: &Hash) -> Result<(), Error> {
 		self.db
 			.delete(&to_key(BLOCK_INPUT_BITMAP_PREFIX, &mut bh.to_vec()))
 	}
 
+	/// Save block_sums for the block.
 	pub fn save_block_sums(&self, h: &Hash, sums: &BlockSums) -> Result<(), Error> {
 		self.db
 			.put_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())[..], &sums)
 	}
 
+	/// Get block_sums for the block.
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())),
@@ -291,10 +320,12 @@ impl<'a> Batch<'a> {
 		)
 	}
 
+	/// Delete the block_sums for the block.
 	fn delete_block_sums(&self, bh: &Hash) -> Result<(), Error> {
 		self.db.delete(&to_key(BLOCK_SUMS_PREFIX, &mut bh.to_vec()))
 	}
 
+	/// Build the input bitmap for the given block.
 	fn build_block_input_bitmap(&self, block: &Block) -> Result<Bitmap, Error> {
 		let bitmap = block
 			.inputs()
@@ -305,6 +336,7 @@ impl<'a> Batch<'a> {
 		Ok(bitmap)
 	}
 
+	/// Build and store the input bitmap for the given block.
 	fn build_and_store_block_input_bitmap(&self, block: &Block) -> Result<Bitmap, Error> {
 		// Build the bitmap.
 		let bitmap = self.build_block_input_bitmap(block)?;
@@ -315,8 +347,8 @@ impl<'a> Batch<'a> {
 		Ok(bitmap)
 	}
 
-	// Get the block input bitmap from the db or build the bitmap from
-	// the full block from the db (if the block is found).
+	/// Get the block input bitmap from the db or build the bitmap from
+	/// the full block from the db (if the block is found).
 	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
 		if let Ok(Some(bytes)) = self
 			.db

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -205,19 +205,25 @@ impl TxHashSet {
 			.get_last_n_insertions(distance)
 	}
 
-	/// Get the header at the specified height based on the current state of the txhashset.
-	/// Derives the MMR pos from the height (insertion index) and retrieves the header hash.
-	/// Looks the header up in the db by hash.
-	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
+	/// Get the header hash at the specified height based on the current state of the txhashset.
+	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
 		let pos = pmmr::insertion_to_pmmr_index(height + 1);
 		let header_pmmr =
 			ReadonlyPMMR::at(&self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
 		if let Some(entry) = header_pmmr.get_data(pos) {
-			let header = self.commit_index.get_block_header(&entry.hash())?;
-			Ok(header)
+			Ok(entry.hash())
 		} else {
-			Err(ErrorKind::Other(format!("get header by height")).into())
+			Err(ErrorKind::Other(format!("get header hash by height")).into())
 		}
+	}
+
+	/// Get the header at the specified height based on the current state of the txhashset.
+	/// Derives the MMR pos from the height (insertion index) and retrieves the header hash.
+	/// Looks the header up in the db by hash.
+	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
+		let hash = self.get_header_hash_by_height(height)?;
+		let header = self.commit_index.get_block_header(&hash)?;
+		Ok(header)
 	}
 
 	/// returns outputs from the given insertion (leaf) index up to the
@@ -279,31 +285,30 @@ impl TxHashSet {
 	}
 
 	/// Compact the MMR data files and flush the rm logs
-	pub fn compact(&mut self) -> Result<(), Error> {
-		let commit_index = self.commit_index.clone();
-		let head_header = commit_index.head_header()?;
+	pub fn compact(&mut self, batch: &mut Batch<'_>) -> Result<(), Error> {
+		debug!("txhashset: starting compaction...");
+
+		let head_header = batch.head_header()?;
 		let current_height = head_header.height;
 
 		// horizon for compacting is based on current_height
-		let horizon = current_height.saturating_sub(global::cut_through_horizon().into());
-		let horizon_header = self.get_header_by_height(horizon)?;
+		let horizon_height = current_height.saturating_sub(global::cut_through_horizon().into());
+		let horizon_hash = self.get_header_hash_by_height(horizon_height)?;
+		let horizon_header = batch.get_block_header(&horizon_hash)?;
 
-		let batch = self.commit_index.batch()?;
+		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, batch)?;
 
-		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, &batch)?;
-
+		debug!("txhashset: check_compact output mmr backend...");
 		self.output_pmmr_h
 			.backend
 			.check_compact(horizon_header.output_mmr_size, &rewind_rm_pos)?;
 
+		debug!("txhashset: check_compact rangeproof mmr backend...");
 		self.rproof_pmmr_h
 			.backend
 			.check_compact(horizon_header.output_mmr_size, &rewind_rm_pos)?;
 
-		// Cleanup output_pos index to reflect current UTXO set.
-
-		// Finally commit the batch, saving everything to the db.
-		batch.commit()?;
+		debug!("txhashset: ... compaction finished");
 
 		Ok(())
 	}
@@ -1248,10 +1253,9 @@ impl<'a> Extension<'a> {
 	pub fn rebuild_index(&self) -> Result<(), Error> {
 		let now = Instant::now();
 
-		// TODO - clear the index out first (via iterator on db?)
+		self.batch.clear_output_pos()?;
 
 		let mut count = 0;
-
 		for pos in self.output_pmmr.leaf_pos_iter() {
 			if let Some(out) = self.output_pmmr.get_data(pos) {
 				self.batch.save_output_pos(&out.commit, pos)?;
@@ -1260,7 +1264,7 @@ impl<'a> Extension<'a> {
 		}
 
 		debug!(
-			"txhashset: rebuild_index ({} UTXOs), took {}s",
+			"txhashset: rebuild_index: {} UTXOs, took {}s",
 			count,
 			now.elapsed().as_secs(),
 		);
@@ -1313,13 +1317,23 @@ impl<'a> Extension<'a> {
 		let total_kernels = pmmr::n_leaves(self.kernel_pmmr.unpruned_size());
 		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
 			if pmmr::is_leaf(n) {
-				if let Some(kernel) = self.kernel_pmmr.get_data(n) {
-					kernel.verify()?;
-					kern_count += 1;
+				let kernel = self
+					.kernel_pmmr
+					.get_data(n)
+					.ok_or::<Error>(ErrorKind::TxKernelNotFound.into())?;
+
+				kernel.verify()?;
+				kern_count += 1;
+
+				if kern_count % 20 == 0 {
+					status.on_validation(kern_count, total_kernels, 0, 0);
 				}
-			}
-			if kern_count % 20 == 0 {
-				status.on_validation(kern_count, total_kernels, 0, 0);
+				if kern_count % 1_000 == 0 {
+					debug!(
+						"txhashset: verify_kernel_signatures: verified {} signatures",
+						kern_count,
+					);
+				}
 			}
 		}
 
@@ -1342,30 +1356,30 @@ impl<'a> Extension<'a> {
 		let mut proof_count = 0;
 		let total_rproofs = pmmr::n_leaves(self.output_pmmr.unpruned_size());
 		for pos in self.output_pmmr.leaf_pos_iter() {
-			if let Some(out) = self.output_pmmr.get_data(pos) {
-				if let Some(rp) = self.rproof_pmmr.get_data(pos) {
-					commits.push(out.commit);
-					proofs.push(rp);
-				} else {
-					// TODO - rangeproof not found
-					// We expect to have a rangeproof for every unspent UTXO.
-					return Err(ErrorKind::OutputNotFound.into());
-				}
-				proof_count += 1;
+			let out = self
+				.output_pmmr
+				.get_data(pos)
+				.ok_or::<Error>(ErrorKind::OutputNotFound.into())?;
+			commits.push(out.commit);
 
-				if proofs.len() >= 1_000 {
-					Output::batch_verify_proofs(&commits, &proofs)?;
-					commits.clear();
-					proofs.clear();
-					debug!(
-						"txhashset: verify_rangeproofs: verified {} rangeproofs",
-						proof_count,
-					);
-				}
-			} else {
-				// We expect to have an output for every unspent UTXO.
-				return Err(ErrorKind::OutputNotFound.into());
+			let proof = self
+				.rproof_pmmr
+				.get_data(pos)
+				.ok_or::<Error>(ErrorKind::RangeproofNotFound.into())?;
+			proofs.push(proof);
+
+			proof_count += 1;
+
+			if proofs.len() >= 1_000 {
+				Output::batch_verify_proofs(&commits, &proofs)?;
+				commits.clear();
+				proofs.clear();
+				debug!(
+					"txhashset: verify_rangeproofs: verified {} rangeproofs",
+					proof_count,
+				);
 			}
+
 			if proof_count % 20 == 0 {
 				status.on_validation(0, 0, proof_count, total_rproofs);
 			}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1248,11 +1248,14 @@ impl<'a> Extension<'a> {
 	pub fn rebuild_index(&self) -> Result<(), Error> {
 		let now = Instant::now();
 
+		// TODO - clear the index out first (via iterator on db?)
+
 		let mut count = 0;
 
 		for pos in self.output_pmmr.leaf_pos_iter() {
 			if let Some(out) = self.output_pmmr.get_data(pos) {
 				self.batch.save_output_pos(&out.commit, pos)?;
+				count += 1;
 			}
 		}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1348,11 +1348,12 @@ impl<'a> Extension<'a> {
 					proofs.push(rp);
 				} else {
 					// TODO - rangeproof not found
+					// We expect to have a rangeproof for every unspent UTXO.
 					return Err(ErrorKind::OutputNotFound.into());
 				}
 				proof_count += 1;
 
-				if proofs.len() >= 1000 {
+				if proofs.len() >= 1_000 {
 					Output::batch_verify_proofs(&commits, &proofs)?;
 					commits.clear();
 					proofs.clear();
@@ -1361,6 +1362,9 @@ impl<'a> Extension<'a> {
 						proof_count,
 					);
 				}
+			} else {
+				// We expect to have an output for every unspent UTXO.
+				return Err(ErrorKind::OutputNotFound.into());
 			}
 			if proof_count % 20 == 0 {
 				status.on_validation(0, 0, proof_count, total_rproofs);

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -52,7 +52,7 @@ pub trait Backend<T: PMMRable> {
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
-	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a>;
+	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_>;
 
 	/// Remove Hash by insertion position. An index is also provided so the
 	/// underlying backend can implement some rollback of positions up to a

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -51,6 +51,8 @@ pub trait Backend<T: PMMRable> {
 	/// (ignoring the remove log).
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
+	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a>;
+
 	/// Remove Hash by insertion position. An index is also provided so the
 	/// underlying backend can implement some rollback of positions up to a
 	/// given index (practically the index is the height of a block that

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -51,6 +51,7 @@ pub trait Backend<T: PMMRable> {
 	/// (ignoring the remove log).
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
+	/// Iterator over current (unpruned, unremoved) leaf positions.
 	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a>;
 
 	/// Remove Hash by insertion position. An index is also provided so the

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -75,6 +75,7 @@ where
 		ReadonlyPMMR::at(&self.backend, self.last_pos)
 	}
 
+	/// Iterator over current (unpruned, unremoved) leaf positions.
 	pub fn leaf_pos_iter(&'a self) -> Box<Iterator<Item = u64> + 'a> {
 		self.backend.leaf_pos_iter()
 	}

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -76,7 +76,7 @@ where
 	}
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
-	pub fn leaf_pos_iter(&'a self) -> Box<Iterator<Item = u64> + 'a> {
+	pub fn leaf_pos_iter(&self) -> impl Iterator<Item = u64> + '_ {
 		self.backend.leaf_pos_iter()
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -75,6 +75,10 @@ where
 		ReadonlyPMMR::at(&self.backend, self.last_pos)
 	}
 
+	pub fn leaf_pos_iter(&'a self) -> Box<Iterator<Item = u64> + 'a> {
+		self.backend.leaf_pos_iter()
+	}
+
 	/// Returns a vec of the peaks of this MMR.
 	pub fn peaks(&self) -> Vec<Hash> {
 		let peaks_pos = peaks(self.last_pos);

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -104,6 +104,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		Some(data.as_elmt())
 	}
 
+	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_> {
+		unimplemented!()
+	}
+
 	fn remove(&mut self, position: u64) -> Result<(), String> {
 		self.remove_list.push(position);
 		Ok(())

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -157,6 +157,7 @@ impl PeerStore {
 		let mut peers = self
 			.db
 			.iter::<PeerData>(&to_key(PEER_PREFIX, &mut "".to_string().into_bytes()))?
+			.map(|(_, v)| v)
 			.filter(|p| p.flags == state && p.capabilities.contains(cap))
 			.collect::<Vec<_>>();
 		thread_rng().shuffle(&mut peers[..]);
@@ -167,7 +168,10 @@ impl PeerStore {
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
 		let key = to_key(PEER_PREFIX, &mut "".to_string().into_bytes());
-		Ok(self.db.iter::<PeerData>(&key)?.collect::<Vec<_>>())
+		Ok(self.db
+			.iter::<PeerData>(&key)?
+			.map(|(_, v)| v)
+			.collect::<Vec<_>>())
 	}
 
 	/// Convenience method to load a peer data, update its status and save it

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -201,7 +201,7 @@ impl LeafSet {
 	}
 
 	/// Iterator over positionns in the leaf_set (all leaf positions).
-	pub fn iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
-		Box::new(self.bitmap.iter().map(|x| x as u64))
+	pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
+		self.bitmap.iter().map(|x| x as u64)
 	}
 }

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -199,4 +199,8 @@ impl LeafSet {
 	pub fn is_empty(&self) -> bool {
 		self.len() == 0
 	}
+
+	pub fn iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
+		Box::new(self.bitmap.iter().map(|x| x as u64))
+	}
 }

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -200,6 +200,7 @@ impl LeafSet {
 		self.len() == 0
 	}
 
+	/// Iterator over positionns in the leaf_set (all leaf positions).
 	pub fn iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
 		Box::new(self.bitmap.iter().map(|x| x as u64))
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -124,7 +124,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Returns an iterator over all the leaf positions.
 	/// for a prunable PMMR this is an iterator over the leaf_set bitmap.
 	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).
-	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
+	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_> {
 		if self.prunable {
 			Box::new(self.leaf_set.iter())
 		} else {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -21,7 +21,7 @@ use crate::core::core::BlockHeader;
 use crate::core::ser::PMMRable;
 use crate::leaf_set::LeafSet;
 use crate::prune_list::PruneList;
-use crate::types::{prune_noop, DataFile};
+use crate::types::DataFile;
 use croaring::Bitmap;
 use std::path::{Path, PathBuf};
 
@@ -119,6 +119,10 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			return None;
 		}
 		self.get_data_from_file(pos)
+	}
+
+	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
+		self.leaf_set.iter()
 	}
 
 	/// Rewind the PMMR backend to the given position.
@@ -278,15 +282,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 	/// aligned. The block_marker in the db/index for the particular block
 	/// will have a suitable output_pos. This is used to enforce a horizon
 	/// after which the local node should have all the data to allow rewinding.
-	pub fn check_compact<P>(
-		&mut self,
-		cutoff_pos: u64,
-		rewind_rm_pos: &Bitmap,
-		prune_cb: P,
-	) -> io::Result<bool>
-	where
-		P: Fn(&[u8]),
-	{
+	pub fn check_compact(&mut self, cutoff_pos: u64, rewind_rm_pos: &Bitmap) -> io::Result<bool> {
 		assert!(self.prunable, "Trying to compact a non-prunable PMMR");
 
 		// Paths for tmp hash and data files.
@@ -306,7 +302,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			});
 
 			self.hash_file
-				.save_prune(&tmp_prune_file_hash, &off_to_rm, &prune_noop)?;
+				.save_prune(&tmp_prune_file_hash, &off_to_rm)?;
 		}
 
 		// 2. Save compact copy of the data file, skipping removed leaves.
@@ -324,7 +320,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			});
 
 			self.data_file
-				.save_prune(&tmp_prune_file_data, &off_to_rm, prune_cb)?;
+				.save_prune(&tmp_prune_file_data, &off_to_rm)?;
 		}
 
 		// 3. Update the prune list and write to disk.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -121,8 +121,15 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.get_data_from_file(pos)
 	}
 
+	/// Returns an iterator over all the leaf positions.
+	/// for a prunable PMMR this is an iterator over the leaf_set bitmap.
+	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).
 	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
-		self.leaf_set.iter()
+		if self.prunable {
+			self.leaf_set.iter()
+		} else {
+			panic!("leaf_pos_iter not implemented for non-prunable PMMR")
+		}
 	}
 
 	/// Rewind the PMMR backend to the given position.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -126,7 +126,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).
 	fn leaf_pos_iter<'a>(&'a self) -> Box<Iterator<Item = u64> + 'a> {
 		if self.prunable {
-			self.leaf_set.iter()
+			Box::new(self.leaf_set.iter())
 		} else {
 			panic!("leaf_pos_iter not implemented for non-prunable PMMR")
 		}

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -26,7 +26,6 @@ use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
 	Error, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
 };
-use crate::store::types::prune_noop;
 
 #[test]
 fn pmmr_append() {
@@ -128,9 +127,7 @@ fn pmmr_compact_leaf_sibling() {
 		assert_eq!(backend.get_from_file(1).unwrap(), pos_1_hash);
 
 		// aggressively compact the PMMR files
-		backend
-			.check_compact(1, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(1, &Bitmap::create()).unwrap();
 
 		// check pos 1, 2, 3 are in the state we expect after compacting
 		{
@@ -188,9 +185,7 @@ fn pmmr_prune_compact() {
 		}
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 
 		// recheck the root and stored data
 		{
@@ -236,9 +231,7 @@ fn pmmr_reload() {
 			backend.sync().unwrap();
 
 			// now check and compact the backend
-			backend
-				.check_compact(1, &Bitmap::create(), &prune_noop)
-				.unwrap();
+			backend.check_compact(1, &Bitmap::create()).unwrap();
 			backend.sync().unwrap();
 
 			// prune another node to force compact to actually do something
@@ -249,9 +242,7 @@ fn pmmr_reload() {
 			}
 			backend.sync().unwrap();
 
-			backend
-				.check_compact(4, &Bitmap::create(), &prune_noop)
-				.unwrap();
+			backend.check_compact(4, &Bitmap::create()).unwrap();
 			backend.sync().unwrap();
 
 			assert_eq!(backend.unpruned_size(), mmr_size);
@@ -351,9 +342,7 @@ fn pmmr_rewind() {
 		}
 
 		// and compact the MMR to remove the pruned elements
-		backend
-			.check_compact(6, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(6, &Bitmap::create()).unwrap();
 		backend.sync().unwrap();
 
 		println!("after compacting - ");
@@ -453,9 +442,7 @@ fn pmmr_compact_single_leaves() {
 		backend.sync().unwrap();
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
@@ -466,9 +453,7 @@ fn pmmr_compact_single_leaves() {
 		backend.sync().unwrap();
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 	}
 
 	teardown(data_dir);
@@ -499,9 +484,7 @@ fn pmmr_compact_entire_peak() {
 		backend.sync().unwrap();
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 
 		// now check we have pruned up to and including the peak at pos 7
 		// hash still available in underlying hash file
@@ -587,9 +570,7 @@ fn pmmr_compact_horizon() {
 			}
 
 			// compact
-			backend
-				.check_compact(4, &Bitmap::of(&vec![1, 2]), &prune_noop)
-				.unwrap();
+			backend.check_compact(4, &Bitmap::of(&vec![1, 2])).unwrap();
 			backend.sync().unwrap();
 
 			// check we can read a hash by pos correctly after compaction
@@ -644,9 +625,7 @@ fn pmmr_compact_horizon() {
 			}
 
 			// compact some more
-			backend
-				.check_compact(9, &Bitmap::create(), &prune_noop)
-				.unwrap();
+			backend.check_compact(9, &Bitmap::create()).unwrap();
 		}
 
 		// recheck stored data
@@ -711,9 +690,7 @@ fn compact_twice() {
 		}
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 
 		// recheck the root and stored data
 		{
@@ -740,9 +717,7 @@ fn compact_twice() {
 		}
 
 		// compact
-		backend
-			.check_compact(2, &Bitmap::create(), &prune_noop)
-			.unwrap();
+		backend.check_compact(2, &Bitmap::create()).unwrap();
 
 		// recheck the root and stored data
 		{

--- a/wallet/src/lmdb_wallet.rs
+++ b/wallet/src/lmdb_wallet.rs
@@ -242,7 +242,7 @@ where
 	}
 
 	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = OutputData> + 'a> {
-		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap())
+		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap().map(|(_, v)| v))
 	}
 
 	fn get_tx_log_entry(&self, u: &Uuid) -> Result<Option<TxLogEntry>, Error> {
@@ -251,7 +251,12 @@ where
 	}
 
 	fn tx_log_iter<'a>(&'a self) -> Box<dyn Iterator<Item = TxLogEntry> + 'a> {
-		Box::new(self.db.iter(&[TX_LOG_ENTRY_PREFIX]).unwrap())
+		Box::new(
+			self.db
+				.iter(&[TX_LOG_ENTRY_PREFIX])
+				.unwrap()
+				.map(|(_, v)| v),
+		)
 	}
 
 	fn get_private_context(&mut self, slate_id: &[u8]) -> Result<Context, Error> {
@@ -272,7 +277,12 @@ where
 	}
 
 	fn acct_path_iter<'a>(&'a self) -> Box<dyn Iterator<Item = AcctPathMapping> + 'a> {
-		Box::new(self.db.iter(&[ACCOUNT_PATH_MAPPING_PREFIX]).unwrap())
+		Box::new(
+			self.db
+				.iter(&[ACCOUNT_PATH_MAPPING_PREFIX])
+				.unwrap()
+				.map(|(_, v)| v),
+		)
 	}
 
 	fn get_acct_path(&self, label: String) -> Result<Option<AcctPathMapping>, Error> {
@@ -418,7 +428,8 @@ where
 				.as_ref()
 				.unwrap()
 				.iter(&[OUTPUT_PREFIX])
-				.unwrap(),
+				.unwrap()
+				.map(|(_, v)| v),
 		)
 	}
 
@@ -456,7 +467,8 @@ where
 				.as_ref()
 				.unwrap()
 				.iter(&[TX_LOG_ENTRY_PREFIX])
-				.unwrap(),
+				.unwrap()
+				.map(|(_, v)| v),
 		)
 	}
 
@@ -525,7 +537,8 @@ where
 				.as_ref()
 				.unwrap()
 				.iter(&[ACCOUNT_PATH_MAPPING_PREFIX])
-				.unwrap(),
+				.unwrap()
+				.map(|(_, v)| v),
 		)
 	}
 


### PR DESCRIPTION
Our existing approach to cleaning up the `output_pos` index was flawed for a variety of reasons.
See #2603 and #2606 for details.

Resolves #2606.

tl;dr lack of type safety from passing around a slice of bytes caused us to never remove old entries from the `output_pos` index. Additionally we could not safely delete them based on the callbacks during pruning as we allow duplicates across full TXO set (both spent and unspent).

This PR implements a simplified approach to maintaining the `output_pos` index - during compaction we simply clear out the existing index and rebuild it from scratch based on current UTXO set.

* Removed the callback in check_compact (passing a raw byte slice around)
* Expose `(key, value)` in our `SerIterator` db iterator.
* Use a single db `batch` for the entire chain `compact()` process.
* Rename `compact_blocks_db -> remove_historical_blocks` (`compact_block` used elsewhere)
* Introduces `leaf_pos_iter()` on the PMMR backend 
    * we can now conveniently iterate over unspent outputs in the output PMMR
* Reworked and simplified `output_pos` maintenance during chain compaction - 
    * clear the index out (using the iterator on the db), then
    * rebuild the index (using the iterator on the PMMR backend)
* Reworked `verify_rangeproofs()` to use the new leaf_pos iterator
* Reworked `verify_kernel_signatures()` for consistency

----

Compaction is pretty fast overall (~1.5s on mainnet at height 51,000).
Rebuilding the full `output_pos` index is a fraction of this -

```
20190220 15:21:10.202 DEBUG grin_chain::txhashset::txhashset - txhashset: starting compaction...
20190220 15:21:10.543 DEBUG grin_chain::txhashset::txhashset - txhashset: check_compact output mmr backend...
20190220 15:21:10.943 DEBUG grin_chain::txhashset::txhashset - txhashset: check_compact rangeproof mmr backend...
20190220 15:21:11.468 DEBUG grin_chain::txhashset::txhashset - txhashset: ... compaction finished
20190220 15:21:11.556 DEBUG grin_chain::txhashset::txhashset - txhashset: rebuild_index: 36920 UTXOs, took 0s
```


