### PR TITLE
add proofsize check in pow verification

### DIFF
--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -27,6 +27,7 @@ use crate::pow::common::{CuckooParams, EdgeType};
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::siphash::siphash_block;
 use crate::pow::{PoWContext, Proof};
+use crate::global;
 
 /// Instantiate a new CuckarooContext as a PowContext. Note that this can't
 /// be moved in the PoWContext trait as this particular trait needs to be
@@ -68,6 +69,10 @@ where
 	}
 
 	fn verify(&self, proof: &Proof) -> Result<(), Error> {
+		if proof.proof_size() != global::proofsize() {
+			return Err(ErrorKind::Verification(
+				"wrong cycle length".to_owned(),))?;
+		}
 		let nonces = &proof.nonces;
 		let mut uvs = vec![0u64; 2 * proof.proof_size()];
 		let mut xor0: u64 = 0;

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -20,6 +20,7 @@ use croaring::Bitmap;
 use crate::pow::common::{CuckooParams, EdgeType, Link};
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::{PoWContext, Proof};
+use crate::global;
 use crate::util;
 
 struct Graph<T>
@@ -280,6 +281,10 @@ where
 	/// Verify that given edges are ascending and form a cycle in a header-generated
 	/// graph
 	pub fn verify_impl(&self, proof: &Proof) -> Result<(), Error> {
+                if proof.proof_size() != global::proofsize() {
+                        return Err(ErrorKind::Verification( 
+                                "wrong cycle length".to_owned(),))?;
+                }
 		let nonces = &proof.nonces;
 		let mut uvs = vec![0u64; 2 * proof.proof_size()];
 		let mut xor0: u64 = (self.params.proof_size as u64 / 2) & 1;


### PR DESCRIPTION
Currently, the only way that solutions are enforced to have length 42 is by function Proof::read at https://github.com/mimblewimble/grin/blob/master/core/src/pow/types.rs#L394-L428
This is rather fragile, and could cause problems if proofs are constructed by other means than deserialization through Proof::read.
A more robust way to check it would be in the core PoW verification functions CuckarooContext::verify and CuckatooContext::verify, which is what this PR adds.
The change has been tested to sync the mainnet chain from scratch.