### PR TITLE
fix: move sync state check from server into test_miner

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -390,19 +390,12 @@ impl Server {
 			self.tx_pool.clone(),
 			self.verifier_cache.clone(),
 			stop_state,
+			sync_state,
 		);
 		miner.set_debug_output_id(format!("Port {}", self.config.p2p_config.port));
 		let _ = thread::Builder::new()
 			.name("test_miner".to_string())
-			.spawn(move || {
-				// TODO push this down in the run loop so miner gets paused anytime we
-				// decide to sync again
-				let secs_5 = time::Duration::from_secs(5);
-				while sync_state.is_syncing() {
-					thread::sleep(secs_5);
-				}
-				miner.run_loop(wallet_listener_url);
-			});
+			.spawn(move || miner.run_loop(wallet_listener_url));
 	}
 
 	/// The chain head
@@ -423,8 +416,7 @@ impl Server {
 	/// Returns a set of stats about this server. This and the ServerStats
 	/// structure
 	/// can be updated over time to include any information needed by tests or
-	/// other
-	/// consumers
+	/// other consumers
 	pub fn get_server_stats(&self) -> Result<ServerStats, Error> {
 		let stratum_stats = self.state_info.stratum_stats.read().clone();
 

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -22,7 +22,7 @@ use chrono::prelude::Utc;
 use std::sync::Arc;
 
 use crate::chain;
-use crate::common::types::{StratumServerConfig, SyncState};
+use crate::common::types::StratumServerConfig;
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{Block, BlockHeader};
@@ -30,6 +30,7 @@ use crate::core::global;
 use crate::mining::mine_block;
 use crate::pool;
 use crate::util::StopState;
+use grin_chain::SyncState;
 use std::thread;
 use std::time::Duration;
 

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -77,7 +77,7 @@ fn real_main() -> i32 {
 	match args.subcommand() {
 		("wallet", _) => {
 			println!();
-			println!("As of v1.1.0, the wallet has been split into a seperate executable.");
+			println!("As of v1.1.0, the wallet has been split into a separate executable.");
 			println!(
 				"Please visit https://github.com/mimblewimble/grin-wallet/releases to download"
 			);


### PR DESCRIPTION
Small change to remove a TODO by pushing sync state into test miner.