### PR TITLE
[1.1.0] CbData Serialization change + reward output test mode

### DIFF
--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -78,7 +78,7 @@ fn data_files() {
 			let prev = chain.head_header().unwrap();
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
 			let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-			let reward = libtx::reward::output(&keychain, &pk, 0).unwrap();
+			let reward = libtx::reward::output(&keychain, &pk, 0, false).unwrap();
 			let mut b =
 				core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
 					.unwrap();
@@ -154,7 +154,7 @@ fn _prepare_block_nosum(
 	let key_id = ExtKeychainPath::new(1, diff as u32, 0, 0, 0).to_identifier();
 
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward = libtx::reward::output(kc, &key_id, fees).unwrap();
+	let reward = libtx::reward::output(kc, &key_id, fees, false).unwrap();
 	let mut b = match core::core::Block::new(
 		prev,
 		txs.into_iter().cloned().collect(),

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -67,7 +67,7 @@ fn mine_genesis_reward_chain() {
 	let mut genesis = genesis::genesis_dev();
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = keychain::ExtKeychain::derive_key_id(0, 1, 0, 0, 0);
-	let reward = reward::output(&keychain, &key_id, 0).unwrap();
+	let reward = reward::output(&keychain, &key_id, 0, false).unwrap();
 	genesis = genesis.with_reward(reward.0, reward.1);
 
 	{
@@ -100,7 +100,7 @@ where
 		let prev = chain.head_header().unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
 		let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-		let reward = libtx::reward::output(keychain, &pk, 0).unwrap();
+		let reward = libtx::reward::output(keychain, &pk, 0, false).unwrap();
 		let mut b =
 			core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
 				.unwrap();
@@ -408,7 +408,7 @@ fn output_header_mappings() {
 		let prev = chain.head_header().unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
 		let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-		let reward = libtx::reward::output(&keychain, &pk, 0).unwrap();
+		let reward = libtx::reward::output(&keychain, &pk, 0, false).unwrap();
 		reward_outputs.push(reward.0.clone());
 		let mut b =
 			core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
@@ -508,7 +508,7 @@ where
 	let key_id = ExtKeychainPath::new(1, diff as u32, 0, 0, 0).to_identifier();
 
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward = libtx::reward::output(kc, &key_id, fees).unwrap();
+	let reward = libtx::reward::output(kc, &key_id, fees, false).unwrap();
 	let mut b = match core::core::Block::new(
 		prev,
 		txs.into_iter().cloned().collect(),

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -60,7 +60,7 @@ fn test_various_store_indices() {
 
 	setup_chain(&genesis, chain_store.clone()).unwrap();
 
-	let reward = libtx::reward::output(&keychain, &key_id, 0).unwrap();
+	let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
 	let block = Block::new(&genesis.header, vec![], Difficulty::min(), reward).unwrap();
 	let block_hash = block.hash();
 

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -64,7 +64,7 @@ fn test_coinbase_maturity() {
 	let key_id4 = ExtKeychainPath::new(1, 4, 0, 0, 0).to_identifier();
 
 	let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
-	let reward = libtx::reward::output(&keychain, &key_id1, 0).unwrap();
+	let reward = libtx::reward::output(&keychain, &key_id1, 0, false).unwrap();
 	let mut block = core::core::Block::new(&prev, vec![], Difficulty::min(), reward).unwrap();
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
@@ -108,7 +108,7 @@ fn test_coinbase_maturity() {
 
 	let txs = vec![coinbase_txn.clone()];
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward = libtx::reward::output(&keychain, &key_id3, fees).unwrap();
+	let reward = libtx::reward::output(&keychain, &key_id3, fees, false).unwrap();
 	let mut block = core::core::Block::new(&prev, txs, Difficulty::min(), reward).unwrap();
 	let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
@@ -142,7 +142,7 @@ fn test_coinbase_maturity() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let pk = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
-		let reward = libtx::reward::output(&keychain, &pk, 0).unwrap();
+		let reward = libtx::reward::output(&keychain, &pk, 0, false).unwrap();
 		let mut block = core::core::Block::new(&prev, vec![], Difficulty::min(), reward).unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
 		block.header.timestamp = prev.timestamp + Duration::seconds(60);
@@ -170,7 +170,7 @@ fn test_coinbase_maturity() {
 	let txs = vec![coinbase_txn];
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
 	let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter());
-	let reward = libtx::reward::output(&keychain, &key_id4, fees).unwrap();
+	let reward = libtx::reward::output(&keychain, &key_id4, fees, false).unwrap();
 	let mut block = core::core::Block::new(&prev, txs, Difficulty::min(), reward).unwrap();
 
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -251,7 +251,7 @@ pub fn verify_partial_sig(
 /// let msg = kernel_sig_msg(0, height, KernelFeatures::HeightLocked).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
-/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, Some(&pubkey)).unwrap();
+/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, None, Some(&pubkey)).unwrap();
 /// ```
 
 pub fn sign_from_key_id<K>(
@@ -260,13 +260,14 @@ pub fn sign_from_key_id<K>(
 	msg: &Message,
 	value: u64,
 	key_id: &Identifier,
+	s_nonce: Option<&SecretKey>,
 	blind_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error>
 where
 	K: Keychain,
 {
 	let skey = k.derive_key(value, key_id)?;
-	let sig = aggsig::sign_single(secp, &msg, &skey, None, None, None, blind_sum, None)?;
+	let sig = aggsig::sign_single(secp, &msg, &skey, s_nonce, None, None, blind_sum, None)?;
 	Ok(sig)
 }
 
@@ -316,7 +317,7 @@ where
 /// let msg = kernel_sig_msg(0, height, KernelFeatures::HeightLocked).unwrap();
 /// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
 /// let pubkey = excess.to_pubkey(&secp).unwrap();
-/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, Some(&pubkey)).unwrap();
+/// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, None, Some(&pubkey)).unwrap();
 ///
 /// // Verify the signature from the excess commit
 /// let sig_verifies =

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -23,7 +23,12 @@ use crate::libtx::{aggsig, proof};
 use crate::util::{secp, static_secp_instance};
 
 /// output a reward output
-pub fn output<K>(keychain: &K, key_id: &Identifier, fees: u64, test_mode: bool) -> Result<(Output, TxKernel), Error>
+pub fn output<K>(
+	keychain: &K,
+	key_id: &Identifier,
+	fees: u64,
+	test_mode: bool,
+) -> Result<(Output, TxKernel), Error>
 where
 	K: Keychain,
 {
@@ -53,9 +58,19 @@ where
 	let sig = match test_mode {
 		true => {
 			let test_nonce = secp::key::SecretKey::from_slice(&secp, &[0u8; 32])?;
-			aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, Some(&test_nonce), Some(&pubkey))?
-		},
-		false =>  aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, None, Some(&pubkey))?
+			aggsig::sign_from_key_id(
+				&secp,
+				keychain,
+				&msg,
+				value,
+				&key_id,
+				Some(&test_nonce),
+				Some(&pubkey),
+			)?
+		}
+		false => {
+			aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, None, Some(&pubkey))?
+		}
 	};
 
 	let proof = TxKernel {

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -20,10 +20,10 @@ use crate::core::{KernelFeatures, Output, OutputFeatures, TxKernel};
 use crate::keychain::{Identifier, Keychain};
 use crate::libtx::error::Error;
 use crate::libtx::{aggsig, proof};
-use crate::util::static_secp_instance;
+use crate::util::{secp, static_secp_instance};
 
 /// output a reward output
-pub fn output<K>(keychain: &K, key_id: &Identifier, fees: u64) -> Result<(Output, TxKernel), Error>
+pub fn output<K>(keychain: &K, key_id: &Identifier, fees: u64, test_mode: bool) -> Result<(Output, TxKernel), Error>
 where
 	K: Keychain,
 {
@@ -50,7 +50,13 @@ where
 	// NOTE: Remember we sign the fee *and* the lock_height.
 	// For a coinbase output the fee is 0 and the lock_height is 0
 	let msg = kernel_sig_msg(0, 0, KernelFeatures::Coinbase)?;
-	let sig = aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, Some(&pubkey))?;
+	let sig = match test_mode {
+		true => {
+			let test_nonce = secp::key::SecretKey::from_slice(&secp, &[0u8; 32])?;
+			aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, Some(&test_nonce), Some(&pubkey))?
+		},
+		false =>  aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, None, Some(&pubkey))?
+	};
 
 	let proof = TxKernel {
 		features: KernelFeatures::Coinbase,

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -91,7 +91,7 @@ where
 	K: Keychain,
 {
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward_output = reward::output(keychain, &key_id, fees).unwrap();
+	let reward_output = reward::output(keychain, &key_id, fees, false).unwrap();
 	Block::new(
 		&previous_header,
 		txs.into_iter().cloned().collect(),

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -44,7 +44,7 @@ fn test_transaction_pool_block_building() {
 		let height = prev_header.height + 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let fee = txs.iter().map(|x| x.fee()).sum();
-		let reward = libtx::reward::output(&keychain, &key_id, fee).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, fee, false).unwrap();
 		let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -49,7 +49,7 @@ fn test_block_building_max_weight() {
 		let height = prev_header.height + 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let fee = txs.iter().map(|x| x.fee()).sum();
-		let reward = libtx::reward::output(&keychain, &key_id, fee).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, fee, false).unwrap();
 		let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -44,7 +44,7 @@ fn test_transaction_pool_block_reconciliation() {
 	let header = {
 		let height = 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
-		let reward = libtx::reward::output(&keychain, &key_id, 0).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
 		let genesis = BlockHeader::default();
 		let mut block = Block::new(&genesis, vec![], Difficulty::min(), reward).unwrap();
 
@@ -63,7 +63,7 @@ fn test_transaction_pool_block_reconciliation() {
 	let block = {
 		let key_id = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 		let fees = initial_tx.fee();
-		let reward = libtx::reward::output(&keychain, &key_id, fees).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, fees, false).unwrap();
 		let mut block = Block::new(&header, vec![initial_tx], Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).
@@ -156,7 +156,7 @@ fn test_transaction_pool_block_reconciliation() {
 	let block = {
 		let key_id = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 		let fees = block_txs.iter().map(|tx| tx.fee()).sum();
-		let reward = libtx::reward::output(&keychain, &key_id, fees).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, fees, false).unwrap();
 		let mut block = Block::new(&header, block_txs, Difficulty::min(), reward).unwrap();
 
 		// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -43,7 +43,7 @@ fn test_the_transaction_pool() {
 	let header = {
 		let height = 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
-		let reward = libtx::reward::output(&keychain, &key_id, 0).unwrap();
+		let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
 		let block = Block::new(&BlockHeader::default(), vec![], Difficulty::min(), reward).unwrap();
 
 		chain.update_db_for_block(&block);

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -26,8 +26,8 @@ use crate::api;
 use crate::chain;
 use crate::common::types::Error;
 use crate::core::core::verifier_cache::VerifierCache;
+use crate::core::core::{Output, TxKernel};
 use crate::core::{consensus, core, global};
-use crate::core::core::{TxKernel, Output};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
 

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -26,10 +26,10 @@ use crate::api;
 use crate::chain;
 use crate::common::types::Error;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::core::{consensus, core, global, ser};
+use crate::core::{consensus, core, global};
+use crate::core::core::{TxKernel, Output};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
-use crate::util;
 
 /// Fees in block to use for coinbase amount calculation
 /// (Duplicated from Grin wallet project)
@@ -54,11 +54,11 @@ impl BlockFees {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CbData {
 	/// Output
-	pub output: String,
+	pub output: Output,
 	/// Kernel
-	pub kernel: String,
+	pub kernel: TxKernel,
 	/// Key Id
-	pub key_id: String,
+	pub key_id: Option<Identifier>,
 }
 
 // Ensure a block suitable for mining is built and returned
@@ -212,7 +212,7 @@ fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, B
 	let keychain = ExtKeychain::from_random_seed(global::is_floonet()).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) =
-		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees).unwrap();
+		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees, false).unwrap();
 	Ok((out, kernel, block_fees))
 }
 
@@ -229,14 +229,11 @@ fn get_coinbase(
 		}
 		Some(wallet_listener_url) => {
 			let res = create_coinbase(&wallet_listener_url, &block_fees)?;
-			let out_bin = util::from_hex(res.output).unwrap();
-			let kern_bin = util::from_hex(res.kernel).unwrap();
-			let key_id_bin = util::from_hex(res.key_id).unwrap();
-			let output = ser::deserialize(&mut &out_bin[..]).unwrap();
-			let kernel = ser::deserialize(&mut &kern_bin[..]).unwrap();
-			let key_id = ser::deserialize(&mut &key_id_bin[..]).unwrap();
+			let output = res.output;
+			let kernel = res.kernel;
+			let key_id = res.key_id;
 			let block_fees = BlockFees {
-				key_id: Some(key_id),
+				key_id: key_id,
 				..block_fees
 			};
 


### PR DESCRIPTION
Changes needed for putting together V2 foreign API:

* CbData struct was being serialized in an odd binary format (just a legacy holdover,) changed serialization format to output proper JSON for each member to be consistent with everywhere else.
* Added a test flag to `reward::output` to allow consistent test result generation