### PR TITLE
Fix TxHashSet file filter for Windows.

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1465,7 +1465,7 @@ fn expected_file(path: &Path) -> bool {
 	lazy_static! {
 		static ref RE: Regex = Regex::new(
 			format!(
-				r#"^({}|{}|{})(/pmmr_(hash|data|leaf|prun)\.bin(\.\w*)?)?$"#,
+				r#"^({}|{}|{})((/|\\)pmmr_(hash|data|leaf|prun)\.bin(\.\w*)?)?$"#,
 				OUTPUT_SUBDIR, KERNEL_SUBDIR, RANGE_PROOF_SUBDIR
 			)
 			.as_str()

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1625,7 +1625,7 @@ mod tests {
 		assert!(!expected_file(Path::new("kernels")));
 		assert!(!expected_file(Path::new("xkernel")));
 		assert!(expected_file(Path::new("kernel")));
-		assert!(expected_file(Path::new("kernel/pmmr_data.bin")));
+		assert!(expected_file(Path::new("kernel\\pmmr_data.bin")));
 		assert!(expected_file(Path::new("kernel/pmmr_hash.bin")));
 		assert!(expected_file(Path::new("kernel/pmmr_leaf.bin")));
 		assert!(expected_file(Path::new("kernel/pmmr_prun.bin")));

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -73,8 +73,14 @@ where
 	for i in 0..archive.len() {
 		let mut file = archive.by_index(i)?;
 		let san_name = file.sanitized_name();
-		if san_name.to_str().unwrap_or("").replace("\\", "/") != file.name().replace("\\", "/") || !expected(&san_name) {
-			info!("ignoring a suspicious file: {}, got {:?}", file.name(), san_name.to_str());
+		if san_name.to_str().unwrap_or("").replace("\\", "/") != file.name().replace("\\", "/")
+			|| !expected(&san_name)
+		{
+			info!(
+				"ignoring a suspicious file: {}, got {:?}",
+				file.name(),
+				san_name.to_str()
+			);
 			continue;
 		}
 		let file_path = dest.join(san_name);

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -73,8 +73,8 @@ where
 	for i in 0..archive.len() {
 		let mut file = archive.by_index(i)?;
 		let san_name = file.sanitized_name();
-		if san_name.to_str().unwrap_or("") != file.name() || !expected(&san_name) {
-			info!("ignoring a suspicious file: {}", file.name());
+		if san_name.to_str().unwrap_or("").replace("\\", "/") != file.name().replace("\\", "/") || !expected(&san_name) {
+			info!("ignoring a suspicious file: {}, got {:?}", file.name(), san_name.to_str());
 			continue;
 		}
 		let file_path = dest.join(san_name);


### PR DESCRIPTION
sanitized_name() converts `/` to `\\` on windows machines, so it does not match the regex filter.
This fix looks for both `/` and `\\`.