### PR TITLE
Replace SyncChannel with Channel in peer

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -201,7 +201,7 @@ impl StopHandle {
 
 pub struct ConnHandle {
 	/// Channel to allow sending data through the connection
-	pub send_channel: mpsc::SyncSender<Vec<u8>>,
+	pub send_channel: mpsc::Sender<Vec<u8>>,
 }
 
 impl ConnHandle {
@@ -211,7 +211,7 @@ impl ConnHandle {
 	{
 		let buf = write_to_buf(body, msg_type)?;
 		let buf_len = buf.len();
-		self.send_channel.try_send(buf)?;
+		self.send_channel.send(buf)?;
 		Ok(buf_len as u64)
 	}
 }
@@ -261,7 +261,7 @@ pub fn listen<H>(
 where
 	H: MessageHandler,
 {
-	let (send_tx, send_rx) = mpsc::sync_channel(SEND_CHANNEL_CAP);
+	let (send_tx, send_rx) = mpsc::channel();
 	let (close_tx, close_rx) = mpsc::channel();
 
 	stream

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -98,8 +98,8 @@ impl From<io::Error> for Error {
 		Error::Connection(e)
 	}
 }
-impl<T> From<mpsc::TrySendError<T>> for Error {
-	fn from(e: mpsc::TrySendError<T>) -> Error {
+impl<T> From<mpsc::SendError<T>> for Error {
+	fn from(e: mpsc::SendError<T>) -> Error {
 		Error::Send(e.to_string())
 	}
 }


### PR DESCRIPTION
We use a buffered SyncChannel (buffer size is 10) to store messages to
be sent to a remote peer. In send impl we use try_send which return
error if channel is closed (peer is disconnected) or the buffer is full.
Such error leads to dropping the peer.

When we send a txhashet archive a peer's thread is busy with sending it
and can't send other messages, eg pings. If the network connection is
slow it may lead to channel sending error hence the peer's drop.

We could increase buffer, but at the same time we use SyncChannel as
regular channel (with unlimited buffer), so it may make more sense to switch to it. It's unlikely that a peer can buffer too many messages, so wasting memory on preallocating a big buffer is not justified.

Addresses #2929