### PR TITLE
Fill BlindingFactor with zeros on Drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,14 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +785,6 @@ version = "1.1.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_util 1.1.0-beta.2",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -807,6 +798,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2641,6 +2633,25 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "zeroize"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "zip"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,7 +2693,6 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -2926,4 +2936,6 @@ dependencies = [
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
+"checksum zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b60a6c572b91d8ecb0a460950d84fe5b40699edd07d65f73789b31237afc8f66"
+"checksum zeroize_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9dac4b660d969bff9c3fe1847a891cacaa8b21dd5f2aae6e0a3e0975aea96431"
 "checksum zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +793,7 @@ version = "1.1.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_util 1.1.0-beta.2",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2673,6 +2682,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -560,8 +560,10 @@ impl Block {
 			.with_kernel(reward_kern);
 
 		// Now add the kernel offset of the previous block for a total
-		let total_kernel_offset =
-			committed::sum_kernel_offsets(vec![agg_tx.offset.clone(), prev.total_kernel_offset.clone()], vec![])?;
+		let total_kernel_offset = committed::sum_kernel_offsets(
+			vec![agg_tx.offset.clone(), prev.total_kernel_offset.clone()],
+			vec![],
+		)?;
 
 		let now = Utc::now().timestamp();
 		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -384,7 +384,7 @@ impl BlockHeader {
 
 	/// Total kernel offset for the chain state up to and including this block.
 	pub fn total_kernel_offset(&self) -> BlindingFactor {
-		self.total_kernel_offset
+		self.total_kernel_offset.clone()
 	}
 }
 
@@ -561,7 +561,7 @@ impl Block {
 
 		// Now add the kernel offset of the previous block for a total
 		let total_kernel_offset =
-			committed::sum_kernel_offsets(vec![agg_tx.offset, prev.total_kernel_offset], vec![])?;
+			committed::sum_kernel_offsets(vec![agg_tx.offset.clone(), prev.total_kernel_offset.clone()], vec![])?;
 
 		let now = Utc::now().timestamp();
 		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);
@@ -698,7 +698,7 @@ impl Block {
 		// verify.body.outputs and kernel sums
 		let (_utxo_sum, kernel_sum) = self.verify_kernel_sums(
 			self.header.overage(),
-			self.block_kernel_offset(*prev_kernel_offset)?,
+			self.block_kernel_offset(prev_kernel_offset.clone())?,
 		)?;
 
 		Ok(kernel_sum)

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -957,7 +957,7 @@ impl Transaction {
 	) -> Result<(), Error> {
 		self.body.validate(weighting, verifier)?;
 		self.body.verify_features()?;
-		self.verify_kernel_sums(self.overage(), self.offset)?;
+		self.verify_kernel_sums(self.overage(), self.offset.clone())?;
 		Ok(())
 	}
 

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -158,7 +158,7 @@ where
 {
 	Box::new(
 		move |_build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
-			(tx.with_offset(offset), kern, sum)
+			(tx.with_offset(offset.clone()), kern, sum)
 		},
 	)
 }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -19,6 +19,7 @@ serde_derive = "1"
 serde_json = "1"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 lazy_static = "1"
+clear_on_drop = "0.2.3"
 
 digest = "0.7"
 hmac = "0.6"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1"
 serde_json = "1"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 lazy_static = "1"
-clear_on_drop = "0.2.3"
+zeroize = "0.8.0"
 
 digest = "0.7"
 hmac = "0.6"

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -324,10 +324,11 @@ mod tests {
 
 	#[test]
 	fn test_bip39_random() {
+		use rand::seq::SliceRandom;
 		let sizes: [usize; 5] = [16, 20, 24, 28, 32];
 
 		let mut rng = thread_rng();
-		let size = *rng.choose(&sizes).unwrap();
+		let size = *sizes.choose(&mut rng).unwrap();
 		let mut entropy: Vec<u8> = Vec::with_capacity(size);
 
 		for _ in 0..size {

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -231,10 +231,10 @@ impl fmt::Display for Identifier {
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
 
-// Intentionally empty `Default` implementation to prevent leakage.
+// Dummy `Debug` implementation that prevents secret leakage.
 impl fmt::Debug for BlindingFactor {
 	fn fmt(&self, _f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {
-		Ok(())
+		write!(f, "BlindingFactor(<secret key hidden>)")
 	}
 }
 

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -32,6 +32,7 @@ use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::secp::pedersen::Commitment;
 use crate::util::secp::{self, Message, Secp256k1, Signature};
 use crate::util::static_secp_instance;
+use clear_on_drop::clear::Clear;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -227,8 +228,14 @@ impl fmt::Display for Identifier {
 	}
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
+
+impl Drop for BlindingFactor {
+	fn drop(&mut self) {
+		self.0.clear();
+	}
+}
 
 impl fmt::Debug for BlindingFactor {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -233,7 +233,7 @@ pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
 
 // Dummy `Debug` implementation that prevents secret leakage.
 impl fmt::Debug for BlindingFactor {
-	fn fmt(&self, _f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {
+	fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "BlindingFactor(<secret key hidden>)")
 	}
 }

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -231,15 +231,17 @@ impl fmt::Display for Identifier {
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
 
+// Implement `Drop` that fills `BlindingFactor` with zeros as security measure.
 impl Drop for BlindingFactor {
 	fn drop(&mut self) {
 		self.0.clear();
 	}
 }
 
+// Intentionally empty `Default` implementation to prevent leakage.
 impl fmt::Debug for BlindingFactor {
-	fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", self.to_hex())
+	fn fmt(&self, _f: &mut ::std::fmt::Formatter<'_>) -> fmt::Result {
+		Ok(())
 	}
 }
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -268,7 +268,7 @@ impl Pool {
 		header: &BlockHeader,
 	) -> Result<BlockSums, PoolError> {
 		let overage = tx.overage();
-		let offset = (header.total_kernel_offset() + tx.offset)?;
+		let offset = (header.total_kernel_offset() + tx.offset.clone())?;
 
 		let block_sums = self.blockchain.get_block_sums(&header.hash())?;
 


### PR DESCRIPTION
This is a first (and probably naïve) step towards security of sensitive data such as `BlindingFactor`.

In response to #2218. Cleaning of `secp`'s `SecretKey` and wallet's mnemonic should be done in corresponding modules.

This PR:
* Adds [zeroize](https://crates.io/crates/zeroize) crate as a dependency for [keychain](https://github.com/mimblewimble/grin/tree/master/keychain)
* Adds `Zeroize` derive for `BlindingFactor` in a way that underlying byte array is filled with zeroes
* Removes `Copy` derive from `BlindingFactor` since it is impossible to implement both `Drop` and `Copy` at the same time. All implicit copying were replaced with more explicit `.clone()`
* Adds unit test for `BlindingFactor` zeroing

Some references:
https://github.com/dalek-cryptography/curve25519-dalek/issues/11
https://github.com/rust-lang/rfcs/issues/2533
https://www.youtube.com/watch?v=cQ9wTyYCdNU

*Feedback is highly appreciated!*