### PR TITLE
support for v2 txhashset (continuing to use v1 in mainnet and floonet)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,7 +20,6 @@ use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{
 	Block, BlockHeader, BlockSums, Committed, Output, OutputIdentifier, Transaction, TxKernel,
-	TxKernelEntry,
 };
 use crate::core::global;
 use crate::core::pow;
@@ -176,9 +175,24 @@ impl Chain {
 		// open the txhashset, creating a new one if necessary
 		let mut txhashset = txhashset::TxHashSet::open(db_root.clone(), store.clone(), None)?;
 
-		let mut header_pmmr =
-			PMMRHandle::new(&db_root, "header", "header_head", false, true, None)?;
-		let mut sync_pmmr = PMMRHandle::new(&db_root, "header", "sync_head", false, true, None)?;
+		let mut header_pmmr = PMMRHandle::new(
+			&db_root,
+			"header",
+			"header_head",
+			false,
+			true,
+			ProtocolVersion(1),
+			None,
+		)?;
+		let mut sync_pmmr = PMMRHandle::new(
+			&db_root,
+			"header",
+			"sync_head",
+			false,
+			true,
+			ProtocolVersion(1),
+			None,
+		)?;
 
 		setup_head(
 			&genesis,
@@ -661,7 +675,7 @@ impl Chain {
 	pub fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<(), Error> {
 		let mut count = 0;
 		let mut stream = StreamingReader::new(reader, ProtocolVersion::local());
-		while let Ok(_kernel) = TxKernelEntry::read(&mut stream) {
+		while let Ok(_kernel) = TxKernel::read(&mut stream) {
 			count += 1;
 		}
 
@@ -1146,7 +1160,7 @@ impl Chain {
 	}
 
 	/// as above, for kernels
-	pub fn get_last_n_kernel(&self, distance: u64) -> Vec<(Hash, TxKernelEntry)> {
+	pub fn get_last_n_kernel(&self, distance: u64) -> Vec<(Hash, TxKernel)> {
 		self.txhashset.read().last_n_kernel(distance)
 	}
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -344,13 +344,20 @@ impl Readable for TxKernel {
 	}
 }
 
-/// We store TxKernelEntry in the kernel MMR.
+/// We store kernels in the kernel MMR.
+/// Note: These are "variable size" to support different kernel featuere variants.
 impl PMMRable for TxKernel {
-	type E = TxKernelEntry;
+	type E = Self;
 
-	fn as_elmt(&self) -> TxKernelEntry {
-		TxKernelEntry::from_kernel(self)
+	fn as_elmt(&self) -> Self::E {
+		self.clone()
 	}
+}
+
+/// Kernels are "variable size" but we need to implement FixedLength for legacy reasons.
+/// At some point we will refactor the MMR backend so this is no longer required.
+impl FixedLength for TxKernel {
+	const LEN: usize = 0;
 }
 
 impl KernelFeatures {
@@ -492,61 +499,6 @@ impl TxKernel {
 			KernelFeatures::Coinbase => panic!("lock_height not supported on coinbase kernel"),
 		}
 	}
-}
-
-/// Wrapper around a tx kernel used when maintaining them in the MMR.
-/// These will be useful once we implement relative lockheights via relative kernels
-/// as a kernel may have an optional rel_kernel but we will not want to store these
-/// directly in the kernel MMR.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TxKernelEntry {
-	/// The underlying tx kernel.
-	pub kernel: TxKernel,
-}
-
-impl Writeable for TxKernelEntry {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		self.kernel.write(writer)?;
-		Ok(())
-	}
-}
-
-impl Readable for TxKernelEntry {
-	fn read(reader: &mut dyn Reader) -> Result<TxKernelEntry, ser::Error> {
-		let kernel = TxKernel::read(reader)?;
-		Ok(TxKernelEntry { kernel })
-	}
-}
-
-impl TxKernelEntry {
-	/// The excess on the underlying tx kernel.
-	pub fn excess(&self) -> Commitment {
-		self.kernel.excess
-	}
-
-	/// Verify the underlying tx kernel.
-	pub fn verify(&self) -> Result<(), Error> {
-		self.kernel.verify()
-	}
-
-	/// Build a new tx kernel entry from a kernel.
-	pub fn from_kernel(kernel: &TxKernel) -> TxKernelEntry {
-		TxKernelEntry {
-			kernel: kernel.clone(),
-		}
-	}
-}
-
-impl From<TxKernel> for TxKernelEntry {
-	fn from(kernel: TxKernel) -> Self {
-		TxKernelEntry { kernel }
-	}
-}
-
-impl FixedLength for TxKernelEntry {
-	const LEN: usize = 17 // features plus fee and lock_height
-		+ secp::constants::PEDERSEN_COMMITMENT_SIZE
-		+ secp::constants::AGG_SIGNATURE_SIZE;
 }
 
 /// Enum of possible tx weight verification options -

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -204,13 +204,9 @@ impl<T: PMMRable> PMMRBackend<T> {
 		data_dir: P,
 		prunable: bool,
 		fixed_size: bool,
+		version: ProtocolVersion,
 		header: Option<&BlockHeader>,
 	) -> io::Result<PMMRBackend<T>> {
-		// Note: Explicit protocol version here.
-		// Regardless of our "default" protocol version we have existing MMR files
-		// and we need to be able to support these across upgrades.
-		let version = ProtocolVersion(1);
-
 		let data_dir = data_dir.as_ref();
 
 		// Are we dealing with "fixed size" data elements or "variable size" data elements

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -35,7 +35,7 @@ impl PhatChunkStruct {
 }
 
 impl Readable for PhatChunkStruct {
-	fn read(reader: &mut Reader) -> Result<PhatChunkStruct, ser::Error> {
+	fn read(reader: &mut dyn Reader) -> Result<PhatChunkStruct, ser::Error> {
 		let mut retval = PhatChunkStruct::new();
 		for _ in 0..TEST_ALLOC_SIZE {
 			retval.phatness = reader.read_u64()?;

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -24,15 +24,22 @@ use croaring::Bitmap;
 use crate::core::core::hash::DefaultHashable;
 use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
-	Error, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
+	Error, FixedLength, PMMRIndexHashable, PMMRable, ProtocolVersion, Readable, Reader, Writeable,
+	Writer,
 };
 
 #[test]
 fn pmmr_append() {
 	let (data_dir, elems) = setup("append");
 	{
-		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+		let mut backend = store::pmmr::PMMRBackend::new(
+			data_dir.to_string(),
+			true,
+			false,
+			ProtocolVersion(1),
+			None,
+		)
+		.unwrap();
 
 		// adding first set of 4 elements and sync
 		let mut mmr_size = load(0, &elems[0..4], &mut backend);
@@ -114,8 +121,14 @@ fn pmmr_compact_leaf_sibling() {
 
 	// setup the mmr store with all elements
 	{
-		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+		let mut backend = store::pmmr::PMMRBackend::new(
+			data_dir.to_string(),
+			true,
+			false,
+			ProtocolVersion(1),
+			None,
+		)
+		.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 
@@ -187,8 +200,14 @@ fn pmmr_prune_compact() {
 
 	// setup the mmr store with all elements
 	{
-		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+		let mut backend = store::pmmr::PMMRBackend::new(
+			data_dir.to_string(),
+			true,
+			false,
+			ProtocolVersion(1),
+			None,
+		)
+		.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 
@@ -238,8 +257,14 @@ fn pmmr_reload() {
 
 	// set everything up with an initial backend
 	{
-		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+		let mut backend = store::pmmr::PMMRBackend::new(
+			data_dir.to_string(),
+			true,
+			false,
+			ProtocolVersion(1),
+			None,
+		)
+		.unwrap();
 
 		let mmr_size = load(0, &elems[..], &mut backend);
 
@@ -298,8 +323,14 @@ fn pmmr_reload() {
 		// create a new backend referencing the data files
 		// and check everything still works as expected
 		{
-			let mut backend =
-				store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+			let mut backend = store::pmmr::PMMRBackend::new(
+				data_dir.to_string(),
+				true,
+				false,
+				ProtocolVersion(1),
+				None,
+			)
+			.unwrap();
 			assert_eq!(backend.unpruned_size(), mmr_size);
 			{
 				let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
@@ -340,7 +371,8 @@ fn pmmr_rewind() {
 	let (data_dir, elems) = setup("rewind");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, None).unwrap();
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+				.unwrap();
 
 		// adding elements and keeping the corresponding root
 		let mut mmr_size = load(0, &elems[0..4], &mut backend);
@@ -456,7 +488,8 @@ fn pmmr_compact_single_leaves() {
 	let (data_dir, elems) = setup("compact_single_leaves");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, None).unwrap();
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+				.unwrap();
 		let mmr_size = load(0, &elems[0..5], &mut backend);
 		backend.sync().unwrap();
 
@@ -491,7 +524,8 @@ fn pmmr_compact_entire_peak() {
 	let (data_dir, elems) = setup("compact_entire_peak");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, None).unwrap();
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+				.unwrap();
 		let mmr_size = load(0, &elems[0..5], &mut backend);
 		backend.sync().unwrap();
 
@@ -546,8 +580,14 @@ fn pmmr_compact_horizon() {
 
 		let mmr_size;
 		{
-			let mut backend =
-				store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, None).unwrap();
+			let mut backend = store::pmmr::PMMRBackend::new(
+				data_dir.clone(),
+				true,
+				false,
+				ProtocolVersion(1),
+				None,
+			)
+			.unwrap();
 			mmr_size = load(0, &elems[..], &mut backend);
 			backend.sync().unwrap();
 
@@ -626,9 +666,14 @@ fn pmmr_compact_horizon() {
 		// recheck stored data
 		{
 			// recreate backend
-			let backend =
-				store::pmmr::PMMRBackend::<TestElem>::new(data_dir.to_string(), true, false, None)
-					.unwrap();
+			let backend = store::pmmr::PMMRBackend::<TestElem>::new(
+				data_dir.to_string(),
+				true,
+				false,
+				ProtocolVersion(1),
+				None,
+			)
+			.unwrap();
 
 			assert_eq!(backend.data_size(), 19);
 			assert_eq!(backend.hash_size(), 35);
@@ -642,9 +687,14 @@ fn pmmr_compact_horizon() {
 		}
 
 		{
-			let mut backend =
-				store::pmmr::PMMRBackend::<TestElem>::new(data_dir.to_string(), true, false, None)
-					.unwrap();
+			let mut backend = store::pmmr::PMMRBackend::<TestElem>::new(
+				data_dir.to_string(),
+				true,
+				false,
+				ProtocolVersion(1),
+				None,
+			)
+			.unwrap();
 
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
@@ -660,9 +710,14 @@ fn pmmr_compact_horizon() {
 		// recheck stored data
 		{
 			// recreate backend
-			let backend =
-				store::pmmr::PMMRBackend::<TestElem>::new(data_dir.to_string(), true, false, None)
-					.unwrap();
+			let backend = store::pmmr::PMMRBackend::<TestElem>::new(
+				data_dir.to_string(),
+				true,
+				false,
+				ProtocolVersion(1),
+				None,
+			)
+			.unwrap();
 
 			// 0010012001001230
 
@@ -691,8 +746,14 @@ fn compact_twice() {
 	// setup the mmr store with all elements
 	// Scoped to allow Windows to teardown
 	{
-		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, false, None).unwrap();
+		let mut backend = store::pmmr::PMMRBackend::new(
+			data_dir.to_string(),
+			true,
+			false,
+			ProtocolVersion(1),
+			None,
+		)
+		.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 


### PR DESCRIPTION
Resolves #3011.

* Cleanup TxKernelEntry wrapper (just store TxKernel directly in the kernel MMR data file)
* Add support for reading/opening kernel MMR with v2 protocol version
* Continue to support v1 kernel MMR - 
  * all nodes on mainnet maintain v1 kernel MMR locally
  * fast sync will _always_ provide v1 kernel MMR
  * _but_ nodes now have the ability to read a v2 kernel MMR for future compatibility

This "future proofs" nodes so that once 2.1.0 is released and widely used we can think about letting nodes migrate to v2 kernel MMR.
Its not safe to do this today because nodes do not support v2 widely.
Fast sync can only really provide the _same_ txhashset that is used locally as converting between v1/v2 cannot be done "on demand" or per fast sync request.

So this PR leaves all nodes continuing to use (and serve) v1 txhashset.
But with support for _receiving_ a v2 txhashset in the future.

----

tl;dr Nodes _maintain_ a txhashset locally, _receive_ a txhashset during fast sync and _serve_ a txhashset to peers when they fast sync.
We want add support for _receiving_ a v2 txhashset. But we want to continue to _maintain_ and _serve_ txhashset files in v1 for now, until v2 is widely supported on the network.

