### PR TITLE
CI: Do not crash on empty terminal

### DIFF
--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -62,6 +62,9 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 pub fn show_status(config: &ServerConfig, api_secret: Option<String>) {
 	println!();
 	let title = format!("Grin Server Status");
+	if term::stdout().is_none() {
+		return;
+	}
 	let mut t = term::stdout().unwrap();
 	let mut e = term::stdout().unwrap();
 	t.fg(term::color::MAGENTA).unwrap();

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -63,6 +63,7 @@ pub fn show_status(config: &ServerConfig, api_secret: Option<String>) {
 	println!();
 	let title = format!("Grin Server Status");
 	if term::stdout().is_none() {
+		println!("Could not open terminal");
 		return;
 	}
 	let mut t = term::stdout().unwrap();

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -35,6 +35,9 @@ pub fn outputs(
 		account, cur_height
 	);
 	println!();
+	if term::stdout().is_none() {
+		return Ok(());
+	}
 	let mut t = term::stdout().unwrap();
 	t.fg(term::color::MAGENTA).unwrap();
 	writeln!(t, "{}", title).unwrap();
@@ -132,6 +135,9 @@ pub fn txs(
 		account, cur_height
 	);
 	println!();
+	if term::stdout().is_none() {
+		return Ok(());
+	}
 	let mut t = term::stdout().unwrap();
 	t.fg(term::color::MAGENTA).unwrap();
 	writeln!(t, "{}", title).unwrap();
@@ -405,6 +411,9 @@ pub fn accounts(acct_mappings: Vec<AcctPathMapping>) {
 pub fn tx_messages(tx: &TxLogEntry, dark_background_color_scheme: bool) -> Result<(), Error> {
 	let title = format!("Transaction Messages - Transaction '{}'", tx.id,);
 	println!();
+	if term::stdout().is_none() {
+		return Ok(());
+	}
 	let mut t = term::stdout().unwrap();
 	t.fg(term::color::MAGENTA).unwrap();
 	writeln!(t, "{}", title).unwrap();

--- a/wallet/src/display.rs
+++ b/wallet/src/display.rs
@@ -36,6 +36,7 @@ pub fn outputs(
 	);
 	println!();
 	if term::stdout().is_none() {
+		println!("Could not open terminal");
 		return Ok(());
 	}
 	let mut t = term::stdout().unwrap();
@@ -136,6 +137,7 @@ pub fn txs(
 	);
 	println!();
 	if term::stdout().is_none() {
+		println!("Could not open terminal");
 		return Ok(());
 	}
 	let mut t = term::stdout().unwrap();
@@ -412,6 +414,7 @@ pub fn tx_messages(tx: &TxLogEntry, dark_background_color_scheme: bool) -> Resul
 	let title = format!("Transaction Messages - Transaction '{}'", tx.id,);
 	println!();
 	if term::stdout().is_none() {
+		println!("Could not open terminal");
 		return Ok(());
 	}
 	let mut t = term::stdout().unwrap();


### PR DESCRIPTION
Mainly for future Azure Pipelines and Gitlab.
Simply return `Ok(())`/`return` with a warning when a terminal could not be opened. Should only happens in CI.
