### PR TITLE
Add flag to override run_tui setting

### DIFF
--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -104,6 +104,10 @@ pub fn server_command(
 			server_config.p2p_config.port = port.parse().unwrap();
 		}
 
+		if let Some(tui_enabled) = a.value_of("tui_enabled") {
+			server_config.run_tui = Some(tui_enabled == "true");
+		}
+		
 		if let Some(api_port) = a.value_of("api_port") {
 			let default_ip = "0.0.0.0";
 			server_config.api_http_addr = format!("{}:{}", default_ip, api_port);

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -16,6 +16,11 @@ subcommands:
   - server:
       about: Control the Grin server
       args:
+        - tui_enabled:
+            help: Run with or without TUI, bypassing config
+            short: t
+            long: tui_enabled
+            takes_value: true
         - config_file:
             help: Path to a grin-server.toml configuration file
             short: c


### PR DESCRIPTION
Add an additional flag to override TUI settings, needed for headless GUI wallets such as Kingfish and Supergrin.