### PR TITLE
Fix unused doc warning in Rust 1.35

### DIFF
--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -74,9 +74,9 @@ impl<H: Hashed> ShortIdentifiable for H {
 pub struct ShortId([u8; 6]);
 
 impl DefaultHashable for ShortId {}
-/// We want to sort short_ids in a canonical and consistent manner so we can
-/// verify sort order in the same way we do for full inputs|outputs|kernels
-/// themselves.
+// We want to sort short_ids in a canonical and consistent manner so we can
+// verify sort order in the same way we do for full inputs|outputs|kernels
+// themselves.
 hashable_ord!(ShortId);
 
 impl ::std::fmt::Debug for ShortId {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -35,7 +35,7 @@ use std::cmp::{max, min};
 use std::sync::Arc;
 use std::{error, fmt};
 
-/// Enum of various supported kernel "features".
+// Enum of various supported kernel "features".
 enum_from_primitive! {
 	/// Various flavors of tx kernel.
 	#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -1214,7 +1214,7 @@ impl Input {
 	}
 }
 
-/// Enum of various supported kernel "features".
+// Enum of various supported kernel "features".
 enum_from_primitive! {
 	/// Various flavors of tx kernel.
 	#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -47,9 +47,9 @@ const OTHER_MAGIC: [u8; 2] = [73, 43];
 const FLOONET_MAGIC: [u8; 2] = [83, 59];
 const MAINNET_MAGIC: [u8; 2] = [97, 61];
 
-/// Types of messages.
-/// Note: Values here are *important* so we should only add new values at the
-/// end.
+// Types of messages.
+// Note: Values here are *important* so we should only add new values at the
+// end.
 enum_from_primitive! {
 	#[derive(Debug, Clone, Copy, PartialEq)]
 	pub enum Type {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -28,7 +28,7 @@ const STORE_SUBPATH: &'static str = "peers";
 
 const PEER_PREFIX: u8 = 'P' as u8;
 
-/// Types of messages
+// Types of messages
 enum_from_primitive! {
 	#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 	pub enum State {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -333,7 +333,7 @@ bitflags! {
 	}
 }
 
-/// Types of connection
+// Types of connection
 enum_from_primitive! {
 	#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 	pub enum Direction {
@@ -342,7 +342,7 @@ enum_from_primitive! {
 	}
 }
 
-/// Ban reason
+// Ban reason
 enum_from_primitive! {
 	#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 	pub enum ReasonForBan {


### PR DESCRIPTION
This version brings a new warning to inform that rustdoc doesn't add docs for macro
expansions