### PR TITLE
[1.1.0] Travis automated windows builds

### DIFF
--- a/.auto-release.sh
+++ b/.auto-release.sh
@@ -6,7 +6,7 @@ export CHANGELOG_GITHUB_TOKEN="$token"
 
 tagname=`git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD`
 
-echo 'make a tarball for the release binary...\n'
+echo 'package the release binary...\n'
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
@@ -16,7 +16,19 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     md5 "grin-$tagname-$TRAVIS_JOB_ID-osx.tgz" > "grin-$tagname-$TRAVIS_JOB_ID-osx.tgz"-md5sum.txt
     /bin/ls -ls *-md5sum.txt  | awk '{print $6,$7,$8,$9,$10}'
     cd - > /dev/null;
-    echo "tarball generated\n"
+    echo "osx tarball generated\n"
+
+    # Only generate changelog on Linux platform, to avoid duplication
+    exit 0
+elif [[ $TRAVIS_OS_NAME == 'windows' ]]; then
+
+    # Custom requirements on windows
+    cd target/release ; rm -f *.zip ; 7z a -tzip "grin-$tagname-$TRAVIS_JOB_ID-win-x64.zip" grin.exe
+    /bin/ls -ls *.zip  | awk '{print $6,$7,$8,$9,$10}'
+    md5sum "grin-$tagname-$TRAVIS_JOB_ID-win-x64.zip" > "grin-$tagname-$TRAVIS_JOB_ID-win-x64.zip"-md5sum.txt
+    /bin/ls -ls *-md5sum.txt  | awk '{print $6,$7,$8,$9,$10}'
+    cd - > /dev/null;
+    echo "win x64 zip file generated\n"
 
     # Only generate changelog on Linux platform, to avoid duplication
     exit 0
@@ -27,7 +39,7 @@ else
     md5sum "grin-$tagname-$TRAVIS_JOB_ID-linux-amd64.tgz" > "grin-$tagname-$TRAVIS_JOB_ID-linux-amd64.tgz"-md5sum.txt
     /bin/ls -ls *-md5sum.txt  | awk '{print $6,$7,$8,$9,$10}'
     cd - > /dev/null;
-    echo "tarball generated\n"
+    echo "linux tarball generated\n"
 fi
 
 version="$tagname"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ matrix:
       env: TEST_SUITE=api-util-store
     - os: osx
       env: TEST_SUITE=release
+#    - os: windows
+#      env: TEST_SUITE=release
 
 script:
   - IFS='-' read -r -a DIRS <<< "$TEST_SUITE"; DIR=${DIRS[0]};
@@ -76,13 +78,16 @@ before_deploy:
       brew update;
       cargo clean && cargo build --release && ./.auto-release.sh;
     fi
+  - if [[ "$TEST_SUITE" == "release" ]]  && [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      cargo clean && cargo build --release && ./.auto-release.sh;
+    fi
 
 deploy:
   provider: releases
   api_key:
     secure: PBTFcoUmiQITkDdtFzrBlNR/5OgYHTCw+xVWGYu205xwTlj/ARBgw7DNt8dIdptLx+jOM2V5SbJqSFxs/CJ2ZcOHQZ6ubwpAJlRfuk3xDAi5JmuHYfcY+4SQ9l/0MgHnGfuml093xP7vTIYm2Vwwgdq8fd3jdWmvwgk9zgaGXB4UIXQA0yIs3EzxZpqiLg629Ouv7edMfyffwlG+rgQ1koe6sqeMCxIs0N3p97GCx19kNe0TV4dC7XAN74HreMdHmwxPKAK4xG/jtA1Snm0pMQ50Z0Kizt+0yrGOPMLnWwO9sS38iosBn3Vh1R8HKle2xBGflTtT/LG9lHdQZ5NF572q6681x6t7str4OjJ5bboy1PtNLFxG7RJCVIpp9gbouzdxIaJWRTxIdlk8UNQMrD8ieiNE6V1vZtbHGtJHRSJN1vO/XxsLlQDCyakLhG/nmSKXgiT9wIsu+zj/3oDe+LBt5QetEGYGBrCwUewjaQ7EP1rsT7alQrHTMad5DPjYftJuvfR+yBtz1qbzQwZVJpQC1KY1c476mXPQsaywuUrj56hH92p7P3vl6aMN2OPJZP+zENOVSURHc56KeTsDS55+KKzcRjCMA2L0LR1hP33+V5kavMHgCRrWIkxAkZ4eRqnermalzp8vlzL6EEoGm0VFLzv4mJmzrY1mC1LyCHo=
   file_glob: true
-  file: target/release/grin-*.tgz*
+  file: target/release/grin-*.*
   skip_cleanup: true
   on:
     repo: mimblewimble/grin


### PR DESCRIPTION
Adds windows as a travis build target for tagging only. 

Annoyingly, there appears to be an issue with travis windows builds whereby if an encrypted env variable is defined the windows build just hangs. Right now the build relies on someone's API key referenced as `$GITHUB_TOKEN`, which causes the build to hang if included. This is only being used to generate a changelog on the linux build.

This will probably be fixed at some stage, but in the meantime, windows builds will have to be done separately using the following highly annoying process:

* Perform tag/build as usual
* Remove $GITHUB_TOKEN from the travis CI project settings
* comment windows release target back into the build matrix, comment other targets out, commit changes
* Perform another tag (possibly appending `-win` to it), and let it build/release
* Re-insert $GITHUB_TOKEN into project in readiness for next build

Hopefully travis ci addresses this before release.

We'll probably need to regenerate the github api key at some stage and ensure it's updated in the travis ci project settings and in .travis.yml.  As a reminder, the command to create an encrypted version to directly embed in travis.yml (under api_key) is:

`travis encrypt [token] deploy.api_key`

Also note this process has only been tested in grin-wallet to create pre-releases: https://github.com/mimblewimble/grin-wallet/releases