### PR TITLE
perf: One less DB call when verifying block sums

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -450,10 +450,8 @@ fn verify_coinbase_maturity(block: &Block, ext: &txhashset::Extension<'_>) -> Re
 /// based on block_sums of previous block, accounting for the inputs|outputs|kernels
 /// of the new block.
 fn verify_block_sums(b: &Block, ext: &mut txhashset::Extension<'_>) -> Result<(), Error> {
-	// TODO - this is 2 db calls, can we optimize this?
 	// Retrieve the block_sums for the previous block.
-	let prev = ext.batch.get_previous_header(&b.header)?;
-	let block_sums = ext.batch.get_block_sums(&prev.hash())?;
+	let block_sums = ext.batch.get_block_sums(&b.header.prev_hash)?;
 
 	// Overage is based purely on the new block.
 	// Previous block_sums have taken all previous overage into account.


### PR DESCRIPTION
Very minor performance enhancement and removal of a TODO in the verification of block sums. Relying on existing test coverage and have fully synced the main chain to test.