### PR TITLE
Kernels v2 (variable size)

### DIFF
--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -75,8 +75,8 @@ impl PoolPushHandler {
 						.map_err(|e| ErrorKind::RequestError(format!("Bad request: {}", e)).into())
 				})
 				.and_then(move |tx_bin| {
-					// TODO - pass protocol version in via the api call?
-					let version = ProtocolVersion::local();
+					// All wallet api interaction explicitly uses protocol version 1 for now.
+					let version = ProtocolVersion(1);
 
 					ser::deserialize(&mut &tx_bin[..], version)
 						.map_err(|e| ErrorKind::RequestError(format!("Bad request: {}", e)).into())

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -128,10 +128,9 @@ impl Writeable for KernelFeatures {
 	/// Protocol version may increment rapidly for other unrelated changes.
 	/// So we want to match on ranges here and not specific version values.
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		match writer.protocol_version() {
-			ProtocolVersion(x) if x < 2 => self.write_v1(writer),
-			ProtocolVersion(x) if x >= 2 => self.write_v2(writer),
-			_ => Err(ser::Error::UnsupportedProtocolVersion),
+		match writer.protocol_version().value() {
+			0..=1 => self.write_v1(writer),
+			2..=ProtocolVersion::MAX => self.write_v2(writer),
 		}
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -93,6 +93,8 @@ impl KernelFeatures {
 		Ok(msg)
 	}
 
+	/// Write tx kernel features out in v1 protocol format.
+	/// Always include the fee and lock_height, writing 0 value if unused.
 	fn write_v1<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		let (fee, lock_height) = match self {
 			KernelFeatures::Plain { fee } => (*fee, 0),
@@ -105,6 +107,10 @@ impl KernelFeatures {
 		Ok(())
 	}
 
+	/// Write tx kernel features out in v2 protocol format.
+	/// These are variable sized based on feature variant.
+	/// Only write fee out for feature variants that support it.
+	/// Only write lock_height out for feature variants that support it.
 	fn write_v2<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		match self {
 			KernelFeatures::Plain { fee } => {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -126,8 +126,14 @@ impl KernelFeatures {
 
 impl Writeable for KernelFeatures {
 	/// Protocol version may increment rapidly for other unrelated changes.
-	/// So we want to match on ranges here and not specific version values.
+	/// So we match on ranges here and not specific version values.
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		// Care must be exercised when writing for hashing purposes.
+		// All kernels are hashed using original v1 serialization strategy.
+		if writer.serialization_mode() == ser::SerializationMode::Hash {
+			return self.write_v1(writer);
+		}
+
 		match writer.protocol_version().value() {
 			0..=1 => self.write_v1(writer),
 			2..=ProtocolVersion::MAX => self.write_v2(writer),

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -38,8 +38,8 @@ use crate::util::RwLock;
 /// We negotiate compatible versions with each peer via Hand/Shake.
 /// Note: We also use a specific (possible different) protocol version
 /// for both the backend database and MMR data files.
-/// This one is p2p layer specific.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// This defines the p2p layer protocol version for this node.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Automated testing edge_bits
 pub const AUTOMATED_TESTING_MIN_EDGE_BITS: u8 = 10;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,6 +69,8 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
+	/// Protocol version unsupported (conversion not possible).
+	UnsupportedProtocolVersion,
 }
 
 impl From<io::Error> for Error {
@@ -92,6 +94,7 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
+			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
 	}
 }
@@ -115,6 +118,7 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
+			Error::UnsupportedProtocolVersion => "unsupported protocol version",
 		}
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,8 +69,6 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
-	/// Protocol version unsupported (conversion not possible).
-	UnsupportedProtocolVersion,
 }
 
 impl From<io::Error> for Error {
@@ -94,7 +92,6 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
-			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
 	}
 }
@@ -118,7 +115,6 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
-			Error::UnsupportedProtocolVersion => "unsupported protocol version",
 		}
 	}
 }
@@ -293,6 +289,12 @@ where
 pub struct ProtocolVersion(pub u32);
 
 impl ProtocolVersion {
+	pub const MAX: u32 = std::u32::MAX;
+
+	pub fn value(&self) -> u32 {
+		self.0
+	}
+
 	/// Our default "local" protocol version.
 	pub fn local() -> ProtocolVersion {
 		ProtocolVersion(PROTOCOL_VERSION)

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -289,13 +289,18 @@ where
 pub struct ProtocolVersion(pub u32);
 
 impl ProtocolVersion {
+	/// The max protocol version supported.
 	pub const MAX: u32 = std::u32::MAX;
 
+	/// Protocol version as u32 to allow for convenient exhaustive matching on values.
 	pub fn value(&self) -> u32 {
 		self.0
 	}
 
 	/// Our default "local" protocol version.
+	/// This protocol version is provided to peers as part of the Hand/Shake
+	/// negotiation in the p2p layer. Connected peers will negotiate a suitable
+	/// protocol version for serialization/deserialization of p2p messages.
 	pub fn local() -> ProtocolVersion {
 		ProtocolVersion(PROTOCOL_VERSION)
 	}

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -269,8 +269,7 @@ fn empty_block_serialized_size() {
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 1_112;
-	assert_eq!(vec.len(), target_len);
+	assert_eq!(vec.len(), 1_096);
 }
 
 #[test]
@@ -284,8 +283,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 2_694;
-	assert_eq!(vec.len(), target_len);
+	assert_eq!(vec.len(), 2_670);
 }
 
 #[test]
@@ -299,8 +297,7 @@ fn empty_compact_block_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_120;
-	assert_eq!(vec.len(), target_len);
+	assert_eq!(vec.len(), 1_104);
 }
 
 #[test]
@@ -315,8 +312,7 @@ fn compact_block_single_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_126;
-	assert_eq!(vec.len(), target_len);
+	assert_eq!(vec.len(), 1_110);
 }
 
 #[test]
@@ -333,10 +329,27 @@ fn block_10_tx_serialized_size() {
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
-	let mut vec = Vec::new();
-	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 16_932;
-	assert_eq!(vec.len(), target_len,);
+
+	// Default protocol version.
+	{
+		let mut vec = Vec::new();
+		ser::serialize_default(&mut vec, &b).expect("serialization failed");
+		assert_eq!(vec.len(), 16_836);
+	}
+
+	// Explicit protocol version 1
+	{
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, ser::ProtocolVersion(1), &b).expect("serialization failed");
+		assert_eq!(vec.len(), 16_932);
+	}
+
+	// Explicit protocol version 2
+	{
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, ser::ProtocolVersion(2), &b).expect("serialization failed");
+		assert_eq!(vec.len(), 16_836);
+	}
 }
 
 #[test]
