### PR TITLE
Support new Bulletproof rewind scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,16 +844,17 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -914,7 +915,7 @@ dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_secp256k1zkp 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_secp256k1zkp 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2739,7 +2740,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_secp256k1zkp 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75e9a265f3eeea4c204470f7262e2c6fe18f3d8ddf5fb24340cb550ac4f909c5"
+"checksum grin_secp256k1zkp 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e96161c7d923bf094e7f4f583e680a03746b692523f2211bff59f642e05aa85"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "570178d5e4952010d138b0f1d581271ff3a02406d990f887d1e87e3d6e43b0ac"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"

--- a/chain/tests/data_file_integrity.rs
+++ b/chain/tests/data_file_integrity.rs
@@ -76,7 +76,14 @@ fn data_files() {
 			let prev = chain.head_header().unwrap();
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 			let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-			let reward = libtx::reward::output(&keychain, &pk, 0, false).unwrap();
+			let reward = libtx::reward::output(
+				&keychain,
+				&libtx::ProofBuilder::new(&keychain),
+				&pk,
+				0,
+				false,
+			)
+			.unwrap();
 			let mut b =
 				core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
 					.unwrap();
@@ -154,7 +161,8 @@ fn _prepare_block_nosum(
 	let key_id = ExtKeychainPath::new(1, diff as u32, 0, 0, 0).to_identifier();
 
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward = libtx::reward::output(kc, &key_id, fees, false).unwrap();
+	let reward =
+		libtx::reward::output(kc, &libtx::ProofBuilder::new(kc), &key_id, fees, false).unwrap();
 	let mut b = match core::core::Block::new(
 		prev,
 		txs.into_iter().cloned().collect(),

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -60,7 +60,14 @@ fn test_various_store_indices() {
 
 	setup_chain(&genesis, chain_store.clone()).unwrap();
 
-	let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
+	let reward = libtx::reward::output(
+		&keychain,
+		&libtx::ProofBuilder::new(&keychain),
+		&key_id,
+		0,
+		false,
+	)
+	.unwrap();
 	let block = Block::new(&genesis.header, vec![], Difficulty::min(), reward).unwrap();
 	let block_hash = block.hash();
 

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -16,7 +16,7 @@ use self::chain::types::NoopAdapter;
 use self::chain::ErrorKind;
 use self::core::core::verifier_cache::LruVerifierCache;
 use self::core::global::{self, ChainTypes};
-use self::core::libtx::{self, build};
+use self::core::libtx::{self, build, ProofBuilder};
 use self::core::pow::Difficulty;
 use self::core::{consensus, pow};
 use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
@@ -59,13 +59,14 @@ fn test_coinbase_maturity() {
 		let prev = chain.head_header().unwrap();
 
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
+		let builder = ProofBuilder::new(&keychain);
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
 		let key_id4 = ExtKeychainPath::new(1, 4, 0, 0, 0).to_identifier();
 
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
-		let reward = libtx::reward::output(&keychain, &key_id1, 0, false).unwrap();
+		let reward = libtx::reward::output(&keychain, &builder, &key_id1, 0, false).unwrap();
 		let mut block = core::core::Block::new(&prev, vec![], Difficulty::min(), reward).unwrap();
 		block.header.timestamp = prev.timestamp + Duration::seconds(60);
 		block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
@@ -104,12 +105,13 @@ fn test_coinbase_maturity() {
 				build::with_fee(2),
 			],
 			&keychain,
+			&builder,
 		)
 		.unwrap();
 
 		let txs = vec![coinbase_txn.clone()];
 		let fees = txs.iter().map(|tx| tx.fee()).sum();
-		let reward = libtx::reward::output(&keychain, &key_id3, fees, false).unwrap();
+		let reward = libtx::reward::output(&keychain, &builder, &key_id3, fees, false).unwrap();
 		let mut block = core::core::Block::new(&prev, txs, Difficulty::min(), reward).unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 		block.header.timestamp = prev.timestamp + Duration::seconds(60);
@@ -141,10 +143,11 @@ fn test_coinbase_maturity() {
 			let prev = chain.head_header().unwrap();
 
 			let keychain = ExtKeychain::from_random_seed(false).unwrap();
+			let builder = ProofBuilder::new(&keychain);
 			let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
-			let reward = libtx::reward::output(&keychain, &key_id1, 0, false).unwrap();
+			let reward = libtx::reward::output(&keychain, &builder, &key_id1, 0, false).unwrap();
 			let mut block =
 				core::core::Block::new(&prev, vec![], Difficulty::min(), reward).unwrap();
 
@@ -185,12 +188,13 @@ fn test_coinbase_maturity() {
 					build::with_fee(2),
 				],
 				&keychain,
+				&builder,
 			)
 			.unwrap();
 
 			let txs = vec![coinbase_txn.clone()];
 			let fees = txs.iter().map(|tx| tx.fee()).sum();
-			let reward = libtx::reward::output(&keychain, &key_id3, fees, false).unwrap();
+			let reward = libtx::reward::output(&keychain, &builder, &key_id3, fees, false).unwrap();
 			let mut block = core::core::Block::new(&prev, txs, Difficulty::min(), reward).unwrap();
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 			block.header.timestamp = prev.timestamp + Duration::seconds(60);
@@ -222,9 +226,10 @@ fn test_coinbase_maturity() {
 				let prev = chain.head_header().unwrap();
 
 				let keychain = ExtKeychain::from_random_seed(false).unwrap();
+				let builder = ProofBuilder::new(&keychain);
 				let pk = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
-				let reward = libtx::reward::output(&keychain, &pk, 0, false).unwrap();
+				let reward = libtx::reward::output(&keychain, &builder, &pk, 0, false).unwrap();
 				let mut block =
 					core::core::Block::new(&prev, vec![], Difficulty::min(), reward).unwrap();
 				let next_header_info =
@@ -254,7 +259,7 @@ fn test_coinbase_maturity() {
 			let txs = vec![coinbase_txn];
 			let fees = txs.iter().map(|tx| tx.fee()).sum();
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
-			let reward = libtx::reward::output(&keychain, &key_id4, fees, false).unwrap();
+			let reward = libtx::reward::output(&keychain, &builder, &key_id4, fees, false).unwrap();
 			let mut block = core::core::Block::new(&prev, txs, Difficulty::min(), reward).unwrap();
 
 			block.header.timestamp = prev.timestamp + Duration::seconds(60);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ siphasher = "0.2"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
+zeroize = "0.8"
 
 grin_keychain = { path = "../keychain", version = "2.0.0-beta.1" }
 grin_util = { path = "../util", version = "2.0.0-beta.1" }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1506,7 +1506,9 @@ mod test {
 	fn test_kernel_ser_deser() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
+		let commit = keychain
+			.commit(5, &key_id, &SwitchCommitmentType::Regular)
+			.unwrap();
 
 		// just some bytes for testing ser/deser
 		let sig = secp::Signature::from_raw_data(&[0; 64]).unwrap();
@@ -1552,10 +1554,14 @@ mod test {
 		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
-		let commit = keychain.commit(1003, &key_id, &SwitchCommitmentType::Regular).unwrap();
+		let commit = keychain
+			.commit(1003, &key_id, &SwitchCommitmentType::Regular)
+			.unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
-		let commit_2 = keychain.commit(1003, &key_id, &SwitchCommitmentType::Regular).unwrap();
+		let commit_2 = keychain
+			.commit(1003, &key_id, &SwitchCommitmentType::Regular)
+			.unwrap();
 
 		assert!(commit == commit_2);
 	}
@@ -1564,7 +1570,9 @@ mod test {
 	fn input_short_id() {
 		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
+		let commit = keychain
+			.commit(5, &key_id, &SwitchCommitmentType::Regular)
+			.unwrap();
 
 		let input = Input {
 			features: OutputFeatures::Plain,

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1499,14 +1499,14 @@ mod test {
 	use super::*;
 	use crate::core::hash::Hash;
 	use crate::core::id::{ShortId, ShortIdentifiable};
-	use crate::keychain::{ExtKeychain, Keychain};
+	use crate::keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
 	use crate::util::secp;
 
 	#[test]
 	fn test_kernel_ser_deser() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let commit = keychain.commit(5, &key_id).unwrap();
+		let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
 
 		// just some bytes for testing ser/deser
 		let sig = secp::Signature::from_raw_data(&[0; 64]).unwrap();
@@ -1552,10 +1552,10 @@ mod test {
 		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
-		let commit = keychain.commit(1003, &key_id).unwrap();
+		let commit = keychain.commit(1003, &key_id, &SwitchCommitmentType::Regular).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
-		let commit_2 = keychain.commit(1003, &key_id).unwrap();
+		let commit_2 = keychain.commit(1003, &key_id, &SwitchCommitmentType::Regular).unwrap();
 
 		assert!(commit == commit_2);
 	}
@@ -1564,7 +1564,7 @@ mod test {
 	fn input_short_id() {
 		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-		let commit = keychain.commit(5, &key_id).unwrap();
+		let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
 
 		let input = Input {
 			features: OutputFeatures::Plain,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,7 @@ extern crate log;
 use failure;
 #[macro_use]
 extern crate failure_derive;
+extern crate zeroize;
 #[macro_use]
 pub mod macros;
 

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -232,15 +232,16 @@ pub fn verify_partial_sig(
 /// use core::libtx::{aggsig, proof};
 /// use core::core::transaction::{kernel_sig_msg, KernelFeatures};
 /// use core::core::{Output, OutputFeatures};
-/// use keychain::{Keychain, ExtKeychain};
+/// use keychain::{Keychain, ExtKeychain, SwitchCommitmentType};
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::Commit);
 /// let keychain = ExtKeychain::from_random_seed(false).unwrap();
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let commit = keychain.commit(value, &key_id).unwrap();
-/// let rproof = proof::create(&keychain, value, &key_id, commit, None).unwrap();
+/// let commit = keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap();
+/// let builder = proof::ProofBuilder::new(&keychain);
+/// let rproof = proof::create(&keychain, &builder, value, &key_id, commit, None).unwrap();
 /// let output = Output {
 ///		features: OutputFeatures::Coinbase,
 ///		commit: commit,
@@ -297,7 +298,7 @@ where
 /// use util::secp::{ContextFlag, Secp256k1};
 /// use core::core::transaction::{kernel_sig_msg, KernelFeatures};
 /// use core::core::{Output, OutputFeatures};
-/// use keychain::{Keychain, ExtKeychain};
+/// use keychain::{Keychain, ExtKeychain, SwitchCommitmentType};
 ///
 /// // Create signature
 /// let secp = Secp256k1::with_caps(ContextFlag::Commit);
@@ -305,8 +306,9 @@ where
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let commit = keychain.commit(value, &key_id).unwrap();
-/// let rproof = proof::create(&keychain, value, &key_id, commit, None).unwrap();
+/// let commit = keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap();
+/// let builder = proof::ProofBuilder::new(&keychain);
+/// let rproof = proof::create(&keychain, &builder, value, &key_id, commit, None).unwrap();
 /// let output = Output {
 ///		features: OutputFeatures::Coinbase,
 ///		commit: commit,

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -239,9 +239,10 @@ pub fn verify_partial_sig(
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let commit = keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap();
+/// let switch = &SwitchCommitmentType::Regular;
+/// let commit = keychain.commit(value, &key_id, switch).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain);
-/// let rproof = proof::create(&keychain, &builder, value, &key_id, commit, None).unwrap();
+/// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();
 /// let output = Output {
 ///		features: OutputFeatures::Coinbase,
 ///		commit: commit,
@@ -306,9 +307,10 @@ where
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let commit = keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap();
+/// let switch = &SwitchCommitmentType::Regular;
+/// let commit = keychain.commit(value, &key_id, switch).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain);
-/// let rproof = proof::create(&keychain, &builder, value, &key_id, commit, None).unwrap();
+/// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();
 /// let output = Output {
 ///		features: OutputFeatures::Coinbase,
 ///		commit: commit,

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -21,6 +21,7 @@ use crate::libtx::error::{Error, ErrorKind};
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::secp::pedersen::Commitment;
 use crate::util::secp::{self, aggsig, Message, Secp256k1, Signature};
+use grin_keychain::SwitchCommitmentType;
 
 /// Creates a new secure nonce (as a SecretKey), guaranteed to be usable during
 /// aggsig creation.
@@ -266,7 +267,7 @@ pub fn sign_from_key_id<K>(
 where
 	K: Keychain,
 {
-	let skey = k.derive_key(value, key_id)?;
+	let skey = k.derive_key(value, key_id, &SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
 	let sig = aggsig::sign_single(secp, &msg, &skey, s_nonce, None, None, blind_sum, None)?;
 	Ok(sig)
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -29,7 +29,6 @@ use crate::core::{Input, Output, OutputFeatures, Transaction, TxKernel};
 use crate::keychain::{BlindSum, BlindingFactor, Identifier, Keychain};
 use crate::libtx::{aggsig, proof, Error};
 use grin_keychain::SwitchCommitmentType;
-use crate::libtx::proof::LegacyProofBuilder;
 
 /// Context information available to transaction combinators.
 pub struct Context<'a, K>
@@ -55,7 +54,10 @@ where
 {
 	Box::new(
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
-			let commit = build.keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap(); // TODO: proper support for different switch commitment schemes
+			let commit = build
+				.keychain
+				.commit(value, &key_id, &SwitchCommitmentType::Regular)
+				.unwrap(); // TODO: proper support for different switch commitment schemes
 			let input = Input::new(features, commit);
 			(
 				tx.with_input(input),
@@ -96,14 +98,18 @@ where
 {
 	Box::new(
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
-			let commit = build.keychain.commit(value, &key_id, &SwitchCommitmentType::Regular).unwrap(); // TODO: proper support for different switch commitment schemes
+			let commit = build
+				.keychain
+				.commit(value, &key_id, &SwitchCommitmentType::Regular)
+				.unwrap(); // TODO: proper support for different switch commitment schemes
 
 			debug!("Building output: {}, {:?}", value, commit);
 
 			// TODO: use the new builder
-			let builder = LegacyProofBuilder::new(build.keychain);
+			let builder = proof::LegacyProofBuilder::new(build.keychain);
 
-			let rproof = proof::create(build.keychain, &builder, value, &key_id, commit, None).unwrap();
+			let rproof =
+				proof::create(build.keychain, &builder, value, &key_id, commit, None).unwrap();
 
 			(
 				tx.with_output(Output {

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -106,15 +106,23 @@ where
 {
 	Box::new(
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
-			let commit = build
-				.keychain
-				.commit(value, &key_id, &SwitchCommitmentType::Regular)
-				.unwrap(); // TODO: proper support for different switch commitment schemes
+			// TODO: proper support for different switch commitment schemes
+			let switch = &SwitchCommitmentType::Regular;
+
+			let commit = build.keychain.commit(value, &key_id, switch).unwrap();
 
 			debug!("Building output: {}, {:?}", value, commit);
 
-			let rproof =
-				proof::create(build.keychain, build.builder, value, &key_id, commit, None).unwrap();
+			let rproof = proof::create(
+				build.keychain,
+				build.builder,
+				value,
+				&key_id,
+				switch,
+				commit,
+				None,
+			)
+			.unwrap();
 
 			(
 				tx.with_output(Output {

--- a/core/src/libtx/mod.rs
+++ b/core/src/libtx/mod.rs
@@ -31,6 +31,7 @@ pub mod secp_ser;
 use crate::consensus;
 use crate::core::Transaction;
 
+pub use self::proof::ProofBuilder;
 pub use crate::libtx::error::{Error, ErrorKind};
 
 const DEFAULT_BASE_FEE: u64 = consensus::MILLI_GRIN;

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -18,7 +18,7 @@ use crate::blake2;
 use crate::keychain::{Identifier, Keychain, SwitchCommitmentType};
 use crate::libtx::error::{Error, ErrorKind};
 use crate::util::secp::key::SecretKey;
-use crate::util::secp::pedersen::{Commitment, ProofInfo, ProofMessage, RangeProof};
+use crate::util::secp::pedersen::{Commitment, ProofMessage, RangeProof};
 use crate::util::secp::{self, Secp256k1};
 
 /// Create a bulletproof
@@ -80,20 +80,26 @@ where
 	K: Keychain,
 	B: ProofBuild,
 {
-	let nonce = b.rewind_nonce(&commit)
+	let nonce = b
+		.rewind_nonce(&commit)
 		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
 	let info = k
 		.secp()
-		.rewind_bullet_proof(commit, nonce, extra_data, proof)
-		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
+		.rewind_bullet_proof(commit, nonce, extra_data, proof);
+	if info.is_err() {
+		return Ok(None);
+	}
+	let info = info.unwrap();
 
 	let amount = info.value;
-	let check = b.check_output(&commit, amount, info.message)
+	let check = b
+		.check_output(&commit, amount, info.message)
 		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
 
 	Ok(check.map(|(id, switch)| (amount, id, switch)))
 }
 
+/// Used for building proofs and checking if the output belongs to the wallet
 pub trait ProofBuild {
 	/// Create a BP nonce that will allow to rewind the derivation path and flags
 	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
@@ -102,13 +108,22 @@ pub trait ProofBuild {
 	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
 
 	/// Create a BP message
-	fn proof_message(&self, id: &Identifier, switch: &SwitchCommitmentType) -> Result<ProofMessage, Error>;
+	fn proof_message(
+		&self,
+		id: &Identifier,
+		switch: &SwitchCommitmentType,
+	) -> Result<ProofMessage, Error>;
 
 	/// Check if the output belongs to this keychain
-	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
-		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error>;
+	fn check_output(
+		&self,
+		commit: &Commitment,
+		amount: u64,
+		message: ProofMessage,
+	) -> Result<Option<(Identifier, SwitchCommitmentType)>, Error>;
 }
 
+/// The new, more flexible proof builder
 pub struct ProofBuilder<'a, K>
 where
 	K: Keychain,
@@ -122,18 +137,21 @@ where
 {
 	/// Creates a new instance of this proof builder
 	pub fn new(keychain: &'a K) -> Self {
-		Self {
-			keychain,
-		}
+		Self { keychain }
 	}
 
 	fn nonce(&self, commit: &Commitment, extra_data: u8) -> Result<SecretKey, Error> {
-		let mut root_key = self.keychain.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::None)?.0.to_vec();
+		let mut root_key = self
+			.keychain
+			.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::None)?
+			.0
+			.to_vec();
 		root_key.push(extra_data);
 		let root_key_hash = blake2::blake2b::blake2b(32, &[], &root_key);
 		let res = blake2::blake2b::blake2b(32, &commit.0, root_key_hash.as_bytes());
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
-			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into())
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
+			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
+		})
 	}
 }
 
@@ -154,7 +172,11 @@ where
 	///     2: wallet type (0 for standard)
 	///     3: switch commitment type (0 for none, 1 for standard)
 	///  4-19: derivation path
-	fn proof_message(&self, id: &Identifier, switch: &SwitchCommitmentType) -> Result<ProofMessage, Error> {
+	fn proof_message(
+		&self,
+		id: &Identifier,
+		switch: &SwitchCommitmentType,
+	) -> Result<ProofMessage, Error> {
 		let mut msg = [0; 20];
 		msg[3] = match *switch {
 			SwitchCommitmentType::Regular => 1,
@@ -167,8 +189,12 @@ where
 		Ok(ProofMessage::from_bytes(&msg))
 	}
 
-	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
-		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
+	fn check_output(
+		&self,
+		commit: &Commitment,
+		amount: u64,
+		message: ProofMessage,
+	) -> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
 		if message.len() != 20 {
 			return Ok(None);
 		}
@@ -192,6 +218,7 @@ where
 	}
 }
 
+/// The legacy proof builder, used before the first hard fork
 pub struct LegacyProofBuilder<'a, K>
 where
 	K: Keychain,
@@ -205,16 +232,17 @@ where
 {
 	/// Creates a new instance of this proof builder
 	pub fn new(keychain: &'a K) -> Self {
-		Self {
-			keychain,
-		}
+		Self { keychain }
 	}
 
 	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
-		let root_key = self.keychain.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::Regular)?;
+		let root_key =
+			self.keychain
+				.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::Regular)?;
 		let res = blake2::blake2b::blake2b(32, &commit.0, &root_key.0[..]);
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
-			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into())
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
+			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
+		})
 	}
 }
 
@@ -234,7 +262,11 @@ where
 	///   0-3: 0
 	///  4-19: derivation path
 	/// All outputs with this scheme are assumed to use regular switch commitments
-	fn proof_message(&self, id: &Identifier, _switch: &SwitchCommitmentType) -> Result<ProofMessage, Error> {
+	fn proof_message(
+		&self,
+		id: &Identifier,
+		_switch: &SwitchCommitmentType,
+	) -> Result<ProofMessage, Error> {
 		let mut msg = [0; 20];
 		let id_ser = id.serialize_path();
 		for i in 0..16 {
@@ -243,8 +275,12 @@ where
 		Ok(ProofMessage::from_bytes(&msg))
 	}
 
-	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
-		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
+	fn check_output(
+		&self,
+		commit: &Commitment,
+		amount: u64,
+		message: ProofMessage,
+	) -> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
 		if message.len() != 20 {
 			return Ok(None);
 		}
@@ -256,7 +292,9 @@ where
 			return Ok(None);
 		}
 
-		let commit_exp = self.keychain.commit(amount, &id, &SwitchCommitmentType::Regular)?;
+		let commit_exp = self
+			.keychain
+			.commit(amount, &id, &SwitchCommitmentType::Regular)?;
 		match commit == &commit_exp {
 			true => Ok(Some((id, SwitchCommitmentType::Regular))),
 			false => Ok(None),

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -21,6 +21,7 @@ use crate::libtx::error::{Error, ErrorKind};
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen::{Commitment, ProofMessage, RangeProof};
 use crate::util::secp::{self, Secp256k1};
+use crate::zeroize::Zeroize;
 use std::convert::TryFrom;
 
 /// Create a bulletproof
@@ -234,6 +235,25 @@ where
 	}
 }
 
+impl<'a, K> Zeroize for ProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn zeroize(&mut self) {
+		self.rewind_hash.zeroize();
+		self.private_hash.zeroize();
+	}
+}
+
+impl<'a, K> Drop for ProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn drop(&mut self) {
+		self.zeroize();
+	}
+}
+
 /// The legacy proof builder, used before the first hard fork
 pub struct LegacyProofBuilder<'a, K>
 where
@@ -322,6 +342,24 @@ where
 			true => Ok(Some((id, SwitchCommitmentType::Regular))),
 			false => Ok(None),
 		}
+	}
+}
+
+impl<'a, K> Zeroize for LegacyProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn zeroize(&mut self) {
+		self.root_hash.zeroize();
+	}
+}
+
+impl<'a, K> Drop for LegacyProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn drop(&mut self) {
+		self.zeroize();
 	}
 }
 

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -14,15 +14,17 @@
 
 //! Rangeproof library functions
 
-use crate::keychain::{Identifier, Keychain};
+use crate::blake2;
+use crate::keychain::{Identifier, Keychain, SwitchCommitmentType};
 use crate::libtx::error::{Error, ErrorKind};
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen::{Commitment, ProofInfo, ProofMessage, RangeProof};
 use crate::util::secp::{self, Secp256k1};
 
 /// Create a bulletproof
-pub fn create<K>(
+pub fn create<K, B>(
 	k: &K,
+	b: &B,
 	amount: u64,
 	key_id: &Identifier,
 	_commit: Commitment,
@@ -30,19 +32,26 @@ pub fn create<K>(
 ) -> Result<RangeProof, Error>
 where
 	K: Keychain,
+	B: ProofBuild,
 {
-	let commit = k.commit(amount, key_id)?;
-	let skey = k.derive_key(amount, key_id)?;
-	let legacy = true; // TODO: set to false when ready
-	let rewind_nonce = k
-		.create_rewind_nonce(&commit, legacy)
-		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
-	let private_nonce = k
-		.create_private_nonce(&commit, legacy)
-		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
-	let message = k.create_proof_message(key_id, legacy);
-	Ok(k.secp()
-		.bullet_proof(amount, skey, rewind_nonce, private_nonce, extra_data, Some(message)))
+	// TODO: proper support for different switch commitment schemes
+	// The new bulletproof scheme encodes and decodes it, but
+	// it is not supported at the wallet level (yet).
+	// So for now we only build outputs with switch commitments
+	let switch = &SwitchCommitmentType::Regular;
+	let commit = k.commit(amount, key_id, switch)?;
+	let skey = k.derive_key(amount, key_id, switch)?;
+	let rewind_nonce = b.rewind_nonce(&commit)?;
+	let private_nonce = b.private_nonce(&commit)?;
+	let message = b.proof_message(key_id, switch)?;
+	Ok(k.secp().bullet_proof(
+		amount,
+		skey,
+		rewind_nonce,
+		private_nonce,
+		extra_data,
+		Some(message),
+	))
 }
 
 /// Verify a proof
@@ -59,36 +68,198 @@ pub fn verify(
 	}
 }
 
-/// Rewind a rangeproof to retrieve the amount
-pub fn rewind<K>(
+/// Rewind a rangeproof to retrieve the amount, derivation path and switch commitment type
+pub fn rewind<K, B>(
 	k: &K,
+	b: &B,
 	commit: Commitment,
 	extra_data: Option<Vec<u8>>,
-	legacy: bool,
 	proof: RangeProof,
-) -> Result<ProofInfo, Error>
+) -> Result<Option<(u64, Identifier, SwitchCommitmentType)>, Error>
+where
+	K: Keychain,
+	B: ProofBuild,
+{
+	let nonce = b.rewind_nonce(&commit)
+		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
+	let info = k
+		.secp()
+		.rewind_bullet_proof(commit, nonce, extra_data, proof)
+		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
+
+	let amount = info.value;
+	let check = b.check_output(&commit, amount, info.message)
+		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
+
+	Ok(check.map(|(id, switch)| (amount, id, switch)))
+}
+
+pub trait ProofBuild {
+	/// Create a BP nonce that will allow to rewind the derivation path and flags
+	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
+
+	/// Create a BP nonce that blinds the private key
+	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
+
+	/// Create a BP message
+	fn proof_message(&self, id: &Identifier, switch: &SwitchCommitmentType) -> Result<ProofMessage, Error>;
+
+	/// Check if the output belongs to this keychain
+	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
+		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error>;
+}
+
+pub struct ProofBuilder<'a, K>
 where
 	K: Keychain,
 {
-	let nonce = k
-		.create_rewind_nonce(&commit, legacy)
-		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
-	let proof_message = k
-		.secp()
-		.rewind_bullet_proof(commit, nonce, extra_data, proof);
-	let proof_info = match proof_message {
-		Ok(p) => p,
-		Err(_) => ProofInfo {
-			success: false,
-			value: 0,
-			message: ProofMessage::empty(),
-			blinding: SecretKey([0; secp::constants::SECRET_KEY_SIZE]),
-			mlen: 0,
-			min: 0,
-			max: 0,
-			exp: 0,
-			mantissa: 0,
-		},
-	};
-	return Ok(proof_info);
+	keychain: &'a K,
+}
+
+impl<'a, K> ProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	/// Creates a new instance of this proof builder
+	pub fn new(keychain: &'a K) -> Self {
+		Self {
+			keychain,
+		}
+	}
+
+	fn nonce(&self, commit: &Commitment, extra_data: u8) -> Result<SecretKey, Error> {
+		let mut root_key = self.keychain.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::None)?.0.to_vec();
+		root_key.push(extra_data);
+		let root_key_hash = blake2::blake2b::blake2b(32, &[], &root_key);
+		let res = blake2::blake2b::blake2b(32, &commit.0, root_key_hash.as_bytes());
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
+			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into())
+	}
+}
+
+impl<'a, K> ProofBuild for ProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+		self.nonce(commit, 0)
+	}
+
+	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+		self.nonce(commit, 1)
+	}
+
+	/// Message bytes:
+	///   0-1: reserved for future use
+	///     2: wallet type (0 for standard)
+	///     3: switch commitment type (0 for none, 1 for standard)
+	///  4-19: derivation path
+	fn proof_message(&self, id: &Identifier, switch: &SwitchCommitmentType) -> Result<ProofMessage, Error> {
+		let mut msg = [0; 20];
+		msg[3] = match *switch {
+			SwitchCommitmentType::Regular => 1,
+			_ => 0,
+		};
+		let id_ser = id.serialize_path();
+		for i in 0..16 {
+			msg[i + 4] = id_ser[i];
+		}
+		Ok(ProofMessage::from_bytes(&msg))
+	}
+
+	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
+		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
+		if message.len() != 20 {
+			return Ok(None);
+		}
+
+		let msg = message.as_bytes();
+		let id = Identifier::from_serialized_path(3, &msg[4..]);
+		let exp: [u8; 3] = [0; 3];
+		if msg[..3] != exp {
+			return Ok(None);
+		}
+		let switch = match msg[3] {
+			1 => SwitchCommitmentType::Regular,
+			_ => SwitchCommitmentType::None,
+		};
+
+		let commit_exp = self.keychain.commit(amount, &id, &switch)?;
+		match commit == &commit_exp {
+			true => Ok(Some((id, switch))),
+			false => Ok(None),
+		}
+	}
+}
+
+pub struct LegacyProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	keychain: &'a K,
+}
+
+impl<'a, K> LegacyProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	/// Creates a new instance of this proof builder
+	pub fn new(keychain: &'a K) -> Self {
+		Self {
+			keychain,
+		}
+	}
+
+	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+		let root_key = self.keychain.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::Regular)?;
+		let res = blake2::blake2b::blake2b(32, &commit.0, &root_key.0[..]);
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
+			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into())
+	}
+}
+
+impl<'a, K> ProofBuild for LegacyProofBuilder<'a, K>
+where
+	K: Keychain,
+{
+	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+		self.nonce(commit)
+	}
+
+	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+		self.nonce(commit)
+	}
+
+	/// Message bytes:
+	///   0-3: 0
+	///  4-19: derivation path
+	/// All outputs with this scheme are assumed to use regular switch commitments
+	fn proof_message(&self, id: &Identifier, _switch: &SwitchCommitmentType) -> Result<ProofMessage, Error> {
+		let mut msg = [0; 20];
+		let id_ser = id.serialize_path();
+		for i in 0..16 {
+			msg[i + 4] = id_ser[i];
+		}
+		Ok(ProofMessage::from_bytes(&msg))
+	}
+
+	fn check_output(&self, commit: &Commitment, amount: u64, message: ProofMessage)
+		-> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
+		if message.len() != 20 {
+			return Ok(None);
+		}
+
+		let msg = message.as_bytes();
+		let id = Identifier::from_serialized_path(3, &msg[4..]);
+		let exp: [u8; 4] = [0; 4];
+		if msg[..4] != exp {
+			return Ok(None);
+		}
+
+		let commit_exp = self.keychain.commit(amount, &id, &SwitchCommitmentType::Regular)?;
+		match commit == &commit_exp {
+			true => Ok(Some((id, SwitchCommitmentType::Regular))),
+			false => Ok(None),
+		}
+	}
 }

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -14,8 +14,9 @@
 
 //! Rangeproof library functions
 
