### PR TITLE
Specify grin or nanogrins in API docs where applicable

### DIFF
--- a/doc/api/wallet_owner_api.md
+++ b/doc/api/wallet_owner_api.md
@@ -108,7 +108,7 @@ Attempt to update and retrieve outputs.
 * **Success Response:**
 
   * **Code:** 200
-  * **Content:** Array of
+  * **Content:** All listed amounts in nanogrin. Array of
 
     | Field                             | Type     | Description                             |
     |:----------------------------------|:---------|:----------------------------------------|

--- a/doc/api/wallet_owner_api.md
+++ b/doc/api/wallet_owner_api.md
@@ -341,7 +341,7 @@ Send a transaction either directly by http or file (then display the slate)
 
     | Field                         | Type     | Description                          |
     |:------------------------------|:---------|:-------------------------------------|
-    | amount                        | number   | Amount to send                       |
+    | amount                        | number   | Amount to send (in nanogrin)         |
     | minimum_confirmations         | number   | Minimum confirmations                |
     | method                        | string   | Payment method                       |
     | dest                          | string   | Destination url                      |


### PR DESCRIPTION
## Problem

API docs are not specifying if amounts are in nanogrin or grin and it should be made explicit wherever possible.

## Solution

Add some docs related to nanogrin / grin where it tripped me up. This is a draft pull request so I am happy to flesh out more but I'm not entirely sure where else this information should be added or what the right information is. 

