### PR TITLE
use head (not header_head) when rewinding full blocks

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -524,8 +524,8 @@ impl Chain {
 		// latest block header. Rewind the extension to the specified header to
 		// ensure the view is consistent.
 		txhashset::extending_readonly(&mut txhashset, |extension| {
-			let header_head = extension.batch.header_head()?;
-			pipe::rewind_and_apply_fork(&header, &header_head, extension)?;
+			let head = extension.batch.head()?;
+			pipe::rewind_and_apply_fork(&header, &head, extension)?;
 			extension.validate(fast_validation, &NoStatus)?;
 			Ok(())
 		})
@@ -538,8 +538,8 @@ impl Chain {
 		let (prev_root, roots, sizes) =
 			txhashset::extending_readonly(&mut txhashset, |extension| {
 				let previous_header = extension.batch.get_previous_header(&b.header)?;
-				let header_head = extension.batch.header_head()?;
-				pipe::rewind_and_apply_fork(&previous_header, &header_head, extension)?;
+				let head = extension.batch.head()?;
+				pipe::rewind_and_apply_fork(&previous_header, &head, extension)?;
 
 				// Retrieve the header root before we apply the new block
 				let prev_root = extension.header_root()?;
@@ -577,8 +577,8 @@ impl Chain {
 	) -> Result<MerkleProof, Error> {
 		let mut txhashset = self.txhashset.write();
 		let merkle_proof = txhashset::extending_readonly(&mut txhashset, |extension| {
-			let header_head = extension.batch.header_head()?;
-			pipe::rewind_and_apply_fork(&header, &header_head, extension)?;
+			let head = extension.batch.head()?;
+			pipe::rewind_and_apply_fork(&header, &head, extension)?;
 			extension.merkle_proof(output)
 		})?;
 
@@ -632,8 +632,8 @@ impl Chain {
 		{
 			let mut txhashset = self.txhashset.write();
 			txhashset::extending_readonly(&mut txhashset, |extension| {
-				let header_head = extension.batch.header_head()?;
-				pipe::rewind_and_apply_fork(&header, &header_head, extension)?;
+				let head = extension.batch.head()?;
+				pipe::rewind_and_apply_fork(&header, &head, extension)?;
 
 				extension.snapshot()?;
 				Ok(())
@@ -1354,8 +1354,8 @@ fn setup_head(
 				})?;
 
 				let res = txhashset::extending(txhashset, &mut batch, |extension| {
-					let header_head = extension.batch.header_head()?;
-					pipe::rewind_and_apply_fork(&header, &header_head, extension)?;
+					let head = extension.batch.head()?;
+					pipe::rewind_and_apply_fork(&header, &head, extension)?;
 					extension.validate_roots()?;
 
 					// now check we have the "block sums" for the block in question

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -526,12 +526,6 @@ pub fn rewind_and_apply_header_fork(
 	header: &BlockHeader,
 	ext: &mut txhashset::HeaderExtension<'_>,
 ) -> Result<(), Error> {
-	let head = ext.head();
-	if header.hash() == head.last_block_h {
-		// Nothing to rewind and nothing to reapply. Done.
-		return Ok(());
-	}
-
 	let mut fork_hashes = vec![];
 	let mut current = header.clone();
 	while current.height > 0 && !ext.is_on_current_chain(&current).is_ok() {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -87,7 +87,6 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 	check_known(&b.header, ctx)?;
 
 	let head = ctx.batch.head()?;
-	let header_head = ctx.batch.header_head()?;
 
 	let is_next = b.header.prev_hash == head.last_block_h;
 
@@ -115,7 +114,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 	// Start a chain extension unit of work dependent on the success of the
 	// internal validation and saving operations
 	let block_sums = txhashset::extending(&mut ctx.txhashset, &mut ctx.batch, |mut extension| {
-		rewind_and_apply_fork(&prev, &header_head, extension)?;
+		rewind_and_apply_fork(&prev, &head, extension)?;
 
 		// Check any coinbase being spent have matured sufficiently.
 		// This needs to be done within the context of a potentially


### PR DESCRIPTION
Resolves #3016

This was nasty.
We fixed the rewind behavior in #3005 to rewind based on the `header_head` when rewinding the header MMR.

But this has now exposed a lingering issue when processing full blocks. We now need to rewind the txhashset MMRs (output, rangeproof, kernel) based on the chain `head` itself, not the head of the header MMR.

99% of the time these are consistent and this issue does not surface.
But if `head` and `header_head` diverge due to processing "header first" on a previous block we need to then be _very_ careful with - 
* using `head_head` to rewind the header MMR (as in #3005)
* using `head` to rewind the txhashet MMRs (resolved in this PR)

Reworked the test coverage from #3005 and added additional test scenarios to exercise the problem seen in #3016.

