### PR TITLE
DB v1->v2 migration

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -189,7 +189,7 @@ impl Chain {
 		)?;
 		Chain::log_heads(&store)?;
 
-		Ok(Chain {
+		let chain = Chain {
 			db_root,
 			store,
 			adapter,
@@ -201,7 +201,18 @@ impl Chain {
 			verifier_cache,
 			archive_mode,
 			genesis: genesis.header.clone(),
-		})
+		};
+
+		// DB migrations to be run prior to the chain being used.
+		{
+			// Migrate full blocks to protocol version v2.
+			chain.migrate_db_v1_v2()?;
+
+			// Rebuild height_for_pos index.
+			chain.rebuild_height_for_pos()?;
+		}
+
+		Ok(chain)
 	}
 
 	/// Return our shared header MMR handle.
@@ -1245,10 +1256,12 @@ impl Chain {
 		self.header_pmmr.read().get_header_hash_by_height(height)
 	}
 
-	pub fn migrate_db_v1_v2(&self) -> Result<(), Error> {
+	/// Migrate our local db from v1 to v2.
+	/// This covers blocks which themselves contain transactions.
+	/// Transaction kernels changed in v2 due to "variable size kernels".
+	fn migrate_db_v1_v2(&self) -> Result<(), Error> {
 		let store_v1 = self.store.with_version(ProtocolVersion(1));
 		let batch = store_v1.batch()?;
-		// Note: the iterator here returns None
 		for (_, block) in batch.blocks_iter()? {
 			batch.migrate_block(&block, ProtocolVersion(2))?;
 		}
@@ -1258,7 +1271,7 @@ impl Chain {
 
 	/// Migrate the index 'commitment -> output_pos' to index 'commitment -> (output_pos, block_height)'
 	/// Note: should only be called when Node start-up, for database migration from the old version.
-	pub fn rebuild_height_for_pos(&self) -> Result<(), Error> {
+	fn rebuild_height_for_pos(&self) -> Result<(), Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		let mut outputs_pos = txhashset.get_all_output_pos()?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1245,6 +1245,17 @@ impl Chain {
 		self.header_pmmr.read().get_header_hash_by_height(height)
 	}
 
+	pub fn migrate_db_v1_v2(&self) -> Result<(), Error> {
+		let store_v1 = self.store.with_version(ProtocolVersion(1));
+		let batch = store_v1.batch()?;
+		// Note: the iterator here returns None
+		for (_, block) in batch.blocks_iter()? {
+			batch.migrate_block(&block, ProtocolVersion(2))?;
+		}
+		batch.commit()?;
+		Ok(())
+	}
+
 	/// Migrate the index 'commitment -> output_pos' to index 'commitment -> (output_pos, block_height)'
 	/// Note: should only be called when Node start-up, for database migration from the old version.
 	pub fn rebuild_height_for_pos(&self) -> Result<(), Error> {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -51,6 +51,10 @@ impl ChainStore {
 		Ok(ChainStore { db })
 	}
 
+	/// Create a new instance of the chain store based on this instance
+	/// but with the provided protocol version. This is used when migrating
+	/// data in the db to a different protocol version, reading using one version and
+	/// writing back to the db with a different version.
 	pub fn with_version(&self, version: ProtocolVersion) -> ChainStore {
 		let db_with_version = self.db.with_version(version);
 		ChainStore {
@@ -266,6 +270,8 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Migrate a block stored in the db by serializing it using the provided protocol version.
+	/// Block may have been read using a previous protocol version but we do not actually care.
 	pub fn migrate_block(&self, b: &Block, version: ProtocolVersion) -> Result<(), Error> {
 		self.db.put_ser_with_version(
 			&to_key(BLOCK_PREFIX, &mut b.hash().to_vec())[..],

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,6 +69,8 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
+	/// Protocol version unsupported (conversion not possible).
+	UnsupportedProtocolVersion,
 }
 
 impl From<io::Error> for Error {
@@ -92,6 +94,7 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
+			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
 	}
 }
@@ -115,6 +118,7 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
+			Error::UnsupportedProtocolVersion => "unsupported protocol version",
 		}
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,8 +69,6 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
-	/// Protocol version unsupported (conversion not possible).
-	UnsupportedProtocolVersion,
 }
 
 impl From<io::Error> for Error {
@@ -94,7 +92,6 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
-			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
 	}
 }
@@ -118,7 +115,6 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
-			Error::UnsupportedProtocolVersion => "unsupported protocol version",
 		}
 	}
 }

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -189,17 +189,6 @@ impl Server {
 			archive_mode,
 		)?);
 
