### PR TITLE
Dandelion++ Rewrite

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -141,9 +141,17 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
-		"relay_secs".to_string(),
+		"epoch_secs".to_string(),
 		"
-#dandelion relay time (choose new relay peer every n secs)
+#dandelion epoch duration
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"aggregation_secs".to_string(),
+		"
+#dandelion aggregation period in secs
 "
 		.to_string(),
 	);
@@ -156,13 +164,6 @@ fn comments() -> HashMap<String, String> {
 		.to_string(),
 	);
 
-	retval.insert(
-		"patience_secs".to_string(),
-		"
-#run dandelion stem/fluff processing every n secs (stem tx aggregation in this window)
-"
-		.to_string(),
-	);
 	retval.insert(
 		"stem_probability".to_string(),
 		"

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::util::{Mutex, RwLock};
+use std::fmt;
 use std::fs::File;
 use std::net::{Shutdown, TcpStream};
 use std::sync::Arc;
@@ -52,6 +53,12 @@ pub struct Peer {
 	// set of all hashes known to this peer (so no need to send)
 	tracking_adapter: TrackingAdapter,
 	connection: Option<Mutex<conn::Tracker>>,
+}
+
+impl fmt::Debug for Peer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "Peer({:?})", &self.info)
+	}
 }
 
 impl Peer {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -37,7 +37,6 @@ pub struct Peers {
 	pub adapter: Arc<dyn ChainAdapter>,
 	store: PeerStore,
 	peers: RwLock<HashMap<PeerAddr, Arc<Peer>>>,
-	dandelion_relay: RwLock<Option<(i64, Arc<Peer>)>>,
 	config: P2PConfig,
 }
 
@@ -48,7 +47,6 @@ impl Peers {
 			store,
 			config,
 			peers: RwLock::new(HashMap::new()),
-			dandelion_relay: RwLock::new(None),
 		}
 	}
 
@@ -85,39 +83,6 @@ impl Peers {
 		};
 		debug!("Banning peer {}.", addr);
 		self.save_peer(&peer_data)
-	}
-
-	// Update the dandelion relay
-	pub fn update_dandelion_relay(&self) {
-		let peers = self.outgoing_connected_peers();
-
-		let peer = &self
-			.config
-			.dandelion_peer
-			.and_then(|ip| peers.iter().find(|x| x.info.addr == ip))
-			.or(thread_rng().choose(&peers));
-
-		match peer {
-			Some(peer) => self.set_dandelion_relay(peer),
-			None => debug!("Could not update dandelion relay"),
-		}
-	}
-
-	fn set_dandelion_relay(&self, peer: &Arc<Peer>) {
-		// Clear the map and add new relay
-		let dandelion_relay = &self.dandelion_relay;
-		dandelion_relay
-			.write()
-			.replace((Utc::now().timestamp(), peer.clone()));
-		debug!(
-			"Successfully updated Dandelion relay to: {}",
-			peer.info.addr
-		);
-	}
-
-	// Get the dandelion relay
-	pub fn get_dandelion_relay(&self) -> Option<(i64, Arc<Peer>)> {
-		self.dandelion_relay.read().clone()
 	}
 
 	pub fn is_known(&self, addr: PeerAddr) -> bool {
@@ -333,26 +298,6 @@ impl Peers {
 			bh.height,
 			count,
 		);
-	}
-
-	/// Relays the provided stem transaction to our single stem peer.
-	pub fn relay_stem_transaction(&self, tx: &core::Transaction) -> Result<(), Error> {
-		self.get_dandelion_relay()
-			.or_else(|| {
-				debug!("No dandelion relay, updating.");
-				self.update_dandelion_relay();
-				self.get_dandelion_relay()
-			})
-			// If still return an error, let the caller handle this as they see fit.
-			// The caller will "fluff" at this point as the stem phase is finished.
-			.ok_or(Error::NoDandelionRelay)
-			.map(|(_, relay)| {
-				if relay.is_connected() {
-					if let Err(e) = relay.send_stem_transaction(tx) {
-						debug!("Error sending stem transaction to peer relay: {:?}", e);
-					}
-				}
-			})
 	}
 
 	/// Broadcasts the provided transaction to PEER_PREFERRED_COUNT of our

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -34,5 +34,8 @@ mod pool;
 pub mod transaction_pool;
 pub mod types;
 
+pub use crate::pool::Pool;
 pub use crate::transaction_pool::TransactionPool;
-pub use crate::types::{BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolError, TxSource};
+pub use crate::types::{
+	BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolEntry, PoolError, TxSource,
+};

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -35,6 +35,4 @@ pub mod transaction_pool;
 pub mod types;
 
 pub use crate::transaction_pool::TransactionPool;
-pub use crate::types::{
-	BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolEntryState, PoolError, TxSource,
-};
+pub use crate::types::{BlockChain, DandelionConfig, PoolAdapter, PoolConfig, PoolError, TxSource};

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -23,7 +23,7 @@ use self::core::core::{
 	Block, BlockHeader, BlockSums, Committed, Transaction, TxKernel, Weighting,
 };
 use self::util::RwLock;
-use crate::types::{BlockChain, PoolEntry, PoolEntryState, PoolError};
+use crate::types::{BlockChain, PoolEntry, PoolError};
 use grin_core as core;
 use grin_util as util;
 use std::collections::{HashMap, HashSet};
@@ -175,23 +175,6 @@ impl Pool {
 	) -> Result<Vec<Transaction>, PoolError> {
 		let valid_txs = self.validate_raw_txs(txs, extra_tx, header, Weighting::NoLimit)?;
 		Ok(valid_txs)
-	}
-
-	pub fn get_transactions_in_state(&self, state: PoolEntryState) -> Vec<Transaction> {
-		self.entries
-			.iter()
-			.filter(|x| x.state == state)
-			.map(|x| x.tx.clone())
-			.collect::<Vec<_>>()
-	}
-
-	// Transition the specified pool entries to the new state.
-	pub fn transition_to_state(&mut self, txs: &[Transaction], state: PoolEntryState) {
-		for x in &mut self.entries {
-			if txs.contains(&x.tx) {
-				x.state = state;
-			}
-		}
 	}
 
 	// Aggregate this new tx with all existing txs in the pool.

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -167,16 +167,6 @@ impl Pool {
 		Ok(Some(tx))
 	}
 
