### PR TITLE
https support for webhooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "grin_util 1.1.0",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 hyper = "0.12"
+hyper-rustls = "0.14"
 fs2 = "0.4"
 futures = "0.1"
 http = "0.1"

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -16,22 +16,22 @@
 //! callback simply implement the coresponding trait and add it to the init function
 
 extern crate hyper;
-extern crate tokio;
 extern crate hyper_rustls;
+extern crate tokio;
 
 use crate::chain::BlockStatus;
 use crate::common::types::{ServerConfig, WebHooksConfig};
 use crate::core::core;
 use crate::core::core::hash::Hashed;
+use crate::p2p::types::PeerAddr;
 use futures::future::Future;
-use hyper_rustls::HttpsConnector;
 use hyper::client::HttpConnector;
 use hyper::header::HeaderValue;
 use hyper::Client;
 use hyper::{Body, Method, Request};
+use hyper_rustls::HttpsConnector;
 use serde::Serialize;
 use serde_json::{json, to_string};
-use crate::p2p::types::PeerAddr;
 use tokio::runtime::Runtime;
 
 /// Returns the list of event hooks that will be initialized for network events
@@ -153,7 +153,10 @@ fn parse_url(value: &Option<String>) -> Option<hyper::Uri> {
 			};
 			let scheme = uri.scheme_part().map(|s| s.as_str());
 			if (scheme != Some("http")) && (scheme != Some("https")) {
-				panic!("Invalid url scheme {}, expected one of ['http', https']", url)
+				panic!(
+					"Invalid url scheme {}, expected one of ['http', https']",
+					url
+				)
 			};
 			Some(uri)
 		}
@@ -186,8 +189,7 @@ impl WebHook {
 		block_accepted_url: Option<hyper::Uri>,
 	) -> WebHook {
 		let https = HttpsConnector::new(4);
-		let client = Client::builder()
-    		.build::<_, hyper::Body>(https);
+		let client = Client::builder().build::<_, hyper::Body>(https);
 		WebHook {
 			tx_received_url,
 			block_received_url,

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -193,8 +193,11 @@ impl WebHook {
 	) -> WebHook {
 		let keep_alive = Duration::from_secs(timeout as u64);
 
-		info!("Spawning {} threads for webhooks (timeout set to {} secs)", nthreads, timeout);
-		
+		info!(
+			"Spawning {} threads for webhooks (timeout set to {} secs)",
+			nthreads, timeout
+		);
+
 		let https = HttpsConnector::new(nthreads as usize);
 		let client = Client::builder()
 			.keep_alive_timeout(keep_alive)

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -192,6 +192,9 @@ impl WebHook {
 		timeout: u16,
 	) -> WebHook {
 		let keep_alive = Duration::from_secs(timeout as u64);
+
+		info!("Spawning {} threads for webhooks (timeout set to {} secs)", nthreads, timeout);
+		
 		let https = HttpsConnector::new(nthreads as usize);
 		let client = Client::builder()
 			.keep_alive_timeout(keep_alive)

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -32,8 +32,8 @@ use hyper::{Body, Method, Request};
 use hyper_rustls::HttpsConnector;
 use serde::Serialize;
 use serde_json::{json, to_string};
-use tokio::runtime::Runtime;
 use std::time::Duration;
+use tokio::runtime::Runtime;
 
 /// Returns the list of event hooks that will be initialized for network events
 pub fn init_net_hooks(config: &ServerConfig) -> Vec<Box<dyn NetEvents + Send + Sync>> {
@@ -193,8 +193,10 @@ impl WebHook {
 	) -> WebHook {
 		let keep_alive = Duration::from_secs(timeout as u64);
 		let https = HttpsConnector::new(nthreads as usize);
-		let client = Client::builder().keep_alive_timeout(keep_alive).build::<_, hyper::Body>(https);
-		
+		let client = Client::builder()
+			.keep_alive_timeout(keep_alive)
+			.build::<_, hyper::Body>(https);
+
 		WebHook {
 			tx_received_url,
 			block_received_url,

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -248,6 +248,20 @@ pub struct WebHooksConfig {
 	pub block_received_url: Option<String>,
 	/// url to POST block data when a new block is accepted by our node (might be a reorg or a fork)
 	pub block_accepted_url: Option<String>,
+	/// number of worker threads in the tokio runtime
+	#[serde(default = "default_nthreads")]
+	pub nthreads: u16,
+	/// timeout in seconds for the http request 
+	#[serde(default = "default_timeout")]
+	pub timeout: u16,
+}
+
+fn default_timeout() -> u16 {
+    10
+}
+
+fn default_nthreads() -> u16 {
+    4
 }
 
 impl Default for WebHooksConfig {
@@ -257,6 +271,8 @@ impl Default for WebHooksConfig {
 			header_received_url: None,
 			block_received_url: None,
 			block_accepted_url: None,
+			nthreads: default_nthreads(),
+			timeout: default_timeout()
 		}
 	}
 }

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -251,17 +251,17 @@ pub struct WebHooksConfig {
 	/// number of worker threads in the tokio runtime
 	#[serde(default = "default_nthreads")]
 	pub nthreads: u16,
-	/// timeout in seconds for the http request 
+	/// timeout in seconds for the http request
 	#[serde(default = "default_timeout")]
 	pub timeout: u16,
 }
 
 fn default_timeout() -> u16 {
-    10
+	10
 }
 
 fn default_nthreads() -> u16 {
-    4
+	4
 }
 
 impl Default for WebHooksConfig {
@@ -272,7 +272,7 @@ impl Default for WebHooksConfig {
 			block_received_url: None,
 			block_accepted_url: None,
 			nthreads: default_nthreads(),
-			timeout: default_timeout()
+			timeout: default_timeout(),
 		}
 	}
 }


### PR DESCRIPTION
Implements the todos from #2598

- Adds https support
- Adds configurable `nthreads` and `timeout`

Usage:

Add these values to your `grin-server.toml`

```
[server.webhook_config]
nthreads = 4
timeout = 10
block_accepted_url = "http://127.0.0.1:8080/acceptedblock"
tx_received_url = "http://127.0.0.1:8080/tx"
header_received_url = "http://127.0.0.1:8080/header"
block_received_url = "http://127.0.0.1:8080/block"
```