### PR TITLE
[WIP] simplify (maybe) is_bad_data peer banning

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -500,7 +500,7 @@ impl ChainAdapter for TrackingAdapter {
 		&self,
 		bh: core::BlockHeader,
 		peer_info: &PeerInfo,
-	) -> Result<bool, chain::Error> {
+	) -> Result<(), chain::Error> {
 		self.push_recv(bh.hash());
 		self.adapter.header_received(bh, peer_info)
 	}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -261,8 +261,8 @@ impl ChainAdapter for DummyAdapter {
 		&self,
 		_bh: core::BlockHeader,
 		_peer_info: &PeerInfo,
-	) -> Result<bool, chain::Error> {
-		Ok(true)
+	) -> Result<(), chain::Error> {
+		Ok(())
 	}
 	fn block_received(&self, _: core::Block, _: &PeerInfo, _: bool) -> Result<bool, chain::Error> {
 		Ok(true)

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -507,7 +507,7 @@ pub trait ChainAdapter: Sync + Send {
 		&self,
 		bh: core::BlockHeader,
 		peer_info: &PeerInfo,
-	) -> Result<bool, chain::Error>;
+	) -> Result<(), chain::Error>;
 
 	/// A set of block header has been received, typically in response to a
 	/// block


### PR DESCRIPTION
Experimental change to `header_received` to rework the peer banning logic - 

* adapter returns `Result<(), chain::Error>` and not `Result<bool, chain::Error>`
* adapter no longer responsible for intercepting the "bad data" error and translating it into an `Ok(false)`
* we ban the peer based on `error.is_bad_data()` 

I'm making the argument here that `adapters.rs` should not be responsible for identifying "bad data" errors and translating them into `Ok(false)`. 
This way `adapters.rs` simply passes any `chain::Error` through to the p2p layer. 
The p2p layer is responsible for deciding to ban the peer based on the underlying `chain::Error` which it already needs to deal with. 
