### PR TITLE
cleanup rebuild sync MMR logic

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1423,9 +1423,8 @@ fn setup_head(
 			head.last_block_h,
 			head.height,
 		);
-		batch.reset_header_head()?;
-		let header_head = batch.header_head()?;
-		batch.save_sync_head(&header_head)?;
+		batch.save_header_head(&head)?;
+		batch.save_sync_head(&head)?;
 	}
 
 	batch.commit()?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -180,12 +180,6 @@ impl<'a> Batch<'a> {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
-	/// Reset sync_head to the current head of the header chain.
-	pub fn reset_sync_head(&self) -> Result<(), Error> {
-		let head = self.header_head()?;
-		self.save_sync_head(&head)
-	}
-
 	/// Reset header_head to the current head of the body chain.
 	pub fn reset_header_head(&self) -> Result<(), Error> {
 		let tip = self.head()?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -180,12 +180,6 @@ impl<'a> Batch<'a> {
 		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
 	}
 
-	/// Reset header_head to the current head of the body chain.
-	pub fn reset_header_head(&self) -> Result<(), Error> {
-		let tip = self.head()?;
-		self.save_header_head(&tip)
-	}
-
 	/// get block
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -73,17 +73,13 @@ impl HeaderSync {
 					header_head.height,
 				);
 
-				// Reset sync_head to header_head on transition to HeaderSync,
+				// Reset sync MMR based on current header MMR on transition to HeaderSync,
 				// but ONLY on initial transition to HeaderSync state.
 				//
 				// The header_head and sync_head may diverge here in the presence of a fork
 				// in the header chain. Ensure we track the new advertised header chain here
 				// correctly, so reset any previous (and potentially stale) sync_head to match
 				// our last known "good" header_head.
-				//
-				self.chain.reset_sync_head()?;
-
-				// Rebuild the sync MMR to match our updated sync_head.
 				self.chain.rebuild_sync_mmr(&header_head)?;
 
 				self.history_locator.retain(|&x| x.0 == 0);


### PR DESCRIPTION
This PR cleans up (and optimizes) how we rebuild the sync MMR during node startup.

We do not need to truncate the sync MMR and rebuild it from the genesis header, we can simply "rewind and apply header fork" based on current sync MMR state and the current head of the header chain. In the common case we will not need to rewind any headers and we can simply "fast forward" the recent headers to allow the sync MMR to catch up to the header MMR.

This saves a significant amount of time when starting a node up if shutdown overnight for example.
Rebuilding a sync MMR from scratch was taking 5s or so on a reasonably fast laptop.

As part of this we have now made the "reset head" logic more explicit, passing in the new head updating as necessary.

This PR also cleans up and simplifies how we apply headers to the MMR when processing, either as part of sync or when processing "header first". This makes processing new headers and processing headers from the local db as part of a fork more consistent.

Previous behavior -
* rewind MMR to fork point if necessary
* apply headers to MMR up to and including previous header
* apply new header to MMR
* validate and store new header in the db

Simplified behavior -
* validate and store new header in the db
* rewind MMR to fork point if necessary
* apply headers to MMR up to and including new header

