### PR TITLE
fix the build warning of deprecated trim_right_matches

### DIFF
--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -79,7 +79,7 @@ impl Handler for PeerHandler {
 		}
 	}
 	fn post(&self, req: Request<Body>) -> ResponseFuture {
-		let mut path_elems = req.uri().path().trim_right_matches('/').rsplit('/');
+		let mut path_elems = req.uri().path().trim_end_matches('/').rsplit('/');
 		let command = match path_elems.next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(c) => c,

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -95,9 +95,9 @@ pub fn amount_to_hr_string(amount: u64, truncate: bool) -> String {
 	if truncate {
 		let nzeros = hr.chars().rev().take_while(|x| x == &'0').count();
 		if nzeros < *WIDTH {
-			return hr.trim_right_matches('0').to_string();
+			return hr.trim_end_matches('0').to_string();
 		} else {
-			return format!("{}0", hr.trim_right_matches('0'));
+			return format!("{}0", hr.trim_end_matches('0'));
 		}
 	}
 	hr

--- a/wallet/src/controller.rs
+++ b/wallet/src/controller.rs
@@ -300,7 +300,7 @@ where
 			match req
 				.uri()
 				.path()
-				.trim_right_matches("/")
+				.trim_end_matches("/")
 				.rsplit("/")
 				.next()
 				.unwrap()
@@ -553,7 +553,7 @@ where
 		match req
 			.uri()
 			.path()
-			.trim_right_matches("/")
+			.trim_end_matches("/")
 			.rsplit("/")
 			.next()
 			.unwrap()
@@ -684,7 +684,7 @@ where
 		match req
 			.uri()
 			.path()
-			.trim_right_matches("/")
+			.trim_end_matches("/")
 			.rsplit("/")
 			.next()
 			.unwrap()


### PR DESCRIPTION
In Ubuntu 18.04, the building has several warnings like this:
```
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`
   --> wallet/src/controller.rs:303:6
    |
303 |                 .trim_right_matches("/")
    |                  ^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default

```
this PR is a minor fix for this warning.
