### PR TITLE
Return Result from methods of ChainAdapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 1.0.2",
  "grin_core 1.0.2",
  "grin_pool 1.0.2",
  "grin_store 1.0.2",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4.4", features = ["serde"] }
 
 grin_core = { path = "../core", version = "1.0.2" }
 grin_store = { path = "../store", version = "1.0.2" }
+grin_chain = { path = "../chain", version = "1.0.2" }
 grin_util = { path = "../util", version = "1.0.2" }
 
 [dev-dependencies]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -29,6 +29,7 @@ use lmdb_zero as lmdb;
 
 #[macro_use]
 extern crate grin_core as core;
+use grin_chain as chain;
 use grin_util as util;
 
 #[macro_use]

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -68,8 +68,8 @@ impl MessageHandler for Protocol {
 				Ok(Some(Response::new(
 					Type::Pong,
 					Pong {
-						total_difficulty: adapter.total_difficulty(),
-						height: adapter.total_height(),
+						total_difficulty: adapter.total_difficulty()?,
+						height: adapter.total_height()?,
 					},
 					writer,
 				)?))
@@ -93,7 +93,7 @@ impl MessageHandler for Protocol {
 					"handle_payload: received tx kernel: {}, msg_len: {}",
 					h, msg.header.msg_len
 				);
-				adapter.tx_kernel_received(h, self.addr);
+				adapter.tx_kernel_received(h, self.addr)?;
 				Ok(None)
 			}
 
@@ -117,7 +117,7 @@ impl MessageHandler for Protocol {
 					msg.header.msg_len
 				);
 				let tx: core::Transaction = msg.body()?;
-				adapter.transaction_received(tx, false);
+				adapter.transaction_received(tx, false)?;
 				Ok(None)
 			}
 
@@ -127,7 +127,7 @@ impl MessageHandler for Protocol {
 					msg.header.msg_len
 				);
 				let tx: core::Transaction = msg.body()?;
-				adapter.transaction_received(tx, true);
+				adapter.transaction_received(tx, true)?;
 				Ok(None)
 			}
 
@@ -155,7 +155,7 @@ impl MessageHandler for Protocol {
 
 				// we can't know at this level whether we requested the block or not,
 				// the boolean should be properly set in higher level adapter
-				adapter.block_received(b, self.addr, false);
+				adapter.block_received(b, self.addr, false)?;
 				Ok(None)
 			}
 
@@ -176,14 +176,14 @@ impl MessageHandler for Protocol {
 				);
 				let b: core::CompactBlock = msg.body()?;
 
