### PR TITLE
[TUI] Replace S and R with corresponding ASCII arrows in bandwidth column

### DIFF
--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -68,7 +68,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::Address => self.addr.clone(),
 			PeerColumn::State => self.state.clone(),
 			PeerColumn::UsedBandwidth => format!(
-				"S: {}, R: {}",
+				"↑: {}, ↓: {}",
 				size_to_string(self.sent_bytes_per_sec),
 				size_to_string(self.received_bytes_per_sec),
 			)


### PR DESCRIPTION
This PR just replaces `S` (sent) and `R` (received) letters in TUI's `Peers and Sync`'s `Bandwidth` column with the corresponding ASCII arrows:

- Arrow up (↑) for *Sent*
- Arrow down (↓) for *Received*

Screenshot:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/36292692/58202482-59a4c580-7ce0-11e9-83fb-af4d451ec999.png">

This makes bandwidth stats column more intuitive and easier to read. 
There shouldn't be issues with different terminals since they're all supporting ASCII.

*Feedback is highly appreciated!*