### PR TITLE
fix: the cpuload 100% in case the tcpstream WouldBlock

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -58,11 +58,12 @@ macro_rules! try_break {
 	($inner:expr) => {
 		match $inner {
 			Ok(v) => Some(v),
-			Err(Error::Connection(ref e))
-				if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut =>
-				{
+			Err(Error::Connection(ref e)) if e.kind() == io::ErrorKind::TimedOut => None,
+			Err(Error::Connection(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
+				// to avoid the heavy polling which will consume CPU 100%
+				thread::sleep(Duration::from_millis(10));
 				None
-				}
+			}
 			Err(Error::Store(_))
 			| Err(Error::Chain(_))
 			| Err(Error::Internal)
@@ -330,14 +331,7 @@ where
 		.spawn(move || {
 			loop {
 				// check the read end
-				let res = read_header(&mut reader, version);
-				if let Err(Error::Connection(ref e)) = res {
-					if e.kind() == io::ErrorKind::WouldBlock {
-						// to avoid the heavy polling which will consume CPU 100%
-						thread::sleep(Duration::from_millis(10));
-					}
-				}
-				match try_break!(res) {
+				match try_break!(read_header(&mut reader, version)) {
 					Some(MsgHeaderWrapper::Known(header)) => {
 						let msg = Message::from_header(header, &mut reader, version);
 
@@ -401,7 +395,7 @@ where
 			}
 
 			debug!(
-				"Shutting down reader connection with {}",
+				"Shutting down writer connection with {}",
 				writer
 					.peer_addr()
 					.map(|a| a.to_string())

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -63,7 +63,7 @@ macro_rules! try_break {
 				// to avoid the heavy polling which will consume CPU 100%
 				thread::sleep(Duration::from_millis(10));
 				None
-			}
+				}
 			Err(Error::Store(_))
 			| Err(Error::Chain(_))
 			| Err(Error::Internal)


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/3025

In https://github.com/mimblewimble/grin/pull/2855, we refactored the p2p code to use blocking IO instead of non-blocking, which returns us the dramatically reduced CPU load.

But the Rust `TcpStream` behavior for blocking mode is not as expected in some cases. 

For example, the `stream.read_exact()` will practically return immediately if the underlined stream would block.

i.e. the so-called `WouldBlock` error: 
`Err(Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" })`

Then, the p2p `poll()` will just seamlessly call the `stream.read_exact()` in the loop, which in result will give us a 100% cpu load at this case.