-		// TODO - Move this to Chain::init() I think.
-		//
-		// DB migrations to be run prior to the chain being used.
-		{
-			// migrate full blocks to protocol version v2 as necessary
-			shared_chain.migrate_db_v1_v2()?;
-
-			// rebuild height_for_pos index as necessary
-			shared_chain.rebuild_height_for_pos()?;
-		}
-
 		pool_adapter.set_chain(shared_chain.clone());
 
 		let net_adapter = Arc::new(NetToChainAdapter::new(

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -189,8 +189,16 @@ impl Server {
 			archive_mode,
 		)?);
 
-		// launching the database migration if needed
-		shared_chain.rebuild_height_for_pos()?;
+		// TODO - Move this to Chain::init() I think.
+		//
+		// DB migrations to be run prior to the chain being used.
+		{
+			// migrate full blocks to protocol version v2 as necessary
+			shared_chain.migrate_db_v1_v2()?;
+
+			// rebuild height_for_pos index as necessary
+			shared_chain.rebuild_height_for_pos()?;
+		}
 
 		pool_adapter.set_chain(shared_chain.clone());
 

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -65,11 +65,13 @@ where
 	}
 }
 
+const DEFAULT_DB_VERSION: ProtocolVersion = ProtocolVersion(2);
+
 /// LMDB-backed store facilitating data access and serialization. All writes
 /// are done through a Batch abstraction providing atomicity.
 pub struct Store {
 	env: Arc<lmdb::Environment>,
-	db: RwLock<Option<Arc<lmdb::Database<'static>>>>,
+	db: Arc<RwLock<Option<Arc<lmdb::Database<'static>>>>>,
 	name: String,
 	version: ProtocolVersion,
 }
@@ -113,9 +115,9 @@ impl Store {
 		);
 		let res = Store {
 			env: Arc::new(env),
-			db: RwLock::new(None),
+			db: Arc::new(RwLock::new(None)),
 			name: db_name,
-			version: ProtocolVersion(1),
+			version: DEFAULT_DB_VERSION,
 		};
 
 		{
@@ -127,6 +129,17 @@ impl Store {
 			)?));
 		}
 		Ok(res)
+	}
+
+	/// Construct a new store using a specific protocol version.
+	/// Permits access to the db with legacy protocol versions for db migrations.
+	pub fn with_version(&self, version: ProtocolVersion) -> Store {
+		Store {
+			env: self.env.clone(),
+			db: self.db.clone(),
+			name: self.name.clone(),
+			version: version,
+		}
 	}
 
 	/// Opens the database environment
@@ -275,11 +288,8 @@ impl Store {
 		if self.needs_resize()? {
 			self.do_resize()?;
 		}
-		let txn = lmdb::WriteTransaction::new(self.env.clone())?;
-		Ok(Batch {
-			store: self,
-			tx: txn,
-		})
+		let tx = lmdb::WriteTransaction::new(self.env.clone())?;
+		Ok(Batch { store: self, tx })
 	}
 }
 
@@ -299,10 +309,21 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
-	/// Writes a single key and its `Writeable` value to the db. Encapsulates
-	/// serialization.
+	/// Writes a single key and its `Writeable` value to the db.
+	/// Encapsulates serialization using the (default) version configured on the store instance.
 	pub fn put_ser<W: ser::Writeable>(&self, key: &[u8], value: &W) -> Result<(), Error> {
-		let ser_value = ser::ser_vec(value, self.store.version);
+		self.put_ser_with_version(key, value, self.store.version)
+	}
+
+	/// Writes a single key and its `Writeable` value to the db.
+	/// Encapsulates serialization using the specified protocol version.
+	pub fn put_ser_with_version<W: ser::Writeable>(
+		&self,
+		key: &[u8],
+		value: &W,
+		version: ProtocolVersion,
+	) -> Result<(), Error> {
+		let ser_value = ser::ser_vec(value, version);
 		match ser_value {
 			Ok(data) => self.put(key, &data),
 			Err(err) => Err(Error::SerErr(format!("{}", err))),
@@ -356,7 +377,7 @@ impl<'a> Batch<'a> {
 	}
 }
 
-/// An iterator thad produces Readable instances back. Wraps the lower level
+/// An iterator that produces Readable instances back. Wraps the lower level
 /// DBIterator and deserializes the returned values.
 pub struct SerIterator<T>
 where


### PR DESCRIPTION
Resolves #3043.

On startup reads all the full blocks from the local db and writes them back into the db using protocol v2. 

We take advantage of the blocks iterator and simply attempt to read them in v1.
Subsequent reads will fail quickly (v2 reader will not successfully read v1 data) causing the iterator to terminate early so can be safely run multiple times.

~Note: This PR is overly noisy right now as it is based on the branch for #3034.
Once #3034 is merged this PR will be rebased against master and should look a lot cleaner.~

