### PR TITLE
[WIP] Cache Hash Computations

### DIFF
--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -14,7 +14,7 @@
 
 //! Base types that the block chain pipeline requires.
 
-use crate::core::core::hash::{Hash, Hashed, ZERO_HASH};
+use crate::core::core::hash::{DefaultHashCache, Hash, Hashed, ZERO_HASH};
 use crate::core::core::{Block, BlockHeader};
 use crate::core::pow::Difficulty;
 use crate::core::ser;
@@ -81,6 +81,7 @@ impl Hashed for Tip {
 		self.last_block_h
 	}
 }
+impl DefaultHashCache for Tip {}
 
 impl Default for Tip {
 	fn default() -> Self {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::consensus::{reward, REWARD};
 use crate::core::committed::{self, Committed};
 use crate::core::compact_block::{CompactBlock, CompactBlockBody};
-use crate::core::hash::{DefaultHashable, Hash, Hashed, ZERO_HASH};
+use crate::core::hash::{DefaultHashCache, DefaultHashable, Hash, Hashed, ZERO_HASH};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{
 	transaction, Commitment, Input, Output, Transaction, TransactionBody, TxKernel, Weighting,
@@ -159,7 +159,7 @@ impl Writeable for HeaderEntry {
 impl FixedLength for HeaderEntry {
 	const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
 }
-
+impl DefaultHashCache for HeaderEntry {}
 impl Hashed for HeaderEntry {
 	/// The hash of the underlying block.
 	fn hash(&self) -> Hash {
@@ -198,6 +198,7 @@ pub struct BlockHeader {
 	pub pow: ProofOfWork,
 }
 impl DefaultHashable for BlockHeader {}
+impl DefaultHashCache for BlockHeader {}
 
 impl Default for BlockHeader {
 	fn default() -> BlockHeader {
@@ -353,7 +354,7 @@ pub struct Block {
 	/// The body - inputs/outputs/kernels
 	body: TransactionBody,
 }
-
+impl DefaultHashCache for Block {}
 impl Hashed for Block {
 	/// The hash of the underlying block.
 	fn hash(&self) -> Hash {

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -17,7 +17,7 @@
 use rand::{thread_rng, Rng};
 
 use crate::core::block::{Block, BlockHeader, Error};
-use crate::core::hash::{DefaultHashable, Hashed};
+use crate::core::hash::{DefaultHashCache, DefaultHashable, Hashed};
 use crate::core::id::ShortIdentifiable;
 use crate::core::{Output, ShortId, TxKernel};
 use crate::ser::{self, read_multi, Readable, Reader, VerifySortedAndUnique, Writeable, Writer};
@@ -138,6 +138,7 @@ pub struct CompactBlock {
 }
 
 impl DefaultHashable for CompactBlock {}
+impl DefaultHashCache for CompactBlock {}
 
 impl CompactBlock {
 	/// "Lightweight" validation.

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 use byteorder::{ByteOrder, LittleEndian};
 use siphasher::sip::SipHasher24;
 
-use crate::core::hash::{DefaultHashable, Hash, Hashed};
+use crate::core::hash::{DefaultHashCache, DefaultHashable, GetHashCache, Hash, Hashed};
 use crate::ser::{self, Readable, Reader, Writeable, Writer};
 use crate::util;
 
@@ -74,6 +74,7 @@ impl<H: Hashed> ShortIdentifiable for H {
 pub struct ShortId([u8; 6]);
 
 impl DefaultHashable for ShortId {}
+impl DefaultHashCache for ShortId {}
 /// We want to sort short_ids in a canonical and consistent manner so we can
 /// verify sort order in the same way we do for full inputs|outputs|kernels
 /// themselves.
@@ -170,6 +171,7 @@ mod test {
 		}
 
 		impl DefaultHashable for Foo {}
+		impl DefaultHashCache for Foo {}
 
 		let foo = Foo(0);
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -49,6 +49,7 @@ where
 impl<'a, T, B> PMMR<'a, T, B>
 where
 	T: PMMRable,
+	T: PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	/// Build a new prunable Merkle Mountain Range using the provided backend.

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -22,7 +22,7 @@ use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
-use crate::core::hash::{DefaultHashable, Hashed};
+use crate::core::hash::{DefaultHashCache, DefaultHashable, Hashed};
 use crate::global;
 use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
 
@@ -325,6 +325,7 @@ pub struct Proof {
 }
 
 impl DefaultHashable for Proof {}
+impl DefaultHashCache for Proof {}
 
 impl fmt::Debug for Proof {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -19,7 +19,7 @@
 //! To use it simply implement `Writeable` or `Readable` and then use the
 //! `serialize` or `deserialize` functions on them as appropriate.
 
-use crate::core::hash::{DefaultHashable, Hash, Hashed};
+use crate::core::hash::{DefaultHashable, GetHashCache, Hash, Hashed};
 use crate::keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
 use crate::util::read_write::read_exact;
 use crate::util::secp::constants::{
@@ -706,7 +706,7 @@ pub trait FixedLength {
 }
 
 /// Trait for types that can be added to a PMMR.
-pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
+pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable + GetHashCache {
 	/// The type of element actually stored in the MMR data file.
 	/// This allows us to store Hash elements in the header MMR for variable size BlockHeaders.
 	type E: FixedLength + Readable + Writeable;
@@ -721,7 +721,10 @@ pub trait PMMRIndexHashable {
 	fn hash_with_index(&self, index: u64) -> Hash;
 }
 
-impl<T: DefaultHashable> PMMRIndexHashable for T {
+impl<T> PMMRIndexHashable for T
+where
+	T: GetHashCache + DefaultHashable,
+{
 	fn hash_with_index(&self, index: u64) -> Hash {
 		(index, self).hash()
 	}

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use self::core::core::hash::{DefaultHashable, Hash};
+use self::core::core::hash::{DefaultHashCache, DefaultHashable, Hash};
 use self::core::core::pmmr::{self, Backend};
 use self::core::core::BlockHeader;
 use self::core::ser;
@@ -26,6 +26,7 @@ use std::path::Path;
 pub struct TestElem(pub [u32; 4]);
 
 impl DefaultHashable for TestElem {}
+impl DefaultHashCache for TestElem {}
 
 impl FixedLength for TestElem {
 	const LEN: usize = 16;

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -21,7 +21,7 @@ use std::fs;
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 
-use crate::core::core::hash::DefaultHashable;
+use crate::core::core::hash::{DefaultHashCache, DefaultHashable};
 use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
 	Error, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
@@ -905,6 +905,7 @@ fn load(pos: u64, elems: &[TestElem], backend: &mut store::pmmr::PMMRBackend<Tes
 struct TestElem(u32);
 
 impl DefaultHashable for TestElem {}
+impl DefaultHashCache for TestElem {}
 
 impl FixedLength for TestElem {
 	const LEN: usize = 4;


### PR DESCRIPTION
This PR demonstrates how we can add a hash caching functionality to existing classes (or not!) easily.

In response to https://github.com/mimblewimble/grin/issues/2584


The trait-fu needed to work this code is pretty ridiculous, especially since Rust doesn't support negative traits (e.g., `impl<T: ~DefaultTrait>`) or default trait functions without experimental flags, but it compiles somehow ;) It does feel a little fragile, if we wanted to add _more_ hash functionality in the future, it... should be doable, but I wouldn't want to be that future maintainer. That said, I can't see wanting more hash functionality later, so maybe this is good 'nuf.

The biggest issue with this approach is that functions like outputs_mut which modify the outputs become hard to work with -- I just defaulted to having these ones destroy the cache permanently as they don't seem to be used outside of testing or wallet code. Validation should be fine.

It would also be pretty easy to feature flag/runtime flag enable or disable the caching behavior on a per-struct basis, which is cool.

I'd also consider not using the Option and just storing a ZERO_HASH and checking for that, since it should be an error.


Definitely a WIP, don't merge till there's consensus on this approach and on which structs should implement the caching hasher.