### PR TITLE
remove the error_channel and simplify how we close peer connections

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -47,7 +47,7 @@ pub trait MessageHandler: Send + 'static {
 // Macro to simplify the boilerplate around async I/O error handling,
 // especially with WouldBlock kind of errors.
 macro_rules! try_break {
-	($chan:ident, $inner:expr) => {
+	($inner:expr) => {
 		match $inner {
 			Ok(v) => Some(v),
 			Err(Error::Connection(ref e)) if e.kind() == io::ErrorKind::WouldBlock => None,
@@ -55,8 +55,8 @@ macro_rules! try_break {
 			| Err(Error::Chain(_))
 			| Err(Error::Internal)
 			| Err(Error::NoDandelionRelay) => None,
-			Err(e) => {
-				let _ = $chan.send(e);
+			Err(ref e) => {
+				debug!("try_break: exit the loop: {:?}", e);
 				break;
 				}
 			}
@@ -171,8 +171,6 @@ pub struct Tracker {
 	pub send_channel: mpsc::SyncSender<Vec<u8>>,
 	/// Channel to close the connection
 	pub close_channel: mpsc::Sender<()>,
-	/// Channel to check for errors on the connection
-	pub error_channel: mpsc::Receiver<Error>,
 }
 
 impl Tracker {
@@ -201,7 +199,6 @@ where
 {
 	let (send_tx, send_rx) = mpsc::sync_channel(SEND_CHANNEL_CAP);
 	let (close_tx, close_rx) = mpsc::channel();
-	let (error_tx, error_rx) = mpsc::channel();
 
 	// Counter of number of bytes received
 	let received_bytes = Arc::new(RwLock::new(RateCounter::new()));
@@ -215,7 +212,6 @@ where
 		stream,
 		handler,
 		send_rx,
-		error_tx,
 		close_rx,
 		received_bytes.clone(),
 		sent_bytes.clone(),
@@ -226,7 +222,6 @@ where
 		received_bytes: received_bytes.clone(),
 		send_channel: send_tx,
 		close_channel: close_tx,
-		error_channel: error_rx,
 	}
 }
 
@@ -234,7 +229,6 @@ fn poll<H>(
 	conn: TcpStream,
 	handler: H,
 	send_rx: mpsc::Receiver<Vec<u8>>,
-	error_tx: mpsc::Sender<Error>,
 	close_rx: mpsc::Receiver<()>,
 	received_bytes: Arc<RwLock<RateCounter>>,
 	sent_bytes: Arc<RwLock<RateCounter>>,
@@ -252,7 +246,7 @@ fn poll<H>(
 			let mut retry_send = Err(());
 			loop {
 				// check the read end
-				if let Some(h) = try_break!(error_tx, read_header(&mut reader, None)) {
+				if let Some(h) = try_break!(read_header(&mut reader, None)) {
 					let msg = Message::from_header(h, &mut reader);
 
 					trace!(
@@ -269,9 +263,9 @@ fn poll<H>(
 					}
 
 					if let Some(Some(resp)) =
-						try_break!(error_tx, handler.consume(msg, &mut writer, received))
+						try_break!(handler.consume(msg, &mut writer, received))
 					{
-						try_break!(error_tx, resp.write(sent_bytes.clone()));
+						try_break!(resp.write(sent_bytes.clone()));
 					}
 				}
 
@@ -279,8 +273,7 @@ fn poll<H>(
 				let maybe_data = retry_send.or_else(|_| send_rx.try_recv());
 				retry_send = Err(());
 				if let Ok(data) = maybe_data {
-					let written =
-						try_break!(error_tx, writer.write_all(&data[..]).map_err(&From::from));
+					let written = try_break!(writer.write_all(&data[..]).map_err(&From::from));
 					if written.is_none() {
 						retry_send = Ok(data);
 					}
@@ -288,17 +281,18 @@ fn poll<H>(
 
 				// check the close channel
 				if let Ok(_) = close_rx.try_recv() {
-					debug!(
-						"Connection close with {} initiated by us",
-						conn.peer_addr()
-							.map(|a| a.to_string())
-							.unwrap_or("?".to_owned())
-					);
 					break;
 				}
 
 				thread::sleep(sleep_time);
 			}
+
+			debug!(
+				"Shutting down connection with {}",
+				conn.peer_addr()
+					.map(|a| a.to_string())
+					.unwrap_or("?".to_owned())
+			);
 			let _ = conn.shutdown(Shutdown::Both);
 		});
 }


### PR DESCRIPTION
Replaces #2794 with a simpler solution.

Existing behavior -

* `try_break!` on certain errors will send an error event to the `error_channel`
* `peers.check_connection` tries to read off the `error_channel`
    * on receiving an error event it will then put a close event on the `close_channel`
* the peer connection poll loop then tries to read off the `close_channel`
    * on receiving a close event it closes the connection

So we have - 

```
error -> error_channel -> close_channel -> close
```

In addition `try_break!` _also_ breaks out of the connection poll loop and immediately closes the connection. 
So none of the above actually affects anything. We have already broken out of the poll loop and we will never read from the peer specific `close_channel`.

This PR simplifies all of the above by replacing the "put an error event on the error_channel" with a simple "stop (close connection) and remove peer".

There is no need for the `error_channel` as we can close peer connection directly without this intermediate layer of indirection.

There are 3 places where we actually use these connections -
1. When we receive a msg from a peer
1. When we broadcast a msg out to peer(s)
1. When we ping all our peers (similar but slightly different to above)

For (1) we want to close the connection if `try_break!` encounters a serious enough peer related error.
We already handle this by breaking out of the poll loop (error_channel never actually used).
For (2) and (3) we now simply `close()` and remove the peer from our list of peers. 

Previously we were relying on the complex `is_connected()` logic to identify a closed or error condition peer connection (and for it to internally clean up the peer and connection).

We now simply attempt to send the msg and on error close the connection (for both ping and broadcast paths).

Related - #2801 removes option wrapper on the peer connection which will make `peer.is_connected()` here even simpler as we no longer need to handle the case where a peer has no initialized connection.

