### PR TITLE
add fixed_difficulty parameter for UserTesting chain

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -96,6 +96,17 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"fixed_difficulty".to_string(),
+		"
+#Fixed difficulty can be set when chain type is set to UserTesting to prevent
+#the mining difficulty to rise. Setting it to 0 turns the feature off.
+#Values below 3, the minimum difficulty will have no effect and will behave as if
+#it was set to 0.
+"
+			.to_string(),
+	);
+
+	retval.insert(
 		"archive_mode".to_string(),
 		"
 #run the node in \"full archive\" mode (default is fast-sync, pruned node)

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -303,7 +303,10 @@ where
 		CLAMP_FACTOR,
 	);
 	// minimum difficulty avoids getting stuck due to dampening
-	let difficulty = max(MIN_DIFFICULTY, diff_sum * BLOCK_TIME_SEC / adj_ts);
+	let difficulty = match global::is_fixed_difficulty() {
+		true => global::get_fixed_difficulty(),
+		false => max(MIN_DIFFICULTY, diff_sum * BLOCK_TIME_SEC / adj_ts),
+	};
 
 	HeaderInfo::from_diff_scaling(Difficulty::from_num(difficulty), sec_pow_scaling)
 }

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -578,7 +578,10 @@ impl Block {
 				prev_hash: prev.hash(),
 				total_kernel_offset,
 				pow: ProofOfWork {
-					total_difficulty: difficulty + prev.pow.total_difficulty,
+					total_difficulty: match global::is_fixed_difficulty() {
+						true => Difficulty::from_num(global::get_fixed_difficulty()),
+						false => difficulty + prev.pow.total_difficulty,
+					},
 					..Default::default()
 				},
 				..Default::default()

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -142,12 +142,22 @@ lazy_static! {
 	/// PoW context type to instantiate
 	pub static ref POW_CONTEXT_TYPE: RwLock<PoWContextTypes> =
 			RwLock::new(PoWContextTypes::Cuckoo);
+
+	/// The fixed difficulty parameter
+	pub static ref FIXED_DIFFICULTY: RwLock<u64> =
+			RwLock::new(0);
 }
 
 /// Set the mining mode
 pub fn set_mining_mode(mode: ChainTypes) {
 	let mut param_ref = CHAIN_TYPE.write();
 	*param_ref = mode;
+}
+
+/// Set fixed difficulty
+pub fn set_fixed_difficulty(difficulty: u64) {
+	let mut param_ref= FIXED_DIFFICULTY.write();
+	*param_ref = difficulty;
 }
 
 /// Return either a cuckoo context or a cuckatoo context
@@ -311,6 +321,21 @@ pub fn is_floonet() -> bool {
 pub fn is_mainnet() -> bool {
 	let param_ref = CHAIN_TYPE.read();
 	ChainTypes::Mainnet == *param_ref
+}
+
+/// Are we using fixed difficulty?
+pub fn is_fixed_difficulty() -> bool {
+	let difficulty_ref = FIXED_DIFFICULTY.read();
+	return (*difficulty_ref >= 3) && is_user_testing_mode()
+}
+
+/// Get fixed difficulty value.
+pub fn get_fixed_difficulty() -> u64 {
+	let difficulty = FIXED_DIFFICULTY.read();
+	if *difficulty < 3 {
+		return 0;
+	}
+	return *difficulty
 }
 
 /// Helper function to get a nonce known to create a valid POW on

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -162,6 +162,9 @@ pub struct ServerConfig {
 	#[serde(default)]
 	pub chain_validation_mode: ChainValidationMode,
 
+	/// Set difficulty to a fixed value, must be 3 or bigger and works only with ChainType UserTesting.
+	pub fixed_difficulty: Option<u64>,
+
 	/// Whether this node is a full archival node or a fast-sync, pruned node
 	pub archive_mode: Option<bool>,
 
@@ -213,6 +216,7 @@ impl Default for ServerConfig {
 			chain_type: ChainTypes::default(),
 			archive_mode: Some(false),
 			chain_validation_mode: ChainValidationMode::default(),
+			fixed_difficulty: Some(0),
 			pool_config: pool::PoolConfig::default(),
 			skip_sync_wait: Some(false),
 			run_tui: Some(true),

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -142,7 +142,13 @@ fn real_main() -> i32 {
 		}
 		init_logger(Some(l));
 
-		global::set_mining_mode(config.members.unwrap().server.clone().chain_type);
+		let server_config = config.members.unwrap().server.clone();
+		global::set_mining_mode(server_config.chain_type.clone());
+
+		match server_config.fixed_difficulty {
+			Some(fixed_difficulty) => global::set_fixed_difficulty(fixed_difficulty),
+			None =>   global::set_fixed_difficulty(0),
+		};
 
 		if let Some(file_path) = &config.config_file_path {
 			info!(


### PR DESCRIPTION
This is enhancement for feature request in #2571

#### Fixed Difficulty
##### Add a way to have fixed difficulty while using UserTesting chain

Change set will add fixed_difficulty parameter which can be set in server-config.toml. 
If chain is UserTesting and parameter is bigger then 2 difficulty will be fixed to that 
value.