### PR TITLE
Simplify peer connection handling

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -188,6 +188,11 @@ impl Tracker {
 
 		Ok(())
 	}
+
+	/// Schedule this connection to safely close via the async close_channel.
+	pub fn close(&self) {
+		let _ = self.close_channel.send(());
+	}
 }
 
 /// Start listening on the provided connection and wraps it. Does not hang

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -61,6 +61,7 @@ impl fmt::Debug for Peer {
 }
 
 impl Peer {
+	// Only accept and connect can be externally used to build a peer
 	fn new(info: PeerInfo, conn: TcpStream, adapter: Arc<dyn NetAdapter>) -> Peer {
 		let state = Arc::new(RwLock::new(State::Connected));
 		let tracking_adapter = TrackingAdapter::new(adapter);

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -246,10 +246,7 @@ impl Peer {
 	/// Send the ban reason before banning
 	pub fn send_ban_reason(&self, ban_reason: ReasonForBan) -> Result<(), Error> {
 		let ban_reason_msg = BanReason { ban_reason };
-		self.connection
-			.lock()
-			.send(ban_reason_msg, msg::Type::BanReason)
-			.map(|_| ())
+		self.send(ban_reason_msg, msg::Type::BanReason).map(|_| ())
 	}
 
 	/// Sends the provided block to the remote peer. The request may be dropped
@@ -302,9 +299,7 @@ impl Peer {
 	pub fn send_tx_kernel_hash(&self, h: Hash) -> Result<bool, Error> {
 		if !self.tracking_adapter.has_recv(h) {
 			debug!("Send tx kernel hash {} to {}", h, self.info.addr);
-			self.connection
-				.lock()
-				.send(h, msg::Type::TransactionKernel)?;
+			self.send(h, msg::Type::TransactionKernel)?;
 			Ok(true)
 		} else {
 			debug!(
@@ -354,9 +349,7 @@ impl Peer {
 
 	/// Sends a request for block headers from the provided block locator
 	pub fn send_header_request(&self, locator: Vec<Hash>) -> Result<(), Error> {
-		self.connection
-			.lock()
-			.send(&Locator { hashes: locator }, msg::Type::GetHeaders)
+		self.send(&Locator { hashes: locator }, msg::Type::GetHeaders)
 	}
 
 	pub fn send_tx_request(&self, h: Hash) -> Result<(), Error> {

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -159,9 +159,6 @@ impl Peer {
 
 	/// Whether this peer is currently connected.
 	pub fn is_connected(&self) -> bool {
-		if self.connection.is_none() {
-			return false;
-		}
 		State::Connected == *self.state.read()
 	}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -138,19 +138,18 @@ impl Server {
 			addr
 		);
 		match TcpStream::connect_timeout(&addr.0, Duration::from_secs(10)) {
-			Ok(mut stream) => {
+			Ok(stream) => {
 				let addr = SocketAddr::new(self.config.host, self.config.port);
 				let total_diff = self.peers.total_difficulty()?;
 
-				let mut peer = Peer::connect(
-					&mut stream,
+				let peer = Peer::connect(
+					stream,
 					self.capabilities,
 					total_diff,
 					PeerAddr(addr),
 					&self.handshake,
 					self.peers.clone(),
 				)?;
-				peer.start(stream);
 				let peer = Arc::new(peer);
 				self.peers.add_connected(peer.clone())?;
 				Ok(peer)
@@ -168,18 +167,17 @@ impl Server {
 		}
 	}
 
-	fn handle_new_peer(&self, mut stream: TcpStream) -> Result<(), Error> {
+	fn handle_new_peer(&self, stream: TcpStream) -> Result<(), Error> {
 		let total_diff = self.peers.total_difficulty()?;
 
 		// accept the peer and add it to the server map
-		let mut peer = Peer::accept(
-			&mut stream,
+		let peer = Peer::accept(
+			stream,
 			self.capabilities,
 			total_diff,
 			&self.handshake,
 			self.peers.clone(),
 		)?;
-		peer.start(stream);
 		self.peers.add_connected(Arc::new(peer))?;
 		Ok(())
 	}

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -67,11 +67,11 @@ fn peer_handshake() {
 	thread::sleep(time::Duration::from_secs(1));
 
 	let addr = SocketAddr::new(p2p_config.host, p2p_config.port);
-	let mut socket = TcpStream::connect_timeout(&addr, time::Duration::from_secs(10)).unwrap();
+	let socket = TcpStream::connect_timeout(&addr, time::Duration::from_secs(10)).unwrap();
 
 	let my_addr = PeerAddr("127.0.0.1:5000".parse().unwrap());
-	let mut peer = Peer::connect(
-		&mut socket,
+	let peer = Peer::connect(
+		socket,
 		p2p::Capabilities::UNKNOWN,
 		Difficulty::min(),
 		my_addr,
@@ -82,7 +82,6 @@ fn peer_handshake() {
 
 	assert!(peer.info.user_agent.ends_with(env!("CARGO_PKG_VERSION")));
 
-	peer.start(socket);
 	thread::sleep(time::Duration::from_secs(1));
 
 	peer.send_ping(Difficulty::min(), 0).unwrap();


### PR DESCRIPTION
The peer connection used to be wrapped in an option.
This complicated the initialization of a peer (with active connection) due to the period between creating the peer and assigning the connection to it.
The workaround was the `connection!` macro to handle the case where the connection was `None`.

This PR simplifies this. `Peer::accept()` and `Peer::connect()` now return a peer with active connection already assigned.

We have less special cases to handle like this.

