### PR TITLE
relax our p2p rules around matching protocol versions

### DIFF
--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -86,12 +86,7 @@ impl Handshake {
 		// write and read the handshake response
 		write_message(conn, hand, Type::Hand)?;
 		let shake: Shake = read_message(conn, Type::Shake)?;
-		if shake.version != PROTOCOL_VERSION {
-			return Err(Error::ProtocolMismatch {
-				us: PROTOCOL_VERSION,
-				peer: shake.version,
-			});
-		} else if shake.genesis != self.genesis {
+		if shake.genesis != self.genesis {
 			return Err(Error::GenesisMismatch {
 				us: self.genesis,
 				peer: shake.genesis,
@@ -132,12 +127,7 @@ impl Handshake {
 		let hand: Hand = read_message(conn, Type::Hand)?;
 
 		// all the reasons we could refuse this connection for
-		if hand.version != PROTOCOL_VERSION {
-			return Err(Error::ProtocolMismatch {
-				us: PROTOCOL_VERSION,
-				peer: hand.version,
-			});
-		} else if hand.genesis != self.genesis {
+		if hand.genesis != self.genesis {
 			return Err(Error::GenesisMismatch {
 				us: self.genesis,
 				peer: hand.genesis,

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -28,7 +28,14 @@ use crate::types::{
 };
 use crate::util::read_write::read_exact;
 
-/// Current latest version of the protocol
+/// Our local node protocol version.
+/// We will increment the protocol version with every change to p2p msg serialization
+/// so we will likely connect with peers with both higher and lower protocol versions.
+/// We need to be aware that some msg formats will be potentially incompatible and handle
+/// this for each individual peer connection.
+/// Note: A peer may disconnect and reconnect with an updated protocol version. Normally
+/// the protocol version will increase but we need to handle decreasing values also
+/// as a peer may rollback to previous version of the code.
 pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Grin's user agent with current version

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -67,10 +67,6 @@ pub enum Error {
 	Chain(chain::Error),
 	PeerWithSelf,
 	NoDandelionRelay,
-	ProtocolMismatch {
-		us: u32,
-		peer: u32,
-	},
 	GenesisMismatch {
 		us: Hash,
 		peer: Hash,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -402,6 +402,11 @@ impl Server {
 		self.chain.header_head().map_err(|e| e.into())
 	}
 
+	/// Current p2p layer protocol version.
+	pub fn protocol_version() -> u32 {
+		p2p::msg::PROTOCOL_VERSION
+	}
+
 	/// Returns a set of stats about this server. This and the ServerStats
 	/// structure
 	/// can be updated over time to include any information needed by tests or

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -88,7 +88,11 @@ impl UI {
 
 		let mut title_string = StyledString::new();
 		title_string.append(StyledString::styled(
-			format!("Grin Version {}", built_info::PKG_VERSION),
+			format!(
+				"Grin Version {} (protocol version: {})",
+				built_info::PKG_VERSION,
+				Server::protocol_version()
+			),
 			Color::Dark(BaseColor::Green),
 		));
 


### PR DESCRIPTION
We currently only allow peer connections if the "protocol version" is an exact match between us and the peer.
We will start refusing peer connections in either direction if we attempt to increment any protocol version numbers on the network.
This PR removes this rule and permits peer connections for any combination of protocol version values.

If/when we need to introduce thresholds or incompatible version checking in the future we can, but for now we just accept arbitrary version numbers.

Also - expose _our_ version number via the TUI.

