### PR TITLE
Fix misuse of NoSync state

### DIFF
--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -316,7 +316,7 @@ pub struct SyncState {
 }
 
 impl SyncState {
-	/// Return a new SyncState initialize to NoSync
+	/// Return a new SyncState initialize to Initial
 	pub fn new() -> SyncState {
 		SyncState {
 			current: RwLock::new(SyncStatus::Initial),

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -62,8 +62,9 @@ impl HeaderSync {
 		let enable_header_sync = match self.sync_state.status() {
 			SyncStatus::BodySync { .. }
 			| SyncStatus::HeaderSync { .. }
-			| SyncStatus::TxHashsetDone => true,
-			SyncStatus::NoSync | SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => {
+			| SyncStatus::TxHashsetDone
+			| SyncStatus::NoSync => true,
+			SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => {
 				let sync_head = self.chain.get_sync_head()?;
 				debug!(
 					"sync: initial transition to HeaderSync. sync_head: {} at {}, resetting to: {} at {}",
@@ -114,9 +115,9 @@ impl HeaderSync {
 		// no headers processed and we're past timeout, need to ask for more
 		let stalling = header_head.height <= latest_height && now > timeout;
 
-		// always enable header sync on initial state transition from NoSync / Initial
+		// always enable header sync on initial state transition from Initial
 		let force_sync = match self.sync_state.status() {
-			SyncStatus::NoSync | SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => true,
+			SyncStatus::Initial | SyncStatus::AwaitingPeers(_) => true,
 			_ => false,
 		};
 


### PR DESCRIPTION
NoSync is basically Running state, but for some (historical?) reason we use it as a substitute of Initial state. The most annoying issue is chain reset every 5-10 minutes or so. This is a really expensive operations, not sure how safe it is.