### PR TITLE
Increasing thread sleeps for socket listener thread and per-connection threads

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -244,7 +244,7 @@ fn poll<H>(
 	let _ = thread::Builder::new()
 		.name("peer".to_string())
 		.spawn(move || {
-			let sleep_time = time::Duration::from_millis(1);
+			let sleep_time = time::Duration::from_millis(5);
 			let mut retry_send = Err(());
 			loop {
 				// check the read end

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -71,7 +71,7 @@ impl Server {
 		let listener = TcpListener::bind(addr)?;
 		listener.set_nonblocking(true)?;
 
-		let sleep_time = Duration::from_millis(1);
+		let sleep_time = Duration::from_millis(5);
 		loop {
 			// Pause peer ingress connection request. Only for tests.
 			if self.stop_state.lock().is_paused() {


### PR DESCRIPTION
This significantly decreases cpu usage, especially for nodes with >20 peers. There's very little reason for the thread sleeps to be 1 ms. The only (theoretical) advantage is during mining, but as long as miners have a sufficient number of peers (~10+), there should be no practical effect.