### PR TITLE
improve checking for p2p connection limits (revised)

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -274,12 +274,18 @@ fn comments() -> HashMap<String, String> {
 #how long a banned peer should stay banned
 #ban_window = 10800
 
-#maximum number of peers
-#peer_max_count = 125
+#maximum number of inbound peer connections
+#peer_max_inbound_count = 128
 
-#preferred minimum number of peers (we'll actively keep trying to add peers
-#until we get to at least this number
-#peer_min_preferred_count = 8
+#maximum number of outbound peer connections
+#peer_max_outbound_count = 8
+
+#preferred minimum number of outbound peers (we'll actively keep trying to add peers
+#until we get to at least this number)
+#peer_min_preferred_outbound_count = 8
+
+#amount of incoming connections temporarily allowed to exceed peer_max_inbound_count
+#peer_listener_buffer_count = 8
 
 # 15 = Bit flags for FULL_NODE
 #This structure needs to be changed internally, to make it more configurable

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -87,6 +87,10 @@ impl Server {
 					let peer_addr = PeerAddr(peer_addr);
 
 					if self.check_undesirable(&stream) {
+						// Shutdown the incoming TCP connection if it is not desired
+						if let Err(e) = stream.shutdown(Shutdown::Both) {
+							debug!("Error shutting down conn: {:?}", e);
+						}
 						continue;
 					}
 					match self.handle_new_peer(stream) {
@@ -194,30 +198,34 @@ impl Server {
 		Ok(())
 	}
 
-	/// Checks whether there's any reason we don't want to accept a peer
-	/// connection. There can be a couple of them:
-	/// 1. The peer has been previously banned and the ban period hasn't
+	/// Checks whether there's any reason we don't want to accept an incoming peer
+	/// connection. There can be a few of them:
+	/// 1. Accepting the peer connection would exceed the configured maximum allowed
+	/// inbound peer count. Note that seed nodes may wish to increase the default
+	/// value for PEER_LISTENER_BUFFER_COUNT to help with network bootstrapping.
+	/// A default buffer of 8 peers is allowed to help with network growth.
+	/// 2. The peer has been previously banned and the ban period hasn't
 	/// expired yet.
-	/// 2. We're already connected to a peer at the same IP. While there are
+	/// 3. We're already connected to a peer at the same IP. While there are
 	/// many reasons multiple peers can legitimately share identical IP
 	/// addresses (NAT), network distribution is improved if they choose
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
+		if self.peers.peer_inbound_count()
+			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
+		{
+			debug!("Accepting new connection will exceed peer limit, refusing connection.");
+			return true;
+		}
 		if let Ok(peer_addr) = stream.peer_addr() {
 			let peer_addr = PeerAddr(peer_addr);
 			if self.peers.is_banned(peer_addr) {
 				debug!("Peer {} banned, refusing connection.", peer_addr);
-				if let Err(e) = stream.shutdown(Shutdown::Both) {
-					debug!("Error shutting down conn: {:?}", e);
-				}
 				return true;
 			}
 			if self.peers.is_known(peer_addr) {
 				debug!("Peer {} already known, refusing connection.", peer_addr);
-				if let Err(e) = stream.shutdown(Shutdown::Both) {
-					debug!("Error shutting down conn: {:?}", e);
-				}
 				return true;
 			}
 		}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -230,10 +230,13 @@ fn monitor_peers(
 
 	// find some peers from our db
 	// and queue them up for a connection attempt
+	// intentionally make too many attempts (2x) as some (most?) will fail
+	// as many nodes in our db are not publicly accessible
+	let max_peer_attempts = 128;
 	let new_peers = peers.find_peers(
 		p2p::State::Healthy,
 		p2p::Capabilities::UNKNOWN,
-		config.peer_max_outbound_count() as usize,
+		max_peer_attempts as usize,
 	);
 
 	for p in new_peers.iter().filter(|p| !peers.is_known(p.addr)) {
@@ -303,14 +306,11 @@ fn listen_for_addrs(
 		return;
 	}
 
-	// Try to connect to (up to max outbound peers) peer addresses.
 	// Note: We drained the rx queue earlier to keep it under control.
-	// Even if there are many addresses to try we will only try a bounded number of them.
+	// Even if there are many addresses to try we will only try a bounded number of them for safety.
 	let connect_min_interval = 30;
-	for addr in addrs
-		.into_iter()
-		.take(p2p.config.peer_max_outbound_count() as usize)
-	{
+	let max_outbound_attempts = 128;
+	for addr in addrs.into_iter().take(max_outbound_attempts) {
 		// ignore the duplicate connecting to same peer within 30 seconds
 		let now = Utc::now();
 		if let Some(last_connect_time) = connecting_history.get(&addr) {

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -86,7 +86,7 @@ impl SyncRunner {
 			// * timeout
 			if wp > MIN_PEERS
 				|| (wp == 0
-					&& self.peers.enough_peers()
+					&& self.peers.enough_outbound_peers()
 					&& head.total_difficulty > Difficulty::zero())
 				|| n > wait_secs
 			{


### PR DESCRIPTION
Replacement PR for #2985 which we reverted in https://github.com/mimblewimble/grin/commit/17dddeeb0d047e761996b42cd3ef544dd2725702

Tweaked the limit in terms of how many peer connections we _attempt_ regardless of our desired outbound connections.

The key point here is the vast majority of our peer addresses in the db are not publicly accessible.
So if we only try a random 8 then we stand a good chance of failing to connect to any new ones.

This is particularly important during the initial seed step on node startup - we want to try _all_ the seeds retrieved via dns, not just 8 of them. If these 8 fail for any reason then we end up stuck with our node not making any further attempts.