### PR TITLE
Improve checking for p2p connection limits

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -274,12 +274,18 @@ fn comments() -> HashMap<String, String> {
 #how long a banned peer should stay banned
 #ban_window = 10800
 
-#maximum number of peers
-#peer_max_count = 125
+#maximum number of inbound peer connections
+#peer_max_inbound_count = 117
+
+#maximum number of outbound peer connections
+#peer_max_outbound_count = 8
 
 #preferred minimum number of peers (we'll actively keep trying to add peers
 #until we get to at least this number
 #peer_min_preferred_count = 8
+
+#amount of incoming connections temporarily allowed to exceed peer_max_inbound_count
+#peer_listener_buffer_count = 8
 
 # 15 = Bit flags for FULL_NODE
 #This structure needs to be changed internally, to make it more configurable

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -275,14 +275,14 @@ fn comments() -> HashMap<String, String> {
 #ban_window = 10800
 
 #maximum number of inbound peer connections
-#peer_max_inbound_count = 117
+#peer_max_inbound_count = 128
 
 #maximum number of outbound peer connections
 #peer_max_outbound_count = 8
 
-#preferred minimum number of peers (we'll actively keep trying to add peers
-#until we get to at least this number
-#peer_min_preferred_count = 8
+#preferred minimum number of outbound peers (we'll actively keep trying to add peers
+#until we get to at least this number)
+#peer_min_preferred_outbound_count = 8
 
 #amount of incoming connections temporarily allowed to exceed peer_max_inbound_count
 #peer_listener_buffer_count = 8

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -126,10 +126,19 @@ impl Peers {
 		res
 	}
 
+	/// Get vec of peers we currently have an outgoing connection with.
 	pub fn outgoing_connected_peers(&self) -> Vec<Arc<Peer>> {
 		self.connected_peers()
 			.into_iter()
 			.filter(|x| x.info.is_outbound())
+			.collect()
+	}
+
+	/// Get vec of peers we currently have an incoming connection with.
+	pub fn incoming_connected_peers(&self) -> Vec<Arc<Peer>> {
+		self.connected_peers()
+			.into_iter()
+			.filter(|x| x.info.is_inbound())
 			.collect()
 	}
 
@@ -153,6 +162,11 @@ impl Peers {
 	/// Number of outbound peers currently connected to.
 	pub fn peer_outbound_count(&self) -> u32 {
 		self.outgoing_connected_peers().len() as u32
+	}
+
+	/// Number of inbound peers currently connected to.
+	pub fn peer_inbound_count(&self) -> u32 {
+		self.incoming_connected_peers().len() as u32
 	}
 
 	// Return vec of connected peers that currently advertise more work
@@ -433,7 +447,7 @@ impl Peers {
 	/// Iterate over the peer list and prune all peers we have
 	/// lost connection to or have been deemed problematic.
 	/// Also avoid connected peer count getting too high.
-	pub fn clean_peers(&self, max_count: usize) {
+	pub fn clean_peers(&self, max_inbound_count: usize, max_outbound_count: usize) {
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up
@@ -477,16 +491,27 @@ impl Peers {
 			}
 		}
 
-		// ensure we do not still have too many connected peers
-		let excess_count = (self.peer_count() as usize)
-			.saturating_sub(rm.len())
-			.saturating_sub(max_count);
-		if excess_count > 0 {
-			// map peers to addrs in a block to bound how long we keep the read lock for
+		// check here to make sure we don't have too many outgoing connections
+		let excess_outgoing_count =
+			(self.peer_outbound_count() as usize).saturating_sub(max_outbound_count);
+		if excess_outgoing_count > 0 {
 			let mut addrs = self
-				.connected_peers()
+				.outgoing_connected_peers()
 				.iter()
-				.take(excess_count)
+				.take(excess_outgoing_count)
+				.map(|x| x.info.addr.clone())
+				.collect::<Vec<_>>();
+			rm.append(&mut addrs);
+		}
+
+		// check here to make sure we don't have too many incoming connections
+		let excess_incoming_count =
+			(self.peer_inbound_count() as usize).saturating_sub(max_inbound_count);
+		if excess_incoming_count > 0 {
+			let mut addrs = self
+				.incoming_connected_peers()
+				.iter()
+				.take(excess_incoming_count)
 				.map(|x| x.info.addr.clone())
 				.collect::<Vec<_>>();
 			rm.append(&mut addrs);
@@ -525,7 +550,7 @@ impl Peers {
 	/// We have enough peers, both total connected and outbound connected
 	pub fn healthy_peers_mix(&self) -> bool {
 		self.enough_peers()
-			&& self.peer_outbound_count() >= self.config.peer_min_preferred_count() / 2
+			&& self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count()
 	}
 
 	/// Removes those peers that seem to have expired

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -545,8 +545,8 @@ impl Peers {
 		}
 	}
 
-	/// We have enough peers, both total connected and outbound connected
-	pub fn healthy_peers_mix(&self) -> bool {
+	/// We have enough outbound connected peers
+	pub fn enough_outbound_peers(&self) -> bool {
 		self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count()
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -338,7 +338,8 @@ impl Peers {
 	/// A peer implementation may drop the broadcast request
 	/// if it knows the remote peer already has the block.
 	pub fn broadcast_compact_block(&self, b: &core::CompactBlock) {
-		let num_peers = self.config.peer_max_count();
+		let num_peers =
+			self.config.peer_max_inbound_count() + self.config.peer_max_outbound_count();
 		let count = self.broadcast("compact block", num_peers, |p| p.send_compact_block(b));
 		debug!(
 			"broadcast_compact_block: {}, {} at {}, to {} peers, done.",
@@ -355,7 +356,7 @@ impl Peers {
 	/// A peer implementation may drop the broadcast request
 	/// if it knows the remote peer already has the header.
 	pub fn broadcast_header(&self, bh: &core::BlockHeader) {
-		let num_peers = self.config.peer_min_preferred_count();
+		let num_peers = self.config.peer_min_preferred_outbound_count();
 		let count = self.broadcast("header", num_peers, |p| p.send_header(bh));
 		debug!(
 			"broadcast_header: {}, {} at {}, to {} peers, done.",
@@ -372,7 +373,8 @@ impl Peers {
 	/// A peer implementation may drop the broadcast request
 	/// if it knows the remote peer already has the transaction.
 	pub fn broadcast_transaction(&self, tx: &core::Transaction) {
-		let num_peers = self.config.peer_max_count();
+		let num_peers =
+			self.config.peer_max_inbound_count() + self.config.peer_max_outbound_count();
 		let count = self.broadcast("transaction", num_peers, |p| p.send_transaction(tx));
 		debug!(
 			"broadcast_transaction: {} to {} peers, done.",
@@ -543,14 +545,9 @@ impl Peers {
 		}
 	}
 
-	pub fn enough_peers(&self) -> bool {
-		self.peer_count() >= self.config.peer_min_preferred_count()
-	}
-
 	/// We have enough peers, both total connected and outbound connected
 	pub fn healthy_peers_mix(&self) -> bool {
-		self.enough_peers()
-			&& self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count()
+		self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count()
 	}
 
 	/// Removes those peers that seem to have expired

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -198,11 +198,12 @@ impl Server {
 		Ok(())
 	}
 
-	/// Checks whether there's any reason we don't want to accept a peer
+	/// Checks whether there's any reason we don't want to accept an incoming peer
 	/// connection. There can be a few of them:
-	/// 1. Accepting the peer connection would exceed the configured maximum
-	/// allowed peer count. Note that seed nodes may wish to allow more than
-	/// the maximum configured connections to help with network bootstrapping.
+	/// 1. Accepting the peer connection would exceed the configured maximum allowed
+	/// inbound peer count. Note that seed nodes may wish to increase the default
+	/// value for PEER_LISTENER_BUFFER_COUNT to help with network bootstrapping.
+	/// A default buffer of 8 peers is allowed to help with network growth.
 	/// 2. The peer has been previously banned and the ban period hasn't
 	/// expired yet.
 	/// 3. We're already connected to a peer at the same IP. While there are
@@ -211,7 +212,9 @@ impl Server {
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
-		if self.peers.peer_count() >= self.config.peer_max_count() {
+		if self.peers.peer_inbound_count()
+			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
+		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");
 			return true;
 		}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -48,11 +48,21 @@ pub const MAX_LOCATORS: u32 = 20;
 /// How long a banned peer should be banned for
 const BAN_WINDOW: i64 = 10800;
 
-/// The max peer count
-const PEER_MAX_COUNT: u32 = 125;
+/// The max inbound peer count
+const PEER_MAX_INBOUND_COUNT: u32 = 117;
+
+/// The max outbound peer count
+const PEER_MAX_OUTBOUND_COUNT: u32 = 8;
 
 /// min preferred peer count
 const PEER_MIN_PREFERRED_COUNT: u32 = 8;
+
+/// The min preferred outbound peer count
+const PEER_MIN_PREFERRED_OUTBOUND_COUNT: u32 = 8;
+
+/// The peer listener buffer count. Allows temporarily accepting more connections
+/// than allowed by PEER_MAX_INBOUND_COUNT to encourage network bootstrapping.
+const PEER_LISTENER_BUFFER_COUNT: u32 = 8;
 
 #[derive(Debug)]
 pub enum Error {
@@ -229,9 +239,15 @@ pub struct P2PConfig {
 
 	pub ban_window: Option<i64>,
 
-	pub peer_max_count: Option<u32>,
+	pub peer_max_inbound_count: Option<u32>,
+
+	pub peer_max_outbound_count: Option<u32>,
 
 	pub peer_min_preferred_count: Option<u32>,
+
+	pub peer_min_preferred_outbound_count: Option<u32>,
+
+	pub peer_listener_buffer_count: Option<u32>,
 
 	pub dandelion_peer: Option<PeerAddr>,
 }
@@ -250,8 +266,11 @@ impl Default for P2PConfig {
 			peers_deny: None,
 			peers_preferred: None,
 			ban_window: None,
-			peer_max_count: None,
+			peer_max_inbound_count: None,
+			peer_max_outbound_count: None,
 			peer_min_preferred_count: None,
+			peer_min_preferred_outbound_count: None,
+			peer_listener_buffer_count: None,
 			dandelion_peer: None,
 		}
 	}
@@ -268,11 +287,24 @@ impl P2PConfig {
 		}
 	}
 
-	/// return peer_max_count
+	/// return total maximum peer count (incoming + outgoing)
 	pub fn peer_max_count(&self) -> u32 {
-		match self.peer_max_count {
+		PEER_MAX_INBOUND_COUNT + PEER_MAX_OUTBOUND_COUNT
+	}
+
+	/// return maximum inbound peer connections count
+	pub fn peer_max_inbound_count(&self) -> u32 {
+		match self.peer_max_inbound_count {
 			Some(n) => n,
-			None => PEER_MAX_COUNT,
+			None => PEER_MAX_INBOUND_COUNT,
+		}
+	}
+
+	/// return maximum outbound peer connections count
+	pub fn peer_max_outbound_count(&self) -> u32 {
+		match self.peer_max_outbound_count {
+			Some(n) => n,
+			None => PEER_MAX_OUTBOUND_COUNT,
 		}
 	}
 
@@ -281,6 +313,22 @@ impl P2PConfig {
 		match self.peer_min_preferred_count {
 			Some(n) => n,
 			None => PEER_MIN_PREFERRED_COUNT,
+		}
+	}
+
+	/// return minimum preferred outbound peer count
+	pub fn peer_min_preferred_outbound_count(&self) -> u32 {
+		match self.peer_min_preferred_outbound_count {
+			Some(n) => n,
+			None => PEER_MIN_PREFERRED_OUTBOUND_COUNT,
+		}
+	}
+
+	/// return peer buffer count for listener
+	pub fn peer_listener_buffer_count(&self) -> u32 {
+		match self.peer_listener_buffer_count {
+			Some(n) => n,
+			None => PEER_LISTENER_BUFFER_COUNT,
 		}
 	}
 }
@@ -396,6 +444,10 @@ impl PeerInfo {
 
 	pub fn is_outbound(&self) -> bool {
 		self.direction == Direction::Outbound
+	}
+
+	pub fn is_inbound(&self) -> bool {
+		self.direction == Direction::Inbound
 	}
 
 	/// The current height of the peer.

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -49,13 +49,10 @@ pub const MAX_LOCATORS: u32 = 20;
 const BAN_WINDOW: i64 = 10800;
 
 /// The max inbound peer count
-const PEER_MAX_INBOUND_COUNT: u32 = 117;
+const PEER_MAX_INBOUND_COUNT: u32 = 128;
 
 /// The max outbound peer count
 const PEER_MAX_OUTBOUND_COUNT: u32 = 8;
-
-/// min preferred peer count
-const PEER_MIN_PREFERRED_COUNT: u32 = 8;
 
 /// The min preferred outbound peer count
 const PEER_MIN_PREFERRED_OUTBOUND_COUNT: u32 = 8;
@@ -243,8 +240,6 @@ pub struct P2PConfig {
 
 	pub peer_max_outbound_count: Option<u32>,
 
-	pub peer_min_preferred_count: Option<u32>,
-
 	pub peer_min_preferred_outbound_count: Option<u32>,
 
 	pub peer_listener_buffer_count: Option<u32>,
@@ -268,7 +263,6 @@ impl Default for P2PConfig {
 			ban_window: None,
 			peer_max_inbound_count: None,
 			peer_max_outbound_count: None,
-			peer_min_preferred_count: None,
 			peer_min_preferred_outbound_count: None,
 			peer_listener_buffer_count: None,
 			dandelion_peer: None,
@@ -287,11 +281,6 @@ impl P2PConfig {
 		}
 	}
 
-	/// return total maximum peer count (incoming + outgoing)
-	pub fn peer_max_count(&self) -> u32 {
-		PEER_MAX_INBOUND_COUNT + PEER_MAX_OUTBOUND_COUNT
-	}
-
 	/// return maximum inbound peer connections count
 	pub fn peer_max_inbound_count(&self) -> u32 {
 		match self.peer_max_inbound_count {
@@ -305,14 +294,6 @@ impl P2PConfig {
 		match self.peer_max_outbound_count {
 			Some(n) => n,
 			None => PEER_MAX_OUTBOUND_COUNT,
-		}
-	}
-
-	/// return peer_preferred_count
-	pub fn peer_min_preferred_count(&self) -> u32 {
-		match self.peer_min_preferred_count {
-			Some(n) => n,
-			None => PEER_MIN_PREFERRED_COUNT,
 		}
 	}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -299,7 +299,7 @@ fn listen_for_addrs(
 	let addrs: Vec<PeerAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
-	if peers.peer_count() > peers.peer_outbound_count() && peers.healthy_peers_mix() {
+	if peers.healthy_peers_mix() {
 		return;
 	}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -233,7 +233,7 @@ fn monitor_peers(
 	let new_peers = peers.find_peers(
 		p2p::State::Healthy,
 		p2p::Capabilities::UNKNOWN,
-		config.peer_max_count() as usize,
+		config.peer_max_outbound_count() as usize,
 	);
 
 	for p in new_peers.iter().filter(|p| !peers.is_known(p.addr)) {
@@ -303,11 +303,14 @@ fn listen_for_addrs(
 		return;
 	}
 
-	// Try to connect to (up to max peers) peer addresses.
+	// Try to connect to (up to max outbound peers) peer addresses.
 	// Note: We drained the rx queue earlier to keep it under control.
 	// Even if there are many addresses to try we will only try a bounded number of them.
 	let connect_min_interval = 30;
-	for addr in addrs.into_iter().take(p2p.config.peer_max_count() as usize) {
+	for addr in addrs
+		.into_iter()
+		.take(p2p.config.peer_max_outbound_count() as usize)
+	{
 		// ignore the duplicate connecting to same peer within 30 seconds
 		let now = Utc::now();
 		if let Some(last_connect_time) = connecting_history.get(&addr) {

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -190,7 +190,7 @@ fn monitor_peers(
 		config.peer_max_outbound_count() as usize,
 	);
 
-	if peers.healthy_peers_mix() {
+	if peers.enough_outbound_peers() {
 		return;
 	}
 
@@ -299,7 +299,7 @@ fn listen_for_addrs(
 	let addrs: Vec<PeerAddr> = rx.try_iter().collect();
 
 	// If we have a healthy number of outbound peers then we are done here.
-	if peers.healthy_peers_mix() {
+	if peers.enough_outbound_peers() {
 		return;
 	}
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -185,7 +185,10 @@ fn monitor_peers(
 	);
 
 	// maintenance step first, clean up p2p server peers
-	peers.clean_peers(config.peer_max_count() as usize);
+	peers.clean_peers(
+		config.peer_max_inbound_count() as usize,
+		config.peer_max_outbound_count() as usize,
+	);
 
 	if peers.healthy_peers_mix() {
 		return;

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -86,7 +86,7 @@ impl SyncRunner {
 			// * timeout
 			if wp > MIN_PEERS
 				|| (wp == 0
-					&& self.peers.enough_peers()
+					&& self.peers.healthy_peers_mix()
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -86,7 +86,7 @@ impl SyncRunner {
 			// * timeout
 			if wp > MIN_PEERS
 				|| (wp == 0
-					&& self.peers.healthy_peers_mix()
+					&& self.peers.enough_outbound_peers()
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{


### PR DESCRIPTION
Connection limiting can be improved by adding a check against maximum allowed peer count immediately after a connection is accepted.