### PR TITLE
bucket_transactions is now fee_to_weight aware

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -396,11 +396,9 @@ impl Pool {
 		}
 
 		// Now sort them by depth (ascending) to maintain dependency ordering.
-		// And then sort them (within each depth) by fee_to_weight descending.
+		// And then sort them (within each depth) by fee_to_weight (descending).
 		// Txs with no dependencies will be toward the start of the vec.
 		// Txs with a big chain of dependencies will be toward the end of the vec.
-		// Will satisfying the "depth" ordering we will then sort txs such that high
-		// fee_to_weight come first.
 		tx_buckets.sort_unstable_by_key(|x| (x.depth, -(x.fee_to_weight as i64)));
 
 		tx_buckets


### PR DESCRIPTION
Reworked `bucket_transactions` to make it `fee_to_weight` aware.
We also return the vec of underlying txs from `bucket_transactions`. We used to return the aggregated bucket txs.

`bucket_transactions` now performs the following logic - 
* Buckets consist of a vec of txs and track the aggregate fee_to_weight ~and  a "depth"~.
* ~Bucket depth is incremented if a bucket depends on an earlier bucket.~
    * buckets only ever have dependencies on buckets with higher fee_to_weight
* We aggregate (cut-through) dependent transactions within a bucket *unless* adding a tx
would reduce the aggregate fee_to_weight, in which case we start a new bucket ~(and increment the depth).~
* We then sort the buckets by ~depth (ascending) _and_~ fee_to_weight (descending) to preserve dependency ordering and maximize both cut-through and overall fees.

The vec of txs returned by `bucket_transactions` satisfies the following - 
* No tx is dependent on any subsequent tx in the vec
* Txs that can be cut-through are adjacent (as long as fee_to_weight is not adversely impacted)
* Cut-through takes max tx weight into account

This prevents low fee 0-conf txs from "piggy-backing" off of higher fee txs in the pool.
While enabling low fee 0-conf txs stuck in the pool to be spent via high fee 0-conf txs (CPFP style).

The pool logic will now attempt to maximize cut-through as long as overall fees are not adversely impacted.

A nice side-effect of all this is related to tx eviction (see #2706). The txs at the end of the vec of txs returned by `bucket_transactions` are good candidates for eviction.
They are likely to have low `fee_to_weight` _and_ can be safely evicted without affecting dependent txs and without impacting cut-through.

