### PR TITLE
[WIP] Chain recovery mechanism

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -172,7 +172,9 @@ impl Chain {
 	) -> Result<Chain, Error> {
 		let store = Arc::new(store::ChainStore::new(&db_root)?);
 
-		let hash = Hash::from_hex("0000018c118c48d32fecb3e586d5a053f18d82963def6a0cc7f4d1d569fa4186").unwrap();
+		let hash =
+			Hash::from_hex("0000018c118c48d32fecb3e586d5a053f18d82963def6a0cc7f4d1d569fa4186")
+				.unwrap();
 		let foo_header = store.get_block_header(&hash)?;
 		let header = Some(&foo_header);
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1060,7 +1060,11 @@ impl<'a> Extension<'a> {
 	/// across).
 	pub fn snapshot(&mut self) -> Result<(), Error> {
 		let header = self.batch.get_block_header(&self.head.hash())?;
-		debug!("snapshot: taking snapshot of UTXO set: {} at {}", header.hash(), header.height);
+		debug!(
+			"snapshot: taking snapshot of UTXO set: {} at {}",
+			header.hash(),
+			header.height
+		);
 		self.output_pmmr
 			.snapshot(&header)
 			.map_err(|e| ErrorKind::Other(e))?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1059,7 +1059,8 @@ impl<'a> Extension<'a> {
 	/// Needed for fast-sync (utxo file needs to be rewound before sending
 	/// across).
 	pub fn snapshot(&mut self) -> Result<(), Error> {
-		let header = self.batch.get_block_header(&self.head.last_block_h)?;
+		let header = self.batch.get_block_header(&self.head.hash())?;
+		debug!("snapshot: taking snapshot of UTXO set: {} at {}", header.hash(), header.height);
 		self.output_pmmr
 			.snapshot(&header)
 			.map_err(|e| ErrorKind::Other(e))?;

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -620,6 +620,9 @@ impl NetToChainAdapter {
 					if let Err(e) = chain.compact() {
 						error!("Could not compact chain: {:?}", e);
 					}
+					if let Err(e) = chain.snapshot() {
+						error!("Could not snapshot chain: {:?}", e);
+					}
 				});
 		}
 	}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -184,6 +184,7 @@ impl Server {
 			config.db_root.clone(),
 			chain_adapter.clone(),
 			genesis.clone(),
+			None,
 			pow::verify_size,
 			verifier_cache.clone(),
 			archive_mode,

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -163,10 +163,12 @@ impl SyncRunner {
 					self.sync_state.update(SyncStatus::NoSync);
 
 					// Initial transition out of a "syncing" state and into NoSync.
-					// This triggers a chain compaction to keep out local node tidy.
+					// This triggers a chain compaction to keep our local node tidy.
 					// Note: Chain compaction runs with an internal threshold
 					// so can be safely run even if the node is restarted frequently.
 					unwrap_or_restart_loop!(self.chain.compact());
+					// Also take a snapshot of the current UTXO set.
+					unwrap_or_restart_loop!(self.chain.snapshot());
 				}
 
 				// sleep for 10 secs but check stop signal every second


### PR DESCRIPTION
Resolves #3018.

Leverages our "snapshot" functionality used during fast sync to allow a local node to revert to a prior chain state and resync full blocks from that point.

Our UTXO set is relatively fragile. It is derived from a pruned output and rangeproof MMR and a corresponding "leaf set" defining which MMR positions are non-removed leaves.

If a single MMR pos is incorrectly marked as removed or non-removed the UTXO set is invalid (for obvious reasons). __Anything__ that results in the leafset getting out of sync with the MMR results in an invalid UTXO set. 

A leafset file is not "rewindable" as it does not track history, it is simply a snapshot in time.

But - we can have multiple snapshots (representing previous UTXO state) present on disk at any given point in time.

This allows us to select a previous "snapshot", revert the UTXO set to be consistent with that snapshot and resolve any "Already Spent" errors resulting from a set of corrupted txhashset backend files.

This PR is a "proof of concept" that we can robustly revert to any previous chain state as long as -
* we have the necessary snapshot files for this header
* the snapshot is not too old (cannot be beyond the 7 day prune/compaction horizon)

TODO - 
- [x] Take a snapshot of the leafset files (UTXO set) on -
  - [x] successful startup 
  - [x] daily compaction
- [ ] Remove hardcoded block hash...
- [ ] Add support for `--recover <hash>` flag on `grin server run`
- [ ] More testing in various scenarios


