### PR TITLE
[1.1.0] LMDB Naming consistency fix

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -45,7 +45,7 @@ pub struct ChainStore {
 impl ChainStore {
 	/// Create new chain store
 	pub fn new(db_root: &str) -> Result<ChainStore, Error> {
-		let db = store::Store::new(db_root, Some(STORE_SUBPATH.clone()), None, None)?;
+		let db = store::Store::new(db_root, None, Some(STORE_SUBPATH.clone()), None)?;
 		Ok(ChainStore { db })
 	}
 }

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -45,7 +45,7 @@ pub struct ChainStore {
 impl ChainStore {
 	/// Create new chain store
 	pub fn new(db_root: &str) -> Result<ChainStore, Error> {
-		let db = store::Store::new(db_root, Some(STORE_SUBPATH.clone()), None)?;
+		let db = store::Store::new(db_root, Some(STORE_SUBPATH.clone()), None, None)?;
 		Ok(ChainStore { db })
 	}
 }

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -115,7 +115,7 @@ pub struct PeerStore {
 impl PeerStore {
 	/// Instantiates a new peer store under the provided root path.
 	pub fn new(db_root: &str) -> Result<PeerStore, Error> {
-		let db = grin_store::Store::new(db_root, Some(STORE_SUBPATH), None)?;
+		let db = grin_store::Store::new(db_root, Some(STORE_SUBPATH), None, None)?;
 		Ok(PeerStore { db: db })
 	}
 

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -22,6 +22,7 @@ use crate::core::ser::{self, Readable, Reader, Writeable, Writer};
 use crate::types::{Capabilities, PeerAddr, ReasonForBan};
 use grin_store::{self, option_to_not_found, to_key, Error};
 
+const DB_NAME: &'static str = "peer";
 const STORE_SUBPATH: &'static str = "peers";
 
 const PEER_PREFIX: u8 = 'P' as u8;
@@ -115,7 +116,7 @@ pub struct PeerStore {
 impl PeerStore {
 	/// Instantiates a new peer store under the provided root path.
 	pub fn new(db_root: &str) -> Result<PeerStore, Error> {
-		let db = grin_store::Store::new(db_root, Some(STORE_SUBPATH), None, None)?;
+		let db = grin_store::Store::new(db_root, Some(DB_NAME), Some(STORE_SUBPATH), None)?;
 		Ok(PeerStore { db: db })
 	}
 

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -54,7 +54,7 @@ impl ChainAdapter {
 	pub fn update_db_for_block(&self, block: &Block) {
 		let header = &block.header;
 		let tip = Tip::from_header(header);
-		let mut s = self.store.write();
+		let s = self.store.write();
 		let batch = s.batch().unwrap();
 
 		batch.save_block_header(header).unwrap();

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -75,12 +75,16 @@ impl Store {
 	/// By default creates an environment named "lmdb".
 	/// Be aware of transactional semantics in lmdb
 	/// (transactions are per environment, not per database).
-	pub fn new(path: &str, name: Option<&str>, max_readers: Option<u32>) -> Result<Store, Error> {
-		let name = match name {
+	pub fn new(root_path: &str, env_name: Option<&str>, db_name: Option<&str>, max_readers: Option<u32>) -> Result<Store, Error> {
+		let name = match env_name {
 			Some(n) => n.to_owned(),
 			None => "lmdb".to_owned(),
 		};
-		let full_path = [path.to_owned(), name.clone()].join("/");
+		let db_name = match db_name {
+			Some(n) => n.to_owned(),
+			None => "lmdb".to_owned(),
+		};
+		let full_path = [root_path.to_owned(), name.clone()].join("/");
 		fs::create_dir_all(&full_path)
 			.expect("Unable to create directory 'db_root' to store chain_data");
 
@@ -101,7 +105,7 @@ impl Store {
 		let res = Store {
 			env: Arc::new(env),
 			db: RwLock::new(None),
-			name: name,
+			name: db_name,
 		};
 
 		{

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -75,7 +75,12 @@ impl Store {
 	/// By default creates an environment named "lmdb".
 	/// Be aware of transactional semantics in lmdb
 	/// (transactions are per environment, not per database).
-	pub fn new(root_path: &str, env_name: Option<&str>, db_name: Option<&str>, max_readers: Option<u32>) -> Result<Store, Error> {
+	pub fn new(
+		root_path: &str,
+		env_name: Option<&str>,
+		db_name: Option<&str>,
+		max_readers: Option<u32>,
+	) -> Result<Store, Error> {
 		let name = match env_name {
 			Some(n) => n.to_owned(),
 			None => "lmdb".to_owned(),

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -70,7 +70,7 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 	// Allocate more than the initial chunk, ensuring
 	// the DB resizes underneath
 	{
-		let store = store::Store::new(test_dir, Some("test1"), None)?;
+		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
 
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
@@ -87,7 +87,7 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 	println!("***********************************");
 	// Open env again and keep adding
 	{
-		let store = store::Store::new(test_dir, Some("test1"), None)?;
+		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
 			let chunk = PhatChunkStruct::new();


### PR DESCRIPTION
Update chain and peer db paths to be consistent with 1.0.x, as well as modification to Store struct to allow all parts of the db path/name to be specified explicitly. For reference, paths and db paths are:

* the chain db itself is under the path `chain_data/lmdb` with a database name of `chain` 
* peer data is at `chain_data/peer` with a db name of `peers`. 
* wallet data is under `db/lmdb` with a database name of `db`

These should probably be cleaned up at some point, though there would have to be a migration feature.