### PR TITLE
Display the current download rate rather than the average when syncing the chain

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -327,12 +327,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 	) -> bool {
 		match self.sync_state.status() {
 			SyncStatus::TxHashsetDownload {
-				start_time: _,
-				prev_update_time: _,
 				update_time: old_update_time,
-				prev_downloaded_size: _,
 				downloaded_size: old_downloaded_size,
-				total_size: _,
+				..
 			} => {
 				self.sync_state
 					.update_txhashset_download(SyncStatus::TxHashsetDownload {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -326,10 +326,20 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		total_size: u64,
 	) -> bool {
 		match self.sync_state.status() {
-			SyncStatus::TxHashsetDownload { .. } => {
+			SyncStatus::TxHashsetDownload {
+				start_time: _,
+				prev_update_time: _,
+				update_time: old_update_time,
+				prev_downloaded_size: _,
+				downloaded_size: old_downloaded_size,
+				total_size: _,
+			} => {
 				self.sync_state
 					.update_txhashset_download(SyncStatus::TxHashsetDownload {
 						start_time,
+						prev_update_time: old_update_time,
+						update_time: Utc::now(),
+						prev_downloaded_size: old_downloaded_size,
 						downloaded_size,
 						total_size,
 					})

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -262,6 +262,9 @@ pub enum SyncStatus {
 	/// Downloading the various txhashsets
 	TxHashsetDownload {
 		start_time: DateTime<Utc>,
+		prev_update_time: DateTime<Utc>,
+		update_time: DateTime<Utc>,
+		prev_downloaded_size: u64,
 		downloaded_size: u64,
 		total_size: u64,
 	},

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -147,6 +147,9 @@ impl StateSync {
 
 				self.sync_state.update(SyncStatus::TxHashsetDownload {
 					start_time: Utc::now(),
+					prev_update_time: Utc::now(),
+					update_time: Utc::now(),
+					prev_downloaded_size: 0,
 					downloaded_size: 0,
 					total_size: 0,
 				});

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -128,6 +128,9 @@ impl TUIStatusListener for TUIStatusView {
 				}
 				SyncStatus::TxHashsetDownload {
 					start_time,
+					prev_update_time,
+					update_time: _,
+					prev_downloaded_size,
 					downloaded_size,
 					total_size,
 				} => {
@@ -137,14 +140,14 @@ impl TUIStatusListener for TUIStatusView {
 						} else {
 							0
 						};
-						let start = start_time.timestamp_nanos();
+						let start = prev_update_time.timestamp_nanos();
 						let fin = Utc::now().timestamp_nanos();
 						let dur_ms = (fin - start) as f64 * NANO_TO_MILLIS;
 
 						format!("Downloading {}(MB) chain state for state sync: {}% at {:.1?}(kB/s), step 2/4",
 						total_size / 1_000_000,
 						percent,
-						if dur_ms > 1.0f64 { downloaded_size as f64 / dur_ms as f64 } else { 0f64 },
+						if dur_ms > 1.0f64 { (downloaded_size - prev_downloaded_size) as f64 / dur_ms as f64 } else { 0f64 },
 						)
 					} else {
 						let start = start_time.timestamp_millis();


### PR DESCRIPTION
Fix for https://github.com/mimblewimble/grin/issues/2488
Currently when syncing the chain, your displayed download rate is calculated as (Total downloaded size/ Total Time), aka the average download rate.  This can be extremely misleading if your download speed suddenly changes (like when you disconnect).

This PR adds to each TxHashsetDownload  the size and timestamp values of the previous TxHashsetDownload, which allows us to calculate the delta between them and get the current rate.

You can test by starting up a sync, letting it run for a minute, then disconnecting from the network; previous behavior was that the rate would slowly decrease, now it will drop to 0 within a few seconds.