### PR TITLE
[DNM] Simplify logic for writing msgs onto the wire

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -201,11 +201,7 @@ impl Worker {
 		if !message.ends_with("\n") {
 			message += "\n";
 		}
-		match util::read_write::write_all(
-			&mut self.stream,
-			message.as_bytes(),
-			Duration::from_secs(1),
-		) {
+		match self.stream.write_all(message.as_bytes()) {
 			Ok(_) => match self.stream.flush() {
 				Ok(_) => {}
 				Err(e) => {


### PR DESCRIPTION
Looking into sending kernel data (see #2743) and went down the rabbit hole of exactly how we end up serializing "attachments" when sending a msg response to a peer.

I think we can clean the `write` logic up pretty significantly, reducing the amount of intermediate writes and allocations - 

* get rid of our custom `write_all()` implementation
* use `buf_writer` to wrap the tcp connection
* use `buf_reader` to wrap reading the txhashset attachment
* track bytes written internally in `BinWriter`
* use `io::copy()` to handle robust write from reader to writer

TODO - 
- [ ] Take this a step further and write the msg body straight to tcp connection via `ser::serialize()` (need to be construct the header as we do this as we care about body size in the header)
- [ ] We needed to touch stratum code here - confirm this still works
- [ ] More testing




