### PR TITLE
return the finalized slate from the post_tx endpoint

### DIFF
--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -445,7 +445,7 @@ where
 		&self,
 		req: Request<Body>,
 		api: APIOwner<T, C, K>,
-	) -> Box<dyn Future<Item = (), Error = Error> + Send> {
+	) -> Box<dyn Future<Item = Slate, Error = Error> + Send> {
 		let params = match req.uri().query() {
 			Some(query_string) => form_urlencoded::parse(query_string.as_bytes())
 				.into_owned()
@@ -458,7 +458,7 @@ where
 		let fluff = params.get("fluff").is_some();
 		Box::new(parse_body(req).and_then(
 			move |slate: Slate| match api.post_tx(&slate.tx, fluff) {
-				Ok(_) => ok(()),
+				Ok(_) => ok(slate),
 				Err(e) => {
 					error!("post_tx: failed with error: {}", e);
 					err(e)


### PR DESCRIPTION
* Includes a proper description of what problems the PR addresses, as well as a detailed explanation as to what it changes

The API for post_tx should return the finalized transaction slate for posterity.

* Explains whether/how the change is consensus breaking or breaks existing client functionality

This change may break some clients and would probably be best to wait for V2 but I wanted to put it here as a discussion point.  

* Contains unit tests exercising new/changed functionality

No unit tests for API at the moment

* Fully considers the potential impact of the change on other parts of the system

Only touching outer skin, really just integration points.

* Describes how you've tested the change (e.g. against Floonet, etc)

WIP 

* Updates any documentation that's affected by the PR

https://github.com/mimblewimble/grin/blob/master/doc/api/wallet_owner_api.md#post-post-tx
