### PR TITLE
Fix doc grin <subcommand> help syntax.

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -98,8 +98,8 @@ For help on grin commands and their switches, try:
 
 ```sh
 grin help
-grin wallet help
-grin client help
+grin wallet --help
+grin client --help
 ```
 
 ## Docker

--- a/doc/build_ES.md
+++ b/doc/build_ES.md
@@ -87,8 +87,8 @@ Para obtener ayuda sobre los comandos de grin y sus cambios intente:
 
 ```sh
 grin help
-grin wallet help
-grin client help
+grin wallet --help
+grin client --help
 ```
 
 ## Docker

--- a/doc/build_JP.md
+++ b/doc/build_JP.md
@@ -93,8 +93,8 @@ grinは気の利いたデフォルト設定で起動するようになってお�
 
 ```sh
 grin help
-grin wallet help
-grin client help
+grin wallet --help
+grin client --help
 ```
 
 ## Docker

--- a/doc/build_KR.md
+++ b/doc/build_KR.md
@@ -94,8 +94,8 @@ Grin을 작동시키는 명령어에 대한 도움말은 다음 명령어를 실
 
 ```sh
 grin help
-grin wallet help
-grin client help
+grin wallet --help
+grin client --help
 ```
 
 ## Docker 사용하기


### PR DESCRIPTION
Fix wrong documentation, the subcommand implements the flag `--help` not `help`
