### PR TITLE
cleanup unused data_file_path

### DIFF
--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -60,15 +60,9 @@ pub trait Backend<T: PMMRable> {
 	/// triggered removal).
 	fn remove(&mut self, position: u64) -> Result<(), String>;
 
-	/// Returns the data file path.. this is a bit of a hack now that doesn't
-	/// sit well with the design, but TxKernels have to be summed and the
-	/// fastest way to to be able to allow direct access to the file
-	fn get_data_file_path(&self) -> &Path;
-
 	/// Release underlying datafiles and locks
 	fn release_files(&mut self);
 
-	/// Also a bit of a hack...
 	/// Saves a snapshot of the rewound utxo file with the block hash as
 	/// filename suffix. We need this when sending a txhashset zip file to a
 	/// node for fast sync.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -335,11 +335,6 @@ where
 		self.last_pos
 	}
 
-	/// Return the path of the data file (needed to sum kernels efficiently)
-	pub fn data_file_path(&self) -> &Path {
-		self.backend.get_data_file_path()
-	}
-
 	/// Debugging utility to print information about the MMRs. Short version
 	/// only prints the last 8 nodes.
 	pub fn dump(&self, short: bool) {

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -124,10 +124,6 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		Ok(())
 	}
 
-	fn get_data_file_path(&self) -> &Path {
-		Path::new("")
-	}
-
 	fn release_files(&mut self) {}
 
 	fn dump_stats(&self) {}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -165,11 +165,6 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		Ok(())
 	}
 
-	/// Return data file path
-	fn get_data_file_path(&self) -> &Path {
-		self.data_file.path()
-	}
-
 	/// Release underlying data files
 	fn release_files(&mut self) {
 		self.data_file.release();


### PR DESCRIPTION
We used to use `data_file_path()` when validating kernel history during fast sync.

But we changed how we implemented this a few months ago - we don't need `data_file_path()` any more and it is unused.

This is purely a cleanup PR, no changed functionality.

