### PR TITLE
Fix peer dropping

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -51,6 +51,10 @@ macro_rules! try_break {
 		match $inner {
 			Ok(v) => Some(v),
 			Err(Error::Connection(ref e)) if e.kind() == io::ErrorKind::WouldBlock => None,
+			Err(Error::Store(_))
+			| Err(Error::Chain(_))
+			| Err(Error::Internal)
+			| Err(Error::NoDandelionRelay) => None,
 			Err(e) => {
 				let _ = $chan.send(e);
 				break;

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -61,7 +61,7 @@ macro_rules! connection {
 	($holder:expr) => {
 		match $holder.connection.as_ref() {
 			Some(conn) => conn.lock(),
-			None => return Err(Error::Internal),
+			None => return Err(Error::ConnectionClose),
 			}
 	};
 }


### PR DESCRIPTION
It turns out that we drop connection if we fail to process a message
because of chain/store/internal error, eg we have a header already, so
we refuse it and drop the peer.
This pr doesn't forward this error to the peer error channel so the
connection will not be dropped.
With this fix my node doesn't drop healthy peers, some peers close connection of course, hopefully I see that Grin++ nodes (which doesn't have this bug) stay forever so now I have 3 grin++ of 25 peers which says something