### PR TITLE
cleanup and simplify how we generate the genesis block in user_testing

### DIFF
--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -22,7 +22,6 @@
 use chrono::prelude::{TimeZone, Utc};
 
 use crate::core;
-use crate::global;
 use crate::pow::{Difficulty, Proof, ProofOfWork};
 use crate::util;
 use crate::util::secp::constants::SINGLE_BULLET_PROOF_SIZE;
@@ -38,10 +37,9 @@ use crate::keychain::BlindingFactor;
 pub fn genesis_dev() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		// previous: core::hash::Hash([0xff; 32]),
-		timestamp: global::get_genesis_timestamp(),
+		timestamp: Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
 		pow: ProofOfWork {
-			nonce: global::get_genesis_nonce(),
+			nonce: 0,
 			..Default::default()
 		},
 		..Default::default()

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -31,8 +31,6 @@ use crate::pow::{
 /// different sets of parameters for different purposes,
 /// e.g. CI, User testing, production values
 use crate::util::RwLock;
-use chrono::prelude::{TimeZone, Utc};
-use chrono::{DateTime, Duration};
 /// Define these here, as they should be developer-set, not really tweakable
 /// by users
 
@@ -311,34 +309,6 @@ pub fn is_production_mode() -> bool {
 pub fn is_floonet() -> bool {
 	let param_ref = CHAIN_TYPE.read();
 	ChainTypes::Floonet == *param_ref
-}
-
-/// Helper function to get a nonce known to create a valid POW on
-/// the genesis block, to prevent it taking ages. Should be fine for now
-/// as the genesis block POW solution turns out to be the same for every new
-/// block chain at the moment
-pub fn get_genesis_nonce() -> u64 {
-	let param_ref = CHAIN_TYPE.read();
-	match *param_ref {
-		// won't make a difference
-		ChainTypes::AutomatedTesting => 0,
-		// Magic nonce for current genesis block at cuckatoo15
-		ChainTypes::UserTesting => 27944,
-		// Placeholder, obviously not the right value
-		ChainTypes::Floonet => 0,
-		// Placeholder, obviously not the right value
-		ChainTypes::Mainnet => 0,
-	}
-}
-
-/// Genesis block timestamp. Dependant on chain type.
-pub fn get_genesis_timestamp() -> DateTime<Utc> {
-	let param_ref = CHAIN_TYPE.read();
-	match *param_ref {
-		ChainTypes::UserTesting => Utc::now(),
-		ChainTypes::AutomatedTesting => Utc::now() - Duration::minutes(60),
-		_ => Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
-	}
 }
 
 /// Converts an iterator of block difficulty data to more a more manageable

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -172,8 +172,8 @@ impl Server {
 		));
 
 		let genesis = match config.chain_type {
-			global::ChainTypes::AutomatedTesting => genesis::genesis_dev(),
-			global::ChainTypes::UserTesting => genesis::genesis_dev(),
+			global::ChainTypes::AutomatedTesting => pow::mine_genesis_block().unwrap(),
+			global::ChainTypes::UserTesting => pow::mine_genesis_block().unwrap(),
 			global::ChainTypes::Floonet => genesis::genesis_floo(),
 			global::ChainTypes::Mainnet => genesis::genesis_main(),
 		};


### PR DESCRIPTION
I suspect some recent changes inadvertently broke "user testing" due to how we set the timestamp on the genesis block.
This PR simplifies genesis block creation in user testing. We just hard-code the timestamp now (we did before but at some point we started overwriting it with `now()`.

We now also just hard-code the nonce to `0` on both testing modes - it is fast to mine the dev genesis block in "user_testing" so just do that each time. 
To make this consistent we simply call `pow::mine_genesis_block()` when setting up the genesis block during user testing.

