### PR TITLE
Increase peer max count significantly

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -228,7 +228,7 @@ fn comments() -> HashMap<String, String> {
 #ban_window = 10800
 
 #maximum number of peers
-#peer_max_count = 250
+#peer_max_count = 125
 
 #preferred minimum number of peers (we'll actively keep trying to add peers
 #until we get to at least this number

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -228,7 +228,7 @@ fn comments() -> HashMap<String, String> {
 #ban_window = 10800
 
 #maximum number of peers
-#peer_max_count = 25
+#peer_max_count = 250
 
 #preferred minimum number of peers (we'll actively keep trying to add peers
 #until we get to at least this number

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -48,7 +48,7 @@ pub const MAX_LOCATORS: u32 = 20;
 const BAN_WINDOW: i64 = 10800;
 
 /// The max peer count
-const PEER_MAX_COUNT: u32 = 250;
+const PEER_MAX_COUNT: u32 = 125;
 
 /// min preferred peer count
 const PEER_MIN_PREFERRED_COUNT: u32 = 8;

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -48,7 +48,7 @@ pub const MAX_LOCATORS: u32 = 20;
 const BAN_WINDOW: i64 = 10800;
 
 /// The max peer count
-const PEER_MAX_COUNT: u32 = 25;
+const PEER_MAX_COUNT: u32 = 250;
 
 /// min preferred peer count
 const PEER_MIN_PREFERRED_COUNT: u32 = 8;


### PR DESCRIPTION
I think several of our peer-related issues stem from a max count of peers that's much too low. At this point a node can easily support 250 peers on a low-spec machine and so I don't see a lot of reasons to have this limit so low. Having it much higher should help a lot in connecting and keeping peers.