@@ -356,8 +369,7 @@ fn compact_block_10_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 1_180;
-	assert_eq!(vec.len(), target_len,);
+	assert_eq!(vec.len(), 1_164);
 }
 
 #[test]

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -38,10 +38,27 @@ use std::sync::Arc;
 #[test]
 fn simple_tx_ser() {
 	let tx = tx2i1o();
-	let mut vec = Vec::new();
-	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 955;
-	assert_eq!(vec.len(), target_len,);
+
+	// Default protocol version.
+	{
+		let mut vec = Vec::new();
+		ser::serialize_default(&mut vec, &tx).expect("serialization failed");
+		assert_eq!(vec.len(), 947);
+	}
+
+	// Explicit protocol version 1.
+	{
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, ser::ProtocolVersion(1), &tx).expect("serialization failed");
+		assert_eq!(vec.len(), 955);
+	}
+
+	// Explicit protocol version 2.
+	{
+		let mut vec = Vec::new();
+		ser::serialize(&mut vec, ser::ProtocolVersion(2), &tx).expect("serialization failed");
+		assert_eq!(vec.len(), 947);
+	}
 }
 
 #[test]

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -109,7 +109,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
-	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_> {
+	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
 		unimplemented!()
 	}
 

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -115,11 +115,12 @@ impl Handshake {
 		}
 
 		debug!(
-			"Connected! Cumulative {} offered from {:?} {:?} {:?}",
+			"Connected! Cumulative {} offered from {:?}, {:?}, {:?}, {:?}",
 			shake.total_difficulty.to_num(),
 			peer_info.addr,
+			peer_info.version,
 			peer_info.user_agent,
-			peer_info.capabilities
+			peer_info.capabilities,
 		);
 		// when more than one protocol version is supported, choosing should go here
 		Ok(peer_info)

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -46,6 +46,7 @@ pub struct Handshake {
 	/// ok).
 	genesis: Hash,
 	config: P2PConfig,
+	protocol_version: ProtocolVersion,
 }
 
 impl Handshake {
@@ -56,7 +57,20 @@ impl Handshake {
 			addrs: Arc::new(RwLock::new(VecDeque::with_capacity(ADDRS_CAP))),
 			genesis,
 			config,
+			protocol_version: ProtocolVersion::local(),
 		}
+	}
+
+	/// Select a protocol version here that we know is supported by both us and the remote peer.
+	///
+	/// Current strategy is to simply use `min(local, remote)`.
+	///
+	/// We can enforce "minimum" protocol version here in the future
+	/// by raising an error and forcing the connection to close.
+	///
+	fn negotiate_protocol_version(&self, other: ProtocolVersion) -> Result<ProtocolVersion, Error> {
+		let version = std::cmp::min(self.protocol_version, other);
+		Ok(version)
 	}
 
 	pub fn initiate(
@@ -73,11 +87,8 @@ impl Handshake {
 			Err(e) => return Err(Error::Connection(e)),
 		};
 
-		// Using our default "local" protocol version.
-		let version = ProtocolVersion::local();
-
 		let hand = Hand {
-			version,
+			version: self.protocol_version,
 			capabilities,
 			nonce,
 			genesis: self.genesis,
@@ -88,22 +99,23 @@ impl Handshake {
 		};
 
 		// write and read the handshake response
-		write_message(conn, hand, Type::Hand, version)?;
+		write_message(conn, hand, Type::Hand, self.protocol_version)?;
 
-		// Note: We have to read the Shake message *before* we know which protocol
-		// version our peer supports (it is in the shake message itself).
-		let shake: Shake = read_message(conn, version, Type::Shake)?;
+		let shake: Shake = read_message(conn, self.protocol_version, Type::Shake)?;
 		if shake.genesis != self.genesis {
 			return Err(Error::GenesisMismatch {
 				us: self.genesis,
 				peer: shake.genesis,
 			});
 		}
+
+		let negotiated_version = self.negotiate_protocol_version(shake.version)?;
+
 		let peer_info = PeerInfo {
 			capabilities: shake.capabilities,
 			user_agent: shake.user_agent,
 			addr: peer_addr,
-			version: shake.version,
+			version: negotiated_version,
 			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(shake.total_difficulty))),
 			direction: Direction::Outbound,
 		};
