### PR TITLE
Clean the unused build_index

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -945,7 +945,6 @@ impl Chain {
 				},
 			)?;
 
-			extension.rebuild_index()?;
 			Ok(())
 		})?;
 
@@ -1128,7 +1127,7 @@ impl Chain {
 		self.txhashset.read().last_n_kernel(distance)
 	}
 
-	/// as above, for kernels
+	/// Return Commit's MMR position
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		Ok(self.txhashset.read().get_output_pos(commit)?)
 	}
@@ -1235,9 +1234,7 @@ impl Chain {
 	}
 
 	/// Migrate the index 'commitment -> output_pos' to index 'commitment -> (output_pos, block_height)'
-	/// Note: should only be called in two cases:
-	///     - Node start-up. For database migration from the old version.
-	/// 	- After the txhashset 'rebuild_index' when state syncing.
+	/// Note: should only be called when Node start-up, for database migration from the old version.
 	pub fn rebuild_height_for_pos(&self) -> Result<(), Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -277,14 +277,6 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
-	/// Save output_pos to index.
-	pub fn save_output_pos(&self, commit: &Commitment, pos: u64) -> Result<(), Error> {
-		self.db.put_ser(
-			&to_key(COMMIT_POS_PREFIX, &mut commit.as_ref().to_vec())[..],
-			&pos,
-		)
-	}
-
 	/// Save output_pos and block height to index.
 	pub fn save_output_pos_height(
 		&self,
@@ -328,7 +320,7 @@ impl<'a> Batch<'a> {
 		)
 	}
 
-	/// Clear all entries from the output_pos index.
+	/// Clear all entries from the output_pos index. (only for migration purpose)
 	pub fn clear_output_pos(&self) -> Result<(), Error> {
 		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
 		for (k, _) in self.db.iter::<u64>(&key)? {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1142,33 +1142,6 @@ impl<'a> Extension<'a> {
 		Ok((output_sum, kernel_sum))
 	}
 
-	/// Rebuild the index of MMR positions to the corresponding UTXOs.
-	/// This is a costly operation performed only when we receive a full new chain state.
-	///
-	/// Note: only called by txhashset_write, and should be replaced by 'rebuild_height_pos_index'
-	/// in the future, after a refactoring of 'txhashset_write'.
-	pub fn rebuild_index(&self) -> Result<(), Error> {
-		let now = Instant::now();
-
-		self.batch.clear_output_pos()?;
-
-		let mut count = 0;
-		for pos in self.output_pmmr.leaf_pos_iter() {
-			if let Some(out) = self.output_pmmr.get_data(pos) {
-				self.batch.save_output_pos(&out.commit, pos)?;
-				count += 1;
-			}
-		}
-
-		debug!(
-			"txhashset: rebuild_index: {} UTXOs, took {}s",
-			count,
-			now.elapsed().as_secs(),
-		);
-
-		Ok(())
-	}
-
 	/// Force the rollback of this extension, no matter the result
 	pub fn force_rollback(&mut self) {
 		self.rollback = true;


### PR DESCRIPTION
clean-up the unused `rebuild_index`, which has been obsoleted by PR #3017 
