### PR TITLE
[1.1.0] Additional secp primitive serialization changes

### DIFF
--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -95,7 +95,6 @@ pub mod option_sig_serde {
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
 	use crate::util::secp;
-	use crate::util::static_secp_instance;
 	use crate::util::{from_hex, to_hex};
 	use serde::de::Error;
 
@@ -104,9 +103,7 @@ pub mod sig_serde {
 	where
 		S: Serializer,
 	{
-		let static_secp = static_secp_instance();
-		let static_secp = static_secp.lock();
-		serializer.serialize_str(&to_hex(sig.serialize_der(&static_secp)))
+	  serializer.serialize_str(&to_hex(sig.to_raw_data().to_vec()))
 	}
 
 	///
@@ -114,12 +111,12 @@ pub mod sig_serde {
 	where
 		D: Deserializer<'de>,
 	{
-		let static_secp = static_secp_instance();
-		let static_secp = static_secp.lock();
 		String::deserialize(deserializer)
 			.and_then(|string| from_hex(string).map_err(|err| Error::custom(err.to_string())))
 			.and_then(|bytes: Vec<u8>| {
-				secp::Signature::from_der(&static_secp, &bytes)
+				let mut b = [0u8; 64];
+				b.copy_from_slice(&bytes[0..64]);
+					secp::Signature::from_raw_data(&b)
 					.map_err(|err| Error::custom(err.to_string()))
 			})
 	}

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -32,7 +32,7 @@ pub mod pubkey_serde {
 	{
 		let static_secp = static_secp_instance();
 		let static_secp = static_secp.lock();
-		serializer.serialize_str(&to_hex(key.serialize_vec(&static_secp, false).to_vec()))
+		serializer.serialize_str(&to_hex(key.serialize_vec(&static_secp, true).to_vec()))
 	}
 
 	///

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -103,7 +103,7 @@ pub mod sig_serde {
 	where
 		S: Serializer,
 	{
-	  serializer.serialize_str(&to_hex(sig.to_raw_data().to_vec()))
+		serializer.serialize_str(&to_hex(sig.to_raw_data().to_vec()))
 	}
 
 	///
@@ -116,8 +116,7 @@ pub mod sig_serde {
 			.and_then(|bytes: Vec<u8>| {
 				let mut b = [0u8; 64];
 				b.copy_from_slice(&bytes[0..64]);
-					secp::Signature::from_raw_data(&b)
-					.map_err(|err| Error::custom(err.to_string()))
+				secp::Signature::from_raw_data(&b).map_err(|err| Error::custom(err.to_string()))
 			})
 	}
 }


### PR DESCRIPTION
Part 2 of #2668, because I make a conscious technical decision to split this PR into 2 parts and certainly didn't just forget to change the second instance in the code where this field is serialized.

Also changed serializer to store public keys in compressed form.