### PR TITLE
use sandbox folder for txhashset validation on state sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -873,17 +873,18 @@ impl Chain {
 
 		// Write txhashset to sandbox
 		txhashset::clean_txhashset_folder(&env::temp_dir());
-		txhashset::zip_write(
-			env::temp_dir(),
-			txhashset_data.try_clone()?,
-			&header,
-		)?;
+		txhashset::zip_write(env::temp_dir(), txhashset_data.try_clone()?, &header)?;
 
 		let mut txhashset = txhashset::TxHashSet::open(
 			self.db_root.clone(),
 			self.store.clone(),
 			Some(&header),
-			Some(env::temp_dir().to_str().expect("invalid temp folder").to_owned()),
+			Some(
+				env::temp_dir()
+					.to_str()
+					.expect("invalid temp folder")
+					.to_owned(),
+			),
 		)?;
 
 		// The txhashset.zip contains the output, rangeproof and kernel MMRs.

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -182,8 +182,7 @@ impl Chain {
 			let store = Arc::new(store::ChainStore::new(db_env)?);
 
 			// open the txhashset, creating a new one if necessary
-			let mut txhashset =
-				txhashset::TxHashSet::open(db_root.clone(), store.clone(), None)?;
+			let mut txhashset = txhashset::TxHashSet::open(db_root.clone(), store.clone(), None)?;
 
 			setup_head(&genesis, &store, &mut txhashset)?;
 			Chain::log_heads(&store)?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -871,13 +871,14 @@ impl Chain {
 		let header = self.get_block_header(&h)?;
 
 		// Write txhashset to sandbox (in the os temporary directory)
-		txhashset::clean_txhashset_folder(&env::temp_dir());
-		txhashset::zip_write(env::temp_dir(), txhashset_data.try_clone()?, &header)?;
+		let sandbox_dir = env::temp_dir();
+		txhashset::clean_txhashset_folder(&sandbox_dir);
+		txhashset::zip_write(sandbox_dir.clone(), txhashset_data.try_clone()?, &header)?;
 
 		let mut txhashset = txhashset::TxHashSet::open(
-			env::temp_dir()
+			sandbox_dir
 				.to_str()
-				.expect("invalid temp folder")
+				.expect("invalid sandbox folder")
 				.to_owned(),
 			self.store.clone(),
 			Some(&header),
@@ -942,7 +943,7 @@ impl Chain {
 
 			// Move sandbox to overwrite
 			txhashset.release_backend_files();
-			txhashset::txhashset_replace(env::temp_dir(), PathBuf::from(self.db_root.clone()))?;
+			txhashset::txhashset_replace(sandbox_dir, PathBuf::from(self.db_root.clone()))?;
 
 			// Re-open on db root dir
 			txhashset = txhashset::TxHashSet::open(

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1460,6 +1460,7 @@ pub fn zip_write(
 	txhashset_data: File,
 	header: &BlockHeader,
 ) -> Result<(), Error> {
+	debug!("zip_write on path: {:?}", root_dir);
 	let txhashset_path = root_dir.clone().join(TXHASHSET_SUBDIR);
 	fs::create_dir_all(txhashset_path.clone())?;
 	zip::decompress(txhashset_data, &txhashset_path, expected_file)
@@ -1469,6 +1470,8 @@ pub fn zip_write(
 
 /// Rename a folder to another
 pub fn txhashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
+	debug!("txhashset_replace: move from {:?} to {:?}", from, to);
+
 	// clean the 'to' folder firstly
 	clean_txhashset_folder(&to);
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -117,7 +117,11 @@ impl TxHashSet {
 		header: Option<&BlockHeader>,
 		sandbox: bool,
 	) -> Result<TxHashSet, Error> {
-		let txhashset_subdir = if sandbox { TXHASHSET_SANDBOX_SUBDIR } else { TXHASHSET_SUBDIR };
+		let txhashset_subdir = if sandbox {
+			TXHASHSET_SANDBOX_SUBDIR
+		} else {
+			TXHASHSET_SUBDIR
+		};
 		Ok(TxHashSet {
 			header_pmmr_h: PMMRHandle::new(
 				&root_dir,
@@ -1458,9 +1462,11 @@ pub fn zip_write(
 	header: &BlockHeader,
 	sandbox: bool,
 ) -> Result<(), Error> {
-	let txhashset_path = Path::new(&root_dir).join(
-		if sandbox { TXHASHSET_SANDBOX_SUBDIR } else { TXHASHSET_SUBDIR }
-	);
+	let txhashset_path = Path::new(&root_dir).join(if sandbox {
+		TXHASHSET_SANDBOX_SUBDIR
+	} else {
+		TXHASHSET_SUBDIR
+	});
 	fs::create_dir_all(txhashset_path.clone())?;
 	zip::decompress(txhashset_data, &txhashset_path, expected_file)
 		.map_err(|ze| ErrorKind::Other(ze.to_string()))?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1468,10 +1468,7 @@ pub fn zip_write(
 }
 
 /// Rename a folder to another
-pub fn txhashset_replace(
-	from: PathBuf,
-	to: PathBuf,
-) -> Result<(), Error>  {
+pub fn txhashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
 	// clean the 'to' folder firstly
 	clean_txhashset_folder(&to);
 
@@ -1487,9 +1484,7 @@ pub fn txhashset_replace(
 }
 
 /// Clean the txhashset folder
-pub fn clean_txhashset_folder(
-	root_dir: &PathBuf,
-) {
+pub fn clean_txhashset_folder(root_dir: &PathBuf) {
 	let txhashset_path = root_dir.clone().join(TXHASHSET_SUBDIR);
 	if txhashset_path.exists() {
 		if let Err(e) = fs::remove_dir_all(txhashset_path.clone()) {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1470,14 +1470,23 @@ pub fn hashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
 	clean_hashset_folder(&to);
 
 	// rename the 'from' folder as the 'to' folder
-	if let Err(e) = fs::rename(from.clone().join(TXHASHSET_SUBDIR), to.clone().join(TXHASHSET_SUBDIR)) {
+	if let Err(e) = fs::rename(
+		from.clone().join(TXHASHSET_SUBDIR),
+		to.clone().join(TXHASHSET_SUBDIR),
+	) {
 		error!("hashset_replace fail on {}. err: {}", TXHASHSET_SUBDIR, e);
 		return Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into());
 	}
 
 	// rename the 'from' folder as the 'to' folder
-	if let Err(e) = fs::rename(from.clone().join(HEADERHASHSET_SUBDIR), to.clone().join(HEADERHASHSET_SUBDIR)) {
-		error!("hashset_replace fail on {}. err: {}", HEADERHASHSET_SUBDIR, e);
+	if let Err(e) = fs::rename(
+		from.clone().join(HEADERHASHSET_SUBDIR),
+		to.clone().join(HEADERHASHSET_SUBDIR),
+	) {
+		error!(
+			"hashset_replace fail on {}. err: {}",
+			HEADERHASHSET_SUBDIR, e
+		);
 		return Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into());
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1462,12 +1462,12 @@ pub fn zip_write(
 	check_and_remove_files(&txhashset_path, header)
 }
 
-/// Overwrite 2 hashset folders ('txhashset' & 'header') in "to" folder with "from" folder
-pub fn hashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
-	debug!("hashset_replace: move from {:?} to {:?}", from, to);
+/// Overwrite txhashset folders in "to" folder with "from" folder
+pub fn txhashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
+	debug!("txhashset_replace: move from {:?} to {:?}", from, to);
 
 	// clean the 'to' folder firstly
-	clean_hashset_folder(&to);
+	clean_txhashset_folder(&to);
 
 	// rename the 'from' folder as the 'to' folder
 	if let Err(e) = fs::rename(
@@ -1475,42 +1475,20 @@ pub fn hashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
 		to.clone().join(TXHASHSET_SUBDIR),
 	) {
 		error!("hashset_replace fail on {}. err: {}", TXHASHSET_SUBDIR, e);
-		return Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into());
+		Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into())
+	} else {
+		Ok(())
 	}
-
-	// rename the 'from' folder as the 'to' folder
-	if let Err(e) = fs::rename(
-		from.clone().join(HEADERHASHSET_SUBDIR),
-		to.clone().join(HEADERHASHSET_SUBDIR),
-	) {
-		error!(
-			"hashset_replace fail on {}. err: {}",
-			HEADERHASHSET_SUBDIR, e
-		);
-		return Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into());
-	}
-
-	return Ok(());
 }
 
-/// Clean the hashset folder (txhashset and header hashset)
-pub fn clean_hashset_folder(root_dir: &PathBuf) {
+/// Clean the txhashset folder
+pub fn clean_txhashset_folder(root_dir: &PathBuf) {
 	let txhashset_path = root_dir.clone().join(TXHASHSET_SUBDIR);
 	if txhashset_path.exists() {
 		if let Err(e) = fs::remove_dir_all(txhashset_path.clone()) {
 			warn!(
-				"clean_hashset_folder: fail on {:?}. err: {}",
+				"clean_txhashset_folder: fail on {:?}. err: {}",
 				txhashset_path, e
-			);
-		}
-	}
-
-	let header_hashset_path = root_dir.clone().join(HEADERHASHSET_SUBDIR);
-	if header_hashset_path.exists() {
-		if let Err(e) = fs::remove_dir_all(header_hashset_path.clone()) {
-			warn!(
-				"clean_hashset_folder: fail on {:?}. err: {}",
-				header_hashset_path, e
 			);
 		}
 	}

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -44,7 +44,7 @@ fn test_unexpected_zip() {
 	let db_env = Arc::new(store::new_env(db_root.clone()));
 	let chain_store = ChainStore::new(db_env).unwrap();
 	let store = Arc::new(chain_store);
-	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None, None).unwrap();
+	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None).unwrap();
 	// First check if everything works out of the box
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -49,7 +49,7 @@ fn test_unexpected_zip() {
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));
 	let zip_file = File::open(&zip_path).unwrap();
-	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
+	assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &BlockHeader::default()).is_ok());
 	// Remove temp txhashset dir
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 	// Then add strange files in the original txhashset folder
@@ -64,7 +64,7 @@ fn test_unexpected_zip() {
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 
 	let zip_file = File::open(zip_path).unwrap();
-	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
+	assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &BlockHeader::default()).is_ok());
 	// Check that the txhashset dir dos not contains the strange files
 	let txhashset_path = Path::new(&db_root).join("txhashset");
 	assert!(txhashset_contains_expected_files(

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -44,13 +44,13 @@ fn test_unexpected_zip() {
 	let db_env = Arc::new(store::new_env(db_root.clone()));
 	let chain_store = ChainStore::new(db_env).unwrap();
 	let store = Arc::new(chain_store);
-	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None, false).unwrap();
+	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None, None).unwrap();
 	// First check if everything works out of the box
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));
 	let zip_file = File::open(&zip_path).unwrap();
 	assert!(
-		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default(), false).is_ok()
+		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok()
 	);
 	// Remove temp txhashset dir
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
@@ -67,7 +67,7 @@ fn test_unexpected_zip() {
 
 	let zip_file = File::open(zip_path).unwrap();
 	assert!(
-		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default(), false).is_ok()
+		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok()
 	);
 	// Check that the txhashset dir dos not contains the strange files
 	let txhashset_path = Path::new(&db_root).join("txhashset");

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -44,12 +44,14 @@ fn test_unexpected_zip() {
 	let db_env = Arc::new(store::new_env(db_root.clone()));
 	let chain_store = ChainStore::new(db_env).unwrap();
 	let store = Arc::new(chain_store);
-	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None).unwrap();
+	txhashset::TxHashSet::open(db_root.clone(), store.clone(), None, false).unwrap();
 	// First check if everything works out of the box
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));
 	let zip_file = File::open(&zip_path).unwrap();
-	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
+	assert!(
+		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default(), false).is_ok()
+	);
 	// Remove temp txhashset dir
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 	// Then add strange files in the original txhashset folder
@@ -64,7 +66,9 @@ fn test_unexpected_zip() {
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 
 	let zip_file = File::open(zip_path).unwrap();
-	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
+	assert!(
+		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default(), false).is_ok()
+	);
 	// Check that the txhashset dir dos not contains the strange files
 	let txhashset_path = Path::new(&db_root).join("txhashset");
 	assert!(txhashset_contains_expected_files(

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -49,9 +49,7 @@ fn test_unexpected_zip() {
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));
 	let zip_file = File::open(&zip_path).unwrap();
-	assert!(
-		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok()
-	);
+	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
 	// Remove temp txhashset dir
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 	// Then add strange files in the original txhashset folder
@@ -66,9 +64,7 @@ fn test_unexpected_zip() {
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 
 	let zip_file = File::open(zip_path).unwrap();
-	assert!(
-		txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok()
-	);
+	assert!(txhashset::zip_write(db_root.clone(), zip_file, &BlockHeader::default()).is_ok());
 	// Check that the txhashset dir dos not contains the strange files
 	let txhashset_path = Path::new(&db_root).join("txhashset");
 	assert!(txhashset_contains_expected_files(

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -49,7 +49,12 @@ fn test_unexpected_zip() {
 	assert!(txhashset::zip_read(db_root.clone(), &BlockHeader::default(), Some(rand)).is_ok());
 	let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", rand));
 	let zip_file = File::open(&zip_path).unwrap();
-	assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &BlockHeader::default()).is_ok());
+	assert!(txhashset::zip_write(
+		PathBuf::from(db_root.clone()),
+		zip_file,
+		&BlockHeader::default()
+	)
+	.is_ok());
 	// Remove temp txhashset dir
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 	// Then add strange files in the original txhashset folder
@@ -64,7 +69,12 @@ fn test_unexpected_zip() {
 	fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", rand))).unwrap();
 
 	let zip_file = File::open(zip_path).unwrap();
-	assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &BlockHeader::default()).is_ok());
+	assert!(txhashset::zip_write(
+		PathBuf::from(db_root.clone()),
+		zip_file,
+		&BlockHeader::default()
+	)
+	.is_ok());
 	// Check that the txhashset dir dos not contains the strange files
 	let txhashset_path = Path::new(&db_root).join("txhashset");
 	assert!(txhashset_contains_expected_files(

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -359,7 +359,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			.chain()
 			.txhashset_write(h, txhashset_data, self.sync_state.as_ref())
 		{
-			self.chain().clean_txhashset_sandbox();
+			self.chain().clean_hashset_sandbox();
 			error!("Failed to save txhashset archive: {}", e);
 			let is_good_data = !e.is_bad_data();
 			self.sync_state.set_sync_error(types::Error::Chain(e));

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -359,7 +359,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			.chain()
 			.txhashset_write(h, txhashset_data, self.sync_state.as_ref())
 		{
-			self.chain().clean_hashset_sandbox();
+			self.chain().clean_txhashset_sandbox();
 			error!("Failed to save txhashset archive: {}", e);
 			let is_good_data = !e.is_bad_data();
 			self.sync_state.set_sync_error(types::Error::Chain(e));

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -360,6 +360,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			.chain()
 			.txhashset_write(h, txhashset_data, self.sync_state.as_ref())
 		{
+			self.chain().clean_txhashset_sandbox();
 			error!("Failed to save txhashset archive: {}", e);
 			let is_good_data = !e.is_bad_data();
 			self.sync_state.set_sync_error(types::Error::Chain(e));

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -330,17 +330,16 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				update_time: old_update_time,
 				downloaded_size: old_downloaded_size,
 				..
-			} => {
-				self.sync_state
-					.update_txhashset_download(SyncStatus::TxHashsetDownload {
-						start_time,
-						prev_update_time: old_update_time,
-						update_time: Utc::now(),
-						prev_downloaded_size: old_downloaded_size,
-						downloaded_size,
-						total_size,
-					})
-			}
+			} => self
+				.sync_state
+				.update_txhashset_download(SyncStatus::TxHashsetDownload {
+					start_time,
+					prev_update_time: old_update_time,
+					update_time: Utc::now(),
+					prev_downloaded_size: old_downloaded_size,
+					downloaded_size,
+					total_size,
+				}),
 			_ => false,
 		}
 	}


### PR DESCRIPTION
An improvement on the txhashset validation procedure: use a sandbox folder for new downloaded txhashset files and the validation is based on sandbox folder firstly. The local txhashset will be overwritten ONLY when validation is ok.

The sandbox folder will be cleaned immediately no matter what's the validation result.

