### PR TITLE
BasicAuthMiddleware: Add option to ignore authentication for a particular URI

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -32,7 +32,11 @@ pub struct BasicAuthMiddleware {
 }
 
 impl BasicAuthMiddleware {
-	pub fn new(api_basic_auth: String, basic_realm: &'static HeaderValue, ignore_uri: Option<String>) -> BasicAuthMiddleware {
+	pub fn new(
+		api_basic_auth: String,
+		basic_realm: &'static HeaderValue,
+		ignore_uri: Option<String>,
+	) -> BasicAuthMiddleware {
 		BasicAuthMiddleware {
 			api_basic_auth,
 			basic_realm,

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -28,13 +28,15 @@ lazy_static! {
 pub struct BasicAuthMiddleware {
 	api_basic_auth: String,
 	basic_realm: &'static HeaderValue,
+	ignore_uri: Option<String>,
 }
 
 impl BasicAuthMiddleware {
-	pub fn new(api_basic_auth: String, basic_realm: &'static HeaderValue) -> BasicAuthMiddleware {
+	pub fn new(api_basic_auth: String, basic_realm: &'static HeaderValue, ignore_uri: Option<String>) -> BasicAuthMiddleware {
 		BasicAuthMiddleware {
 			api_basic_auth,
 			basic_realm,
+			ignore_uri,
 		}
 	}
 }
@@ -51,6 +53,11 @@ impl Handler for BasicAuthMiddleware {
 		};
 		if req.method().as_str() == "OPTIONS" {
 			return next_handler.call(req, handlers);
+		}
+		if let Some(u) = self.ignore_uri.as_ref() {
+			if req.uri().path() == u {
+				return next_handler.call(req, handlers);
+			}
 		}
 		if req.headers().contains_key(AUTHORIZATION)
 			&& verify_slices_are_equal(

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -69,8 +69,11 @@ pub fn start_rest_apis(
 	let mut router = build_router(chain, tx_pool, peers).expect("unable to build API router");
 	if let Some(api_secret) = api_secret {
 		let api_basic_auth = format!("Basic {}", util::to_base64(&format!("grin:{}", api_secret)));
-		let basic_auth_middleware =
-			Arc::new(BasicAuthMiddleware::new(api_basic_auth, &GRIN_BASIC_REALM, None));
+		let basic_auth_middleware = Arc::new(BasicAuthMiddleware::new(
+			api_basic_auth,
+			&GRIN_BASIC_REALM,
+			None,
+		));
 		router.add_middleware(basic_auth_middleware);
 	}
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -70,7 +70,7 @@ pub fn start_rest_apis(
 	if let Some(api_secret) = api_secret {
 		let api_basic_auth = format!("Basic {}", util::to_base64(&format!("grin:{}", api_secret)));
 		let basic_auth_middleware =
-			Arc::new(BasicAuthMiddleware::new(api_basic_auth, &GRIN_BASIC_REALM));
+			Arc::new(BasicAuthMiddleware::new(api_basic_auth, &GRIN_BASIC_REALM, None));
 		router.add_middleware(basic_auth_middleware);
 	}
 


### PR DESCRIPTION
Workaround to support:

https://github.com/mimblewimble/grin-wallet/issues/183

In this case, the Wallet's owner API and Foreign API are being run on the same port, which means that authentication and the owner API secret need to be shared with everyone using the owner API. This change adds an option to specify a particular uri for the authentication to ignore, allowing the wallet to run 2 JSON-RPC endpoint routes without requiring authentication for one of them.

Don't think this opens any holes as this checks for the entire path from the root, but would appreciate a once-over to confirm. 
