### PR TITLE
Updates to support XORed wallet keys/Tokens

### DIFF
--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -103,14 +103,15 @@ pub mod option_seckey_serde {
 	use serde::de::Error;
 
 	///
-	pub fn serialize<S>(key: &Option<secp::key::SecretKey>, serializer: S) -> Result<S::Ok, S::Error>
+	pub fn serialize<S>(
+		key: &Option<secp::key::SecretKey>,
+		serializer: S,
+	) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
 	{
 		match key {
-			Some(key) => {
-				serializer.serialize_str(&to_hex(key.0.to_vec()))
-			}
+			Some(key) => serializer.serialize_str(&to_hex(key.0.to_vec())),
 			None => serializer.serialize_none(),
 		}
 	}

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -96,6 +96,47 @@ pub mod option_sig_serde {
 
 }
 
+/// Serializes an Option<secp::SecretKey> to and from hex
+pub mod option_seckey_serde {
+	use crate::serde::{Deserialize, Deserializer, Serializer};
+	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
+	use serde::de::Error;
+
+	///
+	pub fn serialize<S>(key: &Option<secp::key::SecretKey>, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		match key {
+			Some(key) => {
+				serializer.serialize_str(&to_hex(key.0.to_vec()))
+			}
+			None => serializer.serialize_none(),
+		}
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<secp::key::SecretKey>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		Option::<String>::deserialize(deserializer).and_then(|res| match res {
+			Some(string) => from_hex(string.to_string())
+				.map_err(|err| Error::custom(err.to_string()))
+				.and_then(|bytes: Vec<u8>| {
+					let mut b = [0u8; 32];
+					b.copy_from_slice(&bytes[0..32]);
+					secp::key::SecretKey::from_slice(&static_secp, &b)
+						.map(|val| Some(val))
+						.map_err(|err| Error::custom(err.to_string()))
+				}),
+			None => Ok(None),
+		})
+	}
+}
+
 /// Serializes a secp::Signature to and from hex
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
@@ -286,6 +327,8 @@ mod test {
 
 	#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 	struct SerTest {
+		#[serde(with = "option_seckey_serde")]
+		pub opt_skey: Option<SecretKey>,
 		#[serde(with = "pubkey_serde")]
 		pub pub_key: PublicKey,
 		#[serde(with = "option_sig_serde")]
@@ -308,6 +351,7 @@ mod test {
 			let msg = Message::from_slice(&msg).unwrap();
 			let sig = aggsig::sign_single(&secp, &msg, &sk, None, None).unwrap();
 			SerTest {
+				opt_skey: Some(sk.clone()),
 				pub_key: PublicKey::from_secret_key(&secp, &sk).unwrap(),
 				opt_sig: Some(sig.clone()),
 				sig: sig.clone(),

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -69,6 +69,13 @@ impl Keychain for ExtKeychain {
 		Ok(keychain)
 	}
 
+	fn mask_master_key(&mut self, mask: &SecretKey) -> Result<(), Error> {
+		for i in 0..secp::constants::SECRET_KEY_SIZE {
+			self.master.secret_key.0[i] ^= mask.0[i];
+		}
+		Ok(())
+	}
+
 	/// For testing - probably not a good idea to use outside of tests.
 	fn from_random_seed(is_floo: bool) -> Result<ExtKeychain, Error> {
 		let seed: String = thread_rng().sample_iter(&Alphanumeric).take(16).collect();

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -467,6 +467,9 @@ pub trait Keychain: Sync + Send + Clone {
 	/// Generates a keychain from a randomly generated seed. Mostly used for tests.
 	fn from_random_seed(is_floo: bool) -> Result<Self, Error>;
 
+	/// XOR masks the keychain's master key against another key
+	fn mask_master_key(&mut self, mask: &SecretKey) -> Result<(), Error>;
+
 	/// Root identifier for that keychain
 	fn root_key_id() -> Identifier;
 


### PR DESCRIPTION
Mostly to support: https://github.com/mimblewimble/grin-wallet/pull/200

* add an `option_seckey_serde` de/serialiser (using a seckey internally to represent the mask)
* add a `mask_master_key` helper function to the keychain trait + ExtKeychain implementation

Leaving as WIP for the time being in case there are more changes related to this