-	pub fn select_valid_transactions(
-		&self,
-		extra_tx: Option<Transaction>,
-		header: &BlockHeader,
-	) -> Result<Vec<Transaction>, PoolError> {
-		let txs = self.all_transactions();
-		let valid_txs = self.validate_raw_txs(txs, extra_tx, header, Weighting::NoLimit)?;
-		Ok(valid_txs)
-	}
-
 	// Aggregate this new tx with all existing txs in the pool.
 	// If we can validate the aggregated tx against the current chain state
 	// then we can safely add the tx to the pool.
@@ -250,7 +240,7 @@ impl Pool {
 		Ok(new_sums)
 	}
 
-	fn validate_raw_txs(
+	pub fn validate_raw_txs(
 		&self,
 		txs: Vec<Transaction>,
 		extra_tx: Option<Transaction>,

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -169,10 +169,10 @@ impl Pool {
 
 	pub fn select_valid_transactions(
 		&self,
-		txs: Vec<Transaction>,
 		extra_tx: Option<Transaction>,
 		header: &BlockHeader,
 	) -> Result<Vec<Transaction>, PoolError> {
+		let txs = self.all_transactions();
 		let valid_txs = self.validate_raw_txs(txs, extra_tx, header, Weighting::NoLimit)?;
 		Ok(valid_txs)
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -139,7 +139,7 @@ impl Pool {
 		// Verify these txs produce an aggregated tx below max tx weight.
 		// Return a vec of all the valid txs.
 		let txs = self.validate_raw_txs(
-			tx_buckets,
+			&tx_buckets,
 			None,
 			&header,
 			Weighting::AsLimitedTransaction { max_weight },
@@ -242,7 +242,7 @@ impl Pool {
 
 	pub fn validate_raw_txs(
 		&self,
-		txs: Vec<Transaction>,
+		txs: &[Transaction],
 		extra_tx: Option<Transaction>,
 		header: &BlockHeader,
 		weighting: Weighting,
@@ -262,7 +262,7 @@ impl Pool {
 
 			// We know the tx is valid if the entire aggregate tx is valid.
 			if self.validate_raw_tx(&agg_tx, header, weighting).is_ok() {
-				valid_txs.push(tx);
+				valid_txs.push(tx.clone());
 			}
 		}
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -157,18 +157,12 @@ impl TransactionPool {
 			tx,
 		};
 
+		// If not stem then we are fluff.
 		// If this is a stem tx then attempt to stem.
 		// Any problems fallback to fluff later.
-		// If not stem then we are fluff.
-		let fluff = if stem {
-			// Attempt to add to stempool, notifying adapter to relay to outbound peer.
-			// Fall back to fluffing (via txpool) if stempool interaction fails.
-			self.add_to_stempool(entry.clone(), header)
-				.and_then(|_| self.adapter.stem_tx_accepted(&entry.tx))
-				.is_err()
-		} else {
-			true
-		};
+		let fluff = !stem || self.add_to_stempool(entry.clone(), header)
+			.and_then(|_| self.adapter.stem_tx_accepted(&entry.tx))
+			.is_err();
 
 		// Fluff (broadcast) the tx if tagged as fluff or if
 		// stemming failed for any reason.

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -23,9 +23,7 @@ use self::core::core::verifier_cache::VerifierCache;
 use self::core::core::{transaction, Block, BlockHeader, Transaction, Weighting};
 use self::util::RwLock;
 use crate::pool::Pool;
-use crate::types::{
-	BlockChain, PoolAdapter, PoolConfig, PoolEntry, PoolEntryState, PoolError, TxSource,
-};
+use crate::types::{BlockChain, PoolAdapter, PoolConfig, PoolEntry, PoolError, TxSource};
 use chrono::prelude::*;
 use grin_core as core;
 use grin_util as util;
@@ -79,10 +77,8 @@ impl TransactionPool {
 	fn add_to_stempool(&mut self, entry: PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
 		// Add tx to stempool (passing in all txs from txpool to validate against).
 		self.stempool
-			.add_to_pool(entry, self.txpool.all_transactions(), header)?;
-
-		// Note: we do not notify the adapter here,
-		// we let the dandelion monitor handle this.
+			.add_to_pool(entry.clone(), self.txpool.all_transactions(), header)?;
+		self.adapter.stem_tx_accepted(&entry.tx);
 		Ok(())
 	}
 
@@ -159,28 +155,18 @@ impl TransactionPool {
 		self.blockchain.verify_coinbase_maturity(&tx)?;
 
 		let entry = PoolEntry {
-			state: PoolEntryState::Fresh,
 			src,
 			tx_at: Utc::now(),
 			tx,
 		};
 
-		// If we are in "stem" mode then check if this is a new tx or if we have seen it before.
-		// If new tx - add it to our stempool.
-		// If we have seen any of the kernels before then fallback to fluff,
-		// adding directly to txpool.
-		if stem
-			&& self
-				.stempool
-				.find_matching_transactions(entry.tx.kernels())
-				.is_empty()
-		{
-			self.add_to_stempool(entry, header)?;
-			return Ok(());
+		if stem {
+			self.add_to_stempool(entry.clone(), header)?;
+		} else {
+			self.add_to_txpool(entry.clone(), header)?;
+			self.add_to_reorg_cache(entry);
 		}
 
-		self.add_to_txpool(entry.clone(), header)?;
-		self.add_to_reorg_cache(entry);
 		Ok(())
 	}
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -159,14 +159,13 @@ impl TransactionPool {
 
 		// If not stem then we are fluff.
 		// If this is a stem tx then attempt to stem.
-		// Any problems fallback to fluff later.
-		let fluff = !stem || self.add_to_stempool(entry.clone(), header)
-			.and_then(|_| self.adapter.stem_tx_accepted(&entry.tx))
-			.is_err();
-
-		// Fluff (broadcast) the tx if tagged as fluff or if
-		// stemming failed for any reason.
-		if fluff {
+		// Any problems during stem, fallback to fluff.
+		if !stem
+			|| self
+				.add_to_stempool(entry.clone(), header)
+				.and_then(|_| self.adapter.stem_tx_accepted(&entry.tx))
+				.is_err()
+		{
 			self.add_to_txpool(entry.clone(), header)?;
 			self.add_to_reorg_cache(entry.clone());
 			self.adapter.tx_accepted(&entry.tx);

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -74,10 +74,10 @@ impl TransactionPool {
 		self.blockchain.chain_head()
 	}
 
+	// Add tx to stempool (passing in all txs from txpool to validate against).
 	fn add_to_stempool(&mut self, entry: PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
-		// Add tx to stempool (passing in all txs from txpool to validate against).
 		self.stempool
-			.add_to_pool(entry.clone(), self.txpool.all_transactions(), header)?;
+			.add_to_pool(entry, self.txpool.all_transactions(), header)?;
 		Ok(())
 	}
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -161,11 +161,11 @@ impl TransactionPool {
 		// Any problems fallback to fluff later.
 		// If not stem then we are fluff.
 		let fluff = if stem {
-			// First attempt to add to stempool and return an error if this fails.
-			self.add_to_stempool(entry.clone(), header)?;
-			// Then attempt to relay it to the next stem peer,
-			// falling back to fluffing locally if this fails.
-			self.adapter.stem_tx_accepted(&entry.tx).is_err()
+			// Attempt to add to stempool, notifying adapter to relay to outbound peer.
+			// Fall back to fluffing (via txpool) if stempool interaction fails.
+			self.add_to_stempool(entry.clone(), header)
+				.and_then(|_| self.adapter.stem_tx_accepted(&entry.tx))
+				.is_err()
 		} else {
 			true
 		};

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -161,7 +161,10 @@ impl TransactionPool {
 		// Any problems fallback to fluff later.
 		// If not stem then we are fluff.
 		let fluff = if stem {
+			// First attempt to add to stempool and return an error if this fails.
 			self.add_to_stempool(entry.clone(), header)?;
+			// Then attempt to relay it to the next stem peer,
+			// falling back to fluffing locally if this fails.
 			self.adapter.stem_tx_accepted(&entry.tx).is_err()
 		} else {
 			true

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -27,15 +27,14 @@ use failure::Fail;
 use grin_core as core;
 use grin_keychain as keychain;
 
-/// TODO - This now maps to the "epoch length"?
-/// Dandelion relay timer
-const DANDELION_RELAY_SECS: u64 = 600;
+/// Dandelion "epoch" length.
+const DANDELION_EPOCH_SECS: u64 = 600;
 
-/// Dandelion embargo timer
+/// Dandelion embargo timer.
 const DANDELION_EMBARGO_SECS: u64 = 180;
 
-/// Dandelion patience timer
-const DANDELION_PATIENCE_SECS: u64 = 10;
+/// Dandelion aggregation timer.
+const DANDELION_AGGREGATION_SECS: u64 = 30;
 
 /// Dandelion stem probability (stem 90% of the time, fluff 10%).
 const DANDELION_STEM_PROBABILITY: u64 = 90;
@@ -44,54 +43,42 @@ const DANDELION_STEM_PROBABILITY: u64 = 90;
 /// Note: shared between p2p and pool.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DandelionConfig {
-	/// Choose new Dandelion relay peer every n secs.
-	#[serde = "default_dandelion_relay_secs"]
-	pub relay_secs: Option<u64>,
-	/// Dandelion embargo, fluff and broadcast tx if not seen on network before
-	/// embargo expires.
-	#[serde = "default_dandelion_embargo_secs"]
+	/// Length of each "epoch".
+	#[serde(default = "default_dandelion_epoch_secs")]
+	pub epoch_secs: Option<u64>,
+	/// Dandelion embargo timer. Fluff and broadcast individual txs if not seen
+	/// on network before embargo expires.
+	#[serde(default = "default_dandelion_embargo_secs")]
 	pub embargo_secs: Option<u64>,
-	/// Dandelion patience timer, fluff/stem processing runs every n secs.
-	/// Tx aggregation happens on stem txs received within this window.
-	#[serde = "default_dandelion_patience_secs"]
-	pub patience_secs: Option<u64>,
+	/// Dandelion aggregation timer.
+	#[serde(default = "default_dandelion_aggregation_secs")]
+	pub aggregation_secs: Option<u64>,
 	/// Dandelion stem probability (stem 90% of the time, fluff 10% etc.)
-	#[serde = "default_dandelion_stem_probability"]
+	#[serde(default = "default_dandelion_stem_probability")]
 	pub stem_probability: Option<u64>,
-}
-
-impl DandelionConfig {
-	pub fn stem_probability(&self) -> u64 {
-		self.stem_probability.unwrap_or(DANDELION_STEM_PROBABILITY)
-	}
-
-	// TODO - Cleanup config for Dandelion++
-	pub fn epoch_secs(&self) -> u64 {
-		self.relay_secs.unwrap_or(DANDELION_RELAY_SECS)
-	}
 }
 
 impl Default for DandelionConfig {
 	fn default() -> DandelionConfig {
 		DandelionConfig {
-			relay_secs: default_dandelion_relay_secs(),
+			epoch_secs: default_dandelion_epoch_secs(),
 			embargo_secs: default_dandelion_embargo_secs(),
-			patience_secs: default_dandelion_patience_secs(),
+			aggregation_secs: default_dandelion_aggregation_secs(),
 			stem_probability: default_dandelion_stem_probability(),
 		}
 	}
 }
 
-fn default_dandelion_relay_secs() -> Option<u64> {
-	Some(DANDELION_RELAY_SECS)
+fn default_dandelion_epoch_secs() -> Option<u64> {
+	Some(DANDELION_EPOCH_SECS)
 }
 
 fn default_dandelion_embargo_secs() -> Option<u64> {
 	Some(DANDELION_EMBARGO_SECS)
 }
 
-fn default_dandelion_patience_secs() -> Option<u64> {
-	Some(DANDELION_PATIENCE_SECS)
+fn default_dandelion_aggregation_secs() -> Option<u64> {
+	Some(DANDELION_AGGREGATION_SECS)
 }
 
 fn default_dandelion_stem_probability() -> Option<u64> {

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -264,8 +264,9 @@ pub trait BlockChain: Sync + Send {
 pub trait PoolAdapter: Send + Sync {
 	/// The transaction pool has accepted this transaction as valid.
 	fn tx_accepted(&self, tx: &transaction::Transaction);
+
 	/// The stem transaction pool has accepted this transactions as valid.
-	fn stem_tx_accepted(&self, tx: &transaction::Transaction);
+	fn stem_tx_accepted(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;
 }
 
 /// Dummy adapter used as a placeholder for real implementations
@@ -274,5 +275,7 @@ pub struct NoopAdapter {}
 
 impl PoolAdapter for NoopAdapter {
 	fn tx_accepted(&self, _tx: &transaction::Transaction) {}
-	fn stem_tx_accepted(&self, _tx: &transaction::Transaction) {}
+	fn stem_tx_accepted(&self, _tx: &transaction::Transaction) -> Result<(), PoolError> {
+		Ok(())
+	}
 }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -28,16 +28,16 @@ use grin_core as core;
 use grin_keychain as keychain;
 
 /// Dandelion "epoch" length.
-const DANDELION_EPOCH_SECS: u64 = 600;
+const DANDELION_EPOCH_SECS: u16 = 600;
 
 /// Dandelion embargo timer.
-const DANDELION_EMBARGO_SECS: u64 = 180;
+const DANDELION_EMBARGO_SECS: u16 = 180;
 
 /// Dandelion aggregation timer.
-const DANDELION_AGGREGATION_SECS: u64 = 30;
+const DANDELION_AGGREGATION_SECS: u16 = 30;
 
 /// Dandelion stem probability (stem 90% of the time, fluff 10%).
-const DANDELION_STEM_PROBABILITY: u64 = 90;
+const DANDELION_STEM_PROBABILITY: u8 = 90;
 
 /// Configuration for "Dandelion".
 /// Note: shared between p2p and pool.
@@ -45,17 +45,17 @@ const DANDELION_STEM_PROBABILITY: u64 = 90;
 pub struct DandelionConfig {
 	/// Length of each "epoch".
 	#[serde(default = "default_dandelion_epoch_secs")]
-	pub epoch_secs: Option<u64>,
+	pub epoch_secs: Option<u16>,
 	/// Dandelion embargo timer. Fluff and broadcast individual txs if not seen
 	/// on network before embargo expires.
 	#[serde(default = "default_dandelion_embargo_secs")]
-	pub embargo_secs: Option<u64>,
+	pub embargo_secs: Option<u16>,
 	/// Dandelion aggregation timer.
 	#[serde(default = "default_dandelion_aggregation_secs")]
-	pub aggregation_secs: Option<u64>,
+	pub aggregation_secs: Option<u16>,
 	/// Dandelion stem probability (stem 90% of the time, fluff 10% etc.)
 	#[serde(default = "default_dandelion_stem_probability")]
-	pub stem_probability: Option<u64>,
+	pub stem_probability: Option<u8>,
 }
 
 impl Default for DandelionConfig {
@@ -69,19 +69,19 @@ impl Default for DandelionConfig {
 	}
 }
 
-fn default_dandelion_epoch_secs() -> Option<u64> {
+fn default_dandelion_epoch_secs() -> Option<u16> {
 	Some(DANDELION_EPOCH_SECS)
 }
 
-fn default_dandelion_embargo_secs() -> Option<u64> {
+fn default_dandelion_embargo_secs() -> Option<u16> {
 	Some(DANDELION_EMBARGO_SECS)
 }
 
-fn default_dandelion_aggregation_secs() -> Option<u64> {
+fn default_dandelion_aggregation_secs() -> Option<u16> {
 	Some(DANDELION_AGGREGATION_SECS)
 }
 
-fn default_dandelion_stem_probability() -> Option<u64> {
+fn default_dandelion_stem_probability() -> Option<u8> {
 	Some(DANDELION_STEM_PROBABILITY)
 }
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -691,11 +691,15 @@ pub struct PoolToNetAdapter {
 	dandelion_epoch: Arc<RwLock<DandelionEpoch>>,
 }
 
+/// Adapter between the Dandelion monitor and the current Dandelion "epoch".
 pub trait DandelionAdapter: Send + Sync {
+	/// Is the node stemming (or fluffing) transactions in the current epoch?
 	fn is_stem(&self) -> bool;
 
+	/// Is the current Dandelion epoch expired?
 	fn is_expired(&self) -> bool;
 
+	/// Transition to the next Dandelion epoch (new stem/fluff state, select new relay peer).
 	fn next_epoch(&self);
 }
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -727,7 +727,7 @@ impl pool::PoolAdapter for PoolToNetAdapter {
 
 		// If "stem" epoch attempt to relay the tx to the next Dandelion relay.
 		// Fallback to immediately fluffing the tx if we cannot stem for any reason.
-		// If "fluff" epoch then nothing to do right now (fluff when epoch expires).
+		// If "fluff" epoch then nothing to do right now (fluff via Dandelion monitor).
 		if epoch.is_stem() {
 			if let Some(peer) = epoch.relay_peer(&self.peers()) {
 				match peer.send_stem_transaction(tx) {
@@ -745,7 +745,7 @@ impl pool::PoolAdapter for PoolToNetAdapter {
 				Err(pool::PoolError::DandelionError)
 			}
 		} else {
-			info!("Fluff epoch. Aggregating stem tx(s). Fluffing when epoch expires.");
+			info!("Fluff epoch. Aggregating stem tx(s). Will fluff via Dandelion monitor.");
 			Ok(())
 		}
 	}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -723,11 +723,9 @@ impl pool::PoolAdapter for PoolToNetAdapter {
 	}
 
 	fn stem_tx_accepted(&self, tx: &core::Transaction) -> Result<(), pool::PoolError> {
+		// Take write lock on the current epoch.
+		// We need to be able to update the current relay peer if not currently connected.
 		let mut epoch = self.dandelion_epoch.write();
-		if epoch.is_expired() {
-			debug!("Epoch expired, setting up next epoch.");
-			epoch.next_epoch(&self.peers());
-		}
 
 		// If "stem" epoch attempt to relay the tx to the next Dandelion relay.
 		// Fallback to immediately fluffing the tx if we cannot stem for any reason.

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -453,7 +453,10 @@ impl DandelionEpoch {
 		} else {
 			true
 		};
-		error!("DandelionEpoch: is_expired: {}", expired);
+		error!(
+			"DandelionEpoch: is_expired: {}, is_stem: {}",
+			expired, self.is_stem
+		);
 		expired
 	}
 

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -442,7 +442,7 @@ impl DandelionEpoch {
 		DandelionEpoch {
 			config,
 			start_time: None,
-			is_stem: false,
+			is_stem: true,
 			relay_peer: None,
 		}
 	}
@@ -451,12 +451,9 @@ impl DandelionEpoch {
 		let expired = if let Some(start_time) = self.start_time {
 			Utc::now().timestamp().saturating_sub(start_time) > self.config.epoch_secs() as i64
 		} else {
+			info!("DandelionEpoch: expired, is_stem: {}", self.is_stem);
 			true
 		};
-		error!(
-			"DandelionEpoch: is_expired: {}, is_stem: {}",
-			expired, self.is_stem
-		);
 		expired
 	}
 
@@ -468,7 +465,8 @@ impl DandelionEpoch {
 		let mut rng = rand::thread_rng();
 		self.is_stem = rng.gen_range(0, 101) < self.config.stem_probability();
 
-		error!("DandelionEpoch: next_epoch: {:?}", self);
+		let addr = self.relay_peer.clone().map(|p| p.info.addr);
+		info!("DandelionEpoch: next_epoch: is_stem: {}, relay: {:?}", self.is_stem, addr);
 	}
 
 	// Are we stemming transactions in this epoch?

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -27,6 +27,7 @@ use crate::p2p;
 use crate::pool;
 use crate::pool::types::DandelionConfig;
 use crate::store;
+use crate::util::RwLock;
 
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -474,7 +474,7 @@ impl DandelionEpoch {
 			.config
 			.stem_probability
 			.expect("stem_probability config missing");
-		self.is_stem = rng.gen_range(0, 101) < stem_probability;
+		self.is_stem = rng.gen_range(0, 100) < stem_probability;
 
 		let addr = self.relay_peer.clone().map(|p| p.info.addr);
 		info!(

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -455,11 +455,6 @@ impl DandelionEpoch {
 			let epoch_secs = self.config.epoch_secs.expect("epoch_secs config missing") as i64;
 			Utc::now().timestamp().saturating_sub(start_time) > epoch_secs
 		} else {
-			let addr = self.relay_peer.clone().map(|p| p.info.addr);
-			info!(
-				"DandelionEpoch: epoch expired, is_stem: {}, relay: {:?}",
-				self.is_stem, addr
-			);
 			true
 		};
 		expired
@@ -492,7 +487,7 @@ impl DandelionEpoch {
 		self.is_stem
 	}
 
-	/// What is out current relay peer?
+	/// What is our current relay peer?
 	/// If it is not connected then choose a new one.
 	pub fn relay_peer(&mut self, peers: &Arc<p2p::Peers>) -> Option<Arc<p2p::Peer>> {
 		let mut update_relay = false;

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -468,13 +468,13 @@ impl DandelionEpoch {
 	/// Is the current Dandelion epoch expired?
 	/// It is expired if start_time is older than the configured epoch_secs.
 	pub fn is_expired(&self) -> bool {
-		let expired = if let Some(start_time) = self.start_time {
-			let epoch_secs = self.config.epoch_secs.expect("epoch_secs config missing") as i64;
-			Utc::now().timestamp().saturating_sub(start_time) > epoch_secs
-		} else {
-			true
-		};
-		expired
+		match self.start_time {
+			None => true,
+			Some(start_time) => {
+				let epoch_secs = self.config.epoch_secs.expect("epoch_secs config missing") as i64;
+				Utc::now().timestamp().saturating_sub(start_time) > epoch_secs
+			}
+		}
 	}
 
 	/// Transition to next Dandelion epoch.

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -466,7 +466,10 @@ impl DandelionEpoch {
 		self.is_stem = rng.gen_range(0, 101) < self.config.stem_probability();
 
 		let addr = self.relay_peer.clone().map(|p| p.info.addr);
-		info!("DandelionEpoch: next_epoch: is_stem: {}, relay: {:?}", self.is_stem, addr);
+		info!(
+			"DandelionEpoch: next_epoch: is_stem: {}, relay: {:?}",
+			self.is_stem, addr
+		);
 	}
 
 	// Are we stemming transactions in this epoch?

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -79,7 +79,7 @@ pub fn monitor_transactions(
 
 // Query the pool for transactions older than the cutoff.
 // Used for both periodic fluffing and handling expired embargo timer.
-fn select_txs_cutoff(pool: &Pool, cutoff_secs: u64) -> Vec<PoolEntry> {
+fn select_txs_cutoff(pool: &Pool, cutoff_secs: u16) -> Vec<PoolEntry> {
 	let cutoff = Utc::now().timestamp() - cutoff_secs as i64;
 	pool.entries
 		.iter()
@@ -97,7 +97,7 @@ fn process_fluff_phase(
 	// Take a write lock on the txpool for the duration of this processing.
 	let mut tx_pool = tx_pool.write();
 
-	let all_entries = select_txs_cutoff(&tx_pool.stempool, 0);
+	let all_entries = tx_pool.stempool.entries.clone();
 	if all_entries.is_empty() {
 		return Ok(());
 	}

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::util::{Mutex, RwLock, StopState};
 use chrono::prelude::Utc;
 use rand::{thread_rng, Rng};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use crate::common::adapters::DandelionAdapter;
 use crate::core::core::hash::Hashed;
 use crate::core::core::transaction;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::pool::{DandelionConfig, PoolEntryState, PoolError, TransactionPool, TxSource};
+use crate::pool::{DandelionConfig, PoolError, TransactionPool, TxSource};
+use crate::util::{Mutex, RwLock, StopState};
 
 /// A process to monitor transactions in the stempool.
 /// With Dandelion, transaction can be broadcasted in stem or fluff phase.
@@ -35,6 +36,7 @@ use crate::pool::{DandelionConfig, PoolEntryState, PoolError, TransactionPool, T
 pub fn monitor_transactions(
 	dandelion_config: DandelionConfig,
 	tx_pool: Arc<RwLock<TransactionPool>>,
+	adapter: Arc<DandelionAdapter>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
 	stop_state: Arc<Mutex<StopState>>,
 ) {
@@ -48,101 +50,43 @@ pub fn monitor_transactions(
 					break;
 				}
 
+				// TODO - may be preferable to loop more often and check for expired patience time?
 				// This is the patience timer, we loop every n secs.
 				let patience_secs = dandelion_config.patience_secs.unwrap();
 				thread::sleep(Duration::from_secs(patience_secs));
 
-				// Step 1: find all "ToStem" entries in stempool from last run.
-				// Aggregate them up to give a single (valid) aggregated tx and propagate it
-				// to the next Dandelion relay along the stem.
-				if process_stem_phase(tx_pool.clone(), verifier_cache.clone()).is_err() {
-					error!("dand_mon: Problem with stem phase.");
+				// Our adapter hooks us into the current Dandelion "epoch".
+				// From this we can determine if we should fluff txs in stempool.
+				if adapter.is_expired() {
+					adapter.next_epoch();
 				}
 
-				// Step 2: find all "ToFluff" entries in stempool from last run.
-				// Aggregate them up to give a single (valid) aggregated tx and (re)add it
-				// to our pool with stem=false (which will then broadcast it).
-				if process_fluff_phase(tx_pool.clone(), verifier_cache.clone()).is_err() {
-					error!("dand_mon: Problem with fluff phase.");
+				// Vastly simplified -
+				// check if we are is_stem() via the adapter (current epoch)
+				// * if we are stem then do nothing (nothing to aggregate here)
+				// * if fluff then aggregate and add to txpool
+
+				if !adapter.is_stem() {
+					if process_fluff_phase(&tx_pool, &verifier_cache).is_err() {
+						error!("dand_mon: Problem processing fresh pool entries.");
+					}
 				}
 
-				// Step 3: now find all "Fresh" entries in stempool since last run.
-				// Coin flip for each (90/10) and label them as either "ToStem" or "ToFluff".
-				// We will process these in the next run (waiting patience secs).
-				if process_fresh_entries(dandelion_config.clone(), tx_pool.clone()).is_err() {
-					error!("dand_mon: Problem processing fresh pool entries.");
-				}
-
-				// Step 4: now find all expired entries based on embargo timer.
-				if process_expired_entries(dandelion_config.clone(), tx_pool.clone()).is_err() {
+				// Now find all expired entries based on embargo timer.
+				if process_expired_entries(&dandelion_config, &tx_pool).is_err() {
 					error!("dand_mon: Problem processing fresh pool entries.");
 				}
 			}
 		});
 }
 
-fn process_stem_phase(
-	tx_pool: Arc<RwLock<TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write();
-
-	let header = tx_pool.chain_head()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.get_transactions_in_state(PoolEntryState::ToStem);
-
-	if stem_txs.is_empty() {
-		return Ok(());
-	}
-
-	// Get the aggregate tx representing the entire txpool.
-	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool
-		.stempool
-		.transition_to_state(&stem_txs, PoolEntryState::Stemmed);
-
-	if stem_txs.len() > 0 {
-		debug!("dand_mon: Found {} txs for stemming.", stem_txs.len());
-
-		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(
-			transaction::Weighting::AsTransaction,
-			verifier_cache.clone(),
-		)?;
-
-		let res = tx_pool.adapter.stem_tx_accepted(&agg_tx);
-		if res.is_err() {
-			debug!("dand_mon: Unable to propagate stem tx. No relay, fluffing instead.");
-
-			let src = TxSource {
-				debug_name: "no_relay".to_string(),
-				identifier: "?.?.?.?".to_string(),
-			};
-
-			tx_pool.add_to_pool(src, agg_tx, false, &header)?;
-		}
-	}
-	Ok(())
-}
-
 fn process_fluff_phase(
-	tx_pool: Arc<RwLock<TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	tx_pool: &Arc<RwLock<TransactionPool>>,
+	verifier_cache: &Arc<RwLock<dyn VerifierCache>>,
 ) -> Result<(), PoolError> {
 	let mut tx_pool = tx_pool.write();
 
-	let header = tx_pool.chain_head()?;
-
-	let stem_txs = tx_pool
-		.stempool
-		.get_transactions_in_state(PoolEntryState::ToFluff);
-
+	let stem_txs = tx_pool.stempool.all_transactions();
 	if stem_txs.is_empty() {
 		return Ok(());
 	}
@@ -150,68 +94,35 @@ fn process_fluff_phase(
 	// Get the aggregate tx representing the entire txpool.
 	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
 
+	let header = tx_pool.chain_head()?;
 	let stem_txs = tx_pool
 		.stempool
 		.select_valid_transactions(stem_txs, txpool_tx, &header)?;
-	tx_pool
-		.stempool
-		.transition_to_state(&stem_txs, PoolEntryState::Fluffed);
 
-	if stem_txs.len() > 0 {
-		debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
-
-		let agg_tx = transaction::aggregate(stem_txs)?;
-		agg_tx.validate(
-			transaction::Weighting::AsTransaction,
-			verifier_cache.clone(),
-		)?;
-
-		let src = TxSource {
-			debug_name: "fluff".to_string(),
-			identifier: "?.?.?.?".to_string(),
-		};
-
-		tx_pool.add_to_pool(src, agg_tx, false, &header)?;
+	if stem_txs.is_empty() {
+		return Ok(());
 	}
-	Ok(())
-}
 
-fn process_fresh_entries(
-	dandelion_config: DandelionConfig,
-	tx_pool: Arc<RwLock<TransactionPool>>,
-) -> Result<(), PoolError> {
-	let mut tx_pool = tx_pool.write();
+	debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
 
-	let mut rng = thread_rng();
+	let agg_tx = transaction::aggregate(stem_txs)?;
+	agg_tx.validate(
+		transaction::Weighting::AsTransaction,
+		verifier_cache.clone(),
+	)?;
 
-	let fresh_entries = &mut tx_pool
-		.stempool
-		.entries
-		.iter_mut()
-		.filter(|x| x.state == PoolEntryState::Fresh)
-		.collect::<Vec<_>>();
+	let src = TxSource {
+		debug_name: "fluff".to_string(),
+		identifier: "?.?.?.?".to_string(),
+	};
 
-	if fresh_entries.len() > 0 {
-		debug!(
-			"dand_mon: Found {} fresh entries in stempool.",
-			fresh_entries.len()
-		);
-
-		for x in &mut fresh_entries.iter_mut() {
-			let random = rng.gen_range(0, 101);
-			if random <= dandelion_config.stem_probability.unwrap() {
-				x.state = PoolEntryState::ToStem;
-			} else {
-				x.state = PoolEntryState::ToFluff;
-			}
-		}
-	}
+	tx_pool.add_to_pool(src, agg_tx, false, &header)?;
 	Ok(())
 }
 
 fn process_expired_entries(
-	dandelion_config: DandelionConfig,
-	tx_pool: Arc<RwLock<TransactionPool>>,
+	dandelion_config: &DandelionConfig,
+	tx_pool: &Arc<RwLock<TransactionPool>>,
 ) -> Result<(), PoolError> {
 	let now = Utc::now().timestamp();
 	let embargo_sec = dandelion_config.embargo_secs.unwrap() + thread_rng().gen_range(0, 31);
@@ -231,24 +142,26 @@ fn process_expired_entries(
 		}
 	}
 
-	if expired_entries.len() > 0 {
-		debug!("dand_mon: Found {} expired txs.", expired_entries.len());
-
-		{
-			let mut tx_pool = tx_pool.write();
-			let header = tx_pool.chain_head()?;
-
-			for entry in expired_entries {
-				let src = TxSource {
-					debug_name: "embargo_expired".to_string(),
-					identifier: "?.?.?.?".to_string(),
-				};
-				match tx_pool.add_to_pool(src, entry.tx, false, &header) {
-					Ok(_) => debug!("dand_mon: embargo expired, fluffed tx successfully."),
-					Err(e) => debug!("dand_mon: Failed to fluff expired tx - {:?}", e),
-				};
-			}
-		}
+	if expired_entries.is_empty() {
+		return Ok(());
 	}
+
+	debug!("dand_mon: Found {} expired txs.", expired_entries.len());
+
+	let mut tx_pool = tx_pool.write();
+	let header = tx_pool.chain_head()?;
+
+	let src = TxSource {
+		debug_name: "embargo_expired".to_string(),
+		identifier: "?.?.?.?".to_string(),
+	};
+
+	for entry in expired_entries {
+		match tx_pool.add_to_pool(src.clone(), entry.tx, false, &header) {
+			Ok(_) => debug!("dand_mon: embargo expired, fluffed tx successfully."),
+			Err(e) => debug!("dand_mon: Failed to fluff expired tx - {:?}", e),
+		};
+	}
+
 	Ok(())
 }

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -79,15 +79,11 @@ fn process_fluff_phase(
 	tx_pool: &Arc<RwLock<TransactionPool>>,
 	verifier_cache: &Arc<RwLock<dyn VerifierCache>>,
 ) -> Result<(), PoolError> {
+	// Take a write lock on the txpool for the duration of this processing.
 	let mut tx_pool = tx_pool.write();
 
 	// Get the aggregate tx representing the entire txpool.
 	let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
-
-	// Nothing to process? Then we are done.
-	if txpool_tx.is_none() {
-		return Ok(());
-	}
 
 	// TODO - If this runs every 10s (patience time?) we don't have much time to aggregate txs.
 	// It would be good if we could let txs build up over a longer period of time here.
@@ -115,7 +111,10 @@ fn process_fluff_phase(
 		return Ok(());
 	}
 
-	debug!("dand_mon: Found {} txs for fluffing.", stem_txs.len());
+	debug!(
+		"dand_mon: Found {} txs in local stempool to fluff",
+		stem_txs.len()
+	);
 
 	let agg_tx = transaction::aggregate(stem_txs)?;
 	agg_tx.validate(

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -52,17 +52,17 @@ pub fn monitor_transactions(
 				}
 
 				if !adapter.is_stem() {
-					if process_fluff_phase(&dandelion_config, &tx_pool, &adapter, &verifier_cache)
-						.is_err()
-					{
-						error!("dand_mon: Problem processing fresh pool entries.");
-					}
+					let _ =
+						process_fluff_phase(&dandelion_config, &tx_pool, &adapter, &verifier_cache)
+							.map_err(|e| {
+								error!("dand_mon: Problem processing fluff phase. {:?}", e);
+							});
 				}
 
 				// Now find all expired entries based on embargo timer.
-				if process_expired_entries(&dandelion_config, &tx_pool).is_err() {
-					error!("dand_mon: Problem processing fresh pool entries.");
-				}
+				let _ = process_expired_entries(&dandelion_config, &tx_pool).map_err(|e| {
+					error!("dand_mon: Problem processing expired entries. {:?}", e);
+				});
 
 				// Handle the tx above *before* we transition to next epoch.
 				// This gives us an opportunity to do the final "fluff" before we start

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -119,8 +119,6 @@ pub fn connect_and_monitor(
 						preferred_peers.clone(),
 					);
 
-					update_dandelion_relay(peers.clone(), dandelion_config.clone());
-
 					prev = Utc::now();
 					start_attempt = cmp::min(6, start_attempt + 1);
 				}
@@ -241,21 +239,6 @@ fn monitor_peers(
 			p.addr,
 		);
 		tx.send(p.addr).unwrap();
-	}
-}
-
-fn update_dandelion_relay(peers: Arc<p2p::Peers>, dandelion_config: DandelionConfig) {
-	// Dandelion Relay Updater
-	let dandelion_relay = peers.get_dandelion_relay();
-	if let Some((last_added, _)) = dandelion_relay {
-		let dandelion_interval = Utc::now().timestamp() - last_added;
-		if dandelion_interval >= dandelion_config.relay_secs.unwrap() as i64 {
-			debug!("monitor_peers: updating expired dandelion relay");
-			peers.update_dandelion_relay();
-		}
-	} else {
-		debug!("monitor_peers: no dandelion relay updating");
-		peers.update_dandelion_relay();
 	}
 }
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -29,7 +29,6 @@ use crate::core::global;
 use crate::p2p;
 use crate::p2p::types::PeerAddr;
 use crate::p2p::ChainAdapter;
-use crate::pool::DandelionConfig;
 use crate::util::{Mutex, StopState};
 
 // DNS Seeds with contact email associated
@@ -52,7 +51,6 @@ const FLOONET_DNS_SEEDS: &'static [&'static str] = &[
 pub fn connect_and_monitor(
 	p2p_server: Arc<p2p::Server>,
 	capabilities: p2p::Capabilities,
-	dandelion_config: DandelionConfig,
 	seed_list: Box<dyn Fn() -> Vec<PeerAddr> + Send>,
 	preferred_peers: Option<Vec<PeerAddr>>,
 	stop_state: Arc<Mutex<StopState>>,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -154,7 +154,7 @@ impl Server {
 		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
 
 		let pool_adapter = Arc::new(PoolToChainAdapter::new());
-		let pool_net_adapter = Arc::new(PoolToNetAdapter::new());
+		let pool_net_adapter = Arc::new(PoolToNetAdapter::new(config.dandelion_config.clone()));
 		let tx_pool = Arc::new(RwLock::new(pool::TransactionPool::new(
 			config.pool_config.clone(),
 			pool_adapter.clone(),
@@ -207,6 +207,8 @@ impl Server {
 			genesis.hash(),
 			stop_state.clone(),
 		)?);
+
+		// Initialize various adapters with our dynamic set of connected peers.
 		chain_adapter.init(p2p_server.peers.clone());
 		pool_net_adapter.init(p2p_server.peers.clone());
 		net_adapter.init(p2p_server.peers.clone());
@@ -281,6 +283,7 @@ impl Server {
 		dandelion_monitor::monitor_transactions(
 			config.dandelion_config.clone(),
 			tx_pool.clone(),
+			pool_net_adapter.clone(),
 			verifier_cache.clone(),
 			stop_state.clone(),
 		);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -229,7 +229,6 @@ impl Server {
 			seed::connect_and_monitor(
 				p2p_server.clone(),
 				config.p2p_config.capabilities,
-				config.dandelion_config.clone(),
 				seeder,
 				config.p2p_config.peers_preferred.clone(),
 				stop_state.clone(),


### PR DESCRIPTION
Resolves #2176.

Replaces #2344. Minimizing unrelated changes and keeping focused on Dandelion++.

This is a minimal implementation of Dandelion++ to replace our existing minimal implementation of the original Dandelion.

* Introduce `DandelionEpoch` to track current epoch stem/fluff and current outbound relay peer
* Simplify existing Dandelion monitor
* Get rid of `PoolEntryState`
* Each epoch lasts for (by default) 10 mins.
    * Configurable via `epoch_secs`
* If node is in "stem" epoch then we send stem txs on to outbound relay peer
* If nodes is in "fluff" epoch then we hold stem txs (allowing opportunity to aggregate)
* Dandelion monitor runs every 10s, if current epoch is "fluff" -
    * If epoch expired, aggregate and broadcast all stem txs
    * If any stem txs older than 30s (`aggregation_secs`), aggregate and fluff all stem txs
    * Otherwise wait, allowing stem txs opportunity to aggregate
* Handle expired (3 mins, `embargo_secs`) by broadcasting individual txs

