### PR TITLE
Fix unused import in p2p::protocol

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::conn::{Message, MessageHandler, Response, Tracker};
-use crate::core::core::{self, hash::Hash, hash::Hashed, CompactBlock};
+use crate::core::core::{self, hash::Hash, CompactBlock};
 
 use crate::msg::{
 	BanReason, GetPeerAddrs, Headers, KernelDataResponse, Locator, PeerAddrs, Ping, Pong,


### PR DESCRIPTION
Fixes an unused import warning during compilation.