### PR TITLE
Use sender thread consistently to send msgs to a peer

### DIFF
--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::conn::Tracker;
 use crate::core::core::hash::Hash;
 use crate::core::pow::Difficulty;
 use crate::core::ser::ProtocolVersion;
-use crate::msg::{read_message, write_message, Hand, Shake, Type, USER_AGENT};
+use crate::msg::{read_message, write_message, Hand, Msg, Shake, Type, USER_AGENT};
 use crate::peer::Peer;
 use crate::types::{Capabilities, Direction, Error, P2PConfig, PeerAddr, PeerInfo, PeerLiveInfo};
 use crate::util::RwLock;
@@ -47,6 +48,7 @@ pub struct Handshake {
 	genesis: Hash,
 	config: P2PConfig,
 	protocol_version: ProtocolVersion,
+	tracker: Arc<Tracker>,
 }
 
 impl Handshake {
@@ -58,6 +60,7 @@ impl Handshake {
 			genesis,
 			config,
 			protocol_version: ProtocolVersion::local(),
+			tracker: Arc::new(Tracker::new()),
 		}
 	}
 
@@ -99,7 +102,8 @@ impl Handshake {
 		};
 
 		// write and read the handshake response
-		write_message(conn, hand, Type::Hand, self.protocol_version)?;
+		let msg = Msg::new(Type::Hand, hand, self.protocol_version)?;
+		write_message(conn, &msg, self.tracker.clone())?;
 
 		let shake: Shake = read_message(conn, self.protocol_version, Type::Shake)?;
 		if shake.genesis != self.genesis {
@@ -196,7 +200,9 @@ impl Handshake {
 			user_agent: USER_AGENT.to_string(),
 		};
 
-		write_message(conn, shake, Type::Shake, negotiated_version)?;
+		let msg = Msg::new(Type::Shake, shake, negotiated_version)?;
+		write_message(conn, &msg, self.tracker.clone())?;
+
 		trace!("Success handshake with {}.", peer_info.addr);
 
 		Ok(peer_info)

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -29,7 +29,7 @@ use crate::core::ser::Writeable;
 use crate::core::{core, global};
 use crate::handshake::Handshake;
 use crate::msg::{
-	self, BanReason, GetPeerAddrs, KernelDataRequest, Locator, Ping, TxHashSetRequest, Type,
+	self, BanReason, GetPeerAddrs, KernelDataRequest, Locator, Msg, Ping, TxHashSetRequest, Type,
 };
 use crate::protocol::Protocol;
 use crate::types::{
@@ -233,12 +233,8 @@ impl Peer {
 
 	/// Send a msg with given msg_type to our peer via the connection.
 	fn send<T: Writeable>(&self, msg: T, msg_type: Type) -> Result<(), Error> {
-		let bytes = self
-			.send_handle
-			.lock()
-			.send(msg, msg_type, self.info.version)?;
-		self.tracker.inc_sent(bytes);
-		Ok(())
+		let msg = Msg::new(msg_type, msg, self.info.version)?;
+		self.send_handle.lock().send(msg)
 	}
 
 	/// Send a ping to the remote peer, providing our local difficulty and


### PR DESCRIPTION

We currently send p2p messages two different ways - 
* broadcast msgs to peers via the `peer_write` thread
* receive msgs via the `peer_read` thread then _respond_ with a msg (but still via `peer_read` thread)

Each peer has a dedicated [mpsc](https://doc.rust-lang.org/std/sync/mpsc/) queue for sending messages out via the `peer_write` thread. This is polled regularly, taking a message from the queue and sending it out to the peer.

But message _responses_ are not sent via this queue and instead sent out immediately, using the same `peer_read` thread used to receive the original request from the peer.

This PR reworks the message _response_ implementation to use the mpsc queue as follows - 

* receive a msg from a peer on `peer_read` thread
* if we want to send a response, push it onto the mpsc queue
* the `peer_write` thread will then pull this response msg off the queue and send it

The `peer_read` thread reads from the tcp stream and potentially writes to the mpsc queue.
The `peer_write` thread reads from the mpsc queue and writes to the tcp stream.

Having two threads per peer both potentially sending messages out via the _same_ tcp connection is potentially asking for trouble.
Most messages are "safe" in this situation as we simply create a single buffer and then use a single `stream.write_all()` to send the entire message or none of the message.
But this is not the case for messages with attachments, specifically a response to a txhashset request where we send back the txhashset archive to the peer. This involves multiple calls to `stream.write_all()` and I think there is a risk of the multiple threads effectively corrupting the data here with interleaved messages.

The way to solve this is to funnel _all_ messages back out via the same `peer_write` thread.

* Introduce a `Msg` struct to represent messages on the mpsc queue.
* Send messages out by building `msg` instances and pushing them to the queue.
* Send responses out by building `msg` instances and pushing them onto the same queue.
* The `peer_write` thread polls this queue (as it does currently) and sends to the peer.

These changes had the nice side-effect of removing some duplication as we no longer need to manage message _responses_ as a separate code path.
We also reduced potentially blocking activity on the `peer_read` threads, which should allow a node to receive messages from peers with less latency and process them faster.

