### PR TITLE
Evict transaction from transaction pool

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -310,7 +310,7 @@ impl Pool {
 	/// containing the tx it depends on.
 	/// Sorting the buckets by fee_to_weight will therefore preserve dependency ordering,
 	/// maximizing both cut-through and overall fees.
-	fn bucket_transactions(&self, weighting: Weighting) -> Vec<Transaction> {
+	pub fn bucket_transactions(&self, weighting: Weighting) -> Vec<Transaction> {
 		let mut tx_buckets: Vec<Bucket> = Vec::new();
 		let mut output_commits = HashMap::new();
 		let mut rejected = HashSet::new();

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -138,7 +138,13 @@ impl TransactionPool {
 		}
 
 		// Do we have the capacity to accept this transaction?
-		self.is_acceptable(&tx, stem)?;
+		let acceptability = self.is_acceptable(&tx, stem);
+		let mut evict = false;
+		if !stem && acceptability.as_ref().err() == Some(&PoolError::OverCapacity) {
+			evict = true;
+		} else if acceptability.is_err() {
+			return acceptability;
+		}
 
 		// Make sure the transaction is valid before anything else.
 		// Validate tx accounting for max tx weight.
@@ -171,7 +177,35 @@ impl TransactionPool {
 			self.adapter.tx_accepted(&entry.tx);
 		}
 
+		// Transaction passed all the checks but we have to make space for it
+		if evict {
+			self.evict_from_txpool()?;
+		}
+
 		Ok(())
+	}
+
+	// Remove the last transaction from the flattened bucket transactions.
+	// No other tx depends on it, it has low fee_to_weight and is unlikely to participate in any cut-through.
+	pub fn evict_from_txpool(&mut self) -> Result<(), PoolError> {
+		// Get bucket transactions
+		let bucket_transactions = self.txpool.bucket_transactions(Weighting::NoLimit);
+
+		// Get last transaction and remove it
+		match bucket_transactions.last() {
+			Some(evictable_transaction) => {
+				// Remove transaction
+				self.txpool.entries = self
+					.txpool
+					.entries
+					.iter()
+					.filter(|x| x.tx != *evictable_transaction)
+					.map(|x| x.clone())
+					.collect::<Vec<_>>();
+				Ok(())
+			}
+			None => Err(PoolError::OverCapacity),
+		}
 	}
 
 	// Old txs will "age out" after 30 mins.
@@ -245,11 +279,10 @@ impl TransactionPool {
 		}
 
 		// Check that the stempool can accept this transaction
-		if stem {
-			if self.stempool.size() > self.config.max_stempool_size {
-				// TODO evict old/large transactions instead
-				return Err(PoolError::OverCapacity);
-			}
+		if stem && self.stempool.size() > self.config.max_stempool_size {
+			return Err(PoolError::OverCapacity);
+		} else if self.total_size() > self.config.max_pool_size {
+			return Err(PoolError::OverCapacity);
 		}
 
 		// for a basic transaction (1 input, 2 outputs) -

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -179,7 +179,7 @@ impl TransactionPool {
 
 		// Transaction passed all the checks but we have to make space for it
 		if evict {
-			self.evict_from_txpool()?;
+			self.evict_from_txpool();
 		}
 
 		Ok(())
@@ -187,7 +187,7 @@ impl TransactionPool {
 
 	// Remove the last transaction from the flattened bucket transactions.
 	// No other tx depends on it, it has low fee_to_weight and is unlikely to participate in any cut-through.
-	pub fn evict_from_txpool(&mut self) -> Result<(), PoolError> {
+	pub fn evict_from_txpool(&mut self) {
 		// Get bucket transactions
 		let bucket_transactions = self.txpool.bucket_transactions(Weighting::NoLimit);
 
@@ -202,9 +202,8 @@ impl TransactionPool {
 					.filter(|x| x.tx != *evictable_transaction)
 					.map(|x| x.clone())
 					.collect::<Vec<_>>();
-				Ok(())
 			}
-			None => Err(PoolError::OverCapacity),
+			None => (),
 		}
 	}
 

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -162,7 +162,7 @@ pub struct TxSource {
 }
 
 /// Possible errors when interacting with the transaction pool.
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, PartialEq)]
 pub enum PoolError {
 	/// An invalid pool entry caused by underlying tx validation error
 	#[fail(display = "Invalid Tx {}", _0)]


### PR DESCRIPTION
Replace https://github.com/mimblewimble/grin/pull/2706 and fix https://github.com/mimblewimble/grin/issues/1417.

Thanks to https://github.com/mimblewimble/grin/pull/2758 we can drastically simplify the eviction process when the transaction pool is full:

1. Whenever we receive a stem transaction, we check if adding it would overflow the current pool capacity.
2. Add the transaction to the transaction pool.
3. If overflow then `bucket_transactions` and remove the last one (No other tx depends on it, it has low fee_to_weight and is unlikely to participate in any cut-through).