### PR TITLE
catch the panic to avoid peer thread quit early

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1456,10 +1456,8 @@ pub fn zip_write(
 ) -> Result<(), Error> {
 	let txhashset_path = Path::new(&root_dir).join(TXHASHSET_SUBDIR);
 	fs::create_dir_all(txhashset_path.clone())?;
-
 	zip::decompress(txhashset_data, &txhashset_path, expected_file)
 		.map_err(|ze| ErrorKind::Other(ze.to_string()))?;
-
 	check_and_remove_files(&txhashset_path, header)
 }
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -35,7 +35,6 @@ use grin_store;
 use grin_store::pmmr::{PMMRBackend, PMMR_FILES};
 use std::collections::HashSet;
 use std::fs::{self, File};
-use std::panic;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -1458,29 +1457,8 @@ pub fn zip_write(
 	let txhashset_path = Path::new(&root_dir).join(TXHASHSET_SUBDIR);
 	fs::create_dir_all(txhashset_path.clone())?;
 
-	// catch the panic to avoid the thread quit
-	{
-		panic::set_hook(Box::new(|_info| {
-			// do nothing
-		}));
-		let result = panic::catch_unwind(|| {
-			zip::decompress(txhashset_data, &txhashset_path, expected_file)
-				.map_err(|ze| ErrorKind::Other(ze.to_string()))
-		});
-		match result {
-			Ok(res) => {
-				if let Err(e) = res {
-					return Err(e.into());
-				}
-			}
-			Err(_) => {
-				error!("caught panic on zip::decompress!");
-				return Err(
-					ErrorKind::InvalidTxHashSet("panic on zip::decompress".to_owned()).into(),
-				);
-			}
-		}
-	}
+	zip::decompress(txhashset_data, &txhashset_path, expected_file)
+		.map_err(|ze| ErrorKind::Other(ze.to_string()))?;
 
 	check_and_remove_files(&txhashset_path, header)
 }

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -71,8 +71,8 @@ where
 	let mut decompressed = 0;
 
 	// catch the panic to avoid the thread quit
