### PR TITLE
Gracefully handle WouldBlock and TimedOut when downloading txhashset

### DIFF
--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -117,7 +117,7 @@ impl StateSync {
 
 			if let SyncStatus::TxHashsetDownload { .. } = self.sync_state.status() {
 				if download_timeout {
-					error!("state_sync: TxHashsetDownload status timeout in 10 minutes!");
+					error!("state_sync: TxHashsetDownload download timed out, restarting.");
 					self.sync_state.set_sync_error(
 						chain::ErrorKind::SyncError(format!("{:?}", p2p::Error::Timeout)).into(),
 					);
@@ -219,7 +219,7 @@ impl StateSync {
 				(true, download_timeout)
 			}
 			Some(prev) => {
-				if now - prev > Duration::minutes(10) {
+				if now - prev > Duration::minutes(30) {
 					download_timeout = true;
 				}
 				(false, download_timeout)


### PR DESCRIPTION
Turns out `WouldBlock` can be raised in rust even when using blocking IO.

```
20190902 22:17:46.291 ERROR grin_p2p::protocol - handle_payload: 
txhashset archive save to file fail. err=Connection(Os 
{ code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" })
```

We occasionally see this after getting most of a txhashset dowloaded and it is _very_ frustrating.

Intuitively this should never happen as blocking IO would simply _block_ with no need for a `WouldBlock` error...

Except the docs indicate the following - 

https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout

> Platforms may return a different error code whenever a read times out as a result of setting this option. For example Unix typically returns an error of the kind WouldBlock, but Windows may return TimedOut.

tl;dr We set a read timeout on our blocking tcp stream. Rust tries its hardest to confuse us by surfacing this as a `WouldBlock` error when we call `read_exact`.

We handle this in the `try_break!` macro for the majority of our p2p message handling.
But we do not do this in `copy_attachment` which is used when downloading the txhashset zip file.

This PR adds similar "retry" logic allowing the txhashset download to continue downloading if we experience either a `WouldBlock` or a `TimedOut` error.
Also included `Interrupted` for completeness as the docs indicate this can be safely retried.