-use crate::blake2;
-use crate::keychain::{Identifier, Keychain, SwitchCommitmentType};
+use crate::blake2::blake2b::blake2b;
+use crate::keychain::extkey_bip32::BIP32GrinHasher;
+use crate::keychain::{Identifier, Keychain, SwitchCommitmentType, ViewKey};
 use crate::libtx::error::{Error, ErrorKind};
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen::{Commitment, ProofMessage, RangeProof};
@@ -39,12 +40,13 @@ where
 	// TODO: proper support for different switch commitment schemes
 	// The new bulletproof scheme encodes and decodes it, but
 	// it is not supported at the wallet level (yet).
+	let secp = k.secp();
 	let commit = k.commit(amount, key_id, switch)?;
 	let skey = k.derive_key(amount, key_id, switch)?;
-	let rewind_nonce = b.rewind_nonce(&commit)?;
-	let private_nonce = b.private_nonce(&commit)?;
-	let message = b.proof_message(key_id, switch)?;
-	Ok(k.secp().bullet_proof(
+	let rewind_nonce = b.rewind_nonce(secp, &commit)?;
+	let private_nonce = b.private_nonce(secp, &commit)?;
+	let message = b.proof_message(secp, key_id, switch)?;
+	Ok(secp.bullet_proof(
 		amount,
 		skey,
 		rewind_nonce,
@@ -69,23 +71,20 @@ pub fn verify(
 }
 
 /// Rewind a rangeproof to retrieve the amount, derivation path and switch commitment type
-pub fn rewind<K, B>(
-	k: &K,
+pub fn rewind<B>(
+	secp: &Secp256k1,
 	b: &B,
 	commit: Commitment,
 	extra_data: Option<Vec<u8>>,
 	proof: RangeProof,
 ) -> Result<Option<(u64, Identifier, SwitchCommitmentType)>, Error>
 where
-	K: Keychain,
 	B: ProofBuild,
 {
 	let nonce = b
-		.rewind_nonce(&commit)
+		.rewind_nonce(secp, &commit)
 		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
-	let info = k
-		.secp()
-		.rewind_bullet_proof(commit, nonce, extra_data, proof);
+	let info = secp.rewind_bullet_proof(commit, nonce, extra_data, proof);
 	if info.is_err() {
 		return Ok(None);
 	}
@@ -93,7 +92,7 @@ where
 
 	let amount = info.value;
 	let check = b
-		.check_output(&commit, amount, info.message)
+		.check_output(secp, &commit, amount, info.message)
 		.map_err(|e| ErrorKind::RangeProof(e.to_string()))?;
 
 	Ok(check.map(|(id, switch)| (amount, id, switch)))
@@ -102,14 +101,15 @@ where
 /// Used for building proofs and checking if the output belongs to the wallet
 pub trait ProofBuild {
 	/// Create a BP nonce that will allow to rewind the derivation path and flags
-	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
+	fn rewind_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error>;
 
 	/// Create a BP nonce that blinds the private key
-	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
+	fn private_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error>;
 
 	/// Create a BP message
 	fn proof_message(
 		&self,
+		secp: &Secp256k1,
 		id: &Identifier,
 		switch: &SwitchCommitmentType,
 	) -> Result<ProofMessage, Error>;
@@ -117,6 +117,7 @@ pub trait ProofBuild {
 	/// Check if the output belongs to this keychain
 	fn check_output(
 		&self,
+		secp: &Secp256k1,
 		commit: &Commitment,
 		amount: u64,
 		message: ProofMessage,
@@ -139,22 +140,16 @@ where
 {
 	/// Creates a new instance of this proof builder
 	pub fn new(keychain: &'a K) -> Self {
-		let mut rewind_root_key = keychain
+		let private_root_key = keychain
 			.derive_key(0, &K::root_key_id(), &SwitchCommitmentType::None)
-			.unwrap()
-			.0
-			.to_vec();
-		let mut private_root_key = rewind_root_key.clone();
+			.unwrap();
 
-		rewind_root_key.push(0);
-		private_root_key.push(1);
+		let private_hash = blake2b(32, &[], &private_root_key.0).as_bytes().to_vec();
 
-		let rewind_hash: Vec<u8> = blake2::blake2b::blake2b(32, &[], &rewind_root_key)
-			.as_bytes()
-			.to_vec();
-		let private_hash: Vec<u8> = blake2::blake2b::blake2b(32, &[], &private_root_key)
-			.as_bytes()
-			.to_vec();
+		let public_root_key = keychain
+			.public_root_key()
+			.serialize_vec(keychain.secp(), true);
+		let rewind_hash = blake2b(32, &[], &public_root_key[..]).as_bytes().to_vec();
 
 		Self {
 			keychain,
@@ -169,7 +164,7 @@ where
 		} else {
 			&self.rewind_hash
 		};
-		let res = blake2::blake2b::blake2b(32, &commit.0, hash);
+		let res = blake2b(32, &commit.0, hash);
 		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
 			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
 		})
@@ -180,35 +175,38 @@ impl<'a, K> ProofBuild for ProofBuilder<'a, K>
 where
 	K: Keychain,
 {
-	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+	fn rewind_nonce(&self, _secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		self.nonce(commit, false)
 	}
 
-	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+	fn private_nonce(&self, _secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		self.nonce(commit, true)
 	}
 
 	/// Message bytes:
-	///   0-1: reserved for future use
-	///     2: wallet type (0 for standard)
-	///     3: switch commitment type
+	///     0: reserved for future use
+	///     1: wallet type (0 for standard)
+	///     2: switch commitment type
+	///     3: path depth
 	///  4-19: derivation path
 	fn proof_message(
 		&self,
+		_secp: &Secp256k1,
 		id: &Identifier,
 		switch: &SwitchCommitmentType,
 	) -> Result<ProofMessage, Error> {
 		let mut msg = [0; 20];
-		msg[3] = u8::from(switch);
-		let id_ser = id.serialize_path();
-		for i in 0..16 {
-			msg[i + 4] = id_ser[i];
+		msg[2] = u8::from(switch);
+		let id_bytes = id.to_bytes();
+		for i in 0..17 {
+			msg[i + 3] = id_bytes[i];
 		}
 		Ok(ProofMessage::from_bytes(&msg))
 	}
 
 	fn check_output(
 		&self,
+		_secp: &Secp256k1,
 		commit: &Commitment,
 		amount: u64,
 		message: ProofMessage,
@@ -216,17 +214,17 @@ where
 		if message.len() != 20 {
 			return Ok(None);
 		}
-
 		let msg = message.as_bytes();
-		let id = Identifier::from_serialized_path(3, &msg[4..]);
-		let exp: [u8; 3] = [0; 3];
-		if msg[..3] != exp {
+		let exp: [u8; 2] = [0; 2];
+		if msg[..2] != exp {
 			return Ok(None);
 		}
-		let switch = match SwitchCommitmentType::try_from(msg[3]) {
+		let switch = match SwitchCommitmentType::try_from(msg[2]) {
 			Ok(s) => s,
 			Err(_) => return Ok(None),
 		};
+		let depth = u8::min(msg[3], 4);
+		let id = Identifier::from_serialized_path(depth, &msg[4..]);
 
 		let commit_exp = self.keychain.commit(amount, &id, &switch)?;
 		match commit == &commit_exp {
@@ -262,7 +260,7 @@ where
 	}
 
 	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
-		let res = blake2::blake2b::blake2b(32, &commit.0, &self.root_hash);
+		let res = blake2b(32, &commit.0, &self.root_hash);
 		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
 			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
 		})
@@ -273,11 +271,11 @@ impl<'a, K> ProofBuild for LegacyProofBuilder<'a, K>
 where
 	K: Keychain,
 {
-	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+	fn rewind_nonce(&self, _secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		self.nonce(commit)
 	}
 
-	fn private_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
+	fn private_nonce(&self, _secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		self.nonce(commit)
 	}
 
@@ -287,6 +285,7 @@ where
 	/// All outputs with this scheme are assumed to use regular switch commitments
 	fn proof_message(
 		&self,
+		_secp: &Secp256k1,
 		id: &Identifier,
 		_switch: &SwitchCommitmentType,
 	) -> Result<ProofMessage, Error> {
@@ -300,6 +299,7 @@ where
 
 	fn check_output(
 		&self,
+		_secp: &Secp256k1,
 		commit: &Commitment,
 		amount: u64,
 		message: ProofMessage,
@@ -325,10 +325,85 @@ where
 	}
 }
 
+impl ProofBuild for ViewKey {
+	fn rewind_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
+		let res = blake2b(32, &commit.0, &self.rewind_hash);
+		SecretKey::from_slice(secp, res.as_bytes()).map_err(|e| {
+			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
+		})
+	}
+
+	fn private_nonce(&self, _secp: &Secp256k1, _commit: &Commitment) -> Result<SecretKey, Error> {
+		unimplemented!();
+	}
+
+	fn proof_message(
+		&self,
+		_secp: &Secp256k1,
+		_id: &Identifier,
+		_switch: &SwitchCommitmentType,
+	) -> Result<ProofMessage, Error> {
+		unimplemented!();
+	}
+
+	fn check_output(
+		&self,
+		secp: &Secp256k1,
+		commit: &Commitment,
+		amount: u64,
+		message: ProofMessage,
+	) -> Result<Option<(Identifier, SwitchCommitmentType)>, Error> {
+		if message.len() != 20 {
+			return Ok(None);
+		}
+		let msg = message.as_bytes();
+		let exp: [u8; 2] = [0; 2];
+		if msg[..2] != exp {
+			return Ok(None);
+		}
+		let switch = match SwitchCommitmentType::try_from(msg[2]) {
+			Ok(s) => s,
+			Err(_) => return Ok(None),
+		};
+		let depth = u8::min(msg[3], 4);
+		let id = Identifier::from_serialized_path(depth, &msg[4..]);
+
+		let path = id.to_path();
+		if self.depth > path.depth {
+			return Ok(None);
+		}
+
+		// For non-root key, check child number of current depth
+		if self.depth > 0
+			&& path.depth > 0
+			&& self.child_number != path.path[self.depth as usize - 1]
+		{
+			return Ok(None);
+		}
+
+		let mut key = self.clone();
+		let mut hasher = BIP32GrinHasher::new(self.is_floo);
+		for i in self.depth..path.depth {
+			let child_number = path.path[i as usize];
+			if child_number.is_hardened() {
+				return Ok(None);
+			}
+			key = key.ckd_pub(&secp, &mut hasher, child_number)?;
+		}
+		let pub_key = key.commit(secp, amount, &switch)?;
+		if commit.to_pubkey(&secp)? == pub_key {
+			Ok(Some((id, switch)))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::keychain::ExtKeychain;
+	use grin_keychain::ChildNumber;
 	use rand::{thread_rng, Rng};
 
 	#[test]
@@ -351,7 +426,7 @@ mod tests {
 		)
 		.unwrap();
 		assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
-		let rewind = rewind(&keychain, &builder, commit, None, proof).unwrap();
+		let rewind = rewind(keychain.secp(), &builder, commit, None, proof).unwrap();
 		assert!(rewind.is_some());
 		let (r_amount, r_id, r_switch) = rewind.unwrap();
 		assert_eq!(r_amount, amount);
@@ -381,7 +456,7 @@ mod tests {
 			)
 			.unwrap();
 			assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
-			let rewind = rewind(&keychain, &builder, commit.clone(), None, proof).unwrap();
+			let rewind = rewind(keychain.secp(), &builder, commit.clone(), None, proof).unwrap();
 			assert!(rewind.is_some());
 			let (r_amount, r_id, r_switch) = rewind.unwrap();
 			assert_eq!(r_amount, amount);
@@ -404,7 +479,7 @@ mod tests {
 			)
 			.unwrap();
 			assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
-			let rewind = rewind(&keychain, &builder, commit.clone(), None, proof).unwrap();
+			let rewind = rewind(keychain.secp(), &builder, commit.clone(), None, proof).unwrap();
 			assert!(rewind.is_some());
 			let (r_amount, r_id, r_switch) = rewind.unwrap();
 			assert_eq!(r_amount, amount);
@@ -414,5 +489,233 @@ mod tests {
 		};
 		// The resulting pedersen commitments should be different
 		assert_ne!(commit_a, commit_b);
+	}
+
+	#[test]
+	fn view_key() {
+		// TODO
+		/*let rng = &mut thread_rng();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
+
+		let builder = ProofBuilder::new(&keychain);
+		let mut hasher = keychain.hasher();
+		let view_key = ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
+		assert_eq!(builder.rewind_hash, view_key.rewind_hash);
+
+		let amount = rng.gen();
+		//let id = ExtKeychain::derive_key_id(3, rng.gen::<u16>() as u32, rng.gen::<u16>() as u32, rng.gen::<u16>() as u32, 0);
+		let id = ExtKeychain::derive_key_id(0, 0, 0, 0, 0);
+		let switch = SwitchCommitmentType::Regular;
+		println!("commit_0 = {:?}", keychain.commit(amount, &id, &SwitchCommitmentType::None).unwrap().0.to_vec());
+		let commit = keychain.commit(amount, &id, &switch).unwrap();
+
+		// Generate proof with ProofBuilder..
+		let proof = create(&keychain, &builder, amount, &id, &switch, commit.clone(), None).unwrap();
+		// ..and rewind with ViewKey
+		let rewind = rewind(keychain.secp(), &view_key, commit.clone(), None, proof);
+
+		assert!(rewind.is_ok());
+		let rewind = rewind.unwrap();
+		assert!(rewind.is_some());
+		let (r_amount, r_id, r_switch) = rewind.unwrap();
+		assert_eq!(r_amount, amount);
+		assert_eq!(r_id, id);
+		assert_eq!(r_switch, switch);*/
+	}
+
+	#[test]
+	fn view_key_no_switch() {
+		let rng = &mut thread_rng();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
+
+		let builder = ProofBuilder::new(&keychain);
+		let mut hasher = keychain.hasher();
+		let view_key =
+			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
+		assert_eq!(builder.rewind_hash, view_key.rewind_hash);
+
+		let amount = rng.gen();
+		let id = ExtKeychain::derive_key_id(
+			3,
+			rng.gen::<u16>() as u32,
+			rng.gen::<u16>() as u32,
+			rng.gen::<u16>() as u32,
+			0,
+		);
+		let switch = SwitchCommitmentType::None;
+		let commit = keychain.commit(amount, &id, &switch).unwrap();
+
+		// Generate proof with ProofBuilder..
+		let proof = create(
+			&keychain,
+			&builder,
+			amount,
+			&id,
+			&switch,
+			commit.clone(),
+			None,
+		)
+		.unwrap();
+		// ..and rewind with ViewKey
+		let rewind = rewind(keychain.secp(), &view_key, commit.clone(), None, proof);
+
+		assert!(rewind.is_ok());
+		let rewind = rewind.unwrap();
+		assert!(rewind.is_some());
+		let (r_amount, r_id, r_switch) = rewind.unwrap();
+		assert_eq!(r_amount, amount);
+		assert_eq!(r_id, id);
+		assert_eq!(r_switch, switch);
+	}
+
+	#[test]
+	fn view_key_hardened() {
+		let rng = &mut thread_rng();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
+
+		let builder = ProofBuilder::new(&keychain);
+		let mut hasher = keychain.hasher();
+		let view_key =
+			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
+		assert_eq!(builder.rewind_hash, view_key.rewind_hash);
+
+		let amount = rng.gen();
+		let id = ExtKeychain::derive_key_id(
+			3,
+			rng.gen::<u16>() as u32,
+			u32::max_value() - 2,
+			rng.gen::<u16>() as u32,
+			0,
+		);
+		let switch = SwitchCommitmentType::None;
+		let commit = keychain.commit(amount, &id, &switch).unwrap();
+
+		// Generate proof with ProofBuilder..
+		let proof = create(
+			&keychain,
+			&builder,
+			amount,
+			&id,
+			&switch,
+			commit.clone(),
+			None,
+		)
+		.unwrap();
+		// ..and rewind with ViewKey
+		let rewind = rewind(keychain.secp(), &view_key, commit.clone(), None, proof);
+
+		assert!(rewind.is_ok());
+		let rewind = rewind.unwrap();
+		assert!(rewind.is_none());
+	}
+
+	#[test]
+	fn view_key_child() {
+		let rng = &mut thread_rng();
+		let keychain = ExtKeychain::from_random_seed(false).unwrap();
+
+		let builder = ProofBuilder::new(&keychain);
+		let mut hasher = keychain.hasher();
+		let view_key =
+			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
+		assert_eq!(builder.rewind_hash, view_key.rewind_hash);
+
+		// Same child
+		{
+			let child_view_key = view_key
+				.ckd_pub(
+					keychain.secp(),
+					&mut hasher,
+					ChildNumber::from_normal_idx(10),
+				)
+				.unwrap();
+			assert_eq!(child_view_key.depth, 1);
+
+			let amount = rng.gen();
+			let id = ExtKeychain::derive_key_id(
+				3,
+				10,
+				rng.gen::<u16>() as u32,
+				rng.gen::<u16>() as u32,
+				0,
+			);
+			let switch = SwitchCommitmentType::None;
+			let commit = keychain.commit(amount, &id, &switch).unwrap();
+
+			// Generate proof with ProofBuilder..
+			let proof = create(
+				&keychain,
+				&builder,
+				amount,
+				&id,
+				&switch,
+				commit.clone(),
+				None,
+			)
+			.unwrap();
+			// ..and rewind with child ViewKey
+			let rewind = rewind(
+				keychain.secp(),
+				&child_view_key,
+				commit.clone(),
+				None,
+				proof,
+			);
+
+			assert!(rewind.is_ok());
+			let rewind = rewind.unwrap();
+			assert!(rewind.is_some());
+			let (r_amount, r_id, r_switch) = rewind.unwrap();
+			assert_eq!(r_amount, amount);
+			assert_eq!(r_id, id);
+			assert_eq!(r_switch, switch);
+		}
+
+		// Different child
+		{
+			let child_view_key = view_key
+				.ckd_pub(
+					keychain.secp(),
+					&mut hasher,
+					ChildNumber::from_normal_idx(11),
+				)
+				.unwrap();
+			assert_eq!(child_view_key.depth, 1);
+
+			let amount = rng.gen();
+			let id = ExtKeychain::derive_key_id(
+				3,
+				10,
+				rng.gen::<u16>() as u32,
+				rng.gen::<u16>() as u32,
+				0,
+			);
+			let switch = SwitchCommitmentType::None;
+			let commit = keychain.commit(amount, &id, &switch).unwrap();
+
+			// Generate proof with ProofBuilder..
+			let proof = create(
+				&keychain,
+				&builder,
+				amount,
+				&id,
+				&switch,
+				commit.clone(),
+				None,
+			)
+			.unwrap();
+			// ..and rewind with child ViewKey
+			let rewind = rewind(
+				keychain.secp(),
+				&child_view_key,
+				commit.clone(),
+				None,
+				proof,
+			);
+
+			assert!(rewind.is_ok());
+			let rewind = rewind.unwrap();
+			assert!(rewind.is_none());
+		}
 	}
 }

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -19,19 +19,24 @@ use crate::core::transaction::kernel_sig_msg;
 use crate::core::{KernelFeatures, Output, OutputFeatures, TxKernel};
 use crate::keychain::{Identifier, Keychain};
 use crate::libtx::error::Error;
-use crate::libtx::{aggsig, proof};
+use crate::libtx::{
+	aggsig,
+	proof::{self, ProofBuild},
+};
 use crate::util::{secp, static_secp_instance};
 use grin_keychain::SwitchCommitmentType;
 
 /// output a reward output
-pub fn output<K>(
+pub fn output<K, B>(
 	keychain: &K,
+	builder: &B,
 	key_id: &Identifier,
 	fees: u64,
 	test_mode: bool,
 ) -> Result<(Output, TxKernel), Error>
 where
 	K: Keychain,
+	B: ProofBuild,
 {
 	let value = reward(fees);
 
@@ -39,9 +44,7 @@ where
 
 	trace!("Block reward - Pedersen Commit is: {:?}", commit,);
 
-	// TODO: use the new builder
-	let builder = proof::LegacyProofBuilder::new(keychain);
-	let rproof = proof::create(keychain, &builder, value, key_id, commit, None)?;
+	let rproof = proof::create(keychain, builder, value, key_id, commit, None)?;
 
 	let output = Output {
 		features: OutputFeatures::Coinbase,

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -19,7 +19,7 @@ use crate::core::transaction::kernel_sig_msg;
 use crate::core::{KernelFeatures, Output, OutputFeatures, TxKernel};
 use crate::keychain::{Identifier, Keychain};
 use crate::libtx::error::Error;
-use crate::libtx::{aggsig, proof, proof::LegacyProofBuilder};
+use crate::libtx::{aggsig, proof};
 use crate::util::{secp, static_secp_instance};
 use grin_keychain::SwitchCommitmentType;
 
@@ -35,13 +35,12 @@ where
 {
 	let value = reward(fees);
 
-	// TODO: use the new builder
-	let builder = LegacyProofBuilder::new(keychain);
-
 	let commit = keychain.commit(value, key_id, &SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
 
 	trace!("Block reward - Pedersen Commit is: {:?}", commit,);
 
+	// TODO: use the new builder
+	let builder = proof::LegacyProofBuilder::new(keychain);
 	let rproof = proof::create(keychain, &builder, value, key_id, commit, None)?;
 
 	let output = Output {

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -39,12 +39,13 @@ where
 	B: ProofBuild,
 {
 	let value = reward(fees);
-
-	let commit = keychain.commit(value, key_id, &SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
+	// TODO: proper support for different switch commitment schemes
+	let switch = &SwitchCommitmentType::Regular;
+	let commit = keychain.commit(value, key_id, switch)?;
 
 	trace!("Block reward - Pedersen Commit is: {:?}", commit,);
 
-	let rproof = proof::create(keychain, builder, value, key_id, commit, None)?;
+	let rproof = proof::create(keychain, builder, value, key_id, switch, commit, None)?;
 
 	let output = Output {
 		features: OutputFeatures::Coinbase,

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -25,6 +25,7 @@ use crate::core::core::{
 	Block, BlockHeader, CompactBlock, HeaderVersion, KernelFeatures, OutputFeatures,
 };
 use crate::core::libtx::build::{self, input, output, with_fee};
+use crate::core::libtx::ProofBuilder;
 use crate::core::{global, ser};
 use crate::keychain::{BlindingFactor, ExtKeychain, Keychain};
 use crate::util::secp;
@@ -45,6 +46,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 #[allow(dead_code)]
 fn too_large_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let max_out = global::max_block_weight() / BLOCK_OUTPUT_WEIGHT;
 
 	let mut pks = vec![];
@@ -59,12 +61,12 @@ fn too_large_block() {
 
 	let now = Instant::now();
 	parts.append(&mut vec![input(500000, pks.pop().unwrap()), with_fee(2)]);
-	let tx = build::transaction(parts, &keychain).unwrap();
+	let tx = build::transaction(parts, &keychain, &builder).unwrap();
 	println!("Build tx: {}", now.elapsed().as_secs());
 
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx], &keychain, &builder, &prev, &key_id);
 	assert!(b
 		.validate(&BlindingFactor::zero(), verifier_cache())
 		.is_err());
@@ -86,6 +88,7 @@ fn very_empty_block() {
 // builds a block with a tx spending another and check that cut_through occurred
 fn block_with_cut_through() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -94,17 +97,19 @@ fn block_with_cut_through() {
 	let mut btx2 = build::transaction(
 		vec![input(7, key_id1), output(5, key_id2.clone()), with_fee(2)],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
 	// spending tx2 - reuse key_id2
 
-	let mut btx3 = txspend1i1o(5, &keychain, key_id2.clone(), key_id3);
+	let mut btx3 = txspend1i1o(5, &keychain, &builder, key_id2.clone(), key_id3);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(
 		vec![&mut btx1, &mut btx2, &mut btx3],
 		&keychain,
+		&builder,
 		&prev,
 		&key_id,
 	);
@@ -120,9 +125,10 @@ fn block_with_cut_through() {
 #[test]
 fn empty_block_with_coinbase_is_valid() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 
 	assert_eq!(b.inputs().len(), 0);
 	assert_eq!(b.outputs().len(), 1);
@@ -157,9 +163,10 @@ fn empty_block_with_coinbase_is_valid() {
 // additionally verifying the merkle_inputs_outputs also fails
 fn remove_coinbase_output_flag() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let mut b = new_block(vec![], &keychain, &prev, &key_id);
+	let mut b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 
 	assert!(b.outputs()[0].is_coinbase());
 	b.outputs_mut()[0].features = OutputFeatures::Plain;
@@ -179,9 +186,10 @@ fn remove_coinbase_output_flag() {
 // invalidates the block and specifically it causes verify_coinbase to fail
 fn remove_coinbase_kernel_flag() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let mut b = new_block(vec![], &keychain, &prev, &key_id);
+	let mut b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 
 	assert!(b.kernels()[0].is_coinbase());
 	b.kernels_mut()[0].features = KernelFeatures::Plain;
@@ -220,9 +228,10 @@ fn serialize_deserialize_header_version() {
 #[test]
 fn serialize_deserialize_block_header() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let header1 = b.header;
 
 	let mut vec = Vec::new();
@@ -237,9 +246,10 @@ fn serialize_deserialize_block_header() {
 fn serialize_deserialize_block() {
 	let tx1 = tx1i2o();
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
@@ -255,9 +265,10 @@ fn serialize_deserialize_block() {
 #[test]
 fn empty_block_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
 	let target_len = 1_265;
@@ -267,10 +278,11 @@ fn empty_block_serialized_size() {
 #[test]
 fn block_single_tx_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
 	let target_len = 2_847;
@@ -280,9 +292,10 @@ fn block_single_tx_serialized_size() {
 #[test]
 fn empty_compact_block_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
@@ -293,10 +306,11 @@ fn empty_compact_block_serialized_size() {
 #[test]
 fn compact_block_single_tx_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
@@ -307,6 +321,7 @@ fn compact_block_single_tx_serialized_size() {
 #[test]
 fn block_10_tx_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	global::set_mining_mode(global::ChainTypes::Mainnet);
 
 	let mut txs = vec![];
@@ -316,7 +331,7 @@ fn block_10_tx_serialized_size() {
 	}
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(txs.iter().collect(), &keychain, &prev, &key_id);
+	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &b).expect("serialization failed");
 	let target_len = 17_085;
@@ -326,6 +341,7 @@ fn block_10_tx_serialized_size() {
 #[test]
 fn compact_block_10_tx_serialized_size() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 
 	let mut txs = vec![];
 	for _ in 0..10 {
@@ -334,7 +350,7 @@ fn compact_block_10_tx_serialized_size() {
 	}
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(txs.iter().collect(), &keychain, &prev, &key_id);
+	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize(&mut vec, &cb).expect("serialization failed");
@@ -345,10 +361,11 @@ fn compact_block_10_tx_serialized_size() {
 #[test]
 fn compact_block_hash_with_nonce() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let tx = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx], &keychain, &builder, &prev, &key_id);
 	let cb1: CompactBlock = b.clone().into();
 	let cb2: CompactBlock = b.clone().into();
 
@@ -375,10 +392,11 @@ fn compact_block_hash_with_nonce() {
 #[test]
 fn convert_block_to_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let cb: CompactBlock = b.clone().into();
 
 	assert_eq!(cb.out_full().len(), 1);
@@ -398,9 +416,10 @@ fn convert_block_to_compact_block() {
 #[test]
 fn hydrate_empty_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![], &keychain, &prev, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let cb: CompactBlock = b.clone().into();
 	let hb = Block::hydrate_from(cb, vec![]).unwrap();
 	assert_eq!(hb.header, b.header);
@@ -411,10 +430,11 @@ fn hydrate_empty_compact_block() {
 #[test]
 fn serialize_deserialize_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let b = new_block(vec![&tx1], &keychain, &prev, &key_id);
+	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 
 	let mut cb1: CompactBlock = b.into();
 
@@ -437,6 +457,7 @@ fn serialize_deserialize_compact_block() {
 #[test]
 fn same_amount_outputs_copy_range_proof() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -449,6 +470,7 @@ fn same_amount_outputs_copy_range_proof() {
 			with_fee(1),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
@@ -468,6 +490,7 @@ fn same_amount_outputs_copy_range_proof() {
 			kernels.clone(),
 		)],
 		&keychain,
+		&builder,
 		&prev,
 		&key_id,
 	);
@@ -484,6 +507,7 @@ fn same_amount_outputs_copy_range_proof() {
 #[test]
 fn wrong_amount_range_proof() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -496,6 +520,7 @@ fn wrong_amount_range_proof() {
 			with_fee(1),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 	let tx2 = build::transaction(
@@ -506,6 +531,7 @@ fn wrong_amount_range_proof() {
 			with_fee(1),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
@@ -525,6 +551,7 @@ fn wrong_amount_range_proof() {
 			kernels.clone(),
 		)],
 		&keychain,
+		&builder,
 		&prev,
 		&key_id,
 	);

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -75,16 +75,14 @@ fn tx_double_ser_deser() {
 #[test]
 #[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
-	let mut keychain = ExtKeychain::from_random_seed(false).unwrap();
-	keychain.set_use_switch_commits(false);
+	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
 	build::transaction(
 		vec![
 			input(10, key_id1.clone()),
-			output(9, key_id1.clone()),
-			with_fee(1),
+			output(10, key_id1.clone()),
 		],
 		&keychain,
 	)

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -80,10 +80,7 @@ fn test_zero_commit_fails() {
 
 	// blinding should fail as signing with a zero r*G shouldn't work
 	build::transaction(
-		vec![
-			input(10, key_id1.clone()),
-			output(10, key_id1.clone()),
-		],
+		vec![input(10, key_id1.clone()), output(10, key_id1.clone())],
 		&keychain,
 	)
 	.unwrap();

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -24,6 +24,7 @@ use self::core::core::{aggregate, deaggregate, KernelFeatures, Output, Transacti
 use self::core::libtx::build::{
 	self, initial_tx, input, output, with_excess, with_fee, with_lock_height,
 };
+use self::core::libtx::ProofBuilder;
 use self::core::ser;
 use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
 use self::util::static_secp_instance;
@@ -76,12 +77,14 @@ fn tx_double_ser_deser() {
 #[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
 	build::transaction(
 		vec![input(10, key_id1.clone()), output(10, key_id1.clone())],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 }
@@ -93,6 +96,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 #[test]
 fn build_tx_kernel() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -106,6 +110,7 @@ fn build_tx_kernel() {
 			with_fee(2),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
@@ -345,6 +350,7 @@ fn basic_transaction_deaggregation() {
 #[test]
 fn hash_output() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -357,6 +363,7 @@ fn hash_output() {
 			with_fee(1),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 	let h = tx.outputs()[0].hash();
@@ -402,6 +409,7 @@ fn tx_hash_diff() {
 #[test]
 fn tx_build_exchange() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -414,9 +422,12 @@ fn tx_build_exchange() {
 
 		// Alice builds her transaction, with change, which also produces the sum
 		// of blinding factors before they're obscured.
-		let (tx, sum) =
-			build::partial_transaction(vec![in1, in2, output(1, key_id3), with_fee(2)], &keychain)
-				.unwrap();
+		let (tx, sum) = build::partial_transaction(
+			vec![in1, in2, output(1, key_id3), with_fee(2)],
+			&keychain,
+			&builder,
+		)
+		.unwrap();
 
 		(tx, sum)
 	};
@@ -431,6 +442,7 @@ fn tx_build_exchange() {
 			output(4, key_id4),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
@@ -442,11 +454,12 @@ fn tx_build_exchange() {
 #[test]
 fn reward_empty_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let previous_header = BlockHeader::default();
 
-	let b = new_block(vec![], &keychain, &previous_header, &key_id);
+	let b = new_block(vec![], &keychain, &builder, &previous_header, &key_id);
 
 	b.cut_through()
 		.unwrap()
@@ -457,6 +470,7 @@ fn reward_empty_block() {
 #[test]
 fn reward_with_tx_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -466,7 +480,13 @@ fn reward_with_tx_block() {
 
 	let previous_header = BlockHeader::default();
 
-	let block = new_block(vec![&mut tx1], &keychain, &previous_header, &key_id);
+	let block = new_block(
+		vec![&mut tx1],
+		&keychain,
+		&builder,
+		&previous_header,
+		&key_id,
+	);
 	block
 		.cut_through()
 		.unwrap()
@@ -477,6 +497,7 @@ fn reward_with_tx_block() {
 #[test]
 fn simple_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
+	let builder = ProofBuilder::new(&keychain);
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -488,6 +509,7 @@ fn simple_block() {
 	let b = new_block(
 		vec![&mut tx1, &mut tx2],
 		&keychain,
+		&builder,
 		&previous_header,
 		&key_id,
 	);
@@ -498,7 +520,7 @@ fn simple_block() {
 #[test]
 fn test_block_with_timelocked_tx() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-
+	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -515,12 +537,19 @@ fn test_block_with_timelocked_tx() {
 			with_lock_height(1),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
 	let previous_header = BlockHeader::default();
 
-	let b = new_block(vec![&tx1], &keychain, &previous_header, &key_id3.clone());
+	let b = new_block(
+		vec![&tx1],
+		&keychain,
+		&builder,
+		&previous_header,
+		&key_id3.clone(),
+	);
 	b.validate(&BlindingFactor::zero(), vc.clone()).unwrap();
 
 	// now try adding a timelocked tx where lock height is greater than current
@@ -533,11 +562,18 @@ fn test_block_with_timelocked_tx() {
 			with_lock_height(2),
 		],
 		&keychain,
+		&builder,
 	)
 	.unwrap();
 
 	let previous_header = BlockHeader::default();
-	let b = new_block(vec![&tx1], &keychain, &previous_header, &key_id3.clone());
+	let b = new_block(
+		vec![&tx1],
+		&keychain,
+		&builder,
+		&previous_header,
+		&key_id3.clone(),
+	);
 
 	match b.validate(&BlindingFactor::zero(), vc.clone()) {
 		Err(KernelLockHeight(height)) => {

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -27,7 +27,9 @@ use grin_keychain as keychain;
 fn test_output_ser_deser() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain.commit(5, &key_id, &keychain::SwitchCommitmentType::Regular).unwrap();
+	let commit = keychain
+		.commit(5, &key_id, &keychain::SwitchCommitmentType::Regular)
+		.unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
 	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
 

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -27,8 +27,9 @@ use grin_keychain as keychain;
 fn test_output_ser_deser() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain.commit(5, &key_id).unwrap();
-	let proof = proof::create(&keychain, 5, &key_id, commit, None).unwrap();
+	let commit = keychain.commit(5, &key_id, &keychain::SwitchCommitmentType::Regular).unwrap();
+	let builder = proof::ProofBuilder::new(&keychain);
+	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
 
 	let out = Output {
 		features: OutputFeatures::Plain,

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -27,11 +27,10 @@ use grin_keychain as keychain;
 fn test_output_ser_deser() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain
-		.commit(5, &key_id, &keychain::SwitchCommitmentType::Regular)
-		.unwrap();
+	let switch = &keychain::SwitchCommitmentType::Regular;
+	let commit = keychain.commit(5, &key_id, switch).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
-	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
+	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();
 
 	let out = Output {
 		features: OutputFeatures::Plain,

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -17,7 +17,7 @@ pub mod common;
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use self::core::core::{Output, OutputFeatures};
 use self::core::libtx::proof;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
 use self::util::RwLock;
 use grin_core as core;
 use grin_keychain as keychain;
@@ -34,8 +34,9 @@ fn test_verifier_cache_rangeproofs() {
 
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain.commit(5, &key_id).unwrap();
-	let proof = proof::create(&keychain, 5, &key_id, commit, None).unwrap();
+	let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
+	let builder = proof::ProofBuilder::new(&keychain);
+	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
 
 	let out = Output {
 		features: OutputFeatures::Plain,

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -34,7 +34,9 @@ fn test_verifier_cache_rangeproofs() {
 
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain.commit(5, &key_id, &SwitchCommitmentType::Regular).unwrap();
+	let commit = keychain
+		.commit(5, &key_id, &SwitchCommitmentType::Regular)
+		.unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
 	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
 

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -34,11 +34,10 @@ fn test_verifier_cache_rangeproofs() {
 
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let commit = keychain
-		.commit(5, &key_id, &SwitchCommitmentType::Regular)
-		.unwrap();
+	let switch = &SwitchCommitmentType::Regular;
+	let commit = keychain.commit(5, &key_id, switch).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
-	let proof = proof::create(&keychain, &builder, 5, &key_id, commit, None).unwrap();
+	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();
 
 	let out = Output {
 		features: OutputFeatures::Plain,

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -149,7 +149,7 @@ impl BIP32Hasher for BIP32GrinHasher {
 }
 
 /// Extended private key
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ExtendedPrivKey {
 	/// The network this key is to be used on
 	pub network: [u8; 4],
@@ -399,7 +399,7 @@ impl ExtendedPrivKey {
 	where
 		H: BIP32Hasher,
 	{
-		let mut sk: ExtendedPrivKey = *self;
+		let mut sk: ExtendedPrivKey = self.clone();
 		for cnum in cnums {
 			sk = sk.ckd_priv(secp, hasher, *cnum)?;
 		}

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -34,5 +34,6 @@ pub mod keychain;
 pub use crate::extkey_bip32::ChildNumber;
 pub use crate::keychain::ExtKeychain;
 pub use crate::types::{
-	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier, Keychain, IDENTIFIER_SIZE,
+	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier,
+	Keychain, SwitchCommitmentType, IDENTIFIER_SIZE,
 };

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -34,6 +34,6 @@ pub mod keychain;
 pub use crate::extkey_bip32::ChildNumber;
 pub use crate::keychain::ExtKeychain;
 pub use crate::types::{
-	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier,
-	Keychain, SwitchCommitmentType, IDENTIFIER_SIZE,
+	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier, Keychain, SwitchCommitmentType,
+	IDENTIFIER_SIZE,
 };

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -25,10 +25,13 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate sha2;
+
 mod base58;
 pub mod extkey_bip32;
 pub mod mnemonic;
 mod types;
+pub mod view_key;
 
 pub mod keychain;
 pub use crate::extkey_bip32::ChildNumber;
@@ -37,3 +40,4 @@ pub use crate::types::{
 	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier, Keychain, SwitchCommitmentType,
 	IDENTIFIER_SIZE,
 };
+pub use crate::view_key::ViewKey;

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -322,7 +322,7 @@ impl BlindingFactor {
 
 		// use blind_sum to subtract skey_1 from our key (to give k = k1 + k2)
 		let skey = self.secret_key(secp)?;
-		let skey_2 = secp.blind_sum(vec![skey], vec![skey_1])?;
+		let skey_2 = secp.blind_sum(vec![skey], vec![skey_1.clone()])?;
 
 		let blind_1 = BlindingFactor::from_secret_key(skey_1);
 		let blind_2 = BlindingFactor::from_secret_key(skey_2);
@@ -472,6 +472,10 @@ pub trait Keychain: Sync + Send + Clone {
 	/// Derives a key id from the depth of the keychain and the values at each
 	/// depth level. See `KeychainPath` for more information.
 	fn derive_key_id(depth: u8, d1: u32, d2: u32, d3: u32, d4: u32) -> Identifier;
+
+	/// The public root key
+	fn public_root_key(&self) -> PublicKey;
+
 	fn derive_key(
 		&self,
 		amount: u64,
@@ -565,7 +569,7 @@ mod test {
 	fn split_blinding_factor() {
 		let secp = Secp256k1::new();
 		let skey_in = SecretKey::new(&secp, &mut thread_rng());
-		let blind = BlindingFactor::from_secret_key(skey_in);
+		let blind = BlindingFactor::from_secret_key(skey_in.clone());
 		let split = blind.split(&secp).unwrap();
 
 		// split a key, sum the split keys and confirm the sum matches the original key

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -14,6 +14,7 @@
 
 use rand::thread_rng;
 use std::cmp::min;
+use std::convert::TryFrom;
 use std::io::Cursor;
 use std::ops::Add;
 /// Keychain trait and its main supporting types. The Identifier is a
@@ -499,6 +500,27 @@ pub trait Keychain: Sync + Send + Clone {
 pub enum SwitchCommitmentType {
 	None,
 	Regular,
+}
+
+impl TryFrom<u8> for SwitchCommitmentType {
+	type Error = ();
+
+	fn try_from(value: u8) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(SwitchCommitmentType::None),
+			1 => Ok(SwitchCommitmentType::Regular),
+			_ => Err(()),
+		}
+	}
+}
+
+impl From<&SwitchCommitmentType> for u8 {
+	fn from(switch: &SwitchCommitmentType) -> Self {
+		match *switch {
+			SwitchCommitmentType::None => 0,
+			SwitchCommitmentType::Regular => 1,
+		}
+	}
 }
 
 #[cfg(test)]

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -471,10 +471,26 @@ pub trait Keychain: Sync + Send + Clone {
 	/// Derives a key id from the depth of the keychain and the values at each
 	/// depth level. See `KeychainPath` for more information.
 	fn derive_key_id(depth: u8, d1: u32, d2: u32, d3: u32, d4: u32) -> Identifier;
-	fn derive_key(&self, amount: u64, id: &Identifier, switch: &SwitchCommitmentType) -> Result<SecretKey, Error>;
-	fn commit(&self, amount: u64, id: &Identifier, switch: &SwitchCommitmentType) -> Result<Commitment, Error>;
+	fn derive_key(
+		&self,
+		amount: u64,
+		id: &Identifier,
+		switch: &SwitchCommitmentType,
+	) -> Result<SecretKey, Error>;
+	fn commit(
+		&self,
+		amount: u64,
+		id: &Identifier,
+		switch: &SwitchCommitmentType,
+	) -> Result<Commitment, Error>;
 	fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error>;
-	fn sign(&self, msg: &Message, amount: u64, id: &Identifier, switch: &SwitchCommitmentType) -> Result<Signature, Error>;
+	fn sign(
+		&self,
+		msg: &Message,
+		amount: u64,
+		id: &Identifier,
+		switch: &SwitchCommitmentType,
+	) -> Result<Signature, Error>;
 	fn sign_with_blinding(&self, _: &Message, _: &BlindingFactor) -> Result<Signature, Error>;
 	fn secp(&self) -> &Secp256k1;
 }

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -54,7 +54,7 @@ impl ViewKey {
 		let secp = keychain.secp();
 
 		let ExtendedPubKey {
-			network,
+			network: _,
 			depth,
 			parent_fingerprint,
 			child_number,
@@ -66,7 +66,7 @@ impl ViewKey {
 		switch_public_key.mul_assign(secp, &ext_key.secret_key)?;
 		let switch_public_key = Some(switch_public_key);
 
-		let rewind_hash = Self::rewind_hash(secp, hasher, keychain.public_root_key());
+		let rewind_hash = Self::rewind_hash(secp, keychain.public_root_key());
 
 		Ok(Self {
 			is_floo,
@@ -80,10 +80,7 @@ impl ViewKey {
 		})
 	}
 
-	fn rewind_hash<H>(secp: &Secp256k1, hasher: &mut H, public_root_key: PublicKey) -> Vec<u8>
-	where
-		H: BIP32Hasher,
-	{
+	fn rewind_hash(secp: &Secp256k1, public_root_key: PublicKey) -> Vec<u8> {
 		let ser = public_root_key.serialize_vec(secp, true);
 		blake2b(32, &[], &ser[..]).as_bytes().to_vec()
 	}

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -1,0 +1,198 @@
+use crate::blake2::blake2b::blake2b;
+use byteorder::{BigEndian, ByteOrder};
+//use crate::sha2::{Digest, Sha256};
+use super::extkey_bip32::{
+	BIP32Hasher, ChainCode, ChildNumber, Error as BIP32Error, ExtendedPrivKey, ExtendedPubKey,
+	Fingerprint,
+};
+use super::types::{Error, Keychain};
+use crate::util::secp::constants::GENERATOR_PUB_J_RAW;
+use crate::util::secp::ffi;
+use crate::util::secp::key::{PublicKey, SecretKey};
+use crate::util::secp::Secp256k1;
+use crate::SwitchCommitmentType;
+
+/*const VERSION_FLOO_NS: [u8;4] = [0x03, 0x27, 0x3E, 0x4B];
+const VERSION_FLOO: [u8;4]    = [0x03, 0x27, 0x3E, 0x4B];
+const VERSION_MAIN_NS: [u8;4] = [0x03, 0x3C, 0x08, 0xDF];
+const VERSION_MAIN: [u8;4]    = [0x03, 0x3C, 0x08, 0xDF];*/
+
+/// Key that can be used to scan the chain for owned outputs
+/// This is a public key, meaning it cannot be used to spend those outputs
+/// At the moment only depth 0 keys can be used
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ViewKey {
+	/// Whether this view key is meant for floonet or not
+	pub is_floo: bool,
+	/// How many derivations this key is from the master (which is 0)
+	pub depth: u8,
+	/// Fingerprint of the parent key
+	parent_fingerprint: Fingerprint,
+	/// Child number of the key used to derive from parent (0 for master)
+	pub child_number: ChildNumber,
+	/// Public key
+	public_key: PublicKey,
+	/// Switch public key, required to view outputs that use switch commitment
+	switch_public_key: Option<PublicKey>,
+	/// Chain code
+	chain_code: ChainCode,
+	/// Hash used to generate rewind nonce
+	pub rewind_hash: Vec<u8>,
+}
+
+impl ViewKey {
+	pub fn create<K, H>(
+		keychain: &K,
+		ext_key: ExtendedPrivKey,
+		hasher: &mut H,
+		is_floo: bool,
+	) -> Result<Self, Error>
+	where
+		K: Keychain,
+		H: BIP32Hasher,
+	{
+		let secp = keychain.secp();
+
+		let ExtendedPubKey {
+			network,
+			depth,
+			parent_fingerprint,
+			child_number,
+			public_key,
+			chain_code,
+		} = ExtendedPubKey::from_private(secp, &ext_key, hasher);
+
+		let mut switch_public_key = PublicKey(ffi::PublicKey(GENERATOR_PUB_J_RAW));
+		switch_public_key.mul_assign(secp, &ext_key.secret_key)?;
+		let switch_public_key = Some(switch_public_key);
+
+		let rewind_hash = Self::rewind_hash(secp, hasher, keychain.public_root_key());
+
+		Ok(Self {
+			is_floo,
+			depth,
+			parent_fingerprint,
+			child_number,
+			public_key,
+			switch_public_key,
+			chain_code,
+			rewind_hash,
+		})
+	}
+
+	fn rewind_hash<H>(secp: &Secp256k1, hasher: &mut H, public_root_key: PublicKey) -> Vec<u8>
+	where
+		H: BIP32Hasher,
+	{
+		let ser = public_root_key.serialize_vec(secp, true);
+		blake2b(32, &[], &ser[..]).as_bytes().to_vec()
+	}
+
+	fn ckd_pub_tweak<H>(
+		&self,
+		secp: &Secp256k1,
+		hasher: &mut H,
+		i: ChildNumber,
+	) -> Result<(SecretKey, ChainCode), Error>
+	where
+		H: BIP32Hasher,
+	{
+		match i {
+			ChildNumber::Hardened { .. } => Err(BIP32Error::CannotDeriveFromHardenedKey.into()),
+			ChildNumber::Normal { index: n } => {
+				hasher.init_sha512(&self.chain_code[..]);
+				hasher.append_sha512(&self.public_key.serialize_vec(secp, true)[..]);
+				let mut be_n = [0; 4];
+				BigEndian::write_u32(&mut be_n, n);
+				hasher.append_sha512(&be_n);
+
+				let result = hasher.result_sha512();
+
+				let secret_key = SecretKey::from_slice(secp, &result[..32])?;
+				let chain_code = ChainCode::from(&result[32..]);
+				Ok((secret_key, chain_code))
+			}
+		}
+	}
+
+	pub fn ckd_pub<H>(
+		&self,
+		secp: &Secp256k1,
+		hasher: &mut H,
+		i: ChildNumber,
+	) -> Result<Self, Error>
+	where
+		H: BIP32Hasher,
+	{
+		let (secret_key, chain_code) = self.ckd_pub_tweak(secp, hasher, i)?;
+
+		let mut public_key = self.public_key.clone();
+		public_key.add_exp_assign(secp, &secret_key)?;
+
+		let switch_public_key = match &self.switch_public_key {
+			Some(p) => {
+				let mut j = PublicKey(ffi::PublicKey(GENERATOR_PUB_J_RAW));
+				j.mul_assign(secp, &secret_key)?;
+				Some(PublicKey::from_combination(secp, vec![p, &j])?)
+			}
+			None => None,
+		};
+
+		Ok(Self {
+			is_floo: self.is_floo,
+			depth: self.depth + 1,
+			parent_fingerprint: self.fingerprint(secp, hasher),
+			child_number: i,
+			public_key,
+			switch_public_key,
+			chain_code,
+			rewind_hash: self.rewind_hash.clone(),
+		})
+	}
+
+	pub fn commit(
+		&self,
+		secp: &Secp256k1,
+		amount: u64,
+		switch: &SwitchCommitmentType,
+	) -> Result<PublicKey, Error> {
+		let value_key = secp.commit_value(amount)?.to_pubkey(secp)?;
+		let pub_key = PublicKey::from_combination(secp, vec![&self.public_key, &value_key])?;
+		match *switch {
+			SwitchCommitmentType::None => Ok(pub_key),
+			SwitchCommitmentType::Regular => {
+				// TODO: replace this whole block by a libsecp function
+				/*let switch_pub = self.switch_public_key.ok_or(Error::SwitchCommitment)?;
+				let switch_ser: Vec<u8> = switch_pub.serialize_vec(secp, true)[..].to_vec();
+
+				let mut commit_ser: Vec<u8> = pub_key.serialize_vec(secp, true)[..].to_vec();
+				commit_ser[0] += 6; // This only works sometimes
+
+				let mut hasher = Sha256::new();
+				hasher.input(&commit_ser);
+				hasher.input(&switch_ser);
+				let blind = SecretKey::from_slice(secp, &hasher.result()[..])?;
+				let mut pub_key = pub_key;
+				pub_key.add_exp_assign(secp, &blind)?;
+
+				Ok(pub_key)*/
+				Err(Error::SwitchCommitment)
+			}
+		}
+	}
+
+	fn identifier<H>(&self, secp: &Secp256k1, hasher: &mut H) -> [u8; 20]
+	where
+		H: BIP32Hasher,
+	{
+		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(secp, true)[..]);
+		hasher.ripemd_160(&sha2_res)
+	}
+
+	fn fingerprint<H>(&self, secp: &Secp256k1, hasher: &mut H) -> Fingerprint
+	where
+		H: BIP32Hasher,
+	{
+		Fingerprint::from(&self.identifier(secp, hasher)[0..4])
+	}
+}

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -47,7 +47,14 @@ fn test_transaction_pool_block_building() {
 				let height = prev_header.height + 1;
 				let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 				let fee = txs.iter().map(|x| x.fee()).sum();
-				let reward = libtx::reward::output(&keychain, &key_id, fee, false).unwrap();
+				let reward = libtx::reward::output(
+					&keychain,
+					&libtx::ProofBuilder::new(&keychain),
+					&key_id,
+					fee,
+					false,
+				)
+				.unwrap();
 				let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 				// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -51,7 +51,14 @@ fn test_block_building_max_weight() {
 				let height = prev_header.height + 1;
 				let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 				let fee = txs.iter().map(|x| x.fee()).sum();
-				let reward = libtx::reward::output(&keychain, &key_id, fee, false).unwrap();
+				let reward = libtx::reward::output(
+					&keychain,
+					&libtx::ProofBuilder::new(&keychain),
+					&key_id,
+					fee,
+					false,
+				)
+				.unwrap();
 				let mut block = Block::new(&prev_header, txs, Difficulty::min(), reward).unwrap();
 
 				// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -45,7 +45,14 @@ fn test_transaction_pool_block_reconciliation() {
 		let header = {
 			let height = 1;
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
-			let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
+			let reward = libtx::reward::output(
+				&keychain,
+				&libtx::ProofBuilder::new(&keychain),
+				&key_id,
+				0,
+				false,
+			)
+			.unwrap();
 			let genesis = BlockHeader::default();
 			let mut block = Block::new(&genesis, vec![], Difficulty::min(), reward).unwrap();
 
@@ -65,7 +72,14 @@ fn test_transaction_pool_block_reconciliation() {
 		let block = {
 			let key_id = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 			let fees = initial_tx.fee();
-			let reward = libtx::reward::output(&keychain, &key_id, fees, false).unwrap();
+			let reward = libtx::reward::output(
+				&keychain,
+				&libtx::ProofBuilder::new(&keychain),
+				&key_id,
+				fees,
+				false,
+			)
+			.unwrap();
 			let mut block =
 				Block::new(&header, vec![initial_tx], Difficulty::min(), reward).unwrap();
 
@@ -159,7 +173,14 @@ fn test_transaction_pool_block_reconciliation() {
 		let block = {
 			let key_id = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 			let fees = block_txs.iter().map(|tx| tx.fee()).sum();
-			let reward = libtx::reward::output(&keychain, &key_id, fees, false).unwrap();
+			let reward = libtx::reward::output(
+				&keychain,
+				&libtx::ProofBuilder::new(&keychain),
+				&key_id,
+				fees,
+				false,
+			)
+			.unwrap();
 			let mut block = Block::new(&header, block_txs, Difficulty::min(), reward).unwrap();
 
 			// Set the prev_root to the prev hash for testing purposes (no MMR to obtain a root from).

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -195,7 +195,7 @@ where
 
 	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain).unwrap()
+	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
 }
 
 pub fn test_transaction<K>(
@@ -225,7 +225,7 @@ where
 	}
 	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain).unwrap()
+	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
 }
 
 pub fn test_source() -> TxSource {

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -44,7 +44,14 @@ fn test_the_transaction_pool() {
 	let header = {
 		let height = 1;
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
-		let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
+		let reward = libtx::reward::output(
+			&keychain,
+			&libtx::ProofBuilder::new(&keychain),
+			&key_id,
+			0,
+			false,
+		)
+		.unwrap();
 		let block = Block::new(&BlockHeader::default(), vec![], Difficulty::min(), reward).unwrap();
 
 		chain.update_db_for_block(&block);
@@ -246,7 +253,14 @@ fn test_the_transaction_pool() {
 		let header = {
 			let height = 1;
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
-			let reward = libtx::reward::output(&keychain, &key_id, 0, false).unwrap();
+			let reward = libtx::reward::output(
+				&keychain,
+				&libtx::ProofBuilder::new(&keychain),
+				&key_id,
+				0,
+				false,
+			)
+			.unwrap();
 			let block =
 				Block::new(&BlockHeader::default(), vec![], Difficulty::min(), reward).unwrap();
 

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -28,6 +28,7 @@ use crate::common::types::Error;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{Output, TxKernel};
 use crate::core::libtx::secp_ser;
+use crate::core::libtx::ProofBuilder;
 use crate::core::{consensus, core, global};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
@@ -223,8 +224,14 @@ fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, B
 	warn!("Burning block fees: {:?}", block_fees);
 	let keychain = ExtKeychain::from_random_seed(global::is_floonet())?;
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let (out, kernel) =
-		crate::core::libtx::reward::output(&keychain, &key_id, block_fees.fees, false).unwrap();
+	let (out, kernel) = crate::core::libtx::reward::output(
+		&keychain,
+		&ProofBuilder::new(&keychain),
+		&key_id,
+		block_fees.fees,
+		false,
+	)
+	.unwrap();
 	Ok((out, kernel, block_fees))
 }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -28,5 +28,5 @@ zeroize = "0.5.2"
 #git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
 #tag = "grin_integration_29"
 #path = "../../rust-secp256k1-zkp"
-version = "0.7.5"
+version = "0.7.6"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
Changes to the keychain and builders that are needed for https://github.com/mimblewimble/grin-wallet/issues/105. 

I introduce a new `ProofBuild` trait, that is used in building and rewinding a proof. At the moment there are two of them, `LegacyProofBuilder` and `ProofBuilder`. Wallets can supply the transaction build functions with any struct that implements `ProofBuild`. `grin-wallet` v2.0.0 will only use `ProofBuilder` for creating new outputs, but use `LegacyProofBuilder` to rewind proofs before the hard fork height.

I also did some refactoring around switch commitments. With the new rewind scheme there is a version byte specifically for the switch commitment, which means we have the possibility to turn switch commitments off or use a different type for specific outputs, without requiring additional grinding.
For now all outputs that are created will use the `Regular` type. In the future we could have full support on the wallet level for this, but this will have to be done in another PR.

This PR also has a `ViewKey` struct, that can be used to scan the chain. Currently it cannot detect switch commitment outputs because it requires 2 extra functions to be added to libsecp. See [here](https://github.com/mimblewimble/grin/pull/2848/files#diff-a6d7fb0a9c7c4f62cd0ba642f817f037R164) for more information