### PR TITLE
Split header MMR (and sync MMR) out from txhashset

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1086,7 +1086,7 @@ impl Chain {
 			let current_height = head_header.height;
 			let horizon_height =
 				current_height.saturating_sub(global::cut_through_horizon().into());
-			let horizon_hash = self.get_header_hash_by_height(horizon_height)?;
+			let horizon_hash = header_pmmr.get_header_hash_by_height(horizon_height)?;
 			let horizon_header = batch.get_block_header(&horizon_hash)?;
 
 			txhashset.compact(&horizon_header, &mut batch)?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -962,6 +962,9 @@ impl Chain {
 			batch.save_body_tail(&tip)?;
 		}
 
+		// Rebuild our output_pos index in the db based on current UTXO set.
+		txhashset.rebuild_height_pos_index(&header_pmmr, &mut batch)?;
+
 		// Commit all the changes to the db.
 		batch.commit()?;
 
@@ -990,8 +993,6 @@ impl Chain {
 		}
 
 		debug!("txhashset_write: replaced our txhashset with the new one");
-
-		self.rebuild_height_for_pos()?;
 
 		// Check for any orphan blocks and process them based on the new chain state.
 		self.check_orphans(header.height + 1);

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -29,7 +29,7 @@ use crate::error::{Error, ErrorKind};
 use crate::pipe;
 use crate::store;
 use crate::txhashset;
-use crate::txhashset::TxHashSet;
+use crate::txhashset::{PMMRHandle, TxHashSet};
 use crate::types::{
 	BlockStatus, ChainAdapter, NoStatus, Options, OutputMMRPosition, Tip, TxHashSetRoots,
 	TxHashsetWriteStatus,
@@ -150,6 +150,8 @@ pub struct Chain {
 	adapter: Arc<dyn ChainAdapter + Send + Sync>,
 	orphans: Arc<OrphanBlockPool>,
 	txhashset: Arc<RwLock<txhashset::TxHashSet>>,
+	header_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
+	sync_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
 	// POW verification function
 	pow_verifier: fn(&BlockHeader) -> Result<(), pow::Error>,
@@ -174,7 +176,11 @@ impl Chain {
 		// open the txhashset, creating a new one if necessary
 		let mut txhashset = txhashset::TxHashSet::open(db_root.clone(), store.clone(), None)?;
 
-		setup_head(&genesis, &store, &mut txhashset)?;
+		let mut header_pmmr =
+			PMMRHandle::new(&db_root, "header", "header_head", false, true, None)?;
+		let sync_pmmr = PMMRHandle::new(&db_root, "header", "header_head", false, true, None)?;
+
+		setup_head(&genesis, &store, &mut header_pmmr, &mut txhashset)?;
 		Chain::log_heads(&store)?;
 
 		Ok(Chain {
@@ -183,11 +189,17 @@ impl Chain {
 			adapter,
 			orphans: Arc::new(OrphanBlockPool::new()),
 			txhashset: Arc::new(RwLock::new(txhashset)),
+			header_pmmr: Arc::new(RwLock::new(header_pmmr)),
+			sync_pmmr: Arc::new(RwLock::new(sync_pmmr)),
 			pow_verifier,
 			verifier_cache,
 			archive_mode,
 			genesis: genesis.header.clone(),
 		})
+	}
+
+	pub fn header_pmmr(&self) -> Arc<RwLock<PMMRHandle<BlockHeader>>> {
+		self.header_pmmr.clone()
 	}
 
 	/// Return our shared txhashset instance.
@@ -277,9 +289,10 @@ impl Chain {
 	/// or false if it has added to a fork (or orphan?).
 	fn process_block_single(&self, b: Block, opts: Options) -> Result<Option<Tip>, Error> {
 		let (maybe_new_head, prev_head) = {
+			let mut header_pmmr = self.header_pmmr.write();
 			let mut txhashset = self.txhashset.write();
 			let batch = self.store.batch()?;
-			let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
+			let mut ctx = self.new_ctx(opts, batch, &mut header_pmmr, &mut txhashset)?;
 
 			let prev_head = ctx.batch.head()?;
 
@@ -355,9 +368,10 @@ impl Chain {
 	/// Note: This will update header MMR and corresponding header_head
 	/// if total work increases (on the header chain).
 	pub fn process_block_header(&self, bh: &BlockHeader, opts: Options) -> Result<(), Error> {
+		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		let batch = self.store.batch()?;
-		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
+		let mut ctx = self.new_ctx(opts, batch, &mut header_pmmr, &mut txhashset)?;
 		pipe::process_block_header(bh, &mut ctx)?;
 		ctx.batch.commit()?;
 		Ok(())
@@ -367,9 +381,10 @@ impl Chain {
 	/// This is only ever used during sync and is based on sync_head.
 	/// We update header_head here if our total work increases.
 	pub fn sync_block_headers(&self, headers: &[BlockHeader], opts: Options) -> Result<(), Error> {
+		let mut sync_pmmr = self.sync_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		let batch = self.store.batch()?;
-		let mut ctx = self.new_ctx(opts, batch, &mut txhashset)?;
+		let mut ctx = self.new_ctx(opts, batch, &mut sync_pmmr, &mut txhashset)?;
 
 		// Sync the chunk of block headers, updating sync_head as necessary.
 		pipe::sync_block_headers(headers, &mut ctx)?;
@@ -387,12 +402,14 @@ impl Chain {
 		&self,
 		opts: Options,
 		batch: store::Batch<'a>,
+		header_pmmr: &'a mut txhashset::PMMRHandle<BlockHeader>,
 		txhashset: &'a mut txhashset::TxHashSet,
 	) -> Result<pipe::BlockContext<'a>, Error> {
 		Ok(pipe::BlockContext {
 			opts,
 			pow_verifier: self.pow_verifier,
 			verifier_cache: self.verifier_cache.clone(),
+			header_pmmr,
 			txhashset,
 			batch,
 		})
@@ -476,8 +493,9 @@ impl Chain {
 
 	/// Validate the tx against the current UTXO set.
 	pub fn validate_tx(&self, tx: &Transaction) -> Result<(), Error> {
+		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		txhashset::utxo_view(&txhashset, |utxo| {
+		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo| {
 			utxo.validate_tx(tx)?;
 			Ok(())
 		})
@@ -492,8 +510,9 @@ impl Chain {
 	/// that has not yet sufficiently matured.
 	pub fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), Error> {
 		let height = self.next_block_height()?;
+		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		txhashset::utxo_view(&txhashset, |utxo| {
+		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo| {
 			utxo.verify_coinbase_maturity(&tx.inputs(), height)?;
 			Ok(())
 		})
@@ -519,15 +538,16 @@ impl Chain {
 			return Ok(());
 		}
 
+		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 
 		// Now create an extension from the txhashset and validate against the
 		// latest block header. Rewind the extension to the specified header to
 		// ensure the view is consistent.
-		txhashset::extending_readonly(&mut txhashset, |extension| {
-			let head = extension.batch.head()?;
-			pipe::rewind_and_apply_fork(&header, &head, extension)?;
-			extension.validate(fast_validation, &NoStatus)?;
+		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |mut ext| {
+			pipe::rewind_and_apply_fork(&header, &mut ext)?;
+			let ref mut extension = ext.extension;
+			extension.validate(&self.genesis, fast_validation, &NoStatus)?;
 			Ok(())
 		})
 	}
@@ -535,15 +555,20 @@ impl Chain {
 	/// Sets the txhashset roots on a brand new block by applying the block on
 	/// the current txhashset state.
 	pub fn set_txhashset_roots(&self, b: &mut Block) -> Result<(), Error> {
+		let previous_header = self.store.get_previous_header(&b.header)?;
+
+		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
+
 		let (prev_root, roots, sizes) =
-			txhashset::extending_readonly(&mut txhashset, |extension| {
-				let previous_header = extension.batch.get_previous_header(&b.header)?;
-				let head = extension.batch.head()?;
-				pipe::rewind_and_apply_fork(&previous_header, &head, extension)?;
+			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext| {
+				pipe::rewind_and_apply_fork(&previous_header, ext)?;
+
+				let ref mut extension = ext.extension;
+				let ref mut header_extension = ext.header_extension;
 
 				// Retrieve the header root before we apply the new block
-				let prev_root = extension.header_root()?;
+				let prev_root = header_extension.root()?;
 
 				// Apply the latest block to the chain state via the extension.
 				extension.apply_block(b)?;
@@ -562,7 +587,7 @@ impl Chain {
 		// Set the output and kernel MMR sizes.
 		{
 			// Carefully destructure these correctly...
-			let (_, output_mmr_size, _, kernel_mmr_size) = sizes;
+			let (output_mmr_size, _, kernel_mmr_size) = sizes;
 			b.header.output_mmr_size = output_mmr_size;
 			b.header.kernel_mmr_size = kernel_mmr_size;
 		}
@@ -576,12 +601,14 @@ impl Chain {
 		output: &OutputIdentifier,
 		header: &BlockHeader,
 	) -> Result<MerkleProof, Error> {
+		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
-		let merkle_proof = txhashset::extending_readonly(&mut txhashset, |extension| {
-			let head = extension.batch.head()?;
-			pipe::rewind_and_apply_fork(&header, &head, extension)?;
-			extension.merkle_proof(output)
-		})?;
+		let merkle_proof =
+			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext| {
+				pipe::rewind_and_apply_fork(&header, ext)?;
+				let ref mut extension = ext.extension;
+				extension.merkle_proof(output)
+			})?;
 
 		Ok(merkle_proof)
 	}
@@ -631,11 +658,11 @@ impl Chain {
 		// to rewind after receiving the txhashset zip.
 		let header = self.get_block_header(&h)?;
 		{
+			let mut header_pmmr = self.header_pmmr.write();
 			let mut txhashset = self.txhashset.write();
-			txhashset::extending_readonly(&mut txhashset, |extension| {
-				let head = extension.batch.head()?;
-				pipe::rewind_and_apply_fork(&header, &head, extension)?;
-
+			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext| {
+				pipe::rewind_and_apply_fork(&header, ext)?;
+				let ref mut extension = ext.extension;
 				extension.snapshot()?;
 				Ok(())
 			})?;
@@ -708,28 +735,10 @@ impl Chain {
 	/// have an MMR we can safely rewind based on the headers received from a peer.
 	/// TODO - think about how to optimize this.
 	pub fn rebuild_sync_mmr(&self, head: &Tip) -> Result<(), Error> {
-		let mut txhashset = self.txhashset.write();
+		let mut sync_pmmr = self.sync_pmmr.write();
 		let mut batch = self.store.batch()?;
-		txhashset::sync_extending(&mut txhashset, &mut batch, |extension| {
-			extension.rebuild(head, &self.genesis)?;
-			Ok(())
-		})?;
-		batch.commit()?;
-		Ok(())
-	}
-
-	/// Rebuild the header MMR based on current header_head.
-	/// We rebuild the header MMR after receiving a txhashset from a peer.
-	/// The txhashset contains output, rangeproof and kernel MMRs but we construct
-	/// the header MMR locally based on headers from our db.
-	/// TODO - think about how to optimize this.
-	fn rebuild_header_mmr(
-		&self,
-		head: &Tip,
-		txhashset: &mut txhashset::TxHashSet,
-	) -> Result<(), Error> {
-		let mut batch = self.store.batch()?;
-		txhashset::header_extending(txhashset, &mut batch, |extension| {
+		let sync_head = batch.get_sync_head()?;
+		txhashset::header_extending(&mut sync_pmmr, &sync_head, &mut batch, |extension| {
 			extension.rebuild(head, &self.genesis)?;
 			Ok(())
 		})?;
@@ -824,7 +833,6 @@ impl Chain {
 	/// Clean the temporary sandbox folder
 	pub fn clean_txhashset_sandbox(&self) {
 		txhashset::clean_txhashset_folder(&self.get_tmp_dir());
-		txhashset::clean_header_folder(&self.get_tmp_dir());
 	}
 
 	/// Specific tmp dir.
@@ -868,6 +876,8 @@ impl Chain {
 		txhashset_data: File,
 		status: &dyn TxHashsetWriteStatus,
 	) -> Result<bool, Error> {
+		let mut header_pmmr = self.header_pmmr.write();
+
 		status.on_setup();
 
 		// Initial check whether this txhashset is needed or not
@@ -889,7 +899,6 @@ impl Chain {
 		// Write txhashset to sandbox (in the Grin specific tmp dir)
 		let sandbox_dir = self.get_tmp_dir();
 		txhashset::clean_txhashset_folder(&sandbox_dir);
-		txhashset::clean_header_folder(&sandbox_dir);
 		txhashset::zip_write(sandbox_dir.clone(), txhashset_data.try_clone()?, &header)?;
 
 		let mut txhashset = txhashset::TxHashSet::open(
@@ -903,7 +912,7 @@ impl Chain {
 
 		// The txhashset.zip contains the output, rangeproof and kernel MMRs.
 		// We must rebuild the header MMR ourselves based on the headers in our db.
-		self.rebuild_header_mmr(&Tip::from_header(&header), &mut txhashset)?;
+		// self.rebuild_header_mmr(&Tip::from_header(&header), &mut txhashset)?;
 
 		// Validate the full kernel history (kernel MMR root for every block header).
 		self.validate_kernel_history(&header, &txhashset)?;
@@ -913,12 +922,13 @@ impl Chain {
 
 		let mut batch = self.store.batch()?;
 
-		txhashset::extending(&mut txhashset, &mut batch, |extension| {
+		txhashset::extending(&mut header_pmmr, &mut txhashset, &mut batch, |ext| {
+			let extension = &mut ext.extension;
 			extension.rewind(&header)?;
 
 			// Validate the extension, generating the utxo_sum and kernel_sum.
 			// Full validation, including rangeproofs and kernel signature verification.
-			let (utxo_sum, kernel_sum) = extension.validate(false, status)?;
+			let (utxo_sum, kernel_sum) = extension.validate(&self.genesis, false, status)?;
 
 			// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 			extension.batch.save_block_sums(
@@ -969,9 +979,6 @@ impl Chain {
 				Some(&header),
 			)?;
 
-			self.rebuild_header_mmr(&Tip::from_header(&header), &mut txhashset)?;
-			txhashset::clean_header_folder(&sandbox_dir);
-
 			// Replace the chain txhashset with the newly built one.
 			*txhashset_ref = txhashset;
 		}
@@ -992,7 +999,7 @@ impl Chain {
 	/// *Only* runs if we are not in archive mode.
 	fn remove_historical_blocks(
 		&self,
-		txhashset: &txhashset::TxHashSet,
+		header_pmmr: &txhashset::PMMRHandle<BlockHeader>,
 		batch: &mut store::Batch<'_>,
 	) -> Result<(), Error> {
 		if self.archive_mode {
@@ -1019,7 +1026,7 @@ impl Chain {
 		}
 
 		let mut count = 0;
-		let tail_hash = txhashset.get_header_hash_by_height(head.height - horizon)?;
+		let tail_hash = header_pmmr.get_header_hash_by_height(head.height - horizon)?;
 		let tail = batch.get_block_header(&tail_hash)?;
 
 		// Remove old blocks (including short lived fork blocks) which height < tail.height
@@ -1067,27 +1074,33 @@ impl Chain {
 			}
 		}
 
+		// Take a write lock on the txhashet and start a new writeable db batch.
+		let mut header_pmmr = self.header_pmmr.write();
+		let mut txhashset = self.txhashset.write();
+		let mut batch = self.store.batch()?;
+
+		// Compact the txhashset itself (rewriting the pruned backend files).
 		{
-			// Take a write lock on the txhashet and start a new writeable db batch.
-			let mut txhashset = self.txhashset.write();
-			let mut batch = self.store.batch()?;
+			let head_header = batch.head_header()?;
+			let current_height = head_header.height;
+			let horizon_height =
+				current_height.saturating_sub(global::cut_through_horizon().into());
+			let horizon_hash = self.get_header_hash_by_height(horizon_height)?;
+			let horizon_header = batch.get_block_header(&horizon_hash)?;
 
-			// Compact the txhashset itself (rewriting the pruned backend files).
-			txhashset.compact(&mut batch)?;
+			txhashset.compact(&horizon_header, &mut batch)?;
+		}
 
-			// Rebuild our output_pos index in the db based on current UTXO set.
-			txhashset::extending(&mut txhashset, &mut batch, |extension| {
-				extension.rebuild_height_pos_index()?;
-				Ok(())
-			})?;
+		// Rebuild our output_pos index in the db based on current UTXO set.
+		txhashset::extending(&mut header_pmmr, &mut txhashset, &mut batch, |ext| {
+			let ref extension = ext.extension;
+			extension.rebuild_height_pos_index()?;
+			Ok(())
+		})?;
 
-			// If we are not in archival mode remove historical blocks from the db.
-			if !self.archive_mode {
-				self.remove_historical_blocks(&txhashset, &mut batch)?;
-			}
-
-			// Commit all the above db changes.
-			batch.commit()?;
+		// If we are not in archival mode remove historical blocks from the db.
+		if !self.archive_mode {
+			self.remove_historical_blocks(&header_pmmr, &mut batch)?;
 		}
 
 		Ok(())
@@ -1213,9 +1226,7 @@ impl Chain {
 	/// Note: Takes a read lock on the txhashset.
 	/// Take care not to call this repeatedly in a tight loop.
 	fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		let txhashset = self.txhashset.read();
-		let hash = txhashset.get_header_hash_by_height(height)?;
-		Ok(hash)
+		self.header_pmmr.read().get_header_hash_by_height(height)
 	}
 
 	/// Migrate the index 'commitment -> output_pos' to index 'commitment -> (output_pos, block_height)'
@@ -1223,6 +1234,7 @@ impl Chain {
 	///     - Node start-up. For database migration from the old version.
 	/// 	- After the txhashset 'rebuild_index' when state syncing.
 	pub fn rebuild_height_for_pos(&self) -> Result<(), Error> {
+		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		let mut outputs_pos = txhashset.get_all_output_pos()?;
 		let total_outputs = outputs_pos.len();
@@ -1248,7 +1260,8 @@ impl Chain {
 
 		let mut i = 0;
 		for search_height in 0..max_height {
-			let h = txhashset.get_header_by_height(search_height + 1)?;
+			let hash = header_pmmr.get_header_hash_by_height(search_height + 1)?;
+			let h = batch.get_block_header(&hash)?;
 			while i < total_outputs {
 				let (commit, pos) = outputs_pos[i];
 				if pos > h.output_mmr_size {
@@ -1274,10 +1287,11 @@ impl Chain {
 		&self,
 		output_ref: &OutputIdentifier,
 	) -> Result<BlockHeader, Error> {
+		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-
 		let output_pos = txhashset.is_unspent(output_ref)?;
-		Ok(txhashset.get_header_by_height(output_pos.height)?)
+		let hash = header_pmmr.get_header_hash_by_height(output_pos.height)?;
+		Ok(self.get_block_header(&hash)?)
 	}
 
 	/// Gets the kernel with a given excess and the block height it is included in.
@@ -1386,6 +1400,7 @@ impl Chain {
 fn setup_head(
 	genesis: &Block,
 	store: &store::ChainStore,
+	header_pmmr: &mut txhashset::PMMRHandle<BlockHeader>,
 	txhashset: &mut txhashset::TxHashSet,
 ) -> Result<(), Error> {
 	let mut batch = store.batch()?;
@@ -1405,7 +1420,7 @@ fn setup_head(
 
 				// If we have no header MMR then rebuild as necessary.
 				// Supports old nodes with no header MMR.
-				txhashset::header_extending(txhashset, &mut batch, |extension| {
+				txhashset::header_extending(header_pmmr, &head, &mut batch, |extension| {
 					let needs_rebuild = match extension.get_header_by_height(head.height) {
 						Ok(header) => header.hash() != head.last_block_h,
 						Err(_) => true,
@@ -1418,9 +1433,11 @@ fn setup_head(
 					Ok(())
 				})?;
 
-				let res = txhashset::extending(txhashset, &mut batch, |extension| {
-					let head = extension.batch.head()?;
-					pipe::rewind_and_apply_fork(&header, &head, extension)?;
+				let res = txhashset::extending(header_pmmr, txhashset, &mut batch, |ext| {
+					pipe::rewind_and_apply_fork(&header, ext)?;
+
+					let ref mut extension = ext.extension;
+
 					extension.validate_roots()?;
 
 					// now check we have the "block sums" for the block in question
@@ -1436,7 +1453,8 @@ fn setup_head(
 
 						// Do a full (and slow) validation of the txhashset extension
 						// to calculate the utxo_sum and kernel_sum at this block height.
-						let (utxo_sum, kernel_sum) = extension.validate_kernel_sums()?;
+						let (utxo_sum, kernel_sum) =
+							extension.validate_kernel_sums(&genesis.header)?;
 
 						// Save the block_sums to the db for use later.
 						extension.batch.save_block_sums(
@@ -1494,11 +1512,12 @@ fn setup_head(
 					kernel_sum,
 				};
 			}
-			txhashset::header_extending(txhashset, &mut batch, |extension| {
+			txhashset::header_extending(header_pmmr, &tip, &mut batch, |extension| {
 				extension.apply_header(&genesis.header)?;
 				Ok(())
 			})?;
-			txhashset::extending(txhashset, &mut batch, |extension| {
+			txhashset::extending(header_pmmr, txhashset, &mut batch, |ext| {
+				let ref mut extension = ext.extension;
 				extension.apply_block(&genesis)?;
 				extension.validate_roots()?;
 				extension.validate_sizes()?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -413,10 +413,10 @@ fn validate_block(block: &Block, ctx: &mut BlockContext<'_>) -> Result<(), Error
 /// Verify the block is not spending coinbase outputs before they have sufficiently matured.
 fn verify_coinbase_maturity(
 	block: &Block,
-	ext: &mut txhashset::ExtensionPair<'_>,
+	ext: &txhashset::ExtensionPair<'_>,
 ) -> Result<(), Error> {
-	let ref mut extension = ext.extension;
-	let ref mut header_extension = ext.header_extension;
+	let ref extension = ext.extension;
+	let ref header_extension = ext.header_extension;
 	extension
 		.utxo_view(header_extension)
 		.verify_coinbase_maturity(&block.inputs(), block.header.height)

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -332,15 +332,14 @@ where
 	let commit_index = trees.commit_index.clone();
 	let batch = commit_index.batch()?;
 
-	// We want to use the current head of the most work chain unless
-	// we explicitly rewind the extension.
-	let head = batch.head()?;
-
 	trace!("Starting new txhashset (readonly) extension.");
+
+	let head = batch.head()?;
+	let header_head = batch.header_head()?;
 
 	let res = {
 		let header_pmmr = PMMR::at(&mut handle.backend, handle.last_pos);
-		let mut header_extension = HeaderExtension::new(header_pmmr, &batch, head.clone());
+		let mut header_extension = HeaderExtension::new(header_pmmr, &batch, header_head);
 		let mut extension = Extension::new(trees, &batch, head);
 		let mut extension_pair = ExtensionPair {
 			header_extension: &mut header_extension,
@@ -431,9 +430,8 @@ where
 	let res: Result<T, Error>;
 	let rollback: bool;
 
-	// We want to use the current head of the most work chain unless
-	// we explicitly rewind the extension.
 	let head = batch.head()?;
+	let header_head = batch.header_head()?;
 
 	// create a child transaction so if the state is rolled back by itself, all
 	// index saving can be undone
@@ -442,7 +440,7 @@ where
 		trace!("Starting new txhashset extension.");
 
 		let pmmr = PMMR::at(&mut header_pmmr.backend, header_pmmr.last_pos);
-		let mut header_extension = HeaderExtension::new(pmmr, &child_batch, head.clone());
+		let mut header_extension = HeaderExtension::new(pmmr, &child_batch, header_head);
 		let mut extension = Extension::new(trees, &child_batch, head);
 		let mut extension_pair = ExtensionPair {
 			header_extension: &mut header_extension,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -22,7 +22,6 @@ use crate::core::core::pmmr::{self, Backend, ReadonlyPMMR, RewindablePMMR, PMMR}
 use crate::core::core::{
 	Block, BlockHeader, Input, Output, OutputIdentifier, TxKernel, TxKernelEntry,
 };
-use crate::core::global;
 use crate::core::ser::{PMMRIndexHashable, PMMRable};
 use crate::error::{Error, ErrorKind};
 use crate::store::{Batch, ChainStore};
@@ -38,11 +37,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-const HEADERHASHSET_SUBDIR: &'static str = "header";
 const TXHASHSET_SUBDIR: &'static str = "txhashset";
-
-const HEADER_HEAD_SUBDIR: &'static str = "header_head";
-const SYNC_HEAD_SUBDIR: &'static str = "sync_head";
 
 const OUTPUT_SUBDIR: &'static str = "output";
 const RANGE_PROOF_SUBDIR: &'static str = "rangeproof";
@@ -50,13 +45,13 @@ const KERNEL_SUBDIR: &'static str = "kernel";
 
 const TXHASHSET_ZIP: &'static str = "txhashset_snapshot";
 
-struct PMMRHandle<T: PMMRable> {
-	backend: PMMRBackend<T>,
-	last_pos: u64,
+pub struct PMMRHandle<T: PMMRable> {
+	pub backend: PMMRBackend<T>,
+	pub last_pos: u64,
 }
 
 impl<T: PMMRable> PMMRHandle<T> {
-	fn new(
+	pub fn new(
 		root_dir: &str,
 		sub_dir: &str,
 		file_name: &str,
@@ -75,6 +70,19 @@ impl<T: PMMRable> PMMRHandle<T> {
 	}
 }
 
+impl PMMRHandle<BlockHeader> {
+	// /// Get the header hash at the specified height based on the current state of this header pmmr.
+	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.last_pos);
+		if let Some(entry) = header_pmmr.get_data(pos) {
+			Ok(entry.hash())
+		} else {
+			Err(ErrorKind::Other(format!("get header hash by height")).into())
+		}
+	}
+}
+
 /// An easy to manipulate structure holding the 3 sum trees necessary to
 /// validate blocks and capturing the Output set, the range proofs and the
 /// kernels. Also handles the index of Commitments to positions in the
@@ -85,21 +93,6 @@ impl<T: PMMRable> PMMRHandle<T> {
 /// may have commitments that have already been spent, even with
 /// pruning enabled.
 pub struct TxHashSet {
-	/// Header MMR to support the header_head chain.
-	/// This is rewound and applied transactionally with the
-	/// output, rangeproof and kernel MMRs during an extension or a
-	/// readonly_extension.
-	/// It can also be rewound and applied separately via a header_extension.
-	header_pmmr_h: PMMRHandle<BlockHeader>,
-
-	/// Header MMR to support exploratory sync_head.
-	/// The header_head and sync_head chains can diverge so we need to maintain
-	/// multiple header MMRs during the sync process.
-	///
-	/// Note: this is rewound and applied separately to the other MMRs
-	/// via a "sync_extension".
-	sync_pmmr_h: PMMRHandle<BlockHeader>,
-
 	output_pmmr_h: PMMRHandle<Output>,
 	rproof_pmmr_h: PMMRHandle<RangeProof>,
 	kernel_pmmr_h: PMMRHandle<TxKernel>,
@@ -116,22 +109,6 @@ impl TxHashSet {
 		header: Option<&BlockHeader>,
 	) -> Result<TxHashSet, Error> {
 		Ok(TxHashSet {
-			header_pmmr_h: PMMRHandle::new(
-				&root_dir,
-				HEADERHASHSET_SUBDIR,
-				HEADER_HEAD_SUBDIR,
-				false,
-				true,
-				None,
-			)?,
-			sync_pmmr_h: PMMRHandle::new(
-				&root_dir,
-				HEADERHASHSET_SUBDIR,
-				SYNC_HEAD_SUBDIR,
-				false,
-				true,
-				None,
-			)?,
 			output_pmmr_h: PMMRHandle::new(
 				&root_dir,
 				TXHASHSET_SUBDIR,
@@ -162,8 +139,6 @@ impl TxHashSet {
 
 	/// Close all backend file handles
 	pub fn release_backend_files(&mut self) {
-		self.header_pmmr_h.backend.release_files();
-		self.sync_pmmr_h.backend.release_files();
 		self.output_pmmr_h.backend.release_files();
 		self.rproof_pmmr_h.backend.release_files();
 		self.kernel_pmmr_h.backend.release_files();
@@ -217,23 +192,7 @@ impl TxHashSet {
 			.get_last_n_insertions(distance)
 	}
 
-	/// Get the header hash at the specified height based on the current state of the txhashset.
-	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
-		let header_pmmr =
-			ReadonlyPMMR::at(&self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
-		if let Some(entry) = header_pmmr.get_data(pos) {
-			Ok(entry.hash())
-		} else {
-			Err(ErrorKind::Other(format!("get header hash by height")).into())
-		}
-	}
-
-	/// Get the header at the specified height based on the current state of the txhashset.
-	/// Derives the MMR pos from the height (insertion index) and retrieves the header hash.
-	/// Looks the header up in the db by hash.
-	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
-		let hash = self.get_header_hash_by_height(height)?;
+	pub fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, Error> {
 		let header = self.commit_index.get_block_header(&hash)?;
 		Ok(header)
 	}
@@ -294,8 +253,8 @@ impl TxHashSet {
 
 	/// Get MMR roots.
 	pub fn roots(&self) -> TxHashSetRoots {
-		let header_pmmr =
-			ReadonlyPMMR::at(&self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
+		// let header_pmmr =
+		// 	ReadonlyPMMR::at(&self.header_pmmr_h.backend, self.header_pmmr_h.last_pos);
 		let output_pmmr =
 			ReadonlyPMMR::at(&self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 		let rproof_pmmr =
@@ -304,7 +263,7 @@ impl TxHashSet {
 			ReadonlyPMMR::at(&self.kernel_pmmr_h.backend, self.kernel_pmmr_h.last_pos);
 
 		TxHashSetRoots {
-			header_root: header_pmmr.root(),
+			// header_root: header_pmmr.root(),
 			output_root: output_pmmr.root(),
 			rproof_root: rproof_pmmr.root(),
 			kernel_root: kernel_pmmr.root(),
@@ -325,17 +284,14 @@ impl TxHashSet {
 	}
 
 	/// Compact the MMR data files and flush the rm logs
-	pub fn compact(&mut self, batch: &mut Batch<'_>) -> Result<(), Error> {
+	pub fn compact(
+		&mut self,
+		horizon_header: &BlockHeader,
+		batch: &mut Batch<'_>,
+	) -> Result<(), Error> {
 		debug!("txhashset: starting compaction...");
 
 		let head_header = batch.head_header()?;
-		let current_height = head_header.height;
-
-		// horizon for compacting is based on current_height
-		let horizon_height = current_height.saturating_sub(global::cut_through_horizon().into());
-		let horizon_hash = self.get_header_hash_by_height(horizon_height)?;
-		let horizon_header = batch.get_block_header(&horizon_hash)?;
-
 		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, batch)?;
 
 		debug!("txhashset: check_compact output mmr backend...");
@@ -360,9 +316,13 @@ impl TxHashSet {
 /// of blocks to the txhashset and the checking of the current tree roots.
 ///
 /// The unit of work is always discarded (always rollback) as this is read-only.
-pub fn extending_readonly<F, T>(trees: &mut TxHashSet, inner: F) -> Result<T, Error>
+pub fn extending_readonly<F, T>(
+	handle: &mut PMMRHandle<BlockHeader>,
+	trees: &mut TxHashSet,
+	inner: F,
+) -> Result<T, Error>
 where
-	F: FnOnce(&mut Extension<'_>) -> Result<T, Error>,
+	F: FnOnce(&mut ExtensionPair<'_>) -> Result<T, Error>,
 {
 	let commit_index = trees.commit_index.clone();
 	let batch = commit_index.batch()?;
@@ -374,14 +334,20 @@ where
 	trace!("Starting new txhashset (readonly) extension.");
 
 	let res = {
+		let header_pmmr = PMMR::at(&mut handle.backend, handle.last_pos);
+		let mut header_extension = HeaderExtension::new(header_pmmr, &batch, head.clone());
 		let mut extension = Extension::new(trees, &batch, head);
-		extension.force_rollback();
-		inner(&mut extension)
+		let mut extension_pair = ExtensionPair {
+			header_extension: &mut header_extension,
+			extension: &mut extension,
+		};
+		inner(&mut extension_pair)
 	};
 
 	trace!("Rollbacking txhashset (readonly) extension.");
 
-	trees.header_pmmr_h.backend.discard();
+	handle.backend.discard();
+
 	trees.output_pmmr_h.backend.discard();
 	trees.rproof_pmmr_h.backend.discard();
 	trees.kernel_pmmr_h.backend.discard();
@@ -393,7 +359,11 @@ where
 
 /// Readonly view on the UTXO set.
 /// Based on the current txhashset output_pmmr.
-pub fn utxo_view<F, T>(trees: &TxHashSet, inner: F) -> Result<T, Error>
+pub fn utxo_view<F, T>(
+	handle: &PMMRHandle<BlockHeader>,
+	trees: &TxHashSet,
+	inner: F,
+) -> Result<T, Error>
 where
 	F: FnOnce(&UTXOView<'_>) -> Result<T, Error>,
 {
@@ -401,8 +371,7 @@ where
 	{
 		let output_pmmr =
 			ReadonlyPMMR::at(&trees.output_pmmr_h.backend, trees.output_pmmr_h.last_pos);
-		let header_pmmr =
-			ReadonlyPMMR::at(&trees.header_pmmr_h.backend, trees.header_pmmr_h.last_pos);
+		let header_pmmr = ReadonlyPMMR::at(&handle.backend, handle.last_pos);
 
 		// Create a new batch here to pass into the utxo_view.
 		// Discard it (rollback) after we finish with the utxo_view.
@@ -445,14 +414,15 @@ where
 /// If the closure returns an error, modifications are canceled and the unit
 /// of work is abandoned. Otherwise, the unit of work is permanently applied.
 pub fn extending<'a, F, T>(
+	header_pmmr: &'a mut PMMRHandle<BlockHeader>,
 	trees: &'a mut TxHashSet,
 	batch: &'a mut Batch<'_>,
 	inner: F,
 ) -> Result<T, Error>
 where
-	F: FnOnce(&mut Extension<'_>) -> Result<T, Error>,
+	F: FnOnce(&mut ExtensionPair<'_>) -> Result<T, Error>,
 {
-	let sizes: (u64, u64, u64, u64);
+	let sizes: (u64, u64, u64);
 	let res: Result<T, Error>;
 	let rollback: bool;
 
@@ -466,17 +436,25 @@ where
 	{
 		trace!("Starting new txhashset extension.");
 
+		let pmmr = PMMR::at(&mut header_pmmr.backend, header_pmmr.last_pos);
+		let mut header_extension = HeaderExtension::new(pmmr, &child_batch, head.clone());
 		let mut extension = Extension::new(trees, &child_batch, head);
-		res = inner(&mut extension);
+		let mut extension_pair = ExtensionPair {
+			header_extension: &mut header_extension,
+			extension: &mut extension,
+		};
+		res = inner(&mut extension_pair);
 
-		rollback = extension.rollback;
-		sizes = extension.sizes();
+		rollback = extension_pair.extension.rollback;
+		sizes = extension_pair.extension.sizes();
 	}
+
+	// Always discard any modifications to the header PMMR backend.
+	header_pmmr.backend.discard();
 
 	match res {
 		Err(e) => {
 			debug!("Error returned, discarding txhashset extension: {}", e);
-			trees.header_pmmr_h.backend.discard();
 			trees.output_pmmr_h.backend.discard();
 			trees.rproof_pmmr_h.backend.discard();
 			trees.kernel_pmmr_h.backend.discard();
@@ -485,7 +463,6 @@ where
 		Ok(r) => {
 			if rollback {
 				trace!("Rollbacking txhashset extension. sizes {:?}", sizes);
-				trees.header_pmmr_h.backend.discard();
 				trees.output_pmmr_h.backend.discard();
 				trees.rproof_pmmr_h.backend.discard();
 				trees.kernel_pmmr_h.backend.discard();
@@ -493,75 +470,15 @@ where
 				trace!("Committing txhashset extension. sizes {:?}", sizes);
 				child_batch.commit()?;
 				// NOTE: The header MMR is readonly for a txhashset extension.
-				trees.header_pmmr_h.backend.discard();
 				trees.output_pmmr_h.backend.sync()?;
 				trees.rproof_pmmr_h.backend.sync()?;
 				trees.kernel_pmmr_h.backend.sync()?;
-				trees.output_pmmr_h.last_pos = sizes.1;
-				trees.rproof_pmmr_h.last_pos = sizes.2;
-				trees.kernel_pmmr_h.last_pos = sizes.3;
+				trees.output_pmmr_h.last_pos = sizes.0;
+				trees.rproof_pmmr_h.last_pos = sizes.1;
+				trees.kernel_pmmr_h.last_pos = sizes.2;
 			}
 
 			trace!("TxHashSet extension done.");
-			Ok(r)
-		}
-	}
-}
-
-/// Start a new sync MMR unit of work. This MMR tracks the sync_head.
-/// This is used during header sync to validate batches of headers as they arrive
-/// without needing to repeatedly rewind the header MMR that continues to track
-/// the header_head as they diverge during sync.
-pub fn sync_extending<'a, F, T>(
-	trees: &'a mut TxHashSet,
-	batch: &'a mut Batch<'_>,
-	inner: F,
-) -> Result<T, Error>
-where
-	F: FnOnce(&mut HeaderExtension<'_>) -> Result<T, Error>,
-{
-	let size: u64;
-	let res: Result<T, Error>;
-	let rollback: bool;
-
-	// We want to use the current sync_head unless
-	// we explicitly rewind the extension.
-	let head = batch.get_sync_head()?;
-
-	// create a child transaction so if the state is rolled back by itself, all
-	// index saving can be undone
-	let child_batch = batch.child()?;
-	{
-		trace!("Starting new txhashset sync_head extension.");
-		let pmmr = PMMR::at(&mut trees.sync_pmmr_h.backend, trees.sync_pmmr_h.last_pos);
-		let mut extension = HeaderExtension::new(pmmr, &child_batch, head);
-
-		res = inner(&mut extension);
-
-		rollback = extension.rollback;
-		size = extension.size();
-	}
-
-	match res {
-		Err(e) => {
-			debug!(
-				"Error returned, discarding txhashset sync_head extension: {}",
-				e
-			);
-			trees.sync_pmmr_h.backend.discard();
-			Err(e)
-		}
-		Ok(r) => {
-			if rollback {
-				trace!("Rollbacking txhashset sync_head extension. size {:?}", size);
-				trees.sync_pmmr_h.backend.discard();
-			} else {
-				trace!("Committing txhashset sync_head extension. size {:?}", size);
-				child_batch.commit()?;
-				trees.sync_pmmr_h.backend.sync()?;
-				trees.sync_pmmr_h.last_pos = size;
-			}
-			trace!("TxHashSet sync_head extension done.");
 			Ok(r)
 		}
 	}
@@ -571,7 +488,8 @@ where
 /// This MMR can be extended individually beyond the other (output, rangeproof and kernel) MMRs
 /// to allow headers to be validated before we receive the full block data.
 pub fn header_extending<'a, F, T>(
-	trees: &'a mut TxHashSet,
+	handle: &'a mut PMMRHandle<BlockHeader>,
+	head: &Tip,
 	batch: &'a mut Batch<'_>,
 	inner: F,
 ) -> Result<T, Error>
@@ -582,21 +500,13 @@ where
 	let res: Result<T, Error>;
 	let rollback: bool;
 
-	// We want to use the current head of header chain here.
-	// Caller is responsible for rewinding the header MMR back
-	// to a previous header as necessary when processing a fork.
-	let head = batch.header_head()?;
-
 	// create a child transaction so if the state is rolled back by itself, all
 	// index saving can be undone
 	let child_batch = batch.child()?;
 	{
 		trace!("Starting new txhashset header extension.");
-		let pmmr = PMMR::at(
-			&mut trees.header_pmmr_h.backend,
-			trees.header_pmmr_h.last_pos,
-		);
-		let mut extension = HeaderExtension::new(pmmr, &child_batch, head);
+		let pmmr = PMMR::at(&mut handle.backend, handle.last_pos);
+		let mut extension = HeaderExtension::new(pmmr, &child_batch, head.clone());
 		res = inner(&mut extension);
 
 		rollback = extension.rollback;
@@ -609,18 +519,18 @@ where
 				"Error returned, discarding txhashset header extension: {}",
 				e
 			);
-			trees.header_pmmr_h.backend.discard();
+			handle.backend.discard();
 			Err(e)
 		}
 		Ok(r) => {
 			if rollback {
 				trace!("Rollbacking txhashset header extension. size {:?}", size);
-				trees.header_pmmr_h.backend.discard();
+				handle.backend.discard();
 			} else {
 				trace!("Committing txhashset header extension. size {:?}", size);
 				child_batch.commit()?;
-				trees.header_pmmr_h.backend.sync()?;
-				trees.header_pmmr_h.last_pos = size;
+				handle.backend.sync()?;
+				handle.last_pos = size;
 			}
 			trace!("TxHashSet header extension done.");
 			Ok(r)
@@ -801,13 +711,23 @@ impl<'a> HeaderExtension<'a> {
 	}
 }
 
+pub struct ExtensionPair<'a> {
+	pub header_extension: &'a mut HeaderExtension<'a>,
+	pub extension: &'a mut Extension<'a>,
+}
+
+impl<'a> ExtensionPair<'a> {
+	pub fn batch(&mut self) -> &'a Batch<'a> {
+		self.extension.batch
+	}
+}
+
 /// Allows the application of new blocks on top of the sum trees in a
 /// reversible manner within a unit of work provided by the `extending`
 /// function.
 pub struct Extension<'a> {
 	head: Tip,
 
-	header_pmmr: PMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
 	output_pmmr: PMMR<'a, Output, PMMRBackend<Output>>,
 	rproof_pmmr: PMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 	kernel_pmmr: PMMR<'a, TxKernel, PMMRBackend<TxKernel>>,
@@ -853,10 +773,6 @@ impl<'a> Extension<'a> {
 	fn new(trees: &'a mut TxHashSet, batch: &'a Batch<'_>, head: Tip) -> Extension<'a> {
 		Extension {
 			head,
-			header_pmmr: PMMR::at(
-				&mut trees.header_pmmr_h.backend,
-				trees.header_pmmr_h.last_pos,
-			),
 			output_pmmr: PMMR::at(
 				&mut trees.output_pmmr_h.backend,
 				trees.output_pmmr_h.last_pos,
@@ -879,26 +795,22 @@ impl<'a> Extension<'a> {
 		self.head.clone()
 	}
 
-	/// Build a view of the current UTXO set based on the output PMMR.
-	pub fn utxo_view(&'a self) -> UTXOView<'a> {
+	/// Build a view of the current UTXO set based on the output PMMR
+	/// and the provided header extension.
+	pub fn utxo_view(&'a self, header_ext: &'a HeaderExtension<'a>) -> UTXOView<'a> {
 		UTXOView::new(
 			self.output_pmmr.readonly_pmmr(),
-			self.header_pmmr.readonly_pmmr(),
+			header_ext.pmmr.readonly_pmmr(),
 			self.batch,
 		)
 	}
 
-	/// Apply a new block to the existing state.
-	///
-	/// Applies the following -
-	///   * header
+	/// Apply a new block to the existing state -
 	///   * outputs
 	///   * inputs
 	///   * kernels
 	///
 	pub fn apply_block(&mut self, b: &Block) -> Result<(), Error> {
-		self.apply_header(&b.header)?;
-
 		for out in b.outputs() {
 			let pos = self.apply_output(out)?;
 			// Update the (output_pos,height) index for the new output.
@@ -1000,42 +912,6 @@ impl<'a> Extension<'a> {
 		Ok(())
 	}
 
-	fn apply_header(&mut self, header: &BlockHeader) -> Result<(), Error> {
-		self.header_pmmr
-			.push(header)
-			.map_err(&ErrorKind::TxHashSetErr)?;
-		Ok(())
-	}
-
-	/// Get the header hash for the specified pos from the underlying MMR backend.
-	fn get_header_hash(&self, pos: u64) -> Option<Hash> {
-		self.header_pmmr.get_data(pos).map(|x| x.hash())
-	}
-
-	/// Get the header at the specified height based on the current state of the extension.
-	/// Derives the MMR pos from the height (insertion index) and retrieves the header hash.
-	/// Looks the header up in the db by hash.
-	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
-		if let Some(hash) = self.get_header_hash(pos) {
-			let header = self.batch.get_block_header(&hash)?;
-			Ok(header)
-		} else {
-			Err(ErrorKind::Other(format!("get header by height")).into())
-		}
-	}
-
-	/// Compares the provided header to the header in the header MMR at that height.
-	/// If these match we know the header is on the current chain.
-	pub fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {
-		let chain_header = self.get_header_by_height(header.height)?;
-		if chain_header.hash() == header.hash() {
-			Ok(())
-		} else {
-			Err(ErrorKind::Other(format!("not on current chain")).into())
-		}
-	}
-
 	/// Build a Merkle proof for the given output and the block
 	/// this extension is currently referencing.
 	/// Note: this relies on the MMR being stable even after pruning/compaction.
@@ -1083,10 +959,7 @@ impl<'a> Extension<'a> {
 		let head_header = self.batch.get_block_header(&self.head.last_block_h)?;
 		let rewind_rm_pos = input_pos_to_rewind(header, &head_header, &self.batch)?;
 
-		let header_pos = pmmr::insertion_to_pmmr_index(header.height + 1);
-
 		self.rewind_to_pos(
-			header_pos,
 			header.output_mmr_size,
 			header.kernel_mmr_size,
 			&rewind_rm_pos,
@@ -1102,19 +975,14 @@ impl<'a> Extension<'a> {
 	/// kernel we want to rewind to.
 	fn rewind_to_pos(
 		&mut self,
-		header_pos: u64,
 		output_pos: u64,
 		kernel_pos: u64,
 		rewind_rm_pos: &Bitmap,
 	) -> Result<(), Error> {
 		debug!(
-			"txhashset: rewind_to_pos: header {}, output {}, kernel {}",
-			header_pos, output_pos, kernel_pos,
+			"txhashset: rewind_to_pos: output {}, kernel {}",
+			output_pos, kernel_pos,
 		);
-
-		self.header_pmmr
-			.rewind(header_pos, &Bitmap::create())
-			.map_err(&ErrorKind::TxHashSetErr)?;
 		self.output_pmmr
 			.rewind(output_pos, rewind_rm_pos)
 			.map_err(&ErrorKind::TxHashSetErr)?;
@@ -1131,10 +999,6 @@ impl<'a> Extension<'a> {
 	/// and kernel sum trees.
 	pub fn roots(&self) -> Result<TxHashSetRoots, Error> {
 		Ok(TxHashSetRoots {
-			header_root: self
-				.header_pmmr
-				.root()
-				.map_err(|_| ErrorKind::InvalidRoot)?,
 			output_root: self
 				.output_pmmr
 				.root()
@@ -1148,14 +1012,6 @@ impl<'a> Extension<'a> {
 				.root()
 				.map_err(|_| ErrorKind::InvalidRoot)?,
 		})
-	}
-
-	/// Get the root of the current header MMR.
-	pub fn header_root(&self) -> Result<Hash, Error> {
-		Ok(self
-			.header_pmmr
-			.root()
-			.map_err(|_| ErrorKind::InvalidRoot)?)
 	}
 
 	/// Validate the following MMR roots against the latest header applied -
@@ -1186,20 +1042,6 @@ impl<'a> Extension<'a> {
 		}
 	}
 
-	/// Validate the provided header by comparing its prev_root to the
-	/// root of the current header MMR.
-	pub fn validate_header_root(&self, header: &BlockHeader) -> Result<(), Error> {
-		if header.height == 0 {
-			return Ok(());
-		}
-		let roots = self.roots()?;
-		if roots.header_root != header.prev_root {
-			Err(ErrorKind::InvalidRoot.into())
-		} else {
-			Ok(())
-		}
-	}
-
 	/// Validate the header, output and kernel MMR sizes against the block header.
 	pub fn validate_sizes(&self) -> Result<(), Error> {
 		// If we are validating the genesis block then we have no outputs or
@@ -1209,13 +1051,9 @@ impl<'a> Extension<'a> {
 		}
 
 		let head_header = self.batch.get_block_header(&self.head.last_block_h)?;
-		let (header_mmr_size, output_mmr_size, rproof_mmr_size, kernel_mmr_size) = self.sizes();
-		let expected_header_mmr_size =
-			pmmr::insertion_to_pmmr_index(self.head.height + 2).saturating_sub(1);
+		let (output_mmr_size, rproof_mmr_size, kernel_mmr_size) = self.sizes();
 
-		if header_mmr_size != expected_header_mmr_size {
-			Err(ErrorKind::InvalidMMRSize.into())
-		} else if output_mmr_size != head_header.output_mmr_size {
+		if output_mmr_size != head_header.output_mmr_size {
 			Err(ErrorKind::InvalidMMRSize.into())
 		} else if kernel_mmr_size != head_header.kernel_mmr_size {
 			Err(ErrorKind::InvalidMMRSize.into())
@@ -1230,9 +1068,6 @@ impl<'a> Extension<'a> {
 		let now = Instant::now();
 
 		// validate all hashes and sums within the trees
-		if let Err(e) = self.header_pmmr.validate() {
-			return Err(ErrorKind::InvalidTxHashSet(e).into());
-		}
 		if let Err(e) = self.output_pmmr.validate() {
 			return Err(ErrorKind::InvalidTxHashSet(e).into());
 		}
@@ -1244,8 +1079,7 @@ impl<'a> Extension<'a> {
 		}
 
 		debug!(
-			"txhashset: validated the header {}, output {}, rproof {}, kernel {} mmrs, took {}s",
-			self.header_pmmr.unpruned_size(),
+			"txhashset: validated the output {}, rproof {}, kernel {} mmrs, took {}s",
 			self.output_pmmr.unpruned_size(),
 			self.rproof_pmmr.unpruned_size(),
 			self.kernel_pmmr.unpruned_size(),
@@ -1259,11 +1093,13 @@ impl<'a> Extension<'a> {
 	/// This is an expensive operation as we need to retrieve all the UTXOs and kernels
 	/// from the respective MMRs.
 	/// For a significantly faster way of validating full kernel sums see BlockSums.
-	pub fn validate_kernel_sums(&self) -> Result<((Commitment, Commitment)), Error> {
+	pub fn validate_kernel_sums(
+		&self,
+		genesis: &BlockHeader,
+	) -> Result<((Commitment, Commitment)), Error> {
 		let now = Instant::now();
 
 		let head_header = self.batch.get_block_header(&self.head.last_block_h)?;
-		let genesis = self.get_header_by_height(0)?;
 		let (utxo_sum, kernel_sum) = self.verify_kernel_sums(
 			head_header.total_overage(genesis.kernel_mmr_size > 0),
 			head_header.total_kernel_offset(),
@@ -1281,6 +1117,7 @@ impl<'a> Extension<'a> {
 	/// A "fast validation" will skip rangeproof verification and kernel signature verification.
 	pub fn validate(
 		&self,
+		genesis: &BlockHeader,
 		fast_validation: bool,
 		status: &dyn TxHashsetWriteStatus,
 	) -> Result<((Commitment, Commitment)), Error> {
@@ -1295,7 +1132,7 @@ impl<'a> Extension<'a> {
 
 		// The real magicking happens here. Sum of kernel excesses should equal
 		// sum of unspent outputs minus total supply.
-		let (output_sum, kernel_sum) = self.validate_kernel_sums()?;
+		let (output_sum, kernel_sum) = self.validate_kernel_sums(genesis)?;
 
 		// These are expensive verification step (skipped for "fast validation").
 		if !fast_validation {
@@ -1416,9 +1253,8 @@ impl<'a> Extension<'a> {
 	}
 
 	/// Sizes of each of the sum trees
-	pub fn sizes(&self) -> (u64, u64, u64, u64) {
+	pub fn sizes(&self) -> (u64, u64, u64) {
 		(
-			self.header_pmmr.unpruned_size(),
 			self.output_pmmr.unpruned_size(),
 			self.rproof_pmmr.unpruned_size(),
 			self.kernel_pmmr.unpruned_size(),
@@ -1664,16 +1500,6 @@ pub fn clean_txhashset_folder(root_dir: &PathBuf) {
 				"clean_txhashset_folder: fail on {:?}. err: {}",
 				txhashset_path, e
 			);
-		}
-	}
-}
-
-/// Clean the header folder
-pub fn clean_header_folder(root_dir: &PathBuf) {
-	let header_path = root_dir.clone().join(HEADERHASHSET_SUBDIR);
-	if header_path.exists() {
-		if let Err(e) = fs::remove_dir_all(header_path.clone()) {
-			warn!("clean_header_folder: fail on {:?}. err: {}", header_path, e);
 		}
 	}
 }

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -366,7 +366,7 @@ impl TxHashSet {
 		}
 
 		debug!(
-			"txhashset: rebuild_height_pos_index: {} UTXOs, took {}s",
+			"rebuild_height_pos_index: {} UTXOs, took {}s",
 			total_outputs,
 			now.elapsed().as_secs(),
 		);

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -111,7 +111,7 @@ impl<'a> UTXOView<'a> {
 			.unwrap_or(0);
 
 		if pos > 0 {
-			// If we have not yet reached 1,000 / 1,440 blocks then
+			// If we have not yet reached 1440 blocks then
 			// we can fail immediately as coinbase cannot be mature.
 			if height < global::coinbase_maturity() {
 				return Err(ErrorKind::ImmatureCoinbase.into());

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -207,8 +207,6 @@ impl TxHashsetWriteStatus for SyncState {
 /// readable.
 #[derive(Debug)]
 pub struct TxHashSetRoots {
-	/// Header root
-	pub header_root: Hash,
 	/// Output root
 	pub output_root: Hash,
 	/// Range Proof root

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -205,7 +205,7 @@ impl TxHashsetWriteStatus for SyncState {
 
 /// A helper to hold the roots of the txhashset in order to keep them
 /// readable.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TxHashSetRoots {
 	/// Output root
 	pub output_root: Hash,

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use self::core::core::hash::Hashed;
-use grin_chain as chain;
 use grin_core as core;
 use grin_util as util;
 

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -84,8 +84,6 @@ fn test_unexpected_zip() {
 		);
 
 		assert!(txhashset::zip_read(db_root.clone(), &head).is_ok());
-		let txhashset_zip_path =
-			Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash().to_string()));
 		let _ = fs::remove_dir_all(
 			Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash().to_string())),
 		);

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -216,13 +216,6 @@ where
 		Ok(())
 	}
 
-	/// Truncate the MMR by rewinding back to empty state.
-	pub fn truncate(&mut self) -> Result<(), String> {
-		self.backend.rewind(0, &Bitmap::create())?;
-		self.last_pos = 0;
-		Ok(())
-	}
-
 	/// Rewind the PMMR to a previous position, as if all push operations after
 	/// that had been canceled. Expects a position in the PMMR to rewind and
 	/// bitmaps representing the positions added and removed that we want to

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -86,6 +86,11 @@ where
 		}
 	}
 
+	/// Iterator over current (unpruned, unremoved) leaf positions.
+	pub fn leaf_pos_iter(&self) -> impl Iterator<Item = u64> + '_ {
+		self.backend.leaf_pos_iter()
+	}
+
 	/// Is the MMR empty?
 	pub fn is_empty(&self) -> bool {
 		self.last_pos == 0

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -435,8 +435,8 @@ impl Server {
 			let tip_height = self.head()?.height as i64;
 			let mut height = tip_height as i64 - last_blocks.len() as i64 + 1;
 
-			let txhashset = self.chain.txhashset();
-			let txhashset = txhashset.read();
+			let header_pmmr = self.chain.header_pmmr();
+			let header_pmmr = header_pmmr.read();
 
 			let diff_entries: Vec<DiffBlock> = last_blocks
 				.windows(2)
@@ -449,8 +449,8 @@ impl Server {
 					// Use header hash if real header.
 					// Default to "zero" hash if synthetic header_info.
 					let hash = if height >= 0 {
-						if let Ok(header) = txhashset.get_header_by_height(height as u64) {
-							header.hash()
+						if let Ok(hash) = header_pmmr.get_header_hash_by_height(height as u64) {
+							hash
 						} else {
 							ZERO_HASH
 						}

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -182,9 +182,10 @@ impl Controller {
 			}
 
 			if Utc::now().timestamp() > next_stat_update {
-				let stats = server.get_server_stats().unwrap();
-				self.ui.ui_tx.send(UIMessage::UpdateStatus(stats)).unwrap();
 				next_stat_update = Utc::now().timestamp() + stat_update_interval;
+				if let Ok(stats) = server.get_server_stats() {
+					self.ui.ui_tx.send(UIMessage::UpdateStatus(stats)).unwrap();
+				}
 			}
 		}
 		server.stop();


### PR DESCRIPTION
This PR introduces an explicit separation between the txhashset and the header MMR.
We need both to fully validate full blocks (the output, rangeproofs and kernels are validated w.r.t. the corresponding header, which in turn is validated against the existing header MMR).

But we also need to be able to manipulate the header MMR in isolation - for example when validating "header first" and during initial header sync.

Some thoughts around what we do currently - 

* txhashset is received from a peer as part of fast sync
    * header MMR is built locally from sync'd headers
    * we do some funky temp dir stuff when validating a txhashset (and jump through hoops to copy the local header MMR around with it)
* rebuilding the header MMR during fast sync is expensive (and we don't need to do it as we own the local header MMR)
* we process "header first" and need to be able to mutate our header MMR in isolation
* processing a full block involves processing the header first (is PoW valid etc.)
    * process the output|rangeproof|kernel MMRs based on pre-existing header MMR
* processing a fork/reorg is _tricky_
    * our header chain may diverge from our main (full block) chain due to sync
    * so rewinding to process a block on a fork involves multiple stages of rewind

This PR moves the header MMR out from under the txhashset and into the local chain instance directly.

We now need a "pair" of extensions when processing full blocks - 
* the txhashset extension 
* the corresponding header extension

Both extensions are rewound independently, but consistently to support various fork/reorg scenarios. We rewind to a single consistent common ancestor (similar to a 3 way merge in git).
i.e. Our header MMR has diverged from the main chain due to a peer advertising previously unseen headers. 

Making these changes has allowed a lot of code to be simplified and removed where we no longer need to handle edge cases and complex scenarios across the various MMRs when keeping them all consistent.

----

TODO - 
- [x] missing docs and other build warnings
- [x] more testing

