### PR TITLE
Fix failing test on Windows

### DIFF
--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -43,7 +43,7 @@ fn peer_handshake() {
 	util::init_test_logger();
 
 	let p2p_config = p2p::P2PConfig {
-		host: "0.0.0.0".parse().unwrap(),
+		host: "127.0.0.1".parse().unwrap(),
 		port: open_port(),
 		peers_allow: None,
 		peers_deny: None,


### PR DESCRIPTION
This test fails on windows with error:

```
test peer_handshake ... FAILED

failures:

---- peer_handshake stdout ----
thread 'peer_handshake' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 10049, kind: AddrNotAvailable, message: "The requested address is not valid in its context." }', libcore\result.rs:1009:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

This change fixes it and shouldn't change the behavior because we are already listening on localhost only

https://github.com/mimblewimble/grin/blob/79c97c30baa12bad277ffe39969235450564f929/p2p/tests/peer_handshake.rs#L35
