### PR TITLE
Read header_head and sync_head from header MMRs directly

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -185,7 +185,12 @@ pub fn sync_block_headers(
 	// Check if we know about all these headers. If so we can accept them quickly.
 	// If they *do not* increase total work on the sync chain we are done.
 	// If they *do* increase total work then we should process them to update sync_head.
-	let sync_head = ctx.batch.get_sync_head()?;
+	let sync_head = {
+		let hash = ctx.header_pmmr.head_hash()?;
+		let header = ctx.batch.get_block_header(&hash)?;
+		Tip::from_header(&header)
+	};
+
 	if let Ok(existing) = ctx.batch.get_block_header(&last_header.hash()) {
 		if !has_more_work(&existing, &sync_head) {
 			return Ok(());
@@ -199,15 +204,11 @@ pub fn sync_block_headers(
 		add_block_header(header, &ctx.batch)?;
 	}
 
-	// Now apply this entire chunk of headers to the sync MMR.
-	txhashset::header_extending(&mut ctx.header_pmmr, &sync_head, &mut ctx.batch, |ext| {
+	// Now apply this entire chunk of headers to the sync MMR (ctx is sync MMR specific).
+	txhashset::header_extending(&mut ctx.header_pmmr, &mut ctx.batch, |ext| {
 		rewind_and_apply_header_fork(&last_header, ext)?;
 		Ok(())
 	})?;
-
-	if has_more_work(&last_header, &sync_head) {
-		update_sync_head(&Tip::from_header(&last_header), &mut ctx.batch)?;
-	}
 
 	Ok(())
 }
@@ -229,14 +230,19 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 	// If it does not increase total_difficulty beyond our current header_head
 	// then we can (re)accept this header and process the full block (or request it).
 	// This header is on a fork and we should still accept it as the fork may eventually win.
-	let header_head = ctx.batch.header_head()?;
+	let header_head = {
+		let hash = ctx.header_pmmr.head_hash()?;
+		let header = ctx.batch.get_block_header(&hash)?;
+		Tip::from_header(&header)
+	};
+
 	if let Ok(existing) = ctx.batch.get_block_header(&header.hash()) {
 		if !has_more_work(&existing, &header_head) {
 			return Ok(());
 		}
 	}
 
-	txhashset::header_extending(&mut ctx.header_pmmr, &header_head, &mut ctx.batch, |ext| {
+	txhashset::header_extending(&mut ctx.header_pmmr, &mut ctx.batch, |ext| {
 		rewind_and_apply_header_fork(&prev_header, ext)?;
 		ext.validate_root(header)?;
 		ext.apply_header(header)?;
@@ -248,15 +254,6 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 
 	validate_header(header, ctx)?;
 	add_block_header(header, &ctx.batch)?;
-
-	// Update header_head independently of chain head (full blocks).
-	// If/when we process the corresponding full block we will update the
-	// chain head to match. This allows our header chain to extend safely beyond
-	// the full chain in a fork scenario without needing excessive rewinds to handle
-	// the temporarily divergent chains.
-	if has_more_work(&header, &header_head) {
-		update_header_head(&Tip::from_header(&header), &mut ctx.batch)?;
-	}
 
 	Ok(())
 }
@@ -499,30 +496,6 @@ fn update_head(head: &Tip, batch: &mut store::Batch<'_>) -> Result<(), Error> {
 // Whether the provided block totals more work than the chain tip
 fn has_more_work(header: &BlockHeader, head: &Tip) -> bool {
 	header.total_difficulty() > head.total_difficulty
-}
-
-/// Update the sync head so we can keep syncing from where we left off.
-fn update_sync_head(head: &Tip, batch: &mut store::Batch<'_>) -> Result<(), Error> {
-	batch
-		.save_sync_head(&head)
-		.map_err(|e| ErrorKind::StoreErr(e, "pipe save sync head".to_owned()))?;
-	debug!(
-		"sync_head updated to {} at {}",
-		head.last_block_h, head.height
-	);
-	Ok(())
-}
-
-/// Update the header_head.
-fn update_header_head(head: &Tip, batch: &mut store::Batch<'_>) -> Result<(), Error> {
-	batch
-		.save_header_head(&head)
-		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
-	debug!(
-		"header_head updated to {} at {}",
-		head.last_block_h, head.height
-	);
-	Ok(())
 }
 
 /// Rewind the header chain and reapply headers on a fork.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -32,8 +32,6 @@ const BLOCK_HEADER_PREFIX: u8 = 'h' as u8;
 const BLOCK_PREFIX: u8 = 'b' as u8;
 const HEAD_PREFIX: u8 = 'H' as u8;
 const TAIL_PREFIX: u8 = 'T' as u8;
-const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
-const SYNC_HEAD_PREFIX: u8 = 's' as u8;
 const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const COMMIT_POS_HGT_PREFIX: u8 = 'p' as u8;
 const BLOCK_INPUT_BITMAP_PREFIX: u8 = 'B' as u8;
@@ -77,20 +75,6 @@ impl ChainStore {
 	/// Header of the block at the head of the block chain (not the same thing as header_head).
 	pub fn head_header(&self) -> Result<BlockHeader, Error> {
 		self.get_block_header(&self.head()?.last_block_h)
-	}
-
-	/// Head of the header chain (not the same thing as head_header).
-	pub fn header_head(&self) -> Result<Tip, Error> {
-		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), || {
-			"HEADER_HEAD".to_owned()
-		})
-	}
-
-	/// The "sync" head.
-	pub fn get_sync_head(&self) -> Result<Tip, Error> {
-		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]), || {
-			"SYNC_HEAD".to_owned()
-		})
 	}
 
 	/// Get full block.
@@ -198,20 +182,6 @@ impl<'a> Batch<'a> {
 		self.get_block_header(&self.head()?.last_block_h)
 	}
 
-	/// Head of the header chain (not the same thing as head_header).
-	pub fn header_head(&self) -> Result<Tip, Error> {
-		option_to_not_found(self.db.get_ser(&vec![HEADER_HEAD_PREFIX]), || {
-			"HEADER_HEAD".to_owned()
-		})
-	}
-
-	/// Get "sync" head.
-	pub fn get_sync_head(&self) -> Result<Tip, Error> {
-		option_to_not_found(self.db.get_ser(&vec![SYNC_HEAD_PREFIX]), || {
-			"SYNC_HEAD".to_owned()
-		})
-	}
-
 	/// Save body head to db.
 	pub fn save_body_head(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![HEAD_PREFIX], t)
@@ -220,28 +190,6 @@ impl<'a> Batch<'a> {
 	/// Save body "tail" to db.
 	pub fn save_body_tail(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&vec![TAIL_PREFIX], t)
-	}
-
-	/// Save header_head to db.
-	pub fn save_header_head(&self, t: &Tip) -> Result<(), Error> {
-		self.db.put_ser(&vec![HEADER_HEAD_PREFIX], t)
-	}
-
-	/// Save "sync" head to db.
-	pub fn save_sync_head(&self, t: &Tip) -> Result<(), Error> {
-		self.db.put_ser(&vec![SYNC_HEAD_PREFIX], t)
-	}
-
-	/// Reset sync_head to the current head of the header chain.
-	pub fn reset_sync_head(&self) -> Result<(), Error> {
-		let head = self.header_head()?;
-		self.save_sync_head(&head)
-	}
-
-	/// Reset header_head to the current head of the body chain.
-	pub fn reset_header_head(&self) -> Result<(), Error> {
-		let tip = self.head()?;
-		self.save_header_head(&tip)
 	}
 
 	/// get block

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -59,7 +59,6 @@ impl ChainAdapter {
 
 		batch.save_block_header(header).unwrap();
 		batch.save_body_head(&tip).unwrap();
-		batch.save_header_head(&tip).unwrap();
 
 		// Retrieve previous block_sums from the db.
 		let prev_sums = if let Ok(prev_sums) = batch.get_block_sums(&tip.prev_block_h) {

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -81,9 +81,6 @@ impl HeaderSync {
 				// correctly, so reset any previous (and potentially stale) sync_head to match
 				// our last known "good" header_head.
 				//
-				self.chain.reset_sync_head()?;
-
-				// Rebuild the sync MMR to match our updated sync_head.
 				self.chain.rebuild_sync_mmr(&header_head)?;
 
 				self.history_locator.retain(|&x| x.0 == 0);


### PR DESCRIPTION
~__Will hold of merging this until 2.1.0 is officially released__~

We cannot revert easily to a prior version of the code and reuse an existing db with these changes.

----

We separated the header MMR from the txhashset output|rangeproof|kernel trifecta in #3004.

We now reliably keep the header MMR aligned with the most work header.
Similarly we keep the sync MMR aligned with the most work header during header sync.

There is no longer any need to maintain `header_head` and `sync_head` entries in the local db.
The `header_head` should always be aligned with the rightmost entry in the header MMR.
Similarly for `sync_head` and the rightmost entry in the sync MMR.

If we simply take the header MMR and read the rightmost entry we can determine the current `header_head`.

This gives us one less thing to keep synchronized when flushing updates to disk (across both the MMR files and the db files).

This will be marginally more expensive to read `header_head` as this now involves a single db read and a single MMR read (was previously just a db read). But this is worth it as we no longer need to write an updated `header_head` every time we apply a new header to the MMR.
The MMR files are also very fast to read from as they are mmap'd.



