### PR TITLE
[1.1.0] Win build settings

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
Cargo settings to ensure windows builds link the VC runtime statically so as not to require extra libs to be packaged.