### PR TITLE
Show response code in API client error message

### DIFF
--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -203,9 +203,10 @@ fn send_request_async(req: Request<Body>) -> Box<dyn Future<Item = String, Error
 			.map_err(|e| ErrorKind::RequestError(format!("Cannot make request: {}", e)).into())
 			.and_then(|resp| {
 				if !resp.status().is_success() {
-					Either::A(err(ErrorKind::RequestError(
-						"Wrong response code".to_owned(),
-					)
+					Either::A(err(ErrorKind::RequestError(format!(
+						"Wrong response code: {}",
+						resp.status()
+					))
 					.into()))
 				} else {
 					Either::B(


### PR DESCRIPTION
It's hard to investigate what happens when an API client error is
printed out