### PR TITLE
Provide default values information in generated config file, better handle logging default parameters

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -477,7 +477,7 @@ fn comments() -> HashMap<String, String> {
 }
 
 fn get_key(line: &str) -> String {
-	if line.contains("[") && line.contains("]") {
+	if line.contains("[") && line.contains("]") && !line.contains("=") {
 		return line.to_owned();
 	} else if line.contains("=") {
 		return line.split("=").collect::<Vec<&str>>()[0].trim().to_owned();

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -258,8 +258,58 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
-		"[server.p2p_config.capabilities]".to_string(),
-		"#If the seeding type is List, the list of peers to connect to can
+		"ban_window".to_string(),
+		"
+#how long a banned peer should stay banned
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"peer_max_inbound_count".to_string(),
+		"
+#maximum number of inbound peer connections
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"peer_max_outbound_count".to_string(),
+		"
+#maximum number of outbound peer connections
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"peer_min_preferred_outbound_count".to_string(),
+		"
+#preferred minimum number of outbound peers (we'll actively keep trying to add peers
+#until we get to at least this number)
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"peer_listener_buffer_count".to_string(),
+		"
+#amount of incoming connections temporarily allowed to exceed peer_max_inbound_count
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"dandelion_peer".to_string(),
+		"
+# A preferred dandelion_peer, mainly used for testing dandelion
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"capabilities".to_string(),
+		"
+#If the seeding type is List, the list of peers to connect to can
 #be specified as follows:
 #seeds = [\"192.168.0.1:3414\",\"192.168.0.2:3414\"]
 
@@ -271,28 +321,8 @@ fn comments() -> HashMap<String, String> {
 #a list of preferred peers to connect to
 #peers_preferred = [\"192.168.0.1:3414\",\"192.168.0.2:3414\"]
 
-#how long a banned peer should stay banned
-#ban_window = 10800
-
-#maximum number of inbound peer connections
-#peer_max_inbound_count = 128
-
-#maximum number of outbound peer connections
-#peer_max_outbound_count = 8
-
-#preferred minimum number of outbound peers (we'll actively keep trying to add peers
-#until we get to at least this number)
-#peer_min_preferred_outbound_count = 8
-
-#amount of incoming connections temporarily allowed to exceed peer_max_inbound_count
-#peer_listener_buffer_count = 8
-
 # 15 = Bit flags for FULL_NODE
 #This structure needs to be changed internally, to make it more configurable
-
-# A preferred dandelion_peer, mainly used for testing dandelion
-# dandelion_peer = \"10.0.0.1:13144\"
-
 "
 		.to_string(),
 	);

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -133,6 +133,27 @@ pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalCon
 	}
 }
 
+fn comment_values(orig: String) -> String {
+	let lines: Vec<&str> = orig.split("\n").collect();
+	let mut out_lines = vec![];
+	for l in lines {
+		// Comment lines with values (not starting by #) that don't define paths
+		if l.contains("=") && !l.starts_with("#") && !l.contains("root") && !l.contains("path") {
+			let mut commented = l.to_owned();
+			commented.insert_str(0, "#");
+			out_lines.push(commented.to_owned());
+		} else {
+			out_lines.push(l.to_owned());
+		}
+		out_lines.push("\n".to_owned());
+	}
+	let mut ret_val = String::from("");
+	for l in out_lines {
+		ret_val.push_str(&l);
+	}
+	ret_val.to_owned()
+}
+
 /// Returns the defaults, as strewn throughout the code
 impl Default for ConfigMembers {
 	fn default() -> ConfigMembers {
@@ -297,6 +318,7 @@ impl GlobalConfig {
 	pub fn write_to_file(&mut self, name: &str) -> Result<(), ConfigError> {
 		let conf_out = self.ser_config()?;
 		let conf_out = insert_comments(conf_out);
+		let conf_out = comment_values(conf_out);
 		let mut file = File::create(name)?;
 		file.write_all(conf_out.as_bytes())?;
 		Ok(())

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -515,7 +515,7 @@ impl Peers {
 
 	/// We have enough outbound connected peers
 	pub fn enough_outbound_peers(&self) -> bool {
-		self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count()
+		self.peer_outbound_count() >= self.config.peer_min_preferred_outbound_count
 	}
 
 	/// Removes those peers that seem to have expired

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -213,7 +213,7 @@ impl Server {
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
 		if self.peers.peer_inbound_count()
-			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
+			>= self.config.peer_max_inbound_count + self.config.peer_listener_buffer_count
 		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");
 			return true;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -45,6 +45,15 @@ const DANDELION_STEM_PROBABILITY: u8 = 90;
 /// If set to false we will stem/fluff our txs as per current epoch.
 const DANDELION_ALWAYS_STEM_OUR_TXS: bool = true;
 
+/// Default Base fee for a transaction to be accepted by the pool
+const POOL_ACCEPT_FEE_BASE: u64 = consensus::MILLI_GRIN;
+
+/// Maximum capacity of the pool in number of transactions
+const POOL_MAX_POOL_SIZE: usize = 50_000;
+
+/// Maximum capacity of the Dandelion stempool in number of transactions
+const POOL_MAX_STEMPOOL_SIZE: usize = 50_000;
+
 /// Configuration for "Dandelion".
 /// Note: shared between p2p and pool.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -135,13 +144,13 @@ impl Default for PoolConfig {
 }
 
 fn default_accept_fee_base() -> u64 {
-	consensus::MILLI_GRIN
+	POOL_ACCEPT_FEE_BASE
 }
 fn default_max_pool_size() -> usize {
-	50_000
+	POOL_MAX_POOL_SIZE
 }
 fn default_max_stempool_size() -> usize {
-	50_000
+	POOL_MAX_STEMPOOL_SIZE
 }
 fn default_mineable_max_weight() -> usize {
 	global::max_block_weight()

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -29,6 +29,51 @@ use crate::pool;
 use crate::pool::types::DandelionConfig;
 use crate::store;
 
+/// Directory under which the rocksdb stores will be created
+const SERVER_DB_ROOT: &str = "grin_chain";
+
+/// Network address for the Rest API HTTP server.
+const SERVER_API_HTTP_ADDR: &str = "127.0.0.1:3413";
+
+/// Location of secret for basic auth on Rest API HTTP server.
+const SERVER_API_SECRET: &str = ".api_secret";
+
+/// Whether this node is a full archival node or a fast-sync, pruned node
+const SERVER_ARCHIVE_MODE: bool = false;
+
+/// Whether to skip the sync timeout on startup (To assist testing on solo chains)
+const SERVER_SKIP_SYNC_WAIT: bool = false;
+
+/// Whether to run the TUI
+const SERVER_RUN_TUI: bool = true;
+
+/// Whether to run the test miner
+const SERVER_RUN_TEST_MINER: bool = false;
+
+/// Run a stratum mining server
+const STRATUM_ENABLE_SERVER: bool = false;
+
+/// The address and port the stratum server must listen on
+const STRATUM_SERVER_ADDR: &str = "127.0.0.1:3416";
+
+/// How long to wait before stopping the miner, recollecting transactions and starting again
+const STRATUM_ATTEMPT_TIME_PER_BLOCK: u32 = 15;
+
+/// Minimum difficulty for worker shares
+const STRATUM_MINIMUM_SHARE_DIFFICULTY: u64 = 1;
+
+/// Base address to the HTTP wallet receiver
+const STRATUM_WALLET_LISTENER_URL: &str = "http://127.0.0.1:3415";
+
+/// Attributes the reward to a random private key instead of contacting the wallet receiver
+const STRATUM_BURN_REWARD: bool = false;
+
+/// number of worker threads in the tokio runtime
+const WEBHOOKS_NTHREADS: u16 = 4;
+
+/// timeout in seconds for the http request
+const WEBHOOKS_TIMEOUT: u16 = 10;
+
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]
 pub enum Error {
@@ -140,17 +185,22 @@ impl Default for ChainValidationMode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ServerConfig {
 	/// Directory under which the rocksdb stores will be created
+	#[serde(default = "default_server_db_root")]
 	pub db_root: String,
 
 	/// Network address for the Rest API HTTP server.
+	#[serde(default = "default_server_api_http_addr")]
 	pub api_http_addr: String,
 
 	/// Location of secret for basic auth on Rest API HTTP server.
+	#[serde(default = "default_server_api_secret_path")]
 	pub api_secret_path: Option<String>,
 
 	/// TLS certificate file
+	#[serde(default = "default_server_tls_certificate_file")]
 	pub tls_certificate_file: Option<String>,
 	/// TLS certificate private key file
+	#[serde(default = "default_server_tls_certificate_key")]
 	pub tls_certificate_key: Option<String>,
 
 	/// Setup the server for tests, testnet or mainnet
@@ -162,23 +212,29 @@ pub struct ServerConfig {
 	pub chain_validation_mode: ChainValidationMode,
 
 	/// Whether this node is a full archival node or a fast-sync, pruned node
-	pub archive_mode: Option<bool>,
+	#[serde(default = "default_server_archive_mode")]
+	pub archive_mode: bool,
 
 	/// Whether to skip the sync timeout on startup
 	/// (To assist testing on solo chains)
-	pub skip_sync_wait: Option<bool>,
+	#[serde(default = "default_server_skip_sync_wait")]
+	pub skip_sync_wait: bool,
 
 	/// Whether to run the TUI
 	/// if enabled, this will disable logging to stdout
-	pub run_tui: Option<bool>,
+	#[serde(default = "default_server_run_tui")]
+	pub run_tui: bool,
 
 	/// Whether to run the test miner (internal, cuckoo 16)
-	pub run_test_miner: Option<bool>,
+	#[serde(default = "default_server_run_test_miner")]
+	pub run_test_miner: bool,
 
 	/// Test miner wallet URL
+	#[serde(default = "default_server_test_miner_wallet_url")]
 	pub test_miner_wallet_url: Option<String>,
 
 	/// Configuration for the peer-to-peer server
+	#[serde(default)]
 	pub p2p_config: p2p::P2PConfig,
 
 	/// Transaction pool configuration
@@ -201,25 +257,65 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
 	fn default() -> ServerConfig {
 		ServerConfig {
-			db_root: "grin_chain".to_string(),
-			api_http_addr: "127.0.0.1:3413".to_string(),
-			api_secret_path: Some(".api_secret".to_string()),
-			tls_certificate_file: None,
-			tls_certificate_key: None,
+			db_root: default_server_db_root(),
+			api_http_addr: default_server_api_http_addr(),
+			api_secret_path: default_server_api_secret_path(),
+			tls_certificate_file: default_server_tls_certificate_file(),
+			tls_certificate_key: default_server_tls_certificate_key(),
 			p2p_config: p2p::P2PConfig::default(),
 			dandelion_config: pool::DandelionConfig::default(),
 			stratum_mining_config: Some(StratumServerConfig::default()),
 			chain_type: ChainTypes::default(),
-			archive_mode: Some(false),
+			archive_mode: default_server_archive_mode(),
 			chain_validation_mode: ChainValidationMode::default(),
 			pool_config: pool::PoolConfig::default(),
-			skip_sync_wait: Some(false),
-			run_tui: Some(true),
-			run_test_miner: Some(false),
-			test_miner_wallet_url: None,
+			skip_sync_wait: default_server_skip_sync_wait(),
+			run_tui: default_server_run_tui(),
+			run_test_miner: default_server_run_test_miner(),
+			test_miner_wallet_url: default_server_test_miner_wallet_url(),
 			webhook_config: WebHooksConfig::default(),
 		}
 	}
+}
+
+fn default_server_db_root() -> String {
+	SERVER_DB_ROOT.to_string()
+}
+
+fn default_server_api_http_addr() -> String {
+	SERVER_API_HTTP_ADDR.to_string()
+}
+
+fn default_server_api_secret_path() -> Option<String> {
+	Some(SERVER_API_SECRET.to_string())
+}
+
+fn default_server_tls_certificate_file() -> Option<String> {
+	None
+}
+
+fn default_server_tls_certificate_key() -> Option<String> {
+	None
+}
+
+fn default_server_archive_mode() -> bool {
+	SERVER_ARCHIVE_MODE
+}
+
+fn default_server_skip_sync_wait() -> bool {
+	SERVER_SKIP_SYNC_WAIT
+}
+
+fn default_server_run_tui() -> bool {
+	SERVER_RUN_TUI
+}
+
+fn default_server_run_test_miner() -> bool {
+	SERVER_RUN_TEST_MINER
+}
+
+fn default_server_test_miner_wallet_url() -> Option<String> {
+	None
 }
 
 /// Stratum (Mining server) configuration
@@ -227,75 +323,125 @@ impl Default for ServerConfig {
 pub struct StratumServerConfig {
 	/// Run a stratum mining server (the only way to communicate to mine this
 	/// node via grin-miner
+	#[serde(default = "default_stratum_enable_stratum_server")]
 	pub enable_stratum_server: Option<bool>,
 
 	/// If enabled, the address and port to listen on
+	#[serde(default = "default_stratum_server_addr")]
 	pub stratum_server_addr: Option<String>,
 
 	/// How long to wait before stopping the miner, recollecting transactions
 	/// and starting again
+	#[serde(default = "default_stratum_attempt_time_per_block")]
 	pub attempt_time_per_block: u32,
 
 	/// Minimum difficulty for worker shares
+	#[serde(default = "default_stratum_minimum_share_difficulty")]
 	pub minimum_share_difficulty: u64,
 
 	/// Base address to the HTTP wallet receiver
+	#[serde(default = "default_stratum_wallet_listener_url")]
 	pub wallet_listener_url: String,
 
 	/// Attributes the reward to a random private key instead of contacting the
 	/// wallet receiver. Mostly used for tests.
+	#[serde(default = "default_stratum_burn_reward")]
 	pub burn_reward: bool,
 }
 
 impl Default for StratumServerConfig {
 	fn default() -> StratumServerConfig {
 		StratumServerConfig {
-			wallet_listener_url: "http://127.0.0.1:3415".to_string(),
-			burn_reward: false,
-			attempt_time_per_block: 15,
-			minimum_share_difficulty: 1,
-			enable_stratum_server: Some(false),
-			stratum_server_addr: Some("127.0.0.1:3416".to_string()),
+			wallet_listener_url: default_stratum_wallet_listener_url(),
+			burn_reward: default_stratum_burn_reward(),
+			attempt_time_per_block: default_stratum_attempt_time_per_block(),
+			minimum_share_difficulty: default_stratum_minimum_share_difficulty(),
+			enable_stratum_server: default_stratum_enable_stratum_server(),
+			stratum_server_addr: default_stratum_server_addr(),
 		}
 	}
+}
+
+fn default_stratum_enable_stratum_server() -> Option<bool> {
+	Some(STRATUM_ENABLE_SERVER)
+}
+
+fn default_stratum_server_addr() -> Option<String> {
+	Some(STRATUM_SERVER_ADDR.to_string())
+}
+
+fn default_stratum_attempt_time_per_block() -> u32 {
+	STRATUM_ATTEMPT_TIME_PER_BLOCK
+}
+
+fn default_stratum_minimum_share_difficulty() -> u64 {
+	STRATUM_MINIMUM_SHARE_DIFFICULTY
+}
+
+fn default_stratum_wallet_listener_url() -> String {
+	STRATUM_WALLET_LISTENER_URL.to_string()
+}
+
+fn default_stratum_burn_reward() -> bool {
+	STRATUM_BURN_REWARD
 }
 
 /// Web hooks configuration
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebHooksConfig {
 	/// url to POST transaction data when a new transaction arrives from a peer
+	#[serde(default = "default_webhooks_tx_received_url")]
 	pub tx_received_url: Option<String>,
 	/// url to POST header data when a new header arrives from a peer
+	#[serde(default = "default_webhooks_header_received_url")]
 	pub header_received_url: Option<String>,
 	/// url to POST block data when a new block arrives from a peer
+	#[serde(default = "default_webhooks_block_received_url")]
 	pub block_received_url: Option<String>,
 	/// url to POST block data when a new block is accepted by our node (might be a reorg or a fork)
+	#[serde(default = "default_webhooks_block_accepted_url")]
 	pub block_accepted_url: Option<String>,
 	/// number of worker threads in the tokio runtime
-	#[serde(default = "default_nthreads")]
+	#[serde(default = "default_webhooks_nthreads")]
 	pub nthreads: u16,
 	/// timeout in seconds for the http request
-	#[serde(default = "default_timeout")]
+	#[serde(default = "default_webhooks_timeout")]
 	pub timeout: u16,
 }
 
-fn default_timeout() -> u16 {
-	10
+fn default_webhooks_tx_received_url() -> Option<String> {
+	None
 }
 
-fn default_nthreads() -> u16 {
-	4
+fn default_webhooks_header_received_url() -> Option<String> {
+	None
+}
+
+fn default_webhooks_block_received_url() -> Option<String> {
+	None
+}
+
+fn default_webhooks_block_accepted_url() -> Option<String> {
+	None
+}
+
+fn default_webhooks_nthreads() -> u16 {
+	WEBHOOKS_NTHREADS
+}
+
+fn default_webhooks_timeout() -> u16 {
+	WEBHOOKS_TIMEOUT
 }
 
 impl Default for WebHooksConfig {
 	fn default() -> WebHooksConfig {
 		WebHooksConfig {
-			tx_received_url: None,
-			header_received_url: None,
-			block_received_url: None,
-			block_accepted_url: None,
-			nthreads: default_nthreads(),
-			timeout: default_timeout(),
+			tx_received_url: default_webhooks_tx_received_url(),
+			header_received_url: default_webhooks_header_received_url(),
+			block_received_url: default_webhooks_block_received_url(),
+			block_accepted_url: default_webhooks_block_accepted_url(),
+			nthreads: default_webhooks_nthreads(),
+			timeout: default_webhooks_timeout(),
 		}
 	}
 }

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -156,7 +156,7 @@ fn monitor_peers(
 			p2p::State::Banned => {
 				let interval = Utc::now().timestamp() - x.last_banned;
 				// Unban peer
-				if interval >= config.ban_window() {
+				if interval >= config.ban_window {
 					if let Err(e) = peers.unban_peer(x.addr) {
 						error!("failed to unban peer {}: {:?}", x.addr, e);
 					}
@@ -188,8 +188,8 @@ fn monitor_peers(
 
 	// maintenance step first, clean up p2p server peers
 	peers.clean_peers(
-		config.peer_max_inbound_count() as usize,
-		config.peer_max_outbound_count() as usize,
+		config.peer_max_inbound_count as usize,
+		config.peer_max_outbound_count as usize,
 	);
 
 	if peers.enough_outbound_peers() {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -106,7 +106,7 @@ impl Server {
 		}
 
 		if enable_test_miner {
-				serv.start_test_miner(test_miner_wallet_url, serv.stop_state.clone());
+			serv.start_test_miner(test_miner_wallet_url, serv.stop_state.clone());
 		}
 
 		info_callback(serv);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -105,10 +105,8 @@ impl Server {
 			}
 		}
 
-		if let Some(s) = enable_test_miner {
-			if s {
+		if enable_test_miner {
 				serv.start_test_miner(test_miner_wallet_url, serv.stop_state.clone());
-			}
 		}
 
 		info_callback(serv);
@@ -144,13 +142,6 @@ impl Server {
 	pub fn new(config: ServerConfig) -> Result<Server, Error> {
 		// Obtain our lock_file or fail immediately with an error.
 		let lock_file = Server::one_grin_at_a_time(&config)?;
-
-		// Defaults to None (optional) in config file.
-		// This translates to false here.
-		let archive_mode = match config.archive_mode {
-			None => false,
-			Some(b) => b,
-		};
 
 		let stop_state = Arc::new(StopState::new());
 
@@ -189,7 +180,7 @@ impl Server {
 			genesis.clone(),
 			pow::verify_size,
 			verifier_cache.clone(),
-			archive_mode,
+			config.archive_mode,
 		)?);
 
 		pool_adapter.set_chain(shared_chain.clone());
@@ -246,10 +237,7 @@ impl Server {
 			)?);
 		}
 
-		// Defaults to None (optional) in config file.
-		// This translates to false here so we do not skip by default.
-		let skip_sync_wait = config.skip_sync_wait.unwrap_or(false);
-		sync_state.update(SyncStatus::AwaitingPeers(!skip_sync_wait));
+		sync_state.update(SyncStatus::AwaitingPeers(!config.skip_sync_wait));
 
 		let sync_thread = sync::run_sync(
 			sync_state.clone(),

--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -43,7 +43,7 @@ pub fn start_server(config: servers::ServerConfig) {
 fn start_server_tui(config: servers::ServerConfig) {
 	// Run the UI controller.. here for now for simplicity to access
 	// everything it might need
-	if config.run_tui.unwrap_or(false) {
+	if config.run_tui {
 		warn!("Starting GRIN in UI mode...");
 		servers::Server::start(config, |serv: servers::Server| {
 			let mut controller = ui::Controller::new().unwrap_or_else(|e| {

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -176,7 +176,7 @@ fn real_main() -> i32 {
 				Ok(_) => 0,
 				Err(_) => 1,
 			}
-		},
+		}
 
 		// If nothing is specified, try to just use the config file instead
 		// this could possibly become the way to configure most things

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -138,8 +138,7 @@ fn real_main() -> i32 {
 
 	if let Some(mut config) = node_config.clone() {
 		let mut l = config.members.as_mut().unwrap().logging.clone().unwrap();
-		let run_tui = config.members.as_mut().unwrap().server.run_tui;
-		if let Some(true) = run_tui {
+		if config.members.as_mut().unwrap().server.run_tui {
 			l.log_to_stdout = false;
 			l.tui_running = Some(true);
 		}

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 use backtrace::Backtrace;
 use std::{panic, thread};
 
-use crate::types::{self, LogLevel, LoggingConfig};
+use crate::types::{LogLevel, LoggingConfig};
 
 use log::{LevelFilter, Record};
 use log4rs;

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -123,11 +123,8 @@ pub fn init_logger(config: Option<LoggingConfig>) {
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
-					let count = c
-						.log_max_files
-						.unwrap_or_else(|| types::DEFAULT_ROTATE_LOG_FILES);
 					let roller = FixedWindowRoller::builder()
-						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
+						.build(&format!("{}.{{}}.gz", c.log_file_path), c.log_max_files)
 						.unwrap();
 					let trigger = SizeTrigger::new(size);
 

--- a/util/src/types.rs
+++ b/util/src/types.rs
@@ -14,6 +14,30 @@
 
 //! Logging configuration types
 
+/// whether to log to stdout
+const LOGGING_LOG_TO_STDOUT: bool = true;
+
+/// logging level for stdout
+const LOGGING_STDOUT_LOG_LEVEL: LogLevel = LogLevel::Warning;
+
+/// whether to log to file
+const LOGGING_LOG_TO_FILE: bool = true;
+
+/// log file level
+const LOGGING_FILE_LOG_LEVEL: LogLevel = LogLevel::Info;
+
+/// Log file path
+const LOGGING_LOG_FILE_PATH: &str = "grin.log";
+
+/// Whether to append to log file or replace
+const LOGGING_LOG_FILE_APPEND: bool = true;
+
+/// Size of the log in bytes to rotate over (optional)
+const LOGGING_LOG_MAX_SIZE: u64 = 1024 * 1024 * 16; // 16 megabytes default
+
+/// 32 log files to rotate over by default
+const LOGGING_ROTATE_LOG_FILES: u32 = 32 as u32;
+
 /// Log level types
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum LogLevel {
@@ -29,46 +53,88 @@ pub enum LogLevel {
 	Trace,
 }
 
-/// 32 log files to rotate over by default
-pub const DEFAULT_ROTATE_LOG_FILES: u32 = 32 as u32;
-
 /// Logging config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LoggingConfig {
 	/// whether to log to stdout
+	#[serde(default = "default_logging_log_to_stdout")]
 	pub log_to_stdout: bool,
 	/// logging level for stdout
+	#[serde(default = "default_logging_stdout_log_level")]
 	pub stdout_log_level: LogLevel,
 	/// whether to log to file
+	#[serde(default = "default_logging_log_to_file")]
 	pub log_to_file: bool,
 	/// log file level
+	#[serde(default = "default_logging_file_log_level")]
 	pub file_log_level: LogLevel,
 	/// Log file path
+	#[serde(default = "default_logging_log_file_path")]
 	pub log_file_path: String,
 	/// Whether to append to log or replace
+	#[serde(default = "default_logging_log_file_append")]
 	pub log_file_append: bool,
 	/// Size of the log in bytes to rotate over (optional)
+	#[serde(default = "default_logging_log_max_size")]
 	pub log_max_size: Option<u64>,
 	/// Number of the log files to rotate over (optional)
-	pub log_max_files: Option<u32>,
+	#[serde(default = "default_logging_log_max_files")]
+	pub log_max_files: u32,
 	/// Whether the tui is running (optional)
+	#[serde(default = "default_logging_tui_running")]
 	pub tui_running: Option<bool>,
 }
 
 impl Default for LoggingConfig {
 	fn default() -> LoggingConfig {
 		LoggingConfig {
-			log_to_stdout: true,
-			stdout_log_level: LogLevel::Warning,
-			log_to_file: true,
-			file_log_level: LogLevel::Info,
-			log_file_path: String::from("grin.log"),
-			log_file_append: true,
-			log_max_size: Some(1024 * 1024 * 16), // 16 megabytes default
-			log_max_files: Some(DEFAULT_ROTATE_LOG_FILES),
-			tui_running: None,
+			log_to_stdout: default_logging_log_to_stdout(),
+			stdout_log_level: default_logging_stdout_log_level(),
+			log_to_file: default_logging_log_to_file(),
+			file_log_level: default_logging_file_log_level(),
+			log_file_path: default_logging_log_file_path(),
+			log_file_append: default_logging_log_file_append(),
+			log_max_size: default_logging_log_max_size(),
+			log_max_files: default_logging_log_max_files(),
+			tui_running: default_logging_tui_running(),
 		}
 	}
+}
+
+fn default_logging_log_to_stdout() -> bool {
+	LOGGING_LOG_TO_STDOUT
+}
+
+fn default_logging_stdout_log_level() -> LogLevel {
+	LOGGING_STDOUT_LOG_LEVEL
+}
+
+fn default_logging_log_to_file() -> bool {
+	LOGGING_LOG_TO_FILE
+}
+
+fn default_logging_file_log_level() -> LogLevel {
+	LOGGING_FILE_LOG_LEVEL
+}
+
+fn default_logging_log_file_path() -> String {
+	LOGGING_LOG_FILE_PATH.to_string()
+}
+
+fn default_logging_log_file_append() -> bool {
+	LOGGING_LOG_FILE_APPEND
+}
+
+fn default_logging_log_max_size() -> Option<u64> {
+	Some(LOGGING_LOG_MAX_SIZE)
+}
+
+fn default_logging_log_max_files() -> u32 {
+	LOGGING_ROTATE_LOG_FILES
+}
+
+fn default_logging_tui_running() -> Option<bool> {
+	None
 }
 
 use std::ops::Deref;


### PR DESCRIPTION
Improvements linked to request #3002 

This pull request provides information on default values for each config parameter as comments of the auto-generated `grin-server.toml` file, as per requested in issue mentioned above.
It also better handles cases where some logging parameters are not provided, leading to the program exiting. Instead we use optional parameters set to their default value when absent from the config file.

This PR improves overall configuration experience based on @josef-v feedback but it could be amended to better improve simple configuration inconsistencies coming from anyone else's request.