### PR TITLE
[2.x.x] #2927 Equivalent - Update version number for next (potential)…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,15 +665,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.1-beta.1",
- "grin_chain 2.0.1-beta.1",
- "grin_config 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_servers 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_api 2.0.0-beta.2",
+ "grin_chain 2.0.0-beta.2",
+ "grin_config 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_servers 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,17 +684,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,10 +724,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,13 +739,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_servers 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_servers 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,8 +764,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -782,12 +782,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.1-beta.1",
+ "grin_util 2.0.0-beta.2",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,17 +804,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,17 +826,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,19 +860,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.1-beta.1",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_api 2.0.0-beta.2",
+ "grin_chain 2.0.0-beta.2",
+ "grin_core 2.0.0-beta.2",
+ "grin_keychain 2.0.0-beta.2",
+ "grin_p2p 2.0.0-beta.2",
+ "grin_pool 2.0.0-beta.2",
+ "grin_store 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -897,8 +897,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.0-beta.2",
+ "grin_util 2.0.0-beta.2",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,13 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.0.1-beta.1" }
-grin_config = { path = "./config", version = "2.0.1-beta.1" }
-grin_chain = { path = "./chain", version = "2.0.1-beta.1" }
-grin_core = { path = "./core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "./keychain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "./p2p", version = "2.0.1-beta.1" }
-grin_servers = { path = "./servers", version = "2.0.1-beta.1" }
-grin_util = { path = "./util", version = "2.0.1-beta.1" }
+grin_api = { path = "./api", version = "2.0.0-beta.2" }
+grin_config = { path = "./config", version = "2.0.0-beta.2" }
+grin_core = { path = "./core", version = "2.0.0-beta.2" }
+grin_keychain = { path = "./keychain", version = "2.0.0-beta.2" }
+grin_p2p = { path = "./p2p", version = "2.0.0-beta.2" }
+grin_servers = { path = "./servers", version = "2.0.0-beta.2" }
+grin_util = { path = "./util", version = "2.0.0-beta.2" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +52,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.0.1-beta.1" }
-grin_store = { path = "./store", version = "2.0.1-beta.1" }
+grin_chain = { path = "./chain", version = "2.0.0-beta.2" }
+grin_store = { path = "./store", version = "2.0.0-beta.2" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_chain = { path = "../chain", version = "2.0.0-beta.2" }
+grin_p2p = { path = "../p2p", version = "2.0.0-beta.2" }
+grin_pool = { path = "../pool", version = "2.0.0-beta.2" }
+grin_store = { path = "../store", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_keychain = { path = "../keychain", version = "2.0.0-beta.2" }
+grin_store = { path = "../store", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_servers = { path = "../servers", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_servers = { path = "../servers", version = "2.0.0-beta.2" }
+grin_p2p = { path = "../p2p", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_store = { path = "../store", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
+grin_chain = { path = "../chain", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
+grin_pool = { path = "../pool", version = "2.0.0-beta.2" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_keychain = { path = "../keychain", version = "2.0.0-beta.2" }
+grin_store = { path = "../store", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.0.0-beta.2" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,11 +25,11 @@ serde_json = "1"
 chrono = "0.4.4"
 tokio =  "0.1.11"
 
-grin_api = { path = "../api", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_api = { path = "../api", version = "2.0.0-beta.2" }
+grin_chain = { path = "../chain", version = "2.0.0-beta.2" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_keychain = { path = "../keychain", version = "2.0.0-beta.2" }
+grin_p2p = { path = "../p2p", version = "2.0.0-beta.2" }
+grin_pool = { path = "../pool", version = "2.0.0-beta.2" }
+grin_store = { path = "../store", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.0.0-beta.2" }
+grin_util = { path = "../util", version = "2.0.0-beta.2" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.0.1-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
Equivalent of https://github.com/mimblewimble/grin/pull/2927/commits/71d16d1b4df4b32f2b69044eacdced8ed5dcf850 for `milestone/2.x.x`.