@@ -132,11 +144,7 @@ impl Handshake {
 		total_difficulty: Difficulty,
 		conn: &mut TcpStream,
 	) -> Result<PeerInfo, Error> {
-		// Note: We read the Hand message *before* we know which protocol version
-		// is supported by our peer (in the Hand message).
-		let version = ProtocolVersion::local();
-
-		let hand: Hand = read_message(conn, version, Type::Hand)?;
+		let hand: Hand = read_message(conn, self.protocol_version, Type::Hand)?;
 
 		// all the reasons we could refuse this connection for
 		if hand.genesis != self.genesis {
@@ -159,12 +167,14 @@ impl Handshake {
 			}
 		}
 
+		let negotiated_version = self.negotiate_protocol_version(hand.version)?;
+
 		// all good, keep peer info
 		let peer_info = PeerInfo {
 			capabilities: hand.capabilities,
 			user_agent: hand.user_agent,
 			addr: resolve_peer_addr(hand.sender_addr, &conn),
-			version: hand.version,
+			version: negotiated_version,
 			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(hand.total_difficulty))),
 			direction: Direction::Inbound,
 		};
@@ -179,14 +189,14 @@ impl Handshake {
 
 		// send our reply with our info
 		let shake = Shake {
-			version,
+			version: self.protocol_version,
 			capabilities: capab,
 			genesis: self.genesis,
 			total_difficulty: total_difficulty,
 			user_agent: USER_AGENT.to_string(),
 		};
 
-		write_message(conn, shake, Type::Shake, version)?;
+		write_message(conn, shake, Type::Shake, negotiated_version)?;
 		trace!("Success handshake with {}.", peer_info.addr);
 
 		Ok(peer_info)


### PR DESCRIPTION
RFC (Variable Size Kernels) is here - 
* https://github.com/mimblewimble/grin-rfcs/blob/master/text/0005-variable-size-kernels.md

Tracking issue is here - 
* #3038 

Resolves #3010.

TODO - 
- [x] fix version negotiation `min(our_version, peer_version)`

----

Support for kernel serialization/deserialization with protocol version 2 ("variable size kernels").

Protocol version 1 preserves backward compatibility - 
  * always serialize/deserialize bytes for fee and lock_height
  * always verify these are 0 if unused

Protocol version 2 introduces flexibility - 
  * only serialize/deserialize fee if applicable for kernel variant
  * only serialize/deserialize lock_height if applicable for kernel variant

When writing for the purposes of hashing we use protocol version 1 to maintain backward compatibility. We can only change the serialization strategy for kernel in a HF and not for existing kernels.

These changes only apply to the p2p layer currently - nodes will negotiate protocol version during Hand/Shake and only use v2 if both peers support this.

The local db will continue to use v1 for full backward compatibility. This will be tackled in a separate PR with support for local db migration etc.

The txhashset MMR files will continue to use v1 for full backward compatibility (both on disk and for txhashet.zip archive file during fast sync). See #3011 for separate tracking issue for this.

----

TODO (Testing)

p2p messages - 
- [x] v1 -> v1 
- [x] v1 -> v2
- [x] v2 -> v1
- [x] v2 -> v2


