### PR TITLE
[WIP] Add status call to wallet foreign endpoint

### DIFF
--- a/doc/api/wallet_foreign_api.md
+++ b/doc/api/wallet_foreign_api.md
@@ -8,6 +8,46 @@
 
 ## Wallet Foreign Endpoint
 
+### GET Status
+
+Returns a simple status code that allows clients to check if a wallet foreign endpoint is
+listening.
+
+* **URL**
+
+  /v1/wallet/foreign/status
+
+* **Method:**
+
+  `GET`
+
+* **URL Params**
+
+  None
+
+* **Data Params**
+
+  None
+
+* **Success Response:**
+
+  * **Code:** 200
+  * **Content:**
+
+    None
+
+* **Error Response:**
+
+  None
+
+* **Sample Call:**
+
+  ```javascript
+    $.ajax({url: "/v1/wallet/foreign/status", success: function(r) {
+      console.log("Foreign wallet is listening.");
+	 }});
+  ```
+  
 ### POST Build Coinbase
 
 Creates a coinbase output for the given height and block fees
@@ -19,7 +59,7 @@ Creates a coinbase output for the given height and block fees
 * **Method:**
 
   `POST`
-  
+
 * **URL Params**
 
   None
@@ -81,7 +121,7 @@ Receives a transaction, modifying the slate accordingly (which can then be sent 
 * **Method:**
 
   `POST`
-  
+
 * **URL Params**
 
   None


### PR DESCRIPTION
---
name: Add status call to wallet foreign endpoint
about: Bitforex (and maybe other exchanges) requires an HTTPS address to transfer grin coins to. I was going to use an ELB on AWS to do the SSL termination for me, but ELB needs a way of doing a health check on any endpoint it sends requests to. This PR adds a status check to the wallet foreign endpoint. I've updated the API documentation. I also tried to write a unit test for the endpoint, but the test framework you're using for the wallet foreign endpoint doesn't seem to simulate actual HTTP requests, and this test is so trivial that nothing more than checking for a 200 response is necessary. Perhaps someone could suggest a testing approach that would be compatible with your other test scaffolding. Thanks in advance.
title: ''
labels: ''
assignees: ''