### PR TITLE
[DNM] handle the HF invalid header scenario safely during chain init

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1318,6 +1318,7 @@ fn setup_head(
 		if height > 0 {
 			let header = txhashset.get_header_by_height(height)?;
 			let head = Tip::from_header(&header);
+			batch.save_head(&head)?;
 			debug!(
 				"setup_head: proceeding with head (and corresponding header): {} at {}",
 				head.last_block_h, head.height

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -237,21 +237,6 @@ pub fn sync_block_headers(
 		// Update sync_head regardless of total work.
 		update_sync_head(&Tip::from_header(header), &mut ctx.batch)?;
 
-		{
-			error!(
-				"****** after updating sync head: sync_head: {:?}",
-				ctx.batch.get_sync_head()
-			);
-			error!(
-				"****** after updating sync head: header_head: {:?}",
-				ctx.batch.header_head()
-			);
-			error!(
-				"****** after updating sync head: head: {:?}",
-				ctx.batch.head()
-			);
-		}
-
 		let header_head = ctx.batch.header_head()?;
 		if has_more_work(&header, &header_head) {
 			txhashset::header_extending(
@@ -287,14 +272,6 @@ pub fn sync_block_headers(
 	} else {
 		Ok(None)
 	}
-
-	// 	// Update header_head (but only if this header increases our total known work).
-	// 	// i.e. Only if this header is now the head of the current "most work" chain.
-	// 	let res = update_header_head(header, ctx)?;
-	// 	Ok(res)
-	// } else {
-	// 	Ok(None)
-	// }
 }
 
 /// Process block header as part of "header first" block propagation.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -192,12 +192,6 @@ impl<'a> Batch<'a> {
 		self.save_sync_head(&head)
 	}
 
-	/// Reset header_head to the current head of the body chain.
-	pub fn reset_header_head(&self) -> Result<(), Error> {
-		let tip = self.head()?;
-		self.save_header_head(&tip)
-	}
-
 	/// get block
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -564,10 +564,6 @@ where
 	let child_batch = batch.child()?;
 	{
 		trace!("Starting new txhashset header extension.");
-		error!(
-			"***** starting header extension: last_pos: {}",
-			trees.header_pmmr_h.last_pos
-		);
 		let pmmr = PMMR::at(
 			&mut trees.header_pmmr_h.backend,
 			trees.header_pmmr_h.last_pos,
@@ -680,20 +676,12 @@ impl<'a> HeaderExtension<'a> {
 	/// Rewind the header extension to the specified header.
 	/// Note the close relationship between header height and insertion index.
 	pub fn rewind(&mut self, header: &BlockHeader) -> Result<(), Error> {
-		debug!(
-			"Rewind header extension to {} at {}",
-			header.hash(),
-			header.height
-		);
-
 		let header_pos = pmmr::insertion_to_pmmr_index(header.height + 1);
 		self.pmmr
 			.rewind(header_pos, &Bitmap::create())
 			.map_err(&ErrorKind::TxHashSetErr)?;
-
 		// Update our head to reflect the one we rewound to.
 		self.head = Tip::from_header(header);
-
 		Ok(())
 	}
 


### PR DESCRIPTION
<b>Edit: As @DavidBurkett mentions we are not necessarily rewinding the MMR safely here. We need to rewind all the spent output pos and we do not know these if we cannot read the (now invalid) headers and corresponding hashes. This is going to take some more thinking through...</b>

----

We observed the following when upgrading a node in place _after_ the HF block height had passed.
This node had a header at height 185040 with `version=1` (mined by a miner on pre-HF code).
This header was in the local db and became invalid (was originally valid) once the node had been upgraded.
Reading this header from the db at startup caused the node to fail to startup.

```
stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new::h51d5229f6fcf6886 (0x560bf29d4962)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/internal.rs:44
   1: failure::backtrace::Backtrace::new::h8ccade931a77636b (0x560bf29d377d)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/backtrace/mod.rs:111
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from::hbbda90237adbe1e8 (0x560bf23e9719)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from::hd89c1f37810a28b6 (0x560bf23d1b92)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/error/mod.rs:36
   4: <T as core::convert::Into<U>>::into::h5744f998b1cc987b (0x560bf22f0df2)
             at /rustc/3c235d5600393dfe6c36eeed34042efad8d4f26e/src/libcore/convert.rs:540
   5: failure::context::Context<D>::with_err::h43fc73673ba83dbd (0x560bf23baf1f)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/context.rs:105
   6: failure::Fail::context::h1c4ac468da15b50d (0x560bf22f0edf)
             at /home/mcordner/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.5/src/lib.rs:160
   7: <grin_chain::error::Error as core::convert::From<grin_store::lmdb::Error>>::from::hef23af482336dee5 (0x560bf234469e)
             at chain/src/error.rs:222
   8: grin_chain::chain::setup_head::h6beb6f0b0ff11506 (0x560bf23a097c)
             at chain/src/chain.rs:1314
   9: grin_chain::chain::Chain::init::hbcb8d9493999044f (0x560bf238c273)
             at chain/src/chain.rs:175
  10: grin_servers::grin::server::Server::new::hec21b324331438c3 (0x560bf1910c1b)
             at servers/src/grin/server.rs:183
  11: grin_servers::grin::server::Server::start::h2e0bd121362e5fc7 (0x560bf15c8284)
             at /home/mcordner/projects/rust/grin/servers/src/grin/server.rs:90
```

This PR ensures we handle this scenario robustly by - 
* reading the current `head` from the db
* attempting to read the corresponding `header` from the db based on the height
* "rewinding" back through previous heights until we find a header that can be read successfully

We then save this `head` and continue with the existing `setup_head` processing.

