### PR TITLE
let check_txhashset_needed return true on abnormal case

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -799,6 +799,7 @@ impl Chain {
 				"{}: header_head not found in chain db: {} at {}",
 				caller, header_head.last_block_h, header_head.height,
 			);
+			return false;
 		}
 
 		//
@@ -824,15 +825,20 @@ impl Chain {
 
 		if oldest_height < header_head.height.saturating_sub(horizon) {
 			if oldest_height > 0 {
+				// this is the normal case. for example:
+				// body head height is 1 (and not a fork), oldest_height will be 2
+				// body head height is 0 (a typical fresh node), oldest_height will be 1
+				// body head height is 10,001 (but at a fork), oldest_height will be 10,001
+				// body head height is 10,005 (but at a fork with depth 5), oldest_height will be 10,001
 				debug!(
 					"{}: need a state sync for txhashset. oldest block which is not on local chain: {} at {}",
 					caller, oldest_hash, oldest_height,
 				);
-				return true;
 			} else {
-				error!("{}: something is wrong! oldest_height is 0", caller);
-				return false;
-			};
+				// this is the abnormal case, when is_on_current_chain() already return Err, and even for genesis block.
+				error!("{}: corrupted storage? oldest_height is 0 when check_txhashset_needed. state sync is needed", caller);
+			}
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
At the abnormal case, when`is_on_current_chain()` function already return Err, even for genesis block, the `oldest_height` will be 0. The possible practical situation is the local data file corrupted.

The old behavior is `return false` (i.e. state sync is **NOT needed** in this case).

This PR change this behavior to "state sync is **needed** in this case", to give a chance to restart a downloading to recover the local corrupted data.

Another improvement is giving the early return when `header_head not found in chain db`, to avoid the confusing log since it will also cause `oldest_height = 0`.


