### PR TITLE
[1.1.0] allow specific nonce in aggsig sign_single call

### DIFF
--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -421,14 +421,15 @@ pub fn add_signatures(
 	Ok(sig)
 }
 
-/// Just a simple sig, creates its own nonce, etc
+/// Just a simple sig, creates its own nonce if not provided
 pub fn sign_single(
 	secp: &Secp256k1,
 	msg: &Message,
 	skey: &SecretKey,
+	snonce: Option<&SecretKey>,
 	pubkey_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error> {
-	let sig = aggsig::sign_single(secp, &msg, skey, None, None, None, pubkey_sum, None)?;
+	let sig = aggsig::sign_single(secp, &msg, skey, snonce, None, None, pubkey_sum, None)?;
 	Ok(sig)
 }
 

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -195,7 +195,7 @@ mod test {
 			let mut msg = [0u8; 32];
 			thread_rng().fill(&mut msg);
 			let msg = Message::from_slice(&msg).unwrap();
-			let sig = aggsig::sign_single(&secp, &msg, &sk, None).unwrap();
+			let sig = aggsig::sign_single(&secp, &msg, &sk, None, None).unwrap();
 			SerTest {
 				pub_key: PublicKey::from_secret_key(&secp, &sk).unwrap(),
 				opt_sig: Some(sig.clone()),


### PR DESCRIPTION
Slight modification to the aggsig sign_single call to allow caller to specify the nonce to use. Useful for consistency of test result data.