### PR TITLE
zeroize: Upgrade to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,15 +665,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.0-beta.1",
- "grin_chain 2.0.0-beta.1",
- "grin_config 2.0.0-beta.1",
- "grin_core 2.0.0-beta.1",
- "grin_keychain 2.0.0-beta.1",
- "grin_p2p 2.0.0-beta.1",
- "grin_servers 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_api 2.0.0-beta.2",
+ "grin_chain 2.0.0-beta.2",
+ "grin_config 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_servers 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,17 +684,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0-beta.1",
- "grin_core 2.0.0-beta.1",
- "grin_p2p 2.0.0-beta.1",
- "grin_pool 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,10 +724,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0-beta.1",
- "grin_keychain 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,13 +739,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0-beta.1",
- "grin_p2p 2.0.0-beta.1",
- "grin_servers 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_servers 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,8 +764,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -777,17 +777,17 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_keychain"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0-beta.1",
+ "grin_util 2.0.0-beta.2",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,22 +799,22 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_p2p"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0-beta.1",
- "grin_core 2.0.0-beta.1",
- "grin_pool 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,17 +826,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0-beta.1",
- "grin_core 2.0.0-beta.1",
- "grin_keychain 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,24 +855,24 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_servers"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.0-beta.1",
- "grin_chain 2.0.0-beta.1",
- "grin_core 2.0.0-beta.1",
- "grin_keychain 2.0.0-beta.1",
- "grin_p2p 2.0.0-beta.1",
- "grin_pool 2.0.0-beta.1",
- "grin_store 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_api 2.0.0-beta.2",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -897,8 +897,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0-beta.1",
- "grin_util 2.0.0-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -911,12 +911,12 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_secp256k1zkp 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,7 +925,7 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2631,20 +2631,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "zeroize"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "zeroize_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2741,7 +2736,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_secp256k1zkp 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e96161c7d923bf094e7f4f583e680a03746b692523f2211bff59f642e05aa85"
+"checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "570178d5e4952010d138b0f1d581271ff3a02406d990f887d1e87e3d6e43b0ac"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
@@ -2937,7 +2932,6 @@ dependencies = [
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
-"checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
-"checksum zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b60a6c572b91d8ecb0a460950d84fe5b40699edd07d65f73789b31237afc8f66"
-"checksum zeroize_derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9dac4b660d969bff9c3fe1847a891cacaa8b21dd5f2aae6e0a3e0975aea96431"
+"checksum zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2ea4afc22e9497e26b42bf047083c30f7e3ca566f3bcd7187f83d18b327043"
+"checksum zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afd1469e4bbca3b96606d26ba6e9bd6d3aed3b1299c82b92ec94377d22d78dbc"
 "checksum zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ siphasher = "0.2"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
-zeroize = "0.8"
+zeroize = "0.9"
 
 grin_keychain = { path = "../keychain", version = "2.0.0-beta.2" }
 grin_util = { path = "../util", version = "2.0.0-beta.2" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1"
 serde_json = "1"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 lazy_static = "1"
-zeroize = "0.8.0"
+zeroize = "0.9"
 
 digest = "0.7"
 hmac = "0.6"

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -233,6 +233,7 @@ impl fmt::Display for Identifier {
 }
 
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct BlindingFactor([u8; SECRET_KEY_SIZE]);
 
 // Dummy `Debug` implementation that prevents secret leakage.

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -22,11 +22,11 @@ log = "0.4"
 walkdir = "2"
 zip = { version = "0.4", default-features = false }
 parking_lot = {version = "0.6"}
-zeroize = "0.5.2"
+zeroize = "0.9"
 
 [dependencies.grin_secp256k1zkp]
 #git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
 #tag = "grin_integration_29"
 #path = "../../rust-secp256k1-zkp"
-version = "0.7.6"
+version = "0.7.7"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
can't build because of this error:
```
error: failed to select a version for the requirement `zeroize = "^0.8"`
  candidate versions found which didn't match: 0.9.1, 0.9.0, 0.7.0, ...
```
`zeroize` 0.8 is now marked as "yanked" so we have to upgrade to 0.9.

---

(Note: this PR need wait the `grin_secp256k1zkp` version updated as `0.7.7` into crates.io:  https://crates.io/crates/grin_secp256k1zkp )



