### PR TITLE
Fix state sync for different partitions

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -940,7 +940,13 @@ impl Chain {
 
 			// Move sandbox to overwrite
 			txhashset.release_backend_files();
-			txhashset::txhashset_replace(sandbox_dir.clone(), PathBuf::from(self.db_root.clone()))?;
+			let dest = PathBuf::from(self.db_root.clone());
+			let repl = txhashset::txhashset_replace(sandbox_dir.clone(), dest.clone());
+			if repl.is_err() {
+				// common error case for a move is differing partition, try a full
+				// replica in that case
+				txhashset::zip_write(dest, txhashset_data, &header)?;
+			}
 
 			// Re-open on db root dir
 			txhashset = txhashset::TxHashSet::open(


### PR DESCRIPTION
Replacement of the txhahset does a rename to move the content of
the extracted folder. However one can't use rename across
different partitions (my case, `/tmp` has its own). In case of
failure, this re-extracts the zip to the destination.

Note that I originally tried a copy and delete, but recursively
copying the directory would either add a fair amount of code or
a dedicated dependency. This didn't seem worth (being somewhat of
a degenerate failure case).

---
name: Pull Request
about: Pull Request checklist
title: ''
labels: ''
assignees: ''

---
If your PR is a work in progress, please feel free to create it and include a [WIP] tag in the PR name. We encourage everyone to PR early and often so that other developers know what you're working on.

Before submitting your PR for final review, please ensure that it:

* Includes a proper description of what problems the PR addresses, as well as a detailed explanation as to what it changes
* Explains whether/how the change is consensus breaking or breaks existing client functionality
* Contains unit tests exercising new/changed functionality
* Fully considers the potential impact of the change on other parts of the system
* Describes how you've tested the change (e.g. against Floonet, etc)
* Updates any documentation that's affected by the PR
