### PR TITLE
Remove TODO about transaction eviction

### DIFF
--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -273,7 +273,6 @@ impl TransactionPool {
 	/// full the pool is and the transaction weight.
 	fn is_acceptable(&self, tx: &Transaction, stem: bool) -> Result<(), PoolError> {
 		if self.total_size() > self.config.max_pool_size {
-			// TODO evict old/large transactions instead
 			return Err(PoolError::OverCapacity);
 		}
 


### PR DESCRIPTION
Just removes `TODO` that is misleading since TX eviction is actually already happening at the [top level](https://github.com/mimblewimble/grin/blob/4b88a9b5bd951f1a755c7d4281f0785e985d13c1/pool/src/transaction_pool.rs#L181).