### PR TITLE
cleanup deprecation warnings about missing dyn with trait objects

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -610,7 +610,7 @@ impl Chain {
 	/// Currently does not write these to disk and simply deserializes
 	/// the provided data.
 	/// TODO - Write this data to disk and validate the rebuilt kernel MMR.
-	pub fn kernel_data_write(&self, reader: &mut Read) -> Result<(), Error> {
+	pub fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<(), Error> {
 		let mut count = 0;
 		let mut stream = StreamingReader::new(reader, ProtocolVersion::local());
 		while let Ok(_kernel) = TxKernelEntry::read(&mut stream) {
@@ -1390,7 +1390,7 @@ fn setup_head(
 			batch.save_header_head(&tip)?;
 
 			if genesis.kernels().len() > 0 {
-				let (utxo_sum, kernel_sum) = (sums, genesis as &Committed).verify_kernel_sums(
+				let (utxo_sum, kernel_sum) = (sums, genesis as &dyn Committed).verify_kernel_sums(
 					genesis.header.overage(),
 					genesis.header.total_kernel_offset(),
 				)?;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -123,7 +123,7 @@ pub struct HeaderEntry {
 }
 
 impl Readable for HeaderEntry {
-	fn read(reader: &mut Reader) -> Result<HeaderEntry, ser::Error> {
+	fn read(reader: &mut dyn Reader) -> Result<HeaderEntry, ser::Error> {
 		let hash = Hash::read(reader)?;
 		let timestamp = reader.read_u64()?;
 		let total_difficulty = Difficulty::read(reader)?;

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -53,7 +53,7 @@ pub trait Backend<T: PMMRable> {
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
-	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_>;
+	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_>;
 
 	/// Remove Hash by insertion position. An index is also provided so the
 	/// underlying backend can implement some rollback of positions up to a

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -50,7 +50,7 @@ where
 	}
 
 	/// Reference to the underlying storage backend.
-	pub fn backend(&'a self) -> &Backend<T> {
+	pub fn backend(&'a self) -> &dyn Backend<T> {
 		self.backend
 	}
 

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -567,7 +567,7 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.kernel_data_read()
 	}
 
-	fn kernel_data_write(&self, reader: &mut Read) -> Result<bool, chain::Error> {
+	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
 		self.adapter.kernel_data_write(reader)
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -670,7 +670,7 @@ impl ChainAdapter for Peers {
 		self.adapter.kernel_data_read()
 	}
 
-	fn kernel_data_write(&self, reader: &mut Read) -> Result<bool, chain::Error> {
+	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
 		self.adapter.kernel_data_write(reader)
 	}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -303,7 +303,7 @@ impl ChainAdapter for DummyAdapter {
 	fn kernel_data_read(&self) -> Result<File, chain::Error> {
 		unimplemented!()
 	}
-	fn kernel_data_write(&self, _reader: &mut Read) -> Result<bool, chain::Error> {
+	fn kernel_data_write(&self, _reader: &mut dyn Read) -> Result<bool, chain::Error> {
 		unimplemented!()
 	}
 	fn txhashset_read(&self, _h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -561,7 +561,7 @@ pub trait ChainAdapter: Sync + Send {
 
 	fn kernel_data_read(&self) -> Result<File, chain::Error>;
 
-	fn kernel_data_write(&self, reader: &mut Read) -> Result<bool, chain::Error>;
+	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error>;
 
 	/// Provides a reading view into the current txhashset state as well as
 	/// the required indexes for a consumer to rewind to a consistant state

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -347,7 +347,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		self.chain().kernel_data_read()
 	}
 
-	fn kernel_data_write(&self, reader: &mut Read) -> Result<bool, chain::Error> {
+	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
 		let res = self.chain().kernel_data_write(reader)?;
 		error!("***** kernel_data_write: {:?}", res);
 		Ok(true)

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -37,7 +37,7 @@ use tokio::runtime::Runtime;
 
 /// Returns the list of event hooks that will be initialized for network events
 pub fn init_net_hooks(config: &ServerConfig) -> Vec<Box<dyn NetEvents + Send + Sync>> {
-	let mut list: Vec<Box<NetEvents + Send + Sync>> = Vec::new();
+	let mut list: Vec<Box<dyn NetEvents + Send + Sync>> = Vec::new();
 	list.push(Box::new(EventLogger));
 	if config.webhook_config.block_received_url.is_some()
 		|| config.webhook_config.tx_received_url.is_some()
@@ -50,7 +50,7 @@ pub fn init_net_hooks(config: &ServerConfig) -> Vec<Box<dyn NetEvents + Send + S
 
 /// Returns the list of event hooks that will be initialized for chain events
 pub fn init_chain_hooks(config: &ServerConfig) -> Vec<Box<dyn ChainEvents + Send + Sync>> {
-	let mut list: Vec<Box<ChainEvents + Send + Sync>> = Vec::new();
+	let mut list: Vec<Box<dyn ChainEvents + Send + Sync>> = Vec::new();
 	list.push(Box::new(EventLogger));
 	if config.webhook_config.block_accepted_url.is_some() {
 		list.push(Box::new(WebHook::from_config(&config.webhook_config)));

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -36,7 +36,7 @@ use crate::util::{RwLock, StopState};
 pub fn monitor_transactions(
 	dandelion_config: DandelionConfig,
 	tx_pool: Arc<RwLock<TransactionPool>>,
-	adapter: Arc<DandelionAdapter>,
+	adapter: Arc<dyn DandelionAdapter>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
 	stop_state: Arc<StopState>,
 ) -> std::io::Result<thread::JoinHandle<()>> {
@@ -102,7 +102,7 @@ fn select_txs_cutoff(pool: &Pool, cutoff_secs: u16) -> Vec<PoolEntry> {
 fn process_fluff_phase(
 	dandelion_config: &DandelionConfig,
 	tx_pool: &Arc<RwLock<TransactionPool>>,
-	adapter: &Arc<DandelionAdapter>,
+	adapter: &Arc<dyn DandelionAdapter>,
 	verifier_cache: &Arc<RwLock<dyn VerifierCache>>,
 ) -> Result<(), PoolError> {
 	// Take a write lock on the txpool for the duration of this processing.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -132,7 +132,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Returns an iterator over all the leaf positions.
 	/// for a prunable PMMR this is an iterator over the leaf_set bitmap.
 	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).
-	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_> {
+	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
 		if self.prunable {
 			Box::new(self.leaf_set.iter())
 		} else {
@@ -472,7 +472,7 @@ pub fn clean_files_by_prefix<P: AsRef<std::path::Path>>(
 
 	let number_of_files_deleted: u32 = fs::read_dir(&path)?
 		.flat_map(
-			|possible_dir_entry| -> Result<u32, Box<std::error::Error>> {
+			|possible_dir_entry| -> Result<u32, Box<dyn std::error::Error>> {
 				// result implements iterator and so if we were to use map here
 				// we would have a list of Result<u32, Box<std::error::Error>>
 				// but because we use flat_map, the errors get "discarded" and we are


### PR DESCRIPTION
This PR fixes various deprecation warnings with `rust 1.37.0`, specifically around trait objects and no explicit `dyn` - 

```
rustc --version
rustc 1.37.0 (eae3437df 2019-08-13)
```

```
   Compiling grin_servers v2.0.1-beta.1 (/antiochp/grin/servers)
warning: trait objects without an explicit `dyn` are deprecated
   --> servers/src/grin/dandelion_monitor.rs:105:16
    |
105 |     adapter: &Arc<DandelionAdapter>,
    |                   ^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn DandelionAdapter`
    |
    = note: #[warn(bare_trait_objects)] on by default
```