-				adapter.compact_block_received(b, self.addr);
+				adapter.compact_block_received(b, self.addr)?;
 				Ok(None)
 			}
 
 			Type::GetHeaders => {
 				// load headers from the locator
 				let loc: Locator = msg.body()?;
-				let headers = adapter.locate_headers(&loc.hashes);
+				let headers = adapter.locate_headers(&loc.hashes)?;
 
 				// serialize and send all the headers over
 				Ok(Some(Response::new(
@@ -197,7 +197,7 @@ impl MessageHandler for Protocol {
 			// we can go request it from some of our peers
 			Type::Header => {
 				let header: core::BlockHeader = msg.body()?;
-				adapter.header_received(header, self.addr);
+				adapter.header_received(header, self.addr)?;
 				Ok(None)
 			}
 
@@ -217,7 +217,7 @@ impl MessageHandler for Protocol {
 						headers.push(header);
 						total_bytes_read += bytes_read;
 					}
-					adapter.headers_received(&headers, self.addr);
+					adapter.headers_received(&headers, self.addr)?;
 				}
 
 				// Now check we read the correct total number of bytes off the stream.
@@ -335,7 +335,7 @@ impl MessageHandler for Protocol {
 				let tmp_zip = File::open(tmp)?;
 				let res = self
 					.adapter
-					.txhashset_write(sm_arch.hash, tmp_zip, self.addr);
+					.txhashset_write(sm_arch.hash, tmp_zip, self.addr)?;
 
 				debug!(
 					"handle_payload: txhashset archive for {} at {}, DONE. Data Ok: {}",

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -168,7 +168,8 @@ impl PeerStore {
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
 		let key = to_key(PEER_PREFIX, &mut "".to_string().into_bytes());
-		Ok(self.db
+		Ok(self
+			.db
 			.iter::<PeerData>(&key)?
 			.map(|(_, v)| v)
 			.collect::<Vec<_>>())

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use chrono::prelude::*;
 
+use crate::chain;
 use crate::core::core;
 use crate::core::core::hash::Hash;
 use crate::core::global;
@@ -63,6 +64,7 @@ pub enum Error {
 	ConnectionClose,
 	Timeout,
 	Store(grin_store::Error),
+	Chain(chain::Error),
 	PeerWithSelf,
 	NoDandelionRelay,
 	ProtocolMismatch {
@@ -86,6 +88,11 @@ impl From<ser::Error> for Error {
 impl From<grin_store::Error> for Error {
 	fn from(e: grin_store::Error) -> Error {
 		Error::Store(e)
+	}
+}
+impl From<chain::Error> for Error {
+	fn from(e: chain::Error) -> Error {
+		Error::Chain(e)
 	}
 }
 impl From<io::Error> for Error {
@@ -447,37 +454,51 @@ pub struct TxHashSetRead {
 /// other things.
 pub trait ChainAdapter: Sync + Send {
 	/// Current total difficulty on our chain
-	fn total_difficulty(&self) -> Difficulty;
+	fn total_difficulty(&self) -> Result<Difficulty, chain::Error>;
 
 	/// Current total height
-	fn total_height(&self) -> u64;
+	fn total_height(&self) -> Result<u64, chain::Error>;
 
 	/// A valid transaction has been received from one of our peers
-	fn transaction_received(&self, tx: core::Transaction, stem: bool);
+	fn transaction_received(&self, tx: core::Transaction, stem: bool)
+		-> Result<bool, chain::Error>;
 
 	fn get_transaction(&self, kernel_hash: Hash) -> Option<core::Transaction>;
 
-	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr);
+	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr) -> Result<bool, chain::Error>;
 
 	/// A block has been received from one of our peers. Returns true if the
 	/// block could be handled properly and is not deemed defective by the
 	/// chain. Returning false means the block will never be valid and
 	/// may result in the peer being banned.
-	fn block_received(&self, b: core::Block, addr: PeerAddr, was_requested: bool) -> bool;
+	fn block_received(
+		&self,
+		b: core::Block,
+		addr: PeerAddr,
+		was_requested: bool,
+	) -> Result<bool, chain::Error>;
 
-	fn compact_block_received(&self, cb: core::CompactBlock, addr: PeerAddr) -> bool;
+	fn compact_block_received(
+		&self,
+		cb: core::CompactBlock,
+		addr: PeerAddr,
+	) -> Result<bool, chain::Error>;
 
-	fn header_received(&self, bh: core::BlockHeader, addr: PeerAddr) -> bool;
+	fn header_received(&self, bh: core::BlockHeader, addr: PeerAddr) -> Result<bool, chain::Error>;
 
 	/// A set of block header has been received, typically in response to a
 	/// block
 	/// header request.
-	fn headers_received(&self, bh: &[core::BlockHeader], addr: PeerAddr) -> bool;
+	fn headers_received(
+		&self,
+		bh: &[core::BlockHeader],
+		addr: PeerAddr,
+	) -> Result<bool, chain::Error>;
 
 	/// Finds a list of block headers based on the provided locator. Tries to
 	/// identify the common chain and gets the headers that follow it
 	/// immediately.
-	fn locate_headers(&self, locator: &[Hash]) -> Vec<core::BlockHeader>;
+	fn locate_headers(&self, locator: &[Hash]) -> Result<Vec<core::BlockHeader>, chain::Error>;
 
 	/// Gets a full block by its hash.
 	fn get_block(&self, h: Hash) -> Option<core::Block>;
@@ -505,7 +526,12 @@ pub trait ChainAdapter: Sync + Send {
 	/// If we're willing to accept that new state, the data stream will be
 	/// read as a zip file, unzipped and the resulting state files should be
 	/// rewound to the provided indexes.
-	fn txhashset_write(&self, h: Hash, txhashset_data: File, peer_addr: PeerAddr) -> bool;
+	fn txhashset_write(
+		&self,
+		h: Hash,
+		txhashset_data: File,
+		peer_addr: PeerAddr,
+	) -> Result<bool, chain::Error>;
 }
 
 /// Additional methods required by the protocol that don't need to be

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -129,8 +129,12 @@ pub fn connect_and_monitor(
 				if Utc::now() - prev_ping > Duration::seconds(10) {
 					let total_diff = peers.total_difficulty();
 					let total_height = peers.total_height();
-					peers.check_all(total_diff, total_height);
-					prev_ping = Utc::now();
+					if total_diff.is_ok() && total_height.is_ok() {
+						peers.check_all(total_diff.unwrap(), total_height.unwrap());
+						prev_ping = Utc::now();
+					} else {
+						error!("failed to get peers difficulty and/or height");
+					}
 				}
 
 				thread::sleep(time::Duration::from_secs(1));

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -100,7 +100,7 @@ impl BodySync {
 
 		hashes.reverse();
 
-		let peers = self.peers.more_work_peers();
+		let peers = self.peers.more_work_peers()?;
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -77,7 +77,7 @@ impl SyncRunner {
 		let mut n = 0;
 		const MIN_PEERS: usize = 3;
 		loop {
-			let wp = self.peers.more_or_same_work_peers();
+			let wp = self.peers.more_or_same_work_peers()?;
 			// exit loop when:
 			// * we have more than MIN_PEERS more_or_same_work peers
 			// * we are synced already, e.g. grin was quickly restarted


### PR DESCRIPTION
Most of the methods return nothing or bool which is used to decide if a
sender of a message should be banned or not. However underlying chain
implementation may fail so we need a way to reflect this fact in API.

Also it allows to reduce number of unwraps and makes the code more robust.