-	panic::set_hook(Box::new(|_info| {
-		// do nothing
+	panic::set_hook(Box::new(|panic_info| {
+		error!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
 	}));
 	let result = panic::catch_unwind(move || {
 		let mut archive = zip_rs::ZipArchive::new(src_file)?;
@@ -132,8 +132,8 @@ where
 			Ok(_) => res,
 		},
 		Err(e) => {
-			error!("caught panic on zip::decompress! e: {:?}", e);
-			Err(zip::result::ZipError::InvalidArchive("caught panic"))
+			error!("panic occurred on zip::decompress!");
+			Err(zip::result::ZipError::InvalidArchive("panic occurred on zip::decompress"))
 		}
 	}
 }

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -134,7 +134,7 @@ where
 			Err(e) => Err(e.into()),
 			Ok(_) => res,
 		},
-		Err(e) => {
+		Err(_) => {
 			error!("panic occurred on zip::decompress!");
 			Err(zip::result::ZipError::InvalidArchive(
 				"panic occurred on zip::decompress",

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -72,7 +72,10 @@ where
 
 	// catch the panic to avoid the thread quit
 	panic::set_hook(Box::new(|panic_info| {
-		error!("panic occurred: {:?}", panic_info.payload().downcast_ref::<&str>().unwrap());
+		error!(
+			"panic occurred: {:?}",
+			panic_info.payload().downcast_ref::<&str>().unwrap()
+		);
 	}));
 	let result = panic::catch_unwind(move || {
 		let mut archive = zip_rs::ZipArchive::new(src_file)?;
@@ -133,7 +136,9 @@ where
 		},
 		Err(e) => {
 			error!("panic occurred on zip::decompress!");
-			Err(zip::result::ZipError::InvalidArchive("panic occurred on zip::decompress"))
+			Err(zip::result::ZipError::InvalidArchive(
+				"panic occurred on zip::decompress",
+			))
 		}
 	}
 }

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -15,6 +15,7 @@
 use std::fs::{self, File};
 /// Wrappers around the `zip-rs` library to compress and decompress zip archives.
 use std::io;
+use std::panic;
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -64,58 +65,75 @@ pub fn compress(src_dir: &Path, dst_file: &File) -> ZipResult<()> {
 /// Decompress a source file into the provided destination path.
 pub fn decompress<R, F>(src_file: R, dest: &Path, expected: F) -> ZipResult<usize>
 where
-	R: io::Read + io::Seek,
-	F: Fn(&Path) -> bool,
+	R: io::Read + io::Seek + panic::UnwindSafe,
+	F: Fn(&Path) -> bool + panic::UnwindSafe,
 {
 	let mut decompressed = 0;
-	let mut archive = zip_rs::ZipArchive::new(src_file)?;
 
-	for i in 0..archive.len() {
-		let mut file = archive.by_index(i)?;
-		let san_name = file.sanitized_name();
-		if san_name.to_str().unwrap_or("").replace("\\", "/") != file.name().replace("\\", "/")
-			|| !expected(&san_name)
-		{
-			info!(
-				"ignoring a suspicious file: {}, got {:?}",
-				file.name(),
-				san_name.to_str()
-			);
-			continue;
-		}
-		let file_path = dest.join(san_name);
+	// catch the panic to avoid the thread quit
+	panic::set_hook(Box::new(|_info| {
+		// do nothing
+	}));
+	let result = panic::catch_unwind(move || {
+		let mut archive = zip_rs::ZipArchive::new(src_file)?;
 
-		if (&*file.name()).ends_with('/') {
-			fs::create_dir_all(&file_path)?;
-		} else {
-			if let Some(p) = file_path.parent() {
-				if !p.exists() {
-					fs::create_dir_all(&p)?;
+		for i in 0..archive.len() {
+			let mut file = archive.by_index(i)?;
+			let san_name = file.sanitized_name();
+			if san_name.to_str().unwrap_or("").replace("\\", "/") != file.name().replace("\\", "/")
+				|| !expected(&san_name)
+			{
+				info!(
+					"ignoring a suspicious file: {}, got {:?}",
+					file.name(),
+					san_name.to_str()
+				);
+				continue;
+			}
+			let file_path = dest.join(san_name);
+
+			if (&*file.name()).ends_with('/') {
+				fs::create_dir_all(&file_path)?;
+			} else {
+				if let Some(p) = file_path.parent() {
+					if !p.exists() {
+						fs::create_dir_all(&p)?;
+					}
+				}
+				let res = fs::File::create(&file_path);
+				let mut outfile = match res {
+					Err(e) => {
+						error!("{:?}", e);
+						return Err(zip::result::ZipError::Io(e));
+					}
+					Ok(r) => r,
+				};
+				io::copy(&mut file, &mut outfile)?;
+				decompressed += 1;
+			}
+
+			// Get and Set permissions
+			#[cfg(unix)]
+			{
+				use std::os::unix::fs::PermissionsExt;
+				if let Some(mode) = file.unix_mode() {
+					fs::set_permissions(
+						&file_path.to_str().unwrap(),
+						PermissionsExt::from_mode(mode),
+					)?;
 				}
 			}
-			let res = fs::File::create(&file_path);
-			let mut outfile = match res {
-				Err(e) => {
-					error!("{:?}", e);
-					return Err(zip::result::ZipError::Io(e));
-				}
-				Ok(r) => r,
-			};
-			io::copy(&mut file, &mut outfile)?;
-			decompressed += 1;
 		}
-
-		// Get and Set permissions
-		#[cfg(unix)]
-		{
-			use std::os::unix::fs::PermissionsExt;
-			if let Some(mode) = file.unix_mode() {
-				fs::set_permissions(
-					&file_path.to_str().unwrap(),
-					PermissionsExt::from_mode(mode),
-				)?;
-			}
+		Ok(decompressed)
+	});
+	match result {
+		Ok(res) => match res {
+			Err(e) => Err(e.into()),
+			Ok(_) => res,
+		},
+		Err(e) => {
+			error!("caught panic on zip::decompress! e: {:?}", e);
+			Err(zip::result::ZipError::InvalidArchive("caught panic"))
 		}
 	}
-	Ok(decompressed)
 }


### PR DESCRIPTION
For example, if a peer deserve a ban, we will lose the chance if the thread panic early.

Since the `ban` only happen after a success return from a processing function, for example on message `TxHashSetArchive`.

p2p/src/peers.rs:
```
	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: PeerAddr) -> bool {
		if !self.adapter.txhashset_write(h, txhashset_data, peer_addr) {
			...
			self.ban_peer(peer_addr, ReasonForBan::BadTxHashSet);
			false
		} else {
			true
		}
	}
```

There could be more cases for such kind of panic on message processing functions, please let me know if you find a better way to give a universal panic catching on those processing functions.

Or at least one catch for one message (if needed), like this PR.
