### PR TITLE
2.1.0-beta.1 deadlock fix

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -475,9 +475,17 @@ impl Server {
 			.map(|p| PeerStats::from_peer(&p))
 			.collect();
 
+		let (tx_pool_size, stem_pool_size) = {
+			let tx_pool_lock = self.tx_pool.try_read();
+			match tx_pool_lock {
+				Some(l) => (l.txpool.entries.len(), l.stempool.entries.len()),
+				None => (0, 0),
+			}
+		};
+
 		let tx_stats = TxStats {
-			tx_pool_size: self.tx_pool.read().txpool.entries.len(),
-			stem_pool_size: self.tx_pool.read().stempool.entries.len(),
+			tx_pool_size,
+			stem_pool_size,
 		};
 
 		let head = self.chain.head_header()?;


### PR DESCRIPTION
Can't entirely explain why this would have caused a threading deadlock, but debugging a stuck node showed 2 threads stuck trying to get a lock on the transaction pool at:

server.rs:480: `stem_pool_size: self.tx_pool.read().stempool.entries.len()`
dandelion_monitor.rs:159 - `let mut tx_pool = tx_pool.write();`

I'd conjecture it occurred for some Rusty reason when the write lock happened to be taken just after the first read lock.

Current fix:

* Changes the tui `read' to `try_read`
* Only attempt to read once (was no need to lock twice in the existing code)

I'd guess that only taking the lock once would have been enough to resolve, but no harm just using a `try_read` for tui purposes. Ran with these modifications overnight seems to resolve the freezing issues.