### PR TITLE
Fix invalid root

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -550,9 +550,10 @@ where
 	let res: Result<T, Error>;
 	let rollback: bool;
 
-	// We want to use the current head of the most work chain unless
-	// we explicitly rewind the extension.
-	let head = batch.head()?;
+	// We want to use the current head of header chain here.
+	// Caller is responsible for rewinding the header MMR back
+	// to a previous header as necessary when processing a fork.
+	let head = batch.header_head()?;
 
 	// create a child transaction so if the state is rolled back by itself, all
 	// index saving can be undone


### PR DESCRIPTION
This PR fixes a long standing bug that surfaces with an error like - 

```
20190828 04:04:21.569 INFO grin_chain::chain - Rejected block 00001e7bcb37 at 321399: Error { inner:

Invalid Root }
```

This happens when we process two competing forks simultaneously. But _only_ if we process header first or compact block header, and have not yet processed the first full block. 

* Process header `A`, updating `header_head` but not yet updating `head` (full block chain head)
* Process header `A'` (fork at same height as `A`)
  * We check if we need to rewind the header MMR by incorrectly comparing `A'`s `prev_header` to `head` (should be `header_head` which was updated in previous step). 
  * We have not yet processed full block `A` so we incorrectly determine the header MMR does not need rewinding.
  * We append header `A'` to the header MMR that _already contains_ `A` and hence build an invalid MMR.

We basically have a race condition here between headers `A` and `A'` and we do not rewind the header MMR correctly for the latest one processed.

Note - This problem is hidden as soon as we process the full block `A` as `head` and `header_head` are identical at that point. So using `head` is safe here and the rewind works as expected.

----

This is a simple fix - when creating header extensions for `A` and `A'` we need to treat `header_head` as the rightmost item in the MMR as this is consistent with the current MMR state.

----

Added test coverage to exercise this scenario.
Also took the opportunity to clean up some of the existing test setup code.


