### PR TITLE
fix: the restart of state sync doesn't work sometimes

### DIFF
--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -113,7 +113,7 @@ impl StateSync {
 		}
 
 		// run fast sync if applicable, normally only run one-time, except restart in error
-		if header_head.height == highest_height {
+		if sync_need_restart || header_head.height == highest_height {
 			let (go, download_timeout) = self.state_sync_due();
 
 			if let SyncStatus::TxHashsetDownload { .. } = self.sync_state.status() {


### PR DESCRIPTION
In any case when `sync_need_restart` is true in `check_run` function, the condition ```if header_head.height == highest_height``` could forbid this **restart**.

A possible practical situation is a long time (bigger than 1 minute for example) is spent on a failure case of `TxHashSetArchive` processing, then the `highest_height` is changed but the `sync_state` is pending on `TxHashsetDownload` state and no chance to update `header_head`.

So, with this PR, once `sync_need_restart` is set as true, we don't need care about this `header_head.height == highest_height` anymore.



 
