### PR TITLE
[1.1.0] Remove/Comment out most of fuzz testing crate

### DIFF
--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -10,7 +10,6 @@ cargo-fuzz = true
 [dependencies]
 grin_core = { path = ".."}
 grin_keychain = { path = "../../keychain"}
-grin_wallet = { path = "../../wallet"}
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 

--- a/core/fuzz/fuzz_targets/compact_block_read.rs
+++ b/core/fuzz/fuzz_targets/compact_block_read.rs
@@ -3,10 +3,10 @@ extern crate grin_core;
 #[macro_use]
 extern crate libfuzzer_sys;
 
-use grin_core::core::block;
-use grin_core::ser;
+/*use grin_core::core::block;
+use grin_core::ser;*/
 
-fuzz_target!(|data: &[u8]| {
-	let mut d = data.clone();
-	let _t: Result<block::CompactBlock, ser::Error> = ser::deserialize(&mut d);
+fuzz_target!(|_data: &[u8]| {
+	/*let mut d = data.clone();
+	let _t: Result<block::CompactBlock, ser::Error> = ser::deserialize(&mut d);*/
 });

--- a/core/fuzz/src/main.rs
+++ b/core/fuzz/src/main.rs
@@ -1,8 +1,9 @@
 extern crate grin_core;
 extern crate grin_keychain;
-extern crate grin_wallet;
 
-use grin_core::core::target::Difficulty;
+/* These are completely out of date. Commented out until someone attends to them */
+
+/*use grin_core::core::target::Difficulty;
 use grin_core::core::{Block, BlockHeader, CompactBlock, Transaction};
 use grin_core::libtx::build::{input, output, transaction, with_fee};
 use grin_core::libtx::reward;
@@ -10,14 +11,15 @@ use grin_core::ser;
 use grin_keychain::keychain::ExtKeychain;
 use grin_keychain::Keychain;
 use std::fs::{self, File};
-use std::path::Path;
+use std::path::Path;*/
 
 fn main() {
-	generate("transaction_read", &tx()).unwrap();
+	/*generate("transaction_read", &tx()).unwrap();
 	generate("block_read", &block()).unwrap();
-	generate("compact_block_read", &compact_block()).unwrap();
+	generate("compact_block_read", &compact_block()).unwrap();*/
 }
 
+/*
 fn generate<W: ser::Writeable>(target: &str, obj: W) -> Result<(), ser::Error> {
 	let dir_path = Path::new("corpus").join(target);
 	if !dir_path.is_dir() {
@@ -80,3 +82,4 @@ fn tx() -> Transaction {
 	)
 	.unwrap()
 }
+*/


### PR DESCRIPTION
Neglected core/fuzz crate causing downstream issues for the wallet, removed wallet reference and comment out most of it until someone wants to pay some attention to it.