### PR TITLE
Increase peer's send buffer

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -163,7 +163,7 @@ impl<'a> Response<'a> {
 	}
 }
 
-pub const SEND_CHANNEL_CAP: usize = 10;
+pub const SEND_CHANNEL_CAP: usize = 100;
 
 pub struct StopHandle {
 	/// Channel to close the connection

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -106,7 +106,7 @@ impl BodySync {
 		// 10) max will be 80 if all 8 peers are advertising more work
 		// also if the chain is already saturated with orphans, throttle
 		let block_count = cmp::min(
-			cmp::min(100, peers.len() * p2p::SEND_CHANNEL_CAP),
+			cmp::min(100, peers.len() * 10),
 			chain::MAX_ORPHAN_SIZE.saturating_sub(self.chain.orphans_len()) + 1,
 		);
 


### PR DESCRIPTION
When we send a txhashet archive a peer's thread is busy with sending it
and can't send other messages, eg pings. If the network connection is
slow buffer capacity 10 may be not enough,  hence the peer's drop.

Safer attempt to address #2929 in 2.0.0, more info https://github.com/mimblewimble/grin/pull/2930