### PR TITLE
pass peer_info around rather than peer_addr (includes protocol version)

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -27,16 +27,16 @@ use crate::msg::{
 	BanReason, GetPeerAddrs, Headers, Locator, PeerAddrs, Ping, Pong, TxHashSetArchive,
 	TxHashSetRequest, Type,
 };
-use crate::types::{Error, NetAdapter, PeerAddr};
+use crate::types::{Error, NetAdapter, PeerInfo};
 
 pub struct Protocol {
 	adapter: Arc<dyn NetAdapter>,
-	addr: PeerAddr,
+	peer_info: PeerInfo,
 }
 
 impl Protocol {
-	pub fn new(adapter: Arc<dyn NetAdapter>, addr: PeerAddr) -> Protocol {
-		Protocol { adapter, addr }
+	pub fn new(adapter: Arc<dyn NetAdapter>, peer_info: PeerInfo) -> Protocol {
+		Protocol { adapter, peer_info }
 	}
 }
 
@@ -52,10 +52,10 @@ impl MessageHandler for Protocol {
 		// If we received a msg from a banned peer then log and drop it.
 		// If we are getting a lot of these then maybe we are not cleaning
 		// banned peers up correctly?
-		if adapter.is_banned(self.addr.clone()) {
+		if adapter.is_banned(self.peer_info.addr) {
 			debug!(
 				"handler: consume: peer {:?} banned, received: {:?}, dropping.",
-				self.addr, msg.header.msg_type,
+				self.peer_info.addr, msg.header.msg_type,
 			);
 			return Ok(None);
 		}
@@ -63,7 +63,7 @@ impl MessageHandler for Protocol {
 		match msg.header.msg_type {
 			Type::Ping => {
 				let ping: Ping = msg.body()?;
-				adapter.peer_difficulty(self.addr, ping.total_difficulty, ping.height);
+				adapter.peer_difficulty(self.peer_info.addr, ping.total_difficulty, ping.height);
 
 				Ok(Some(Response::new(
 					Type::Pong,
@@ -77,7 +77,7 @@ impl MessageHandler for Protocol {
 
 			Type::Pong => {
 				let pong: Pong = msg.body()?;
-				adapter.peer_difficulty(self.addr, pong.total_difficulty, pong.height);
+				adapter.peer_difficulty(self.peer_info.addr, pong.total_difficulty, pong.height);
 				Ok(None)
 			}
 
@@ -93,7 +93,7 @@ impl MessageHandler for Protocol {
 					"handle_payload: received tx kernel: {}, msg_len: {}",
 					h, msg.header.msg_len
 				);
-				adapter.tx_kernel_received(h, self.addr)?;
+				adapter.tx_kernel_received(h, &self.peer_info)?;
 				Ok(None)
 			}
 
@@ -155,7 +155,7 @@ impl MessageHandler for Protocol {
 
 				// we can't know at this level whether we requested the block or not,
 				// the boolean should be properly set in higher level adapter
-				adapter.block_received(b, self.addr, false)?;
+				adapter.block_received(b, &self.peer_info, false)?;
 				Ok(None)
 			}
 
@@ -176,7 +176,7 @@ impl MessageHandler for Protocol {
 				);
 				let b: core::CompactBlock = msg.body()?;
 
-				adapter.compact_block_received(b, self.addr)?;
+				adapter.compact_block_received(b, &self.peer_info)?;
 				Ok(None)
 			}
 
@@ -197,7 +197,7 @@ impl MessageHandler for Protocol {
 			// we can go request it from some of our peers
 			Type::Header => {
 				let header: core::BlockHeader = msg.body()?;
-				adapter.header_received(header, self.addr)?;
+				adapter.header_received(header, &self.peer_info)?;
 				Ok(None)
 			}
 
@@ -217,7 +217,7 @@ impl MessageHandler for Protocol {
 						headers.push(header);
 						total_bytes_read += bytes_read;
 					}
-					adapter.headers_received(&headers, self.addr)?;
+					adapter.headers_received(&headers, &self.peer_info)?;
 				}
 
 				// Now check we read the correct total number of bytes off the stream.
@@ -335,7 +335,7 @@ impl MessageHandler for Protocol {
 				let tmp_zip = File::open(tmp)?;
 				let res = self
 					.adapter
-					.txhashset_write(sm_arch.hash, tmp_zip, self.addr)?;
+					.txhashset_write(sm_arch.hash, tmp_zip, &self.peer_info)?;
 
 				debug!(
 					"handle_payload: txhashset archive for {} at {}, DONE. Data Ok: {}",

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -28,7 +28,8 @@ use crate::peer::Peer;
 use crate::peers::Peers;
 use crate::store::PeerStore;
 use crate::types::{
-	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerAddr, ReasonForBan, TxHashSetRead,
+	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerAddr, PeerInfo, ReasonForBan,
+	TxHashSetRead,
 };
 use crate::util::{Mutex, StopState};
 use chrono::prelude::{DateTime, Utc};
@@ -240,7 +241,7 @@ impl ChainAdapter for DummyAdapter {
 		None
 	}
 
-	fn tx_kernel_received(&self, _h: Hash, _addr: PeerAddr) -> Result<bool, chain::Error> {
+	fn tx_kernel_received(&self, _h: Hash, _peer_info: &PeerInfo) -> Result<bool, chain::Error> {
 		Ok(true)
 	}
 	fn transaction_received(
@@ -253,21 +254,25 @@ impl ChainAdapter for DummyAdapter {
 	fn compact_block_received(
 		&self,
 		_cb: core::CompactBlock,
-		_addr: PeerAddr,
+		_peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		Ok(true)
 	}
 	fn header_received(
 		&self,
 		_bh: core::BlockHeader,
-		_addr: PeerAddr,
+		_peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		Ok(true)
 	}
-	fn block_received(&self, _: core::Block, _: PeerAddr, _: bool) -> Result<bool, chain::Error> {
+	fn block_received(&self, _: core::Block, _: &PeerInfo, _: bool) -> Result<bool, chain::Error> {
 		Ok(true)
 	}
-	fn headers_received(&self, _: &[core::BlockHeader], _: PeerAddr) -> Result<bool, chain::Error> {
+	fn headers_received(
+		&self,
+		_: &[core::BlockHeader],
+		_: &PeerInfo,
+	) -> Result<bool, chain::Error> {
 		Ok(true)
 	}
 	fn locate_headers(&self, _: &[Hash]) -> Result<Vec<core::BlockHeader>, chain::Error> {
@@ -288,7 +293,7 @@ impl ChainAdapter for DummyAdapter {
 		&self,
 		_h: Hash,
 		_txhashset_data: File,
-		_peer_addr: PeerAddr,
+		_peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		Ok(false)
 	}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -483,7 +483,11 @@ pub trait ChainAdapter: Sync + Send {
 
 	fn get_transaction(&self, kernel_hash: Hash) -> Option<core::Transaction>;
 
-	fn tx_kernel_received(&self, kernel_hash: Hash, addr: PeerAddr) -> Result<bool, chain::Error>;
+	fn tx_kernel_received(
+		&self,
+		kernel_hash: Hash,
+		peer_info: &PeerInfo,
+	) -> Result<bool, chain::Error>;
 
 	/// A block has been received from one of our peers. Returns true if the
 	/// block could be handled properly and is not deemed defective by the
@@ -492,17 +496,21 @@ pub trait ChainAdapter: Sync + Send {
 	fn block_received(
 		&self,
 		b: core::Block,
-		addr: PeerAddr,
+		peer_info: &PeerInfo,
 		was_requested: bool,
 	) -> Result<bool, chain::Error>;
 
 	fn compact_block_received(
 		&self,
 		cb: core::CompactBlock,
-		addr: PeerAddr,
+		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error>;
 
-	fn header_received(&self, bh: core::BlockHeader, addr: PeerAddr) -> Result<bool, chain::Error>;
+	fn header_received(
+		&self,
+		bh: core::BlockHeader,
+		peer_info: &PeerInfo,
+	) -> Result<bool, chain::Error>;
 
 	/// A set of block header has been received, typically in response to a
 	/// block
@@ -510,7 +518,7 @@ pub trait ChainAdapter: Sync + Send {
 	fn headers_received(
 		&self,
 		bh: &[core::BlockHeader],
-		addr: PeerAddr,
+		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error>;
 
 	/// Finds a list of block headers based on the provided locator. Tries to
@@ -548,7 +556,7 @@ pub trait ChainAdapter: Sync + Send {
 		&self,
 		h: Hash,
 		txhashset_data: File,
-		peer_addr: PeerAddr,
+		peer_peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error>;
 }
 


### PR DESCRIPTION
We discussed using `PROTOCOL_VERSION` to handle various changes to p2p msgs.
This PR changes the various adapter fns to pass around a ref to a `PeerInfo` rather than simply a `PeerAddr`.
The `PeerInfo` contains both the `PeerAddr` and the `version`.

This would allow the various handlers to handle msgs in a protocol version specific way, based on the peer version via the initial hand/shake msg.



