### PR TITLE
Update intro.md

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -257,12 +257,12 @@ that for any `r*G + v*H` we can build a proof that will show that _v_ is greater
 zero and does not overflow.
 
 It's also important to note that in order to create a valid range proof from the example above, both of the values 113 and 28 used in creating and signing for the excess value must be known. The reason for this, as well as a more detailed description of range proofs are further detailed in the [range proof paper](https://eprint.iacr.org/2017/1066.pdf).
-The requirement to know both values to generate valid rangeproofs is an important feature since it prevents an attack where a third party could lock up UTXO's without knowing their private key by creating a transaction from
+The requirement to know both values to generate valid rangeproofs is an important feature since it prevents a censoring attack where a third party could lock up UTXOs without knowing their private key by creating a transaction from
 
-    Carol's UTXO:    113*G + 2*H
-    Attakers output: (113 + 99)*G + 2*H
+    Carol's UTXO:       113*G + 2*H
+    Attacker's output:  (113 + 99)*G + 2*H
     
-which can be signed by the attacker since Carols privtae key of 113 cancels due to the adverserial choice of keys. The new output could only be spent by both the attacker and Carol togeter. However, while the attacker can provide a valid siganture for the transaction, it is impossible to create a valid rangeproof for the new output invalidating this attack.  
+which can be signed by the attacker since Carols private key of 113 cancels due to the adverserial choice of keys. The new output could only be spent by both the attacker and Carol together. However, while the attacker can provide a valid signature for the transaction, it is impossible to create a valid rangeproof for the new output invalidating this attack.  
 
 
 #### Putting It All Together

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -257,6 +257,13 @@ that for any `r*G + v*H` we can build a proof that will show that _v_ is greater
 zero and does not overflow.
 
 It's also important to note that in order to create a valid range proof from the example above, both of the values 113 and 28 used in creating and signing for the excess value must be known. The reason for this, as well as a more detailed description of range proofs are further detailed in the [range proof paper](https://eprint.iacr.org/2017/1066.pdf).
+The requirement to know both values to generate valid rangeproofs is an important feature since it prevents an attack where a third party could lock up UTXO's without knowing their private key by creating a transaction from
+
+    Carol's UTXO:    113*G + 2*H
+    Attakers output: (113 + 99)*G + 2*H
+    
+which can be signed by the attacker since Carols privtae key of 113 cancels due to the adverserial choice of keys. The new output could only be spent by both the attacker and Carol togeter. However, while the attacker can provide a valid siganture for the transaction, it is impossible to create a valid rangeproof for the new output invalidating this attack.  
+
 
 #### Putting It All Together
 


### PR DESCRIPTION
name: Lock funds attack in intro.md
about: updating grin.md
title: 'Lock funds attack in intro.md'
labels: 'documentation'
assignees: ''

The intro.md explains why the MW transactions are secure and why a malicious actor cannot steal UTXO's. But it does not mention the potential attack where a malicious actor locks up funds that can then only be spent by the combined signature of the original owner and the attacker.

The current intro.md does not address this attack which is prevented by the use of rangeproofs. Instead it is only mentioned that rangeproofs are needed in order to prevent inflation attacks.

I added a short section that explains that, in addition to preventing inflation, rangeproofs further create security against this type of fund locking attacks.