### PR TITLE
bump version for 2.1.0 dev (still on master)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.1-beta.1",
- "grin_chain 2.0.1-beta.1",
- "grin_config 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_servers 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_api 2.1.0-dev.1",
+ "grin_chain 2.1.0-dev.1",
+ "grin_config 2.1.0-dev.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_keychain 2.1.0-dev.1",
+ "grin_p2p 2.1.0-dev.1",
+ "grin_servers 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.1.0-dev.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_p2p 2.1.0-dev.1",
+ "grin_pool 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -725,10 +725,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_keychain 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -740,13 +740,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_servers 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_p2p 2.1.0-dev.1",
+ "grin_servers 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,8 +765,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_keychain 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -783,12 +783,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.1-beta.1",
+ "grin_util 2.1.0-dev.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -805,17 +805,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.1.0-dev.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_pool 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,17 +827,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.1.0-dev.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_keychain 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,19 +861,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.1-beta.1",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_api 2.1.0-dev.1",
+ "grin_chain 2.1.0-dev.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_keychain 2.1.0-dev.1",
+ "grin_p2p 2.1.0-dev.1",
+ "grin_pool 2.1.0-dev.1",
+ "grin_store 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,8 +898,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.1.0-dev.1",
+ "grin_util 2.1.0-dev.1",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.0.1-beta.1" }
-grin_config = { path = "./config", version = "2.0.1-beta.1" }
-grin_chain = { path = "./chain", version = "2.0.1-beta.1" }
-grin_core = { path = "./core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "./keychain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "./p2p", version = "2.0.1-beta.1" }
-grin_servers = { path = "./servers", version = "2.0.1-beta.1" }
-grin_util = { path = "./util", version = "2.0.1-beta.1" }
+grin_api = { path = "./api", version = "2.1.0-dev.1" }
+grin_config = { path = "./config", version = "2.1.0-dev.1" }
+grin_chain = { path = "./chain", version = "2.1.0-dev.1" }
+grin_core = { path = "./core", version = "2.1.0-dev.1" }
+grin_keychain = { path = "./keychain", version = "2.1.0-dev.1" }
+grin_p2p = { path = "./p2p", version = "2.1.0-dev.1" }
+grin_servers = { path = "./servers", version = "2.1.0-dev.1" }
+grin_util = { path = "./util", version = "2.1.0-dev.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.0.1-beta.1" }
-grin_store = { path = "./store", version = "2.0.1-beta.1" }
+grin_chain = { path = "./chain", version = "2.1.0-dev.1" }
+grin_store = { path = "./store", version = "2.1.0-dev.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_chain = { path = "../chain", version = "2.1.0-dev.1" }
+grin_p2p = { path = "../p2p", version = "2.1.0-dev.1" }
+grin_pool = { path = "../pool", version = "2.1.0-dev.1" }
+grin_store = { path = "../store", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_keychain = { path = "../keychain", version = "2.1.0-dev.1" }
+grin_store = { path = "../store", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_servers = { path = "../servers", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_servers = { path = "../servers", version = "2.1.0-dev.1" }
+grin_p2p = { path = "../p2p", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_store = { path = "../store", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
+grin_chain = { path = "../chain", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.0-dev.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_keychain = { path = "../keychain", version = "2.1.0-dev.1" }
+grin_store = { path = "../store", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.0-dev.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,11 +25,11 @@ serde_json = "1"
 chrono = "0.4.4"
 tokio =  "0.1.11"
 
-grin_api = { path = "../api", version = "2.0.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.0.1-beta.1" }
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.0.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.0.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.0.1-beta.1" }
-grin_store = { path = "../store", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_api = { path = "../api", version = "2.1.0-dev.1" }
+grin_chain = { path = "../chain", version = "2.1.0-dev.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_keychain = { path = "../keychain", version = "2.1.0-dev.1" }
+grin_p2p = { path = "../p2p", version = "2.1.0-dev.1" }
+grin_pool = { path = "../pool", version = "2.1.0-dev.1" }
+grin_store = { path = "../store", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.0.1-beta.1" }
-grin_util = { path = "../util", version = "2.0.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.0-dev.1" }
+grin_util = { path = "../util", version = "2.1.0-dev.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.0.1-beta.1"
+version = "2.1.0-dev.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the crate versions to reflect upcoming release `2.1.0`.

This is on `master` so I bumped the version to `2.1.0-dev.1` which I think makes more sense than the `2.0.1-beta.1` currently in place.

Proposing we stick with `-dev` suffix until we cut the beta release when we can bump the versioning again to `2.1.0-beta.1` on the 2.1.0 branch itself.

I'd like to be able to visually inspect peer user agents in the TUI and have a rough idea of which are running against a recent build from master.

I toyed with the idea of including the build date or timestamp in the user agent when built from master. But there are some privacy and anonymity concerns involved there.

