### PR TITLE
cleanup legacy "3 dot" incorrect filename check

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1503,7 +1503,7 @@ fn check_and_remove_files(txhashset_path: &PathBuf, header: &BlockHeader) -> Res
 	}
 
 	// Then compare the files found in the subdirectories
-	let mut pmmr_files_expected: HashSet<_> = PMMR_FILES
+	let pmmr_files_expected: HashSet<_> = PMMR_FILES
 		.iter()
 		.cloned()
 		.map(|s| {
@@ -1514,8 +1514,6 @@ fn check_and_remove_files(txhashset_path: &PathBuf, header: &BlockHeader) -> Res
 			}
 		})
 		.collect();
-	// prevent checker from deleting 3 dot file, could be removed after mainnet
-	pmmr_files_expected.insert(format!("pmmr_leaf.bin.{}...", header.hash()));
 
 	let subdirectories = fs::read_dir(txhashset_path)?;
 	for subdirectory in subdirectories {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -199,13 +199,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 				data_dir.join(PMMR_LEAF_FILE).to_str().unwrap(),
 				header.hash()
 			);
-			// Check for a ... (3 dot) ending version of the file - could probably be removed after mainnet
-			let compatible_snapshot_path = PathBuf::from(leaf_snapshot_path.clone() + "...");
-			if compatible_snapshot_path.exists() {
-				LeafSet::copy_snapshot(&leaf_set_path, &compatible_snapshot_path)?;
-			} else {
-				LeafSet::copy_snapshot(&leaf_set_path, &PathBuf::from(leaf_snapshot_path))?;
-			}
+			LeafSet::copy_snapshot(&leaf_set_path, &PathBuf::from(leaf_snapshot_path))?;
 		}
 
 		let leaf_set = LeafSet::open(&leaf_set_path)?;


### PR DESCRIPTION
We had an issue in `floonet` where we were incorrectly naming the leaf_set file during fast sync.

This PR reverts these temporary changes as they as unneeded in `mainnet` (and `floonet` has been running long enough not to need this anymore either).

