### PR TITLE
Kernel lookup api method

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -26,6 +26,7 @@ use self::blocks_api::HeaderHandler;
 use self::chain_api::ChainCompactHandler;
 use self::chain_api::ChainHandler;
 use self::chain_api::ChainValidationHandler;
+use self::chain_api::KernelHandler;
 use self::chain_api::OutputHandler;
 use self::peers_api::PeerHandler;
 use self::peers_api::PeersAllHandler;
@@ -119,7 +120,9 @@ pub fn build_router(
 	let output_handler = OutputHandler {
 		chain: Arc::downgrade(&chain),
 	};
-
+	let kernel_handler = KernelHandler {
+		chain: Arc::downgrade(&chain),
+	};
 	let block_handler = BlockHandler {
 		chain: Arc::downgrade(&chain),
 	};
@@ -171,6 +174,7 @@ pub fn build_router(
 	router.add_route("/v1/headers/*", Arc::new(header_handler))?;
 	router.add_route("/v1/chain", Arc::new(chain_tip_handler))?;
 	router.add_route("/v1/chain/outputs/*", Arc::new(output_handler))?;
+	router.add_route("/v1/chain/kernels/*", Arc::new(kernel_handler))?;
 	router.add_route("/v1/chain/compact", Arc::new(chain_compact_handler))?;
 	router.add_route("/v1/chain/validate", Arc::new(chain_validation_handler))?;
 	router.add_route("/v1/txhashset/*", Arc::new(txhashset_handler))?;

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -199,7 +199,8 @@ impl Handler for OutputHandler {
 }
 
 /// Kernel handler, search for a kernel by excess commitment
-/// GET /v1/chain/kernels/XXX?start_height=YYY
+/// GET /v1/chain/kernels/XXX?min_height=YYY&max_height=ZZZ
+/// The `min_height` and `max_height` parameters are optional
 pub struct KernelHandler {
 	pub chain: Weak<chain::Chain>,
 }

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -205,7 +205,7 @@ pub struct KernelHandler {
 }
 
 impl KernelHandler {
-	fn get_kernel(&self, req: Request<Body>) -> Result<LocatedTxKernel, Error> {
+	fn get_kernel(&self, req: Request<Body>) -> Result<Option<LocatedTxKernel>, Error> {
 		let excess = req
 			.uri()
 			.path()
@@ -248,16 +248,15 @@ impl KernelHandler {
 			}
 		}
 
-		let (tx_kernel, height, mmr_index) = chain
+		let kernel = chain
 			.get_kernel_height(&excess, min_height, max_height)
 			.map_err(|e| ErrorKind::Internal(format!("{}", e)))?
-			.ok_or(ErrorKind::NotFound)?;
-
-		Ok(LocatedTxKernel {
-			tx_kernel: TxKernelPrintable::from_txkernel(&tx_kernel),
-			height,
-			mmr_index,
-		})
+			.map(|(tx_kernel, height, mmr_index)| LocatedTxKernel {
+				tx_kernel: TxKernelPrintable::from_txkernel(&tx_kernel),
+				height,
+				mmr_index,
+			});
+		Ok(kernel)
 	}
 }
 

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -252,7 +252,7 @@ impl KernelHandler {
 			.get_kernel_height(&excess, min_height, max_height)
 			.map_err(|e| ErrorKind::Internal(format!("{}", e)))?
 			.map(|(tx_kernel, height, mmr_index)| LocatedTxKernel {
-				tx_kernel: TxKernelPrintable::from_txkernel(&tx_kernel),
+				tx_kernel,
 				height,
 				mmr_index,
 			});

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use crate::chain;
 use crate::core::core::hash::Hashed;
 use crate::core::core::merkle_proof::MerkleProof;
-use crate::core::core::KernelFeatures;
+use crate::core::core::{KernelFeatures, TxKernel};
 use crate::core::{core, ser};
 use crate::p2p;
 use crate::util;
@@ -700,7 +700,7 @@ pub struct OutputListing {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocatedTxKernel {
-	pub tx_kernel: TxKernelPrintable,
+	pub tx_kernel: TxKernel,
 	pub height: u64,
 	pub mmr_index: u64,
 }

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -698,6 +698,13 @@ pub struct OutputListing {
 	pub outputs: Vec<OutputPrintable>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LocatedTxKernel {
+	pub tx_kernel: TxKernelPrintable,
+	pub height: u64,
+	pub mmr_index: u64,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct PoolInfo {
 	/// Size of the pool

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -19,7 +19,8 @@ use crate::core::core::hash::{Hash, Hashed, ZERO_HASH};
 use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{
-	Block, BlockHeader, BlockSums, Committed, Output, OutputIdentifier, Transaction, TxKernelEntry,
+	Block, BlockHeader, BlockSums, Committed, Output, OutputIdentifier, Transaction, TxKernel,
+	TxKernelEntry,
 };
 use crate::core::global;
 use crate::core::pow;
@@ -1251,18 +1252,50 @@ impl Chain {
 		}
 	}
 
+	/// Gets the kernel with a given excess and the block height it is included in.
+	pub fn get_kernel_height(
+		&self,
+		excess: &Commitment,
+		min_height: Option<u64>,
+		max_height: Option<u64>,
+	) -> Result<Option<(TxKernel, u64, u64)>, Error> {
+		let min_index = match min_height {
+			Some(h) => Some(self.get_header_by_height(h - 1)?.kernel_mmr_size + 1),
+			None => None,
+		};
+
+		let max_index = match max_height {
+			Some(h) => Some(self.get_header_by_height(h)?.kernel_mmr_size),
+			None => None,
+		};
+
+		let (kernel, mmr_index) = match self
+			.txhashset
+			.read()
+			.find_kernel(&excess, min_index, max_index)
+		{
+			Some(k) => k,
+			None => return Ok(None),
+		};
+
+		let header = self.get_header_for_kernel_index(mmr_index, min_height, max_height)?;
+
+		Ok(Some((kernel, header.height, mmr_index)))
+	}
+
 	/// Gets the block header in which a given kernel mmr index appears in the txhashset.
 	pub fn get_header_for_kernel_index(
 		&self,
 		kernel_mmr_index: u64,
-		start_height: u64,
+		min_height: Option<u64>,
+		max_height: Option<u64>,
 	) -> Result<BlockHeader, Error> {
 		let txhashset = self.txhashset.read();
 
-		let mut min = start_height;
-		let mut max = {
-			let head = self.head()?;
-			head.height
+		let mut min = min_height.unwrap_or(0).saturating_sub(1);
+		let mut max = match max_height {
+			Some(h) => h,
+			None => self.head()?.height,
 		};
 
 		loop {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -260,6 +260,23 @@ impl TxHashSet {
 			.elements_from_insertion_index(start_index, max_count)
 	}
 
+	/// Find a kernel with a given excess
+	pub fn find_kernel(&self, excess: &Commitment, start_index: u64) -> Option<(u64, TxKernel)> {
+		let last_pos = self.kernel_pmmr_h.last_pos;
+		let pmmr = ReadonlyPMMR::at(&self.kernel_pmmr_h.backend, last_pos);
+
+		let mut index = start_index;
+		while index <= last_pos {
+			if let Some(t) = pmmr.get_data(index) {
+				if &t.kernel.excess == excess {
+					return Some((index, t.kernel));
+				}
+			}
+			index += 1;
+		}
+		None
+	}
+
 	/// Get MMR roots.
 	pub fn roots(&self) -> TxHashSetRoots {
 		let header_pmmr =


### PR DESCRIPTION
This PR adds an API call to look up an on-chain kernel and the height of the block it is included in.
It has an optional minimum search height. If provided (and close to the actual height), the request will be really fast (<10ms). Without this parameter the request can currently take up to 2.5s. Seeing as in the worst case scenario this time will increase linearly with the chain head height (which keeps increasing forever), it is recommended to always set the minimum height parameter.

Requesting review from @antiochp since I am not very experienced with MMRs and as a result some implementation details might be sub-optimal.

Closes https://github.com/mimblewimble/grin/issues/2460

__Use cases:__
- Wallets can check the status of a transaction without having to rely on the change output, which may or may not exist or might already be spent (https://github.com/mimblewimble/grin-wallet/issues/169)
- The on-chain kernel signature is required in some scriptless scripts applications

__Usage:__
`v1/chain/kernels/XXX?min_height=YYY&max_height=ZZZ` where `XXX` is the excess commitment. The `min_height` and `max_height` parameters are both optional. If not supplied, `min_height` will be set to 0 and `max_height` will be set to the head of the chain. The method will start at the block height `max_height` and traverse the kernel MMR backwards, until either the kernel is found or `min_height` is reached.

__Example:__
Request:
```
/v1/chain/kernels/0939fe3dc6a35350da91c6288138b7a257e0c0322eae30bda3938229d649e2e642?max_height=324300
```

Response:
```json
{
  "tx_kernel": {
    "features": {
      "Plain": {
        "fee": 12000000
      }
    },
    "excess": "0939fe3dc6a35350da91c6288138b7a257e0c0322eae30bda3938229d649e2e642",
    "excess_sig": "c6f269b98f611c03cde361467daa5c27109dea0e8b28a3189646a4e1e9ad96fe92ea86b65dc76151686c5a4f3922202bd298b665ec80ba2b1e43fb46df34f6a4"
  },
  "height": 324016,
  "mmr_index": 1946151
}
```