### PR TITLE
remove root = true from .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-# top-most .editorconfig file
-root = true
-
 # use hard tabs for rust source files
 [*.rs]
 indent_style = tab


### PR DESCRIPTION
The current .editorconfig file sets root to true, preventing editors from reading .editorconfig files in parent directories.

This pr removes that setting so we can use the .editorconfig in our home directories.

Tagging @casey because he added the file initially.
