### PR TITLE
make sure we use BigEndian when reading numbers via StreamingReader

### DIFF
--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -393,32 +393,32 @@ impl<'a> StreamingReader<'a> {
 impl<'a> Reader for StreamingReader<'a> {
 	fn read_u8(&mut self) -> Result<u8, Error> {
 		let buf = self.read_fixed_bytes(1)?;
-		deserialize(&mut &buf[..])
+		Ok(buf[0])
 	}
 
 	fn read_u16(&mut self) -> Result<u16, Error> {
 		let buf = self.read_fixed_bytes(2)?;
-		deserialize(&mut &buf[..])
+		Ok(BigEndian::read_u16(&buf[..]))
 	}
 
 	fn read_u32(&mut self) -> Result<u32, Error> {
 		let buf = self.read_fixed_bytes(4)?;
-		deserialize(&mut &buf[..])
+		Ok(BigEndian::read_u32(&buf[..]))
 	}
 
 	fn read_i32(&mut self) -> Result<i32, Error> {
 		let buf = self.read_fixed_bytes(4)?;
-		deserialize(&mut &buf[..])
+		Ok(BigEndian::read_i32(&buf[..]))
 	}
 
 	fn read_u64(&mut self) -> Result<u64, Error> {
 		let buf = self.read_fixed_bytes(8)?;
-		deserialize(&mut &buf[..])
+		Ok(BigEndian::read_u64(&buf[..]))
 	}
 
 	fn read_i64(&mut self) -> Result<i64, Error> {
 		let buf = self.read_fixed_bytes(8)?;
-		deserialize(&mut &buf[..])
+		Ok(BigEndian::read_i64(&buf[..]))
 	}
 
 	/// Read a variable size vector from the underlying stream. Expects a usize


### PR DESCRIPTION
Resolves #2820.

This PR fixes a narrow part of #2820 where we are not using `BigEndian` explicitly in `StreamingReader`.

This has an additional benefit where we get rid of a couple of levels of indirection. We used to deserialize numbers (`u64` etc.) in a `StreamingReader` by instantiating a new `BinReader` within the `deserialize` call for each number being deserialized.
