### PR TITLE
Update Master version to 3.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.3",
- "grin_chain 2.1.0-beta.3",
- "grin_config 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_servers 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_api 3.0.0-alpha.1",
+ "grin_chain 3.0.0-alpha.1",
+ "grin_config 3.0.0-alpha.1",
+ "grin_core 3.0.0-alpha.1",
+ "grin_keychain 3.0.0-alpha.1",
+ "grin_p2p 3.0.0-alpha.1",
+ "grin_servers 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 3.0.0-alpha.1",
+ "grin_core 3.0.0-alpha.1",
+ "grin_p2p 3.0.0-alpha.1",
+ "grin_pool 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 3.0.0-alpha.1",
+ "grin_keychain 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_servers 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 3.0.0-alpha.1",
+ "grin_p2p 3.0.0-alpha.1",
+ "grin_servers 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_keychain 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.0-beta.3",
+ "grin_util 3.0.0-alpha.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 3.0.0-alpha.1",
+ "grin_core 3.0.0-alpha.1",
+ "grin_pool 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 3.0.0-alpha.1",
+ "grin_core 3.0.0-alpha.1",
+ "grin_keychain 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.3",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_api 3.0.0-alpha.1",
+ "grin_chain 3.0.0-alpha.1",
+ "grin_core 3.0.0-alpha.1",
+ "grin_keychain 3.0.0-alpha.1",
+ "grin_p2p 3.0.0-alpha.1",
+ "grin_pool 3.0.0-alpha.1",
+ "grin_store 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 3.0.0-alpha.1",
+ "grin_util 3.0.0-alpha.1",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.0-beta.3" }
-grin_config = { path = "./config", version = "2.1.0-beta.3" }
-grin_chain = { path = "./chain", version = "2.1.0-beta.3" }
-grin_core = { path = "./core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "./keychain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "./p2p", version = "2.1.0-beta.3" }
-grin_servers = { path = "./servers", version = "2.1.0-beta.3" }
-grin_util = { path = "./util", version = "2.1.0-beta.3" }
+grin_api = { path = "./api", version = "3.0.0-alpha.1" }
+grin_config = { path = "./config", version = "3.0.0-alpha.1" }
+grin_chain = { path = "./chain", version = "3.0.0-alpha.1" }
+grin_core = { path = "./core", version = "3.0.0-alpha.1" }
+grin_keychain = { path = "./keychain", version = "3.0.0-alpha.1" }
+grin_p2p = { path = "./p2p", version = "3.0.0-alpha.1" }
+grin_servers = { path = "./servers", version = "3.0.0-alpha.1" }
+grin_util = { path = "./util", version = "3.0.0-alpha.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.0-beta.3" }
-grin_store = { path = "./store", version = "2.1.0-beta.3" }
+grin_chain = { path = "./chain", version = "3.0.0-alpha.1" }
+grin_store = { path = "./store", version = "3.0.0-alpha.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_chain = { path = "../chain", version = "3.0.0-alpha.1" }
+grin_p2p = { path = "../p2p", version = "3.0.0-alpha.1" }
+grin_pool = { path = "../pool", version = "3.0.0-alpha.1" }
+grin_store = { path = "../store", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_keychain = { path = "../keychain", version = "3.0.0-alpha.1" }
+grin_store = { path = "../store", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_servers = { path = "../servers", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_servers = { path = "../servers", version = "3.0.0-alpha.1" }
+grin_p2p = { path = "../p2p", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_keychain = { path = "../keychain", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_store = { path = "../store", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
+grin_chain = { path = "../chain", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
+grin_pool = { path = "../pool", version = "3.0.0-alpha.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_keychain = { path = "../keychain", version = "3.0.0-alpha.1" }
+grin_store = { path = "../store", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
+grin_chain = { path = "../chain", version = "3.0.0-alpha.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_api = { path = "../api", version = "3.0.0-alpha.1" }
+grin_chain = { path = "../chain", version = "3.0.0-alpha.1" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_keychain = { path = "../keychain", version = "3.0.0-alpha.1" }
+grin_p2p = { path = "../p2p", version = "3.0.0-alpha.1" }
+grin_pool = { path = "../pool", version = "3.0.0-alpha.1" }
+grin_store = { path = "../store", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "3.0.0-alpha.1" }
+grin_util = { path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.0-beta.3"
+version = "3.0.0-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
As titled, for 3.0.0 functionality development. 2.1.x has been branched to `current/2.1.x`, with `current/2.0.x` to be removed on release of 2.1.0