### PR TITLE
Fix keychain to work with non-Copy secp::SecretKey

### DIFF
--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -149,7 +149,7 @@ impl BIP32Hasher for BIP32GrinHasher {
 }
 
 /// Extended private key
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ExtendedPrivKey {
 	/// The network this key is to be used on
 	pub network: [u8; 4],
@@ -399,7 +399,7 @@ impl ExtendedPrivKey {
 	where
 		H: BIP32Hasher,
 	{
-		let mut sk: ExtendedPrivKey = *self;
+		let mut sk: ExtendedPrivKey = self.clone();
 		for cnum in cnums {
 			sk = sk.ckd_priv(secp, hasher, *cnum)?;
 		}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -128,9 +128,7 @@ impl Keychain for ExtKeychain {
 			.filter_map(|b| b.secret_key(&self.secp).ok().clone())
 			.collect::<Vec<SecretKey>>();
 
-		pos_keys.extend(
-			keys,
-		);
+		pos_keys.extend(keys);
 
 		let keys = blind_sum
 			.negative_blinding_factors
@@ -138,9 +136,7 @@ impl Keychain for ExtKeychain {
 			.filter_map(|b| b.secret_key(&self.secp).ok().clone())
 			.collect::<Vec<SecretKey>>();
 
-		neg_keys.extend(
-			keys,
-		);
+		neg_keys.extend(keys);
 
 		let sum = self.secp.blind_sum(pos_keys, neg_keys)?;
 		Ok(BlindingFactor::from_secret_key(sum))

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -316,7 +316,7 @@ impl BlindingFactor {
 
 		// use blind_sum to subtract skey_1 from our key (to give k = k1 + k2)
 		let skey = self.secret_key(secp)?;
-		let skey_2 = secp.blind_sum(vec![skey], vec![skey_1])?;
+		let skey_2 = secp.blind_sum(vec![skey], vec![skey_1.clone()])?;
 
 		let blind_1 = BlindingFactor::from_secret_key(skey_1);
 		let blind_2 = BlindingFactor::from_secret_key(skey_2);
@@ -487,7 +487,7 @@ mod test {
 	fn split_blinding_factor() {
 		let secp = Secp256k1::new();
 		let skey_in = SecretKey::new(&secp, &mut thread_rng());
-		let blind = BlindingFactor::from_secret_key(skey_in);
+		let blind = BlindingFactor::from_secret_key(skey_in.clone());
 		let split = blind.split(&secp).unwrap();
 
 		// split a key, sum the split keys and confirm the sum matches the original key


### PR DESCRIPTION
This PR allows keychain to work with `secp::SecretKey` which made non-`Copy`able in https://github.com/mimblewimble/rust-secp256k1-zkp/pull/51

This fix should be merged as soon as https://github.com/mimblewimble/rust-secp256k1-zkp/pull/51 is.

*Update*: https://github.com/mimblewimble/rust-secp256k1-zkp/pull/51 is merged, so this PR can be merged as well.