### PR TITLE
add block_hash to head_info so we can easily use them later

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -562,6 +562,7 @@ impl<'a> Iterator for DifficultyIter<'a> {
 			let scaling = header.pow.secondary_scaling;
 
 			Some(HeaderInfo::new(
+				header.hash(),
 				header.timestamp.timestamp() as u64,
 				difficulty,
 				scaling,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -21,6 +21,7 @@
 use std::cmp::{max, min};
 
 use crate::core::block::HeaderVersion;
+use crate::core::hash::{Hash, ZERO_HASH};
 use crate::global;
 use crate::pow::Difficulty;
 
@@ -219,6 +220,8 @@ pub const INITIAL_DIFFICULTY: u64 = 1_000_000 * UNIT_DIFFICULTY;
 /// take place
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HeaderInfo {
+	/// Block hash, ZERO_HASH when this is a sythetic entry.
+	pub block_hash: Hash,
 	/// Timestamp of the header, 1 when not used (returned info)
 	pub timestamp: u64,
 	/// Network difficulty or next difficulty to use
@@ -232,12 +235,14 @@ pub struct HeaderInfo {
 impl HeaderInfo {
 	/// Default constructor
 	pub fn new(
+		block_hash: Hash,
 		timestamp: u64,
 		difficulty: Difficulty,
 		secondary_scaling: u32,
 		is_secondary: bool,
 	) -> HeaderInfo {
 		HeaderInfo {
+			block_hash,
 			timestamp,
 			difficulty,
 			secondary_scaling,
@@ -249,6 +254,7 @@ impl HeaderInfo {
 	/// PoW factor
 	pub fn from_ts_diff(timestamp: u64, difficulty: Difficulty) -> HeaderInfo {
 		HeaderInfo {
+			block_hash: ZERO_HASH,
 			timestamp,
 			difficulty,
 			secondary_scaling: global::initial_graph_weight(),
@@ -261,6 +267,7 @@ impl HeaderInfo {
 	/// timestamp
 	pub fn from_diff_scaling(difficulty: Difficulty, secondary_scaling: u32) -> HeaderInfo {
 		HeaderInfo {
+			block_hash: ZERO_HASH,
 			timestamp: 1,
 			difficulty,
 			secondary_scaling,

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -86,6 +86,7 @@ fn repeat(interval: u64, diff: HeaderInfo, len: u64, cur_time: Option<u64>) -> V
 	pairs
 		.map(|(t, d)| {
 			HeaderInfo::new(
+				diff.block_hash,
 				cur_time + t as u64,
 				d.clone(),
 				diff.secondary_scaling,


### PR DESCRIPTION
I suspect the `header_mmr.read()` lock in get_server_stats is causing issues as _every_ peer thread needs write access to the header_mmr for processing blocks and block headers.

I have seen anecdotal evidence that something is causing a deadlock and gdb indicates the stuck tui is blocked waiting on a read() lock. Just not 100% sure _which_ read lock, but this is a likely candidate).

There is no need to lock the header_mmr here just to read several headers by height to find their block hashes. It makes more sense to simply track these block hashes when we build the difficulty iterator initially.
We also update the tui stats every 1s or so, which introduces the potential for lock contention on this header_mmr via the tui thread.

Currently running a node on mainnet with these changes applied and TUI enabled. I'd like to let this run for a bit to see if we can still reproduce the deadlock scenario or if these changes do appear to alleviate the issue.

