### PR TITLE
Add Medium post to intro

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -23,6 +23,8 @@ The main goal and characteristics of the Grin project are:
 * Design simplicity that makes it easy to audit and maintain over time.
 * Community driven, encouraging mining decentralization.
 
+A detailed post on the step-by-step of how Grin transactions work (with graphics) can be found [in this Medium post](https://medium.com/@brandonarvanaghi/grin-transactions-explained-step-by-step-fdceb905a853). 
+
 ## Tongue Tying for Everyone
 
 This document is targeted at readers with a good


### PR DESCRIPTION
Spoke to @yeastplume who agreed it makes sense to add the "Grin Transactions Explained, Step-by-Step" Medium post to intro.md

Open for suggestions on a better location.

---
name: Add Medium post to intro
about: Inro documentation
title: ''Add Medium post to intro.md"
labels: ''docs"
assignees: ''yeastplume"

---
If your PR is a work in progress, please feel free to create it and include a [WIP] tag in the PR name. We encourage everyone to PR early and often so that other developers know what you're working on.

Before submitting your PR for final review, please ensure that it:

* Includes a proper description of what problems the PR addresses, as well as a detailed explanation as to what it changes
* Explains whether/how the change is consensus breaking or breaks existing client functionality
* Contains unit tests exercising new/changed functionality
* Fully considers the potential impact of the change on other parts of the system
* Describes how you've tested the change (e.g. against Floonet, etc)
* Updates any documentation that's affected by the PR
