### PR TITLE
Gracefully shutdown if SIGINT was sent in TUI mode

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -75,12 +75,12 @@ impl Server {
 	/// to poll info about the server status
 	pub fn start<F>(config: ServerConfig, mut info_callback: F) -> Result<(), Error>
 	where
-		F: FnMut(Arc<Server>),
+		F: FnMut(Server) -> thread::JoinHandle<()>,
 	{
 		let mining_config = config.stratum_mining_config.clone();
 		let enable_test_miner = config.run_test_miner;
 		let test_miner_wallet_url = config.test_miner_wallet_url.clone();
-		let serv = Arc::new(Server::new(config)?);
+		let serv = Server::new(config)?;
 
 		if let Some(c) = mining_config {
 			let enable_stratum_server = c.enable_stratum_server;
@@ -101,13 +101,10 @@ impl Server {
 			}
 		}
 
-		info_callback(serv.clone());
-		loop {
-			thread::sleep(time::Duration::from_secs(1));
-			if serv.stop_state.lock().is_stopped() {
-				return Ok(());
-			}
-		}
+		info_callback(serv)
+			.join()
+			.expect("failed to join UI thread");
+		Ok(())
 	}
 
 	// Exclusive (advisory) lock_file to ensure we do not run multiple

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -75,7 +75,7 @@ impl Server {
 	/// to poll info about the server status
 	pub fn start<F>(config: ServerConfig, mut info_callback: F) -> Result<(), Error>
 	where
-		F: FnMut(Server) -> thread::JoinHandle<()>,
+		F: FnMut(Server),
 	{
 		let mining_config = config.stratum_mining_config.clone();
 		let enable_test_miner = config.run_test_miner;
@@ -101,9 +101,7 @@ impl Server {
 			}
 		}
 
-		info_callback(serv)
-			.join()
-			.expect("failed to join UI thread");
+		info_callback(serv);
 		Ok(())
 	}
 

--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -46,14 +46,13 @@ fn start_server_tui(config: servers::ServerConfig) {
 	if config.run_tui.unwrap_or(false) {
 		warn!("Starting GRIN in UI mode...");
 		servers::Server::start(config, |serv: servers::Server| -> thread::JoinHandle<()> {
-			let running = Arc::new(AtomicBool::new(true));
 			thread::Builder::new()
 				.name("ui".to_string())
 				.spawn(move || {
 					let mut controller = ui::Controller::new().unwrap_or_else(|e| {
 						panic!("Error loading UI controller: {}", e);
 					});
-					controller.run(serv, running);
+					controller.run(serv);
 				})
 				.expect("can't launch UI thread")
 		})

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -180,13 +180,8 @@ impl Controller {
 			while let Some(message) = self.rx.try_iter().next() {
 				match message {
 					ControllerMessage::Shutdown => {
-						debug!("Got shutdown message");
 						server.stop();
 						self.ui.stop();
-						/*self.ui
-						.ui_tx
-						.send(UIMessage::UpdateOutput("update".to_string()))
-						.unwrap();*/
 					}
 				}
 			}

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -16,9 +16,6 @@
 //! of various subsystems
 
 use chrono::prelude::Utc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
-
 use cursive::direction::Orientation;
 use cursive::theme::BaseColor::{Black, Blue, Cyan, White};
 use cursive::theme::Color::Dark;
@@ -31,14 +28,13 @@ use cursive::traits::Identifiable;
 use cursive::utils::markup::StyledString;
 use cursive::views::{LinearLayout, Panel, StackView, TextView, ViewBox};
 use cursive::Cursive;
+use std::sync::mpsc;
 
+use crate::built_info;
 use crate::servers::Server;
-
 use crate::tui::constants::ROOT_STACK;
 use crate::tui::types::{TUIStatusListener, UIMessage};
 use crate::tui::{menu, mining, peers, status, version};
-
-use crate::built_info;
 
 pub struct UI {
 	cursive: Cursive,
@@ -63,12 +59,19 @@ impl UI {
 	/// Create a new UI
 	pub fn new(controller_tx: mpsc::Sender<ControllerMessage>) -> UI {
 		let (ui_tx, ui_rx) = mpsc::channel::<UIMessage>();
+		let close_tx = controller_tx.clone();
 		let mut grin_ui = UI {
 			cursive: Cursive::default(),
 			ui_tx: ui_tx,
 			ui_rx: ui_rx,
 			controller_tx: controller_tx,
 		};
+		if let Err(e) = ctrlc::set_handler(move || {
+			let _ = close_tx.send(ControllerMessage::Shutdown);
+			std::thread::sleep(std::time::Duration::from_millis(1000));
+		}) {
+			error!("failed to register ctrl-c handler: {:?}", e);
+		}
 
 		// Create UI objects, etc
 		let status_view = status::TUIStatusView::create();
@@ -166,25 +169,20 @@ impl Controller {
 		let (tx, rx) = mpsc::channel::<ControllerMessage>();
 		Ok(Controller {
 			rx: rx,
-			ui: UI::new(tx.clone()),
+			ui: UI::new(tx),
 		})
 	}
 	/// Run the controller
-	pub fn run(&mut self, server: Server, running: Arc<AtomicBool>) {
+	pub fn run(&mut self, server: Server) {
 		let stat_update_interval = 1;
 		let mut next_stat_update = Utc::now().timestamp() + stat_update_interval;
 		while self.ui.step() {
-			if !running.load(Ordering::SeqCst) {
-				warn!("Received SIGINT (Ctrl+C).");
-				server.stop();
-				self.ui.stop();
-			}
 			while let Some(message) = self.rx.try_iter().next() {
 				match message {
 					ControllerMessage::Shutdown => {
+						debug!("Got shutdown message");
 						server.stop();
 						self.ui.stop();
-						running.store(false, Ordering::SeqCst)
 						/*self.ui
 						.ui_tx
 						.send(UIMessage::UpdateOutput("update".to_string()))

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -170,7 +170,7 @@ impl Controller {
 		})
 	}
 	/// Run the controller
-	pub fn run(&mut self, server: Arc<Server>, running: Arc<AtomicBool>) {
+	pub fn run(&mut self, server: Server, running: Arc<AtomicBool>) {
 		let stat_update_interval = 1;
 		let mut next_stat_update = Utc::now().timestamp() + stat_update_interval;
 		while self.ui.step() {

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -59,19 +59,12 @@ impl UI {
 	/// Create a new UI
 	pub fn new(controller_tx: mpsc::Sender<ControllerMessage>) -> UI {
 		let (ui_tx, ui_rx) = mpsc::channel::<UIMessage>();
-		let close_tx = controller_tx.clone();
 		let mut grin_ui = UI {
 			cursive: Cursive::default(),
 			ui_tx: ui_tx,
 			ui_rx: ui_rx,
 			controller_tx: controller_tx,
 		};
-		if let Err(e) = ctrlc::set_handler(move || {
-			let _ = close_tx.send(ControllerMessage::Shutdown);
-			std::thread::sleep(std::time::Duration::from_millis(1000));
-		}) {
-			error!("failed to register ctrl-c handler: {:?}", e);
-		}
 
 		// Create UI objects, etc
 		let status_view = status::TUIStatusView::create();
@@ -192,5 +185,6 @@ impl Controller {
 				next_stat_update = Utc::now().timestamp() + stat_update_interval;
 			}
 		}
+		server.stop();
 	}
 }


### PR DESCRIPTION
Fixes #2799

Also 2 Arc's were replaced by one server's instance.
It is needed for p2p thread management in https://github.com/mimblewimble/grin/pull/2778, currently there is no point where we could store thread handles and join them because `thread::join`
consume the caller, which is impossible in case of Arc.

