### PR TITLE
outputs building optimization with multi-threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +774,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2679,6 +2693,7 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "71152d60cec9dfdc5d9d793bccfa9ad95927372b80cd00e983db5eb2ce103e3b"
 "checksum croaring-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ac84a4f975e67fc418be3911b7ca9aa74ee8a9717ca75452da7d6839421e2d67"
+"checksum crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b14492071ca110999a20bf90e3833406d5d66bfd93b4e52ec9539025ff43fe0d"
 "checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,8 @@ siphasher = "0.2"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
+crossbeam = "0.7"
+
 
 grin_keychain = { path = "../keychain", version = "1.1.0-beta.2" }
 grin_util = { path = "../util", version = "1.1.0-beta.2" }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -547,6 +547,19 @@ impl TransactionBody {
 		self
 	}
 
+	/// Builds a new TransactionBody with the provided outputs added. Existing
+	/// outputs, if any, are kept intact.
+	/// Sort order is maintained.
+	pub fn with_outputs(mut self, outputs: Vec<Output>) -> TransactionBody {
+		for output in outputs {
+			self.outputs
+				.binary_search(&output)
+				.err()
+				.map(|e| self.outputs.insert(e, output));
+		}
+		self
+	}
+
 	/// Builds a new TransactionBody with the provided kernel added. Existing
 	/// kernels, if any, are kept intact.
 	/// Sort order is maintained.
@@ -877,6 +890,16 @@ impl Transaction {
 	pub fn with_output(self, output: Output) -> Transaction {
 		Transaction {
 			body: self.body.with_output(output),
+			..self
+		}
+	}
+
+	/// Builds a new transaction with the provided outputs added. Existing
+	/// outputs, if any, are kept intact.
+	/// Sort order is maintained.
+	pub fn with_outputs(self, outputs: Vec<Output>) -> Transaction {
+		Transaction {
+			body: self.body.with_outputs(outputs),
 			..self
 		}
 	}

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -124,18 +124,21 @@ where
 	const MAX_THREADS: usize = 8;
 	Box::new(
 		move |build, (tx, kern, sum)| -> (Transaction, TxKernel, BlindSum) {
-
 			let num_outputs = amounts_and_keys.len();
-			assert!(num_outputs>0);
+			assert!(num_outputs > 0);
 
 			// Sum the blinding
-			let mut blind_sum= sum;
-			for (value,key_id) in &amounts_and_keys {
+			let mut blind_sum = sum;
+			for (value, key_id) in &amounts_and_keys {
 				blind_sum = blind_sum.add_key_id(key_id.to_value_path(*value));
 			}
 
 			// Calculate how many threads needed.
-			let num_threads = if num_outputs < MAX_THREADS { num_outputs } else { MAX_THREADS };
+			let num_threads = if num_outputs < MAX_THREADS {
+				num_outputs
+			} else {
+				MAX_THREADS
+			};
 
 			// Split for threads
 			let chunk_size = std::cmp::max(1, (num_outputs + num_threads - 1) / num_threads);
@@ -155,19 +158,19 @@ where
 							debug!("Building output: {}, {:?}", elem.0, commit);
 
 							let rproof =
-								proof::create(&keychain, elem.0, &elem.1, commit, None)
-									.unwrap();
+								proof::create(&keychain, elem.0, &elem.1, commit, None).unwrap();
 
 							let mut outputs = outputs_arc.lock();
 							outputs.push(Output {
-									features: OutputFeatures::Plain,
-									commit,
-									proof: rproof,
-								});
+								features: OutputFeatures::Plain,
+								commit,
+								proof: rproof,
+							});
 						}
 					});
 				}
-			}).expect("One of output building threads has panicked");
+			})
+			.expect("One of output building threads has panicked");
 
 			(
 				tx.with_outputs(outputs.clone().lock().to_vec()),


### PR DESCRIPTION
The output/s creation procedure is the slowest part when creating a transaction, mainly for the complex calculation of bulletproof creation.

In case of multiple outputs in a transaction for example multiple change outputs, we have a chance to use multi-threads to speed up this creation.

This PR create a new `build::outputs` ability for this case.

With the existing `build::output`,  the creation of `1,000` change outputs spent `85.4` seconds on my laptop.
```
20190427 14:07:15.675 DEBUG grin_core::libtx::build - Building output: 6484940, Commitment(0959cc8602f621321a88bbabd957ddb4006ee21877e3e2ef620b94f6d143b66dfb)
20190427 14:07:15.774 DEBUG grin_core::libtx::build - Building output: 6484940, Commitment(09d3fb99ae7e23beed06c2efed7e285dd7ae93f986dc4e7c4593f185bfd044f21c)
...
20190427 14:08:41.085 DEBUG grin_core::libtx::build - Building output: 6484940, Commitment(082ae47e3bf0483c020acce3f6d6b31745655b4f1a16656f176e4f2a4ab27bd5c4)
```

With this new `build::outputs`, the creation of `1,000` change outputs spent `32.1` seconds on same laptop.

My laptop CPU is: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz which has 2 cores and 4 threads.

```
20190527 11:41:18.814 DEBUG grin_core::libtx::build - Building output: 347135, Commitment(095ac5469ea4c3aa6539eb2977db12f1da3215f2b0b0d93b74deb7a4daa699dcb0)
20190527 11:41:18.814 DEBUG grin_core::libtx::build - Building output: 347135, Commitment(08f00461d05507563053f9939aefce2f1f67616b59be7c1121d82c30ec3dd73cf0)
20190527 11:41:18.818 DEBUG grin_core::libtx::build - Building output: 347135, Commitment(09af8ad538fb6cc88673c3268ca0027c00ceed7a3fb1b3d32f616a9250014def65)
...
20190527 11:41:50.953 DEBUG grin_core::libtx::build - Building output: 347135, Commitment(09c09c63b89ea338c9dee0b7c7e7e19b9fd0230f94bb2a34189ab3dc8603d198aa)
```

A related PR (https://github.com/mimblewimble/grin-wallet/pull/120) has been submitted on grin-wallet repo to use this optimized `build::outputs`.

