### PR TITLE
add debug logging on startup to provide size of our leaf_set (UTXO set)

### DIFF
--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -47,6 +47,14 @@ impl LeafSet {
 			Bitmap::create()
 		};
 
+		if !bitmap.is_empty() {
+			debug!(
+				"bitmap {} pos ({} bytes)",
+				bitmap.cardinality(),
+				bitmap.get_serialized_size_in_bytes(),
+			);
+		}
+
 		Ok(LeafSet {
 			path: file_path.to_path_buf(),
 			bitmap_bak: bitmap.clone(),

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -83,7 +83,7 @@ impl PruneList {
 		prune_list.init_caches();
 
 		if !prune_list.bitmap.is_empty() {
-			debug!("prune_list: bitmap {} pos ({} bytes), pruned_cache {} pos ({} bytes), shift_cache {}, leaf_shift_cache {}",
+			debug!("bitmap {} pos ({} bytes), pruned_cache {} pos ({} bytes), shift_cache {}, leaf_shift_cache {}",
 				prune_list.bitmap.cardinality(),
 				prune_list.bitmap.get_serialized_size_in_bytes(),
 				prune_list.pruned_cache.cardinality(),


### PR DESCRIPTION
We do this for the `prune_list` already, so logging the `leaf_set` as well for visibility.

```
20190430 12:09:04.789 DEBUG grin_store::leaf_set - bitmap 41834 pos (82320 bytes)
```

