### PR TITLE
[2.x.x] Fix check_known logic for blocks/headers

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -386,7 +386,6 @@ impl Chain {
 			verifier_cache: self.verifier_cache.clone(),
 			txhashset,
 			batch,
-			orphans: self.orphans.clone(),
 		})
 	}
 


### PR DESCRIPTION
We made some recent changes (on the 2.x.x branch) to how we check for "known" blocks when processing headers in the block processing pipeline - https://github.com/mimblewimble/grin/pull/2834

This introduced a subtle bug in how we process full blocks.

Processing a full block that is an orphan (processed out of order, not yet processed the previous block) will add the block the the "orphan block pool".
When checking for "known" blocks we would look in the orphan block pool in addition to the db.

#2834 changed how we process block _headers_ to use the same "known" rules as full blocks - the rationale being we processed headers as part of processing full blocks and we cared about full blocks themselves. Processing a header could stop early if we know we already processed the full block.

But - we do _not_ want to halt processing a header if the block is known via the orphan pool. It has not _yet_ been processed successfully.

This PR changes the `check_known` rules to only look in the db (and the current head, itself in the db). We already handle "orphan" blocks in a performant way by looking for the previous block (in the db). We don not need to inspect the "block orphan pool" when checking if we have seen a block before. We only want to use the orphan pool when seeing if we can now process ex-orphans (which we are already doing).
