### PR TITLE
De/Serialize signatures (for slate consumption) to compressed format rather than raw

### DIFF
--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -55,8 +55,7 @@ pub mod pubkey_serde {
 /// Serializes an Option<secp::Signature> to and from hex
 pub mod option_sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::secp;
-	use crate::util::{from_hex, to_hex};
+	use crate::util::{secp, static_secp_instance, to_hex, from_hex};
 	use serde::de::Error;
 
 	///
@@ -64,8 +63,10 @@ pub mod option_sig_serde {
 	where
 		S: Serializer,
 	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
 		match sig {
-			Some(sig) => serializer.serialize_str(&to_hex(sig.to_raw_data().to_vec())),
+			Some(sig) => serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec())),
 			None => serializer.serialize_none(),
 		}
 	}
@@ -75,13 +76,15 @@ pub mod option_sig_serde {
 	where
 		D: Deserializer<'de>,
 	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
 		Option::<String>::deserialize(deserializer).and_then(|res| match res {
 			Some(string) => from_hex(string.to_string())
 				.map_err(|err| Error::custom(err.to_string()))
 				.and_then(|bytes: Vec<u8>| {
 					let mut b = [0u8; 64];
 					b.copy_from_slice(&bytes[0..64]);
-					secp::Signature::from_raw_data(&b)
+					secp::Signature::from_compact(&static_secp, &b)
 						.map(|val| Some(val))
 						.map_err(|err| Error::custom(err.to_string()))
 				}),
@@ -94,8 +97,7 @@ pub mod option_sig_serde {
 /// Serializes a secp::Signature to and from hex
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::secp;
-	use crate::util::{from_hex, to_hex};
+	use crate::util::{secp, static_secp_instance, to_hex, from_hex};
 	use serde::de::Error;
 
 	///
@@ -103,7 +105,9 @@ pub mod sig_serde {
 	where
 		S: Serializer,
 	{
-		serializer.serialize_str(&to_hex(sig.to_raw_data().to_vec()))
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec()))
 	}
 
 	///
@@ -111,12 +115,14 @@ pub mod sig_serde {
 	where
 		D: Deserializer<'de>,
 	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
 		String::deserialize(deserializer)
 			.and_then(|string| from_hex(string).map_err(|err| Error::custom(err.to_string())))
 			.and_then(|bytes: Vec<u8>| {
 				let mut b = [0u8; 64];
 				b.copy_from_slice(&bytes[0..64]);
-				secp::Signature::from_raw_data(&b).map_err(|err| Error::custom(err.to_string()))
+				secp::Signature::from_compact(&static_secp, &b).map_err(|err| Error::custom(err.to_string()))
 			})
 	}
 }

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -55,7 +55,7 @@ pub mod pubkey_serde {
 /// Serializes an Option<secp::Signature> to and from hex
 pub mod option_sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::{secp, static_secp_instance, to_hex, from_hex};
+	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
 	use serde::de::Error;
 
 	///
@@ -66,7 +66,9 @@ pub mod option_sig_serde {
 		let static_secp = static_secp_instance();
 		let static_secp = static_secp.lock();
 		match sig {
-			Some(sig) => serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec())),
+			Some(sig) => {
+				serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec()))
+			}
 			None => serializer.serialize_none(),
 		}
 	}
@@ -97,7 +99,7 @@ pub mod option_sig_serde {
 /// Serializes a secp::Signature to and from hex
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::{secp, static_secp_instance, to_hex, from_hex};
+	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
 	use serde::de::Error;
 
 	///
@@ -122,7 +124,8 @@ pub mod sig_serde {
 			.and_then(|bytes: Vec<u8>| {
 				let mut b = [0u8; 64];
 				b.copy_from_slice(&bytes[0..64]);
-				secp::Signature::from_compact(&static_secp, &b).map_err(|err| Error::custom(err.to_string()))
+				secp::Signature::from_compact(&static_secp, &b)
+					.map_err(|err| Error::custom(err.to_string()))
 			})
 	}
 }


### PR DESCRIPTION
This appears to have been an oversight during development of the custom serialization code for secp primitives to change JSON output from arrays to bytes to hex strings. The original byte array format was being output in compressed format, while the custom serializers were using raw data. This wasn't an intentional change, so it would make sense to ensure the data being output as hex strings is in the same format.

This is only being used by grin_wallet to create slates, and no versions have actually been released with the hex/raw data signature format, so it should be safe to include this in 1.1.0. It will mean inconsistencies between beta versions and the 1.1.0 release, but given 1.1.0 should be released any day, this change shouldn't have too much of a negative impact. 