### PR TITLE
Derive --version output dynamically from cargo package version

### DIFF
--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -70,7 +70,9 @@ fn main() {
 
 fn real_main() -> i32 {
 	let yml = load_yaml!("grin.yml");
-	let args = App::from_yaml(yml).get_matches();
+	let args = App::from_yaml(yml)
+		.version(built_info::PKG_VERSION)
+		.get_matches();
 	let node_config;
 
 	// Temporary wallet warning message

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -1,5 +1,4 @@
 name: grin
-version: "2.0.1-beta.1"
 about: Lightweight implementation of the MimbleWimble protocol.
 author: The Grin Team
 


### PR DESCRIPTION
The version reported by grin --version is currently set manually in grin.yml, which means it can easily be missed on release. Small fix to ensure this output comes from the cargo package version instead.