### PR TITLE
Refactor transaction building combinators 

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -16,7 +16,7 @@ use self::chain::types::{NoopAdapter, Tip};
 use self::chain::Chain;
 use self::core::core::hash::Hashed;
 use self::core::core::verifier_cache::LruVerifierCache;
-use self::core::core::{Block, BlockHeader, OutputIdentifier, Transaction};
+use self::core::core::{Block, BlockHeader, KernelFeatures, OutputIdentifier, Transaction};
 use self::core::global::ChainTypes;
 use self::core::libtx::{self, build, ProofBuilder};
 use self::core::pow::Difficulty;
@@ -562,10 +562,10 @@ fn spend_in_fork_and_compact() {
 		let key_id31 = ExtKeychainPath::new(1, 31, 0, 0, 0).to_identifier();
 
 		let tx1 = build::transaction(
+			KernelFeatures::Plain { fee: 20000 },
 			vec![
 				build::coinbase_input(consensus::REWARD, key_id2.clone()),
 				build::output(consensus::REWARD - 20000, key_id30.clone()),
-				build::with_fee(20000),
 			],
 			&kc,
 			&pb,
@@ -580,10 +580,10 @@ fn spend_in_fork_and_compact() {
 		chain.validate(false).unwrap();
 
 		let tx2 = build::transaction(
+			KernelFeatures::Plain { fee: 20000 },
 			vec![
 				build::input(consensus::REWARD - 20000, key_id30.clone()),
 				build::output(consensus::REWARD - 40000, key_id31.clone()),
-				build::with_fee(20000),
 			],
 			&kc,
 			&pb,

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -15,6 +15,7 @@
 use self::chain::types::NoopAdapter;
 use self::chain::ErrorKind;
 use self::core::core::verifier_cache::LruVerifierCache;
+use self::core::core::KernelFeatures;
 use self::core::global::{self, ChainTypes};
 use self::core::libtx::{self, build, ProofBuilder};
 use self::core::pow::Difficulty;
@@ -99,10 +100,10 @@ fn test_coinbase_maturity() {
 		// here we build a tx that attempts to spend the earlier coinbase output
 		// this is not a valid tx as the coinbase output cannot be spent yet
 		let coinbase_txn = build::transaction(
+			KernelFeatures::Plain { fee: 2 },
 			vec![
 				build::coinbase_input(amount, key_id1.clone()),
 				build::output(amount - 2, key_id2.clone()),
-				build::with_fee(2),
 			],
 			&keychain,
 			&builder,
@@ -182,10 +183,10 @@ fn test_coinbase_maturity() {
 			// here we build a tx that attempts to spend the earlier coinbase output
 			// this is not a valid tx as the coinbase output cannot be spent yet
 			let coinbase_txn = build::transaction(
+				KernelFeatures::Plain { fee: 2 },
 				vec![
 					build::coinbase_input(amount, key_id1.clone()),
 					build::output(amount - 2, key_id2.clone()),
-					build::with_fee(2),
 				],
 				&keychain,
 				&builder,

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -659,6 +659,13 @@ impl TransactionBody {
 		self
 	}
 
+	/// Builds a new TransactionBody replacing any existing kernels with the provided kernel.
+	pub fn replace_kernel(mut self, kernel: TxKernel) -> TransactionBody {
+		self.kernels.clear();
+		self.kernels.push(kernel);
+		self
+	}
+
 	/// Total fee for a TransactionBody is the sum of fees of all fee carrying kernels.
 	pub fn fee(&self) -> u64 {
 		self.kernels
@@ -987,12 +994,20 @@ impl Transaction {
 		}
 	}
 
-	/// Builds a new transaction with the provided output added. Existing
-	/// outputs, if any, are kept intact.
+	/// Builds a new transaction with the provided kernel added. Existing
+	/// kernels, if any, are kept intact.
 	/// Sort order is maintained.
 	pub fn with_kernel(self, kernel: TxKernel) -> Transaction {
 		Transaction {
 			body: self.body.with_kernel(kernel),
+			..self
+		}
+	}
+
+	/// Builds a new transaction replacing any existing kernels with the provided kernel.
+	pub fn replace_kernel(self, kernel: TxKernel) -> Transaction {
+		Transaction {
+			body: self.body.replace_kernel(kernel),
 			..self
 		}
 	}

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -463,16 +463,16 @@ impl TxKernel {
 
 	/// Build an empty tx kernel with zero values.
 	pub fn empty() -> TxKernel {
+		TxKernel::with_features(KernelFeatures::Plain { fee: 0 })
+	}
+
+	/// Build an empty tx kernel with the provided kernel features.
+	pub fn with_features(features: KernelFeatures) -> TxKernel {
 		TxKernel {
-			features: KernelFeatures::Plain { fee: 0 },
+			features,
 			excess: Commitment::from_vec(vec![0; 33]),
 			excess_sig: secp::Signature::from_raw_data(&[0; 64]).unwrap(),
 		}
-	}
-
-	/// Build a new tx kernel with the provided kernel feature variant.
-	pub fn with_features(self, features: KernelFeatures) -> TxKernel {
-		TxKernel { features, ..self }
 	}
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -470,34 +470,9 @@ impl TxKernel {
 		}
 	}
 
-	/// Builds a new tx kernel with the provided fee.
-	/// Will panic if we cannot safely do this on the existing kernel.
-	/// i.e. Do not try and set a fee on a coinbase kernel.
-	pub fn with_fee(self, fee: u64) -> TxKernel {
-		match self.features {
-			KernelFeatures::Plain { .. } => {
-				let features = KernelFeatures::Plain { fee };
-				TxKernel { features, ..self }
-			}
-			KernelFeatures::HeightLocked { lock_height, .. } => {
-				let features = KernelFeatures::HeightLocked { fee, lock_height };
-				TxKernel { features, ..self }
-			}
-			KernelFeatures::Coinbase => panic!("fee not supported on coinbase kernel"),
-		}
-	}
-
-	/// Builds a new tx kernel with the provided lock_height.
-	/// Will panic if we cannot safely do this on the existing kernel.
-	/// i.e. Do not try and set a lock_height on a coinbase kernel.
-	pub fn with_lock_height(self, lock_height: u64) -> TxKernel {
-		match self.features {
-			KernelFeatures::Plain { fee } | KernelFeatures::HeightLocked { fee, .. } => {
-				let features = KernelFeatures::HeightLocked { fee, lock_height };
-				TxKernel { features, ..self }
-			}
-			KernelFeatures::Coinbase => panic!("lock_height not supported on coinbase kernel"),
-		}
+	/// Build a new tx kernel with the provided kernel feature variant.
+	pub fn with_features(self, features: KernelFeatures) -> TxKernel {
+		TxKernel { features, ..self }
 	}
 }
 

--- a/core/src/libtx/error.rs
+++ b/core/src/libtx/error.rs
@@ -44,6 +44,9 @@ pub enum ErrorKind {
 	/// Rangeproof error
 	#[fail(display = "Rangeproof Error")]
 	RangeProof(String),
+	/// Other error
+	#[fail(display = "Other Error")]
+	Other(String),
 }
 
 impl Fail for Error {

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -24,7 +24,7 @@ use crate::core::core::Committed;
 use crate::core::core::{
 	Block, BlockHeader, CompactBlock, HeaderVersion, KernelFeatures, OutputFeatures,
 };
-use crate::core::libtx::build::{self, input, output, with_fee};
+use crate::core::libtx::build::{self, input, output, with_features};
 use crate::core::libtx::ProofBuilder;
 use crate::core::{global, ser};
 use crate::keychain::{BlindingFactor, ExtKeychain, Keychain};
@@ -58,7 +58,10 @@ fn too_large_block() {
 		parts.push(output(5, pks.pop().unwrap()));
 	}
 
-	parts.append(&mut vec![input(500000, pks.pop().unwrap()), with_fee(2)]);
+	parts.append(&mut vec![
+		input(500000, pks.pop().unwrap()),
+		with_features(KernelFeatures::Plain { fee: 2 }),
+	]);
 	let tx = build::transaction(parts, &keychain, &builder).unwrap();
 
 	let prev = BlockHeader::default();
@@ -92,7 +95,11 @@ fn block_with_cut_through() {
 
 	let mut btx1 = tx2i1o();
 	let mut btx2 = build::transaction(
-		vec![input(7, key_id1), output(5, key_id2.clone()), with_fee(2)],
+		vec![
+			input(7, key_id1),
+			output(5, key_id2.clone()),
+			with_features(KernelFeatures::Plain { fee: 2 }),
+		],
 		&keychain,
 		&builder,
 	)
@@ -481,7 +488,7 @@ fn same_amount_outputs_copy_range_proof() {
 			input(7, key_id1),
 			output(3, key_id2),
 			output(3, key_id3),
-			with_fee(1),
+			with_features(KernelFeatures::Plain { fee: 1 }),
 		],
 		&keychain,
 		&builder,
@@ -531,7 +538,7 @@ fn wrong_amount_range_proof() {
 			input(7, key_id1.clone()),
 			output(3, key_id2.clone()),
 			output(3, key_id3.clone()),
-			with_fee(1),
+			with_features(KernelFeatures::Plain { fee: 1 }),
 		],
 		&keychain,
 		&builder,
@@ -542,7 +549,7 @@ fn wrong_amount_range_proof() {
 			input(7, key_id1),
 			output(2, key_id2),
 			output(4, key_id3),
-			with_fee(1),
+			with_features(KernelFeatures::Plain { fee: 1 }),
 		],
 		&keychain,
 		&builder,

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -24,7 +24,7 @@ use crate::core::core::Committed;
 use crate::core::core::{
 	Block, BlockHeader, CompactBlock, HeaderVersion, KernelFeatures, OutputFeatures,
 };
-use crate::core::libtx::build::{self, input, output, with_features};
+use crate::core::libtx::build::{self, input, output};
 use crate::core::libtx::ProofBuilder;
 use crate::core::{global, ser};
 use crate::keychain::{BlindingFactor, ExtKeychain, Keychain};
@@ -58,11 +58,9 @@ fn too_large_block() {
 		parts.push(output(5, pks.pop().unwrap()));
 	}
 
-	parts.append(&mut vec![
-		input(500000, pks.pop().unwrap()),
-		with_features(KernelFeatures::Plain { fee: 2 }),
-	]);
-	let tx = build::transaction(parts, &keychain, &builder).unwrap();
+	parts.append(&mut vec![input(500000, pks.pop().unwrap())]);
+	let tx =
+		build::transaction(KernelFeatures::Plain { fee: 2 }, parts, &keychain, &builder).unwrap();
 
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -95,11 +93,8 @@ fn block_with_cut_through() {
 
 	let mut btx1 = tx2i1o();
 	let mut btx2 = build::transaction(
-		vec![
-			input(7, key_id1),
-			output(5, key_id2.clone()),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(7, key_id1), output(5, key_id2.clone())],
 		&keychain,
 		&builder,
 	)
@@ -484,12 +479,8 @@ fn same_amount_outputs_copy_range_proof() {
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 
 	let tx = build::transaction(
-		vec![
-			input(7, key_id1),
-			output(3, key_id2),
-			output(3, key_id3),
-			with_features(KernelFeatures::Plain { fee: 1 }),
-		],
+		KernelFeatures::Plain { fee: 1 },
+		vec![input(7, key_id1), output(3, key_id2), output(3, key_id3)],
 		&keychain,
 		&builder,
 	)
@@ -534,23 +525,19 @@ fn wrong_amount_range_proof() {
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 
 	let tx1 = build::transaction(
+		KernelFeatures::Plain { fee: 1 },
 		vec![
 			input(7, key_id1.clone()),
 			output(3, key_id2.clone()),
 			output(3, key_id3.clone()),
-			with_features(KernelFeatures::Plain { fee: 1 }),
 		],
 		&keychain,
 		&builder,
 	)
 	.unwrap();
 	let tx2 = build::transaction(
-		vec![
-			input(7, key_id1),
-			output(2, key_id2),
-			output(4, key_id3),
-			with_features(KernelFeatures::Plain { fee: 1 }),
-		],
+		KernelFeatures::Plain { fee: 1 },
+		vec![input(7, key_id1), output(2, key_id2), output(4, key_id3)],
 		&keychain,
 		&builder,
 	)

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -15,12 +15,9 @@
 //! Common test functions
 
 use crate::keychain::{Identifier, Keychain};
-use grin_core::core::{
-	block::{Block, BlockHeader},
-	Transaction,
-};
+use grin_core::core::{Block, BlockHeader, KernelFeatures, Transaction};
 use grin_core::libtx::{
-	build::{self, input, output, with_fee},
+	build::{self, input, output, with_features},
 	proof::{ProofBuild, ProofBuilder},
 	reward,
 };
@@ -40,7 +37,7 @@ pub fn tx2i1o() -> Transaction {
 			input(10, key_id1),
 			input(11, key_id2),
 			output(19, key_id3),
-			with_fee(2),
+			with_features(KernelFeatures::Plain { fee: 2 }),
 		],
 		&keychain,
 		&builder,
@@ -56,7 +53,11 @@ pub fn tx1i1o() -> Transaction {
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 
 	build::transaction(
-		vec![input(5, key_id1), output(3, key_id2), with_fee(2)],
+		vec![
+			input(5, key_id1),
+			output(3, key_id2),
+			with_features(KernelFeatures::Plain { fee: 2 }),
+		],
 		&keychain,
 		&builder,
 	)
@@ -78,7 +79,7 @@ pub fn tx1i2o() -> Transaction {
 			input(6, key_id1),
 			output(3, key_id2),
 			output(1, key_id3),
-			with_fee(2),
+			with_features(KernelFeatures::Plain { fee: 2 }),
 		],
 		&keychain,
 		&builder,
@@ -124,7 +125,11 @@ where
 	B: ProofBuild,
 {
 	build::transaction(
-		vec![input(v, key_id1), output(3, key_id2), with_fee(2)],
+		vec![
+			input(v, key_id1),
+			output(3, key_id2),
+			with_features(KernelFeatures::Plain { fee: 2 }),
+		],
 		keychain,
 		builder,
 	)

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -17,7 +17,7 @@
 use crate::keychain::{Identifier, Keychain};
 use grin_core::core::{Block, BlockHeader, KernelFeatures, Transaction};
 use grin_core::libtx::{
-	build::{self, input, output, with_features},
+	build::{self, input, output},
 	proof::{ProofBuild, ProofBuilder},
 	reward,
 };
@@ -33,12 +33,8 @@ pub fn tx2i1o() -> Transaction {
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 
 	build::transaction(
-		vec![
-			input(10, key_id1),
-			input(11, key_id2),
-			output(19, key_id3),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(10, key_id1), input(11, key_id2), output(19, key_id3)],
 		&keychain,
 		&builder,
 	)
@@ -53,11 +49,8 @@ pub fn tx1i1o() -> Transaction {
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 
 	build::transaction(
-		vec![
-			input(5, key_id1),
-			output(3, key_id2),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(5, key_id1), output(3, key_id2)],
 		&keychain,
 		&builder,
 	)
@@ -75,12 +68,8 @@ pub fn tx1i2o() -> Transaction {
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 
 	build::transaction(
-		vec![
-			input(6, key_id1),
-			output(3, key_id2),
-			output(1, key_id3),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(6, key_id1), output(3, key_id2), output(1, key_id3)],
 		&keychain,
 		&builder,
 	)
@@ -125,11 +114,8 @@ where
 	B: ProofBuild,
 {
 	build::transaction(
-		vec![
-			input(v, key_id1),
-			output(3, key_id2),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(v, key_id1), output(3, key_id2)],
 		keychain,
 		builder,
 	)

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -20,7 +20,9 @@ use self::core::core::block::BlockHeader;
 use self::core::core::block::Error::KernelLockHeight;
 use self::core::core::hash::{Hashed, ZERO_HASH};
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
-use self::core::core::{aggregate, deaggregate, KernelFeatures, Output, Transaction, Weighting};
+use self::core::core::{
+	aggregate, deaggregate, KernelFeatures, Output, Transaction, TxKernel, Weighting,
+};
 use self::core::libtx::build::{self, initial_tx, input, output, with_excess};
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
@@ -430,13 +432,11 @@ fn tx_build_exchange() {
 
 		// Alice builds her transaction, with change, which also produces the sum
 		// of blinding factors before they're obscured.
-		let (tx, sum) = build::partial_transaction(
-			KernelFeatures::Plain { fee: 2 },
-			vec![in1, in2, output(1, key_id3)],
-			&keychain,
-			&builder,
-		)
-		.unwrap();
+		let tx = Transaction::empty()
+			.with_kernel(TxKernel::with_features(KernelFeatures::Plain { fee: 2 }));
+		let (tx, sum) =
+			build::partial_transaction(tx, vec![in1, in2, output(1, key_id3)], &keychain, &builder)
+				.unwrap();
 
 		(tx, sum)
 	};

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -21,9 +21,7 @@ use self::core::core::block::Error::KernelLockHeight;
 use self::core::core::hash::{Hashed, ZERO_HASH};
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use self::core::core::{aggregate, deaggregate, KernelFeatures, Output, Transaction, Weighting};
-use self::core::libtx::build::{
-	self, initial_tx, input, output, with_excess, with_fee, with_lock_height,
-};
+use self::core::libtx::build::{self, initial_tx, input, output, with_excess, with_features};
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
 use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
@@ -124,7 +122,7 @@ fn build_tx_kernel() {
 			input(10, key_id1),
 			output(5, key_id2),
 			output(3, key_id3),
-			with_fee(2),
+			with_features(KernelFeatures::Plain { fee: 2 }),
 		],
 		&keychain,
 		&builder,
@@ -377,7 +375,7 @@ fn hash_output() {
 			input(75, key_id1),
 			output(42, key_id2),
 			output(32, key_id3),
-			with_fee(1),
+			with_features(KernelFeatures::Plain { fee: 1 }),
 		],
 		&keychain,
 		&builder,
@@ -440,7 +438,12 @@ fn tx_build_exchange() {
 		// Alice builds her transaction, with change, which also produces the sum
 		// of blinding factors before they're obscured.
 		let (tx, sum) = build::partial_transaction(
-			vec![in1, in2, output(1, key_id3), with_fee(2)],
+			vec![
+				in1,
+				in2,
+				output(1, key_id3),
+				with_features(KernelFeatures::Plain { fee: 2 }),
+			],
 			&keychain,
 			&builder,
 		)
@@ -550,8 +553,10 @@ fn test_block_with_timelocked_tx() {
 		vec![
 			input(5, key_id1.clone()),
 			output(3, key_id2.clone()),
-			with_fee(2),
-			with_lock_height(1),
+			with_features(KernelFeatures::HeightLocked {
+				fee: 2,
+				lock_height: 1,
+			}),
 		],
 		&keychain,
 		&builder,
@@ -575,8 +580,10 @@ fn test_block_with_timelocked_tx() {
 		vec![
 			input(5, key_id1.clone()),
 			output(3, key_id2.clone()),
-			with_fee(2),
-			with_lock_height(2),
+			with_features(KernelFeatures::HeightLocked {
+				fee: 2,
+				lock_height: 2,
+			}),
 		],
 		&keychain,
 		&builder,

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -445,7 +445,7 @@ fn tx_build_exchange() {
 	// blinding factors. He adds his output, finalizes the transaction so it's
 	// ready for broadcast.
 	let tx_final = build::transaction(
-		KernelFeatures::Plain { fee: 0 },
+		KernelFeatures::Plain { fee: 2 },
 		vec![
 			initial_tx(tx_alice),
 			with_excess(blind_sum),

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -21,7 +21,7 @@ use self::core::core::block::Error::KernelLockHeight;
 use self::core::core::hash::{Hashed, ZERO_HASH};
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use self::core::core::{aggregate, deaggregate, KernelFeatures, Output, Transaction, Weighting};
-use self::core::libtx::build::{self, initial_tx, input, output, with_excess, with_features};
+use self::core::libtx::build::{self, initial_tx, input, output, with_excess};
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
 use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
@@ -97,6 +97,7 @@ fn test_zero_commit_fails() {
 
 	// blinding should fail as signing with a zero r*G shouldn't work
 	build::transaction(
+		KernelFeatures::Plain { fee: 0 },
 		vec![input(10, key_id1.clone()), output(10, key_id1.clone())],
 		&keychain,
 		&builder,
@@ -118,12 +119,8 @@ fn build_tx_kernel() {
 
 	// first build a valid tx with corresponding blinding factor
 	let tx = build::transaction(
-		vec![
-			input(10, key_id1),
-			output(5, key_id2),
-			output(3, key_id3),
-			with_features(KernelFeatures::Plain { fee: 2 }),
-		],
+		KernelFeatures::Plain { fee: 2 },
+		vec![input(10, key_id1), output(5, key_id2), output(3, key_id3)],
 		&keychain,
 		&builder,
 	)
@@ -371,12 +368,8 @@ fn hash_output() {
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
 
 	let tx = build::transaction(
-		vec![
-			input(75, key_id1),
-			output(42, key_id2),
-			output(32, key_id3),
-			with_features(KernelFeatures::Plain { fee: 1 }),
-		],
+		KernelFeatures::Plain { fee: 1 },
+		vec![input(75, key_id1), output(42, key_id2), output(32, key_id3)],
 		&keychain,
 		&builder,
 	)
@@ -438,12 +431,8 @@ fn tx_build_exchange() {
 		// Alice builds her transaction, with change, which also produces the sum
 		// of blinding factors before they're obscured.
 		let (tx, sum) = build::partial_transaction(
-			vec![
-				in1,
-				in2,
-				output(1, key_id3),
-				with_features(KernelFeatures::Plain { fee: 2 }),
-			],
+			KernelFeatures::Plain { fee: 2 },
+			vec![in1, in2, output(1, key_id3)],
 			&keychain,
 			&builder,
 		)
@@ -456,6 +445,7 @@ fn tx_build_exchange() {
 	// blinding factors. He adds his output, finalizes the transaction so it's
 	// ready for broadcast.
 	let tx_final = build::transaction(
+		KernelFeatures::Plain { fee: 0 },
 		vec![
 			initial_tx(tx_alice),
 			with_excess(blind_sum),
@@ -550,14 +540,11 @@ fn test_block_with_timelocked_tx() {
 	// first check we can add a timelocked tx where lock height matches current
 	// block height and that the resulting block is valid
 	let tx1 = build::transaction(
-		vec![
-			input(5, key_id1.clone()),
-			output(3, key_id2.clone()),
-			with_features(KernelFeatures::HeightLocked {
-				fee: 2,
-				lock_height: 1,
-			}),
-		],
+		KernelFeatures::HeightLocked {
+			fee: 2,
+			lock_height: 1,
+		},
+		vec![input(5, key_id1.clone()), output(3, key_id2.clone())],
 		&keychain,
 		&builder,
 	)
@@ -577,14 +564,11 @@ fn test_block_with_timelocked_tx() {
 	// now try adding a timelocked tx where lock height is greater than current
 	// block height
 	let tx1 = build::transaction(
-		vec![
-			input(5, key_id1.clone()),
-			output(3, key_id2.clone()),
-			with_features(KernelFeatures::HeightLocked {
-				fee: 2,
-				lock_height: 2,
-			}),
-		],
+		KernelFeatures::HeightLocked {
+			fee: 2,
+			lock_height: 2,
+		},
+		vec![input(5, key_id1.clone()), output(3, key_id2.clone())],
 		&keychain,
 		&builder,
 	)

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -18,7 +18,7 @@ use self::chain::store::ChainStore;
 use self::chain::types::Tip;
 use self::core::core::hash::{Hash, Hashed};
 use self::core::core::verifier_cache::VerifierCache;
-use self::core::core::{Block, BlockHeader, BlockSums, Committed, Transaction};
+use self::core::core::{Block, BlockHeader, BlockSums, Committed, KernelFeatures, Transaction};
 use self::core::libtx;
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::types::*;
@@ -193,9 +193,13 @@ where
 		tx_elements.push(libtx::build::output(output_value, key_id));
 	}
 
-	tx_elements.push(libtx::build::with_fee(fees as u64));
-
-	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
+	libtx::build::transaction(
+		KernelFeatures::Plain { fee: fees as u64 },
+		tx_elements,
+		keychain,
+		&libtx::ProofBuilder::new(keychain),
+	)
+	.unwrap()
 }
 
 pub fn test_transaction<K>(
@@ -223,9 +227,14 @@ where
 		let key_id = ExtKeychain::derive_key_id(1, output_value as u32, 0, 0, 0);
 		tx_elements.push(libtx::build::output(output_value, key_id));
 	}
-	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
+	libtx::build::transaction(
+		KernelFeatures::Plain { fee: fees as u64 },
+		tx_elements,
+		keychain,
+		&libtx::ProofBuilder::new(keychain),
+	)
+	.unwrap()
 }
 
 pub fn test_source() -> TxSource {


### PR DESCRIPTION
This allows for more robust error handling as we can now propagate errors up to the top level.

Specifically the `Append` type which takes a Result and returns a Result.

```
pub type Append<K, B> = dyn for<'a> Fn(
	&'a mut Context<'_, K, B>,
	Result<(Transaction, TxKernel, BlindSum), Error>,
) -> Result<(Transaction, TxKernel, BlindSum), Error>;
```

Also replaced `with_fee()` and `with_lock_height()` combinators with simply passing in kernel features to `build::transaction()` and `build::partial_transaction()`. It was confusing (and fragile) setting `fee` and `lock_height` individually via combinators. We now explicitly specify the features for the kernel of the tx being built.

```
let tx = transaction(
    KernelFeatures::Plain { fee: 4 },
    vec![
        input(6, key_id1),
        output(2, key_id2),
    ],
    &keychain,
    &builder,
)
```

----

__NOTE:__ Wallet uses `build::transaction()` and `build::partial_transaction()` so we need to be careful merging this to make sure the wallet project is updated to reflect this.