### PR TITLE
Add version endpoint to node API, rename pool/push

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -18,6 +18,7 @@ mod peers_api;
 mod pool_api;
 mod server_api;
 mod transactions_api;
+mod version_api;
 mod utils;
 
 use self::blocks_api::BlockHandler;
@@ -34,6 +35,7 @@ use self::pool_api::PoolPushHandler;
 use self::server_api::IndexHandler;
 use self::server_api::StatusHandler;
 use self::server_api::KernelDownloadHandler;
+use self::version_api::VersionHandler;
 use self::transactions_api::TxHashSetHandler;
 use crate::auth::{BasicAuthMiddleware, GRIN_BASIC_REALM};
 use crate::chain;
@@ -104,12 +106,13 @@ pub fn build_router(
 		"get txhashset/outputs?start_index=1&max=100".to_string(),
 		"get txhashset/merkleproof?n=1".to_string(),
 		"get pool".to_string(),
-		"post pool/push".to_string(),
+		"post pool/push_tx".to_string(),
 		"post peers/a.b.c.d:p/ban".to_string(),
 		"post peers/a.b.c.d:p/unban".to_string(),
 		"get peers/all".to_string(),
 		"get peers/connected".to_string(),
 		"get peers/a.b.c.d".to_string(),
+		"get version".to_string(),
 	];
 	let index_handler = IndexHandler { list: route_list };
 
@@ -157,6 +160,7 @@ pub fn build_router(
 	let peer_handler = PeerHandler {
 		peers: Arc::downgrade(&peers),
 	};
+	let version_handler = VersionHandler;
 
 	let mut router = Router::new();
 
@@ -171,9 +175,10 @@ pub fn build_router(
 	router.add_route("/v1/status", Arc::new(status_handler))?;
 	router.add_route("/v1/kerneldownload", Arc::new(kernel_download_handler))?;
 	router.add_route("/v1/pool", Arc::new(pool_info_handler))?;
-	router.add_route("/v1/pool/push", Arc::new(pool_push_handler))?;
+	router.add_route("/v1/pool/push_tx", Arc::new(pool_push_handler))?;
 	router.add_route("/v1/peers/all", Arc::new(peers_all_handler))?;
 	router.add_route("/v1/peers/connected", Arc::new(peers_connected_handler))?;
 	router.add_route("/v1/peers/**", Arc::new(peer_handler))?;
+	router.add_route("/v1/version", Arc::new(version_handler))?;
 	Ok(router)
 }

--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -53,7 +53,7 @@ struct TxWrapper {
 }
 
 /// Push new transaction to our local transaction pool.
-/// POST /v1/pool/push
+/// POST /v1/pool/push_tx
 pub struct PoolPushHandler {
 	pub tx_pool: Weak<RwLock<pool::TransactionPool>>,
 }

--- a/api/src/handlers/version_api.rs
+++ b/api/src/handlers/version_api.rs
@@ -16,8 +16,8 @@ use crate::core::core::block::HeaderVersion;
 
 use crate::rest::*;
 use crate::router::{Handler, ResponseFuture};
-use crate::web::*;
 use crate::types::Version;
+use crate::web::*;
 use hyper::{Body, Request};
 
 const CRATE_VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/api/src/handlers/version_api.rs
+++ b/api/src/handlers/version_api.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::core::core::block::HeaderVersion;
+
+use crate::rest::*;
+use crate::router::{Handler, ResponseFuture};
+use crate::web::*;
+use crate::types::Version;
+use hyper::{Body, Request};
+
+const CRATE_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+/// Version handler. Get running node API version
+/// GET /v1/version
+pub struct VersionHandler;
+
+impl VersionHandler {
+	fn get_version(&self) -> Result<Version, Error> {
+		Ok(Version {
+			node_version: CRATE_VERSION.to_owned(),
+			block_header_version: HeaderVersion::default().into(),
+		})
+	}
+}
+
+impl Handler for VersionHandler {
+	fn get(&self, _req: Request<Body>) -> ResponseFuture {
+		result_to_response(self.get_version())
+	}
+}

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -34,6 +34,15 @@ macro_rules! no_dup {
 	};
 }
 
+/// API Version Information
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Version {
+	/// Current node API Version (api crate version)
+	pub node_version: String,
+	/// Block header version
+	pub block_header_version: u16,
+}
+
 /// The state of the current fork tip
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tip {


### PR DESCRIPTION
2 points:

* Adds a `v1/version` endpoint to allow the wallet (or other clients) to easily decide whether it wants to continue doing business with a particular node (facilitates https://github.com/mimblewimble/grin-wallet/issues/149). The 2.0.0 wallet will be checking this version and refusing to post if it's pre-2.0.0 or the block header version is 1.
* change the `v1/pool/push` endpoint to `v1/pool/push_tx` endpoint, to create a minor incompatibility (that should only really affect wallets,) which will prevent pre-2.0.0 wallets from posting to a pre 2.0.0 node.

I think this is a fairly clean way to do it, happy to hear if anyone else has other ideas, particularly on the second point.
