### PR TITLE
Peers: use iterator to reduce number of heap allocations

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -48,7 +48,7 @@ pub mod types;
 
 pub use crate::conn::SEND_CHANNEL_CAP;
 pub use crate::peer::Peer;
-pub use crate::peers::Peers;
+pub use crate::peers::{Peers, PeersCursor};
 pub use crate::serv::{DummyAdapter, Server};
 pub use crate::store::{PeerData, State};
 pub use crate::types::{


### PR DESCRIPTION
Currently we allocate a vector inside peers.connected_peers(). A few
methods build on top of it, apply additional filters
(outgoing/incoming_peers) and allocate a new vector. Even peers_count
uses it. Some clients eg TUI does the same on top, so in some cases we
allocate 2-3 vectors in the heap to get some peers data.

This PR introduces PeersCursor which returns iterators, so additional
processing could be done without extra allocations. API is a bit
clumsy because a client has to keep RWLockReadGuard to use iterator,
but in some places it allows to reduce number of lines.