### PR TITLE
Use read_u16 etc (byteorder) in StreamingReader

### DIFF
--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -392,33 +392,22 @@ impl<'a> StreamingReader<'a> {
 
 impl<'a> Reader for StreamingReader<'a> {
 	fn read_u8(&mut self) -> Result<u8, Error> {
-		let buf = self.read_fixed_bytes(1)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_u8().map_err(map_io_err)
 	}
-
 	fn read_u16(&mut self) -> Result<u16, Error> {
-		let buf = self.read_fixed_bytes(2)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_u16::<BigEndian>().map_err(map_io_err)
 	}
-
 	fn read_u32(&mut self) -> Result<u32, Error> {
-		let buf = self.read_fixed_bytes(4)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_u32::<BigEndian>().map_err(map_io_err)
 	}
-
 	fn read_i32(&mut self) -> Result<i32, Error> {
-		let buf = self.read_fixed_bytes(4)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_i32::<BigEndian>().map_err(map_io_err)
 	}
-
 	fn read_u64(&mut self) -> Result<u64, Error> {
-		let buf = self.read_fixed_bytes(8)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_u64::<BigEndian>().map_err(map_io_err)
 	}
-
 	fn read_i64(&mut self) -> Result<i64, Error> {
-		let buf = self.read_fixed_bytes(8)?;
-		deserialize(&mut &buf[..])
+		self.stream.read_i64::<BigEndian>().map_err(map_io_err)
 	}
 
 	/// Read a variable size vector from the underlying stream. Expects a usize


### PR DESCRIPTION
Our `StreamingReader` impl differs from the `BinReader` impl as we are not using byteorder to ensure consistent handling of multiple byte values.

BinReader - 

https://github.com/mimblewimble/grin/blob/998824ecf3e0d8a53c26b93060cc8bba4f51a65d/core/src/ser.rs#L321-L323

StreamingReader - 

https://github.com/mimblewimble/grin/blob/998824ecf3e0d8a53c26b93060cc8bba4f51a65d/core/src/ser.rs#L399-L402

This PR makes `StreamingReader` use the various `byteorder` fns and makes `BigEndian` explicit in these various read fns.

