### PR TITLE
Retrieves OutputPrintable instead of Output

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -57,7 +57,7 @@ impl HeaderHandler {
 	}
 
 	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {
-		let oid = get_output(&self.chain, &commit_id)?.1;
+		let oid = get_output(&self.chain, &commit_id, false)?.1;
 		match w(&self.chain)?.get_header_for_output(&oid) {
 			Ok(header) => Ok(BlockHeaderPrintable::from_header(&header)),
 			Err(_) => Err(ErrorKind::NotFound)?,

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -92,19 +92,19 @@ pub struct OutputHandler {
 }
 
 impl OutputHandler {
-	fn get_output(&self, id: &str) -> Result<Output, Error> {
+	fn get_output(&self, id: &str) -> Result<OutputPrintable, Error> {
 		let res = get_output(&self.chain, id)?;
 		Ok(res.0)
 	}
 
-	fn outputs_by_ids(&self, req: &Request<Body>) -> Result<Vec<Output>, Error> {
+	fn outputs_by_ids(&self, req: &Request<Body>) -> Result<Vec<OutputPrintable>, Error> {
 		let mut commitments: Vec<String> = vec![];
 
 		let query = must_get_query!(req);
 		let params = QueryParams::from(query);
 		params.process_multival_param("id", |id| commitments.push(id.to_owned()));
 
-		let mut outputs: Vec<Output> = vec![];
+		let mut outputs: Vec<OutputPrintable> = vec![];
 		for x in commitments {
 			match self.get_output(&x) {
 				Ok(output) => outputs.push(output),

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -92,8 +92,8 @@ pub struct OutputHandler {
 }
 
 impl OutputHandler {
-	fn get_output(&self, id: &str) -> Result<OutputPrintable, Error> {
-		let res = get_output(&self.chain, id)?;
+	fn get_output(&self, id: &str, include_proof: bool) -> Result<OutputPrintable, Error> {
+		let res = get_output(&self.chain, id, include_proof)?;
 		Ok(res.0)
 	}
 
@@ -104,9 +104,11 @@ impl OutputHandler {
 		let params = QueryParams::from(query);
 		params.process_multival_param("id", |id| commitments.push(id.to_owned()));
 
+		let include_proof = params.get("include_rp").is_some();
+
 		let mut outputs: Vec<OutputPrintable> = vec![];
 		for x in commitments {
-			match self.get_output(&x) {
+			match self.get_output(&x, include_proof) {
 				Ok(output) => outputs.push(output),
 				Err(e) => error!(
 					"Failure to get output for commitment {} with error {}",
@@ -122,6 +124,7 @@ impl OutputHandler {
 		block_height: u64,
 		commitments: Vec<Commitment>,
 		include_proof: bool,
+		include_merkle_proof: bool,
 	) -> Result<BlockOutputs, Error> {
 		let header = w(&self.chain)?
 			.get_header_by_height(block_height)
@@ -143,11 +146,11 @@ impl OutputHandler {
 					chain.clone(),
 					Some(&header),
 					include_proof,
-					true,
+					include_merkle_proof,
 				)
 			})
 			.collect::<Result<Vec<_>, _>>()
-			.context(ErrorKind::Internal("cain error".to_owned()))?;
+			.context(ErrorKind::Internal("chain error".to_owned()))?;
 
 		Ok(BlockOutputs {
 			header: BlockHeaderInfo::from_header(&header),
@@ -169,15 +172,18 @@ impl OutputHandler {
 		let start_height = parse_param!(params, "start_height", 1);
 		let end_height = parse_param!(params, "end_height", 1);
 		let include_rp = params.get("include_rp").is_some();
+		let include_merkle_proof = params.get("include_mp").is_some();
 
 		debug!(
-			"outputs_block_batch: {}-{}, {:?}, {:?}",
-			start_height, end_height, commitments, include_rp,
+			"outputs_block_batch: {}-{}, {:?}, {:?}, {:?}",
+			start_height, end_height, commitments, include_rp, include_merkle_proof
 		);
 
 		let mut return_vec = vec![];
 		for i in (start_height..=end_height).rev() {
-			if let Ok(res) = self.outputs_at_height(i, commitments.clone(), include_rp) {
+			if let Ok(res) =
+				self.outputs_at_height(i, commitments.clone(), include_rp, include_merkle_proof)
+			{
 				if res.outputs.len() > 0 {
 					return_vec.push(res);
 				}

--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -108,7 +108,7 @@ impl TxHashSetHandler {
 			spent: false,
 			proof: None,
 			proof_hash: "".to_string(),
-			block_height: None,
+			block_height: 0,
 			merkle_proof: Some(merkle_proof),
 			mmr_index: output_pos,
 		})

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -26,13 +26,14 @@ use std::sync::{Arc, Weak};
 // boilerplate of dealing with `Weak`.
 pub fn w<T>(weak: &Weak<T>) -> Result<Arc<T>, Error> {
 	weak.upgrade()
-		.ok_or_else(|| ErrorKind::Internal("failed to upgrade weak refernce".to_owned()).into())
+		.ok_or_else(|| ErrorKind::Internal("failed to upgrade weak reference".to_owned()).into())
 }
 
 /// Retrieves an output from the chain given a commit id (a tiny bit iteratively)
 pub fn get_output(
 	chain: &Weak<chain::Chain>,
 	id: &str,
+	include_proof: bool,
 ) -> Result<(OutputPrintable, OutputIdentifier), Error> {
 	let c = util::from_hex(String::from(id)).context(ErrorKind::Argument(format!(
 		"Not a valid commitment: {}",
@@ -56,7 +57,13 @@ pub fn get_output(
 		match res {
 			Ok(output_pos) => match chain.get_unspent_output_at(output_pos.position) {
 				Ok(output) => {
-					match OutputPrintable::from_output(&output, chain.clone(), None, true, true) {
+					match OutputPrintable::from_output(
+						&output,
+						chain.clone(),
+						None,
+						include_proof,
+						false,
+					) {
 						Ok(output_printable) => return Ok((output_printable, x.clone())),
 						Err(e) => {
 							trace!(

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -175,28 +175,6 @@ pub enum OutputType {
 	Transaction,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Output {
-	/// The output commitment representing the amount
-	pub commit: PrintableCommitment,
-	/// Height of the block which contains the output
-	pub height: u64,
-	/// MMR Index of output
-	pub mmr_index: u64,
-}
-
-impl Output {
-	pub fn new(commit: &pedersen::Commitment, height: u64, mmr_index: u64) -> Output {
-		Output {
-			commit: PrintableCommitment {
-				commit: commit.clone(),
-			},
-			height: height,
-			mmr_index: mmr_index,
-		}
-	}
-}
-
 #[derive(Debug, Clone)]
 pub struct PrintableCommitment {
 	pub commit: pedersen::Commitment,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -529,6 +529,15 @@ impl Chain {
 		txhashset.is_unspent(output_ref)
 	}
 
+	/// Retrieves an unspent output using its PMMR position
+	pub fn get_unspent_output_at(&self, pos: u64) -> Result<Output, Error> {
+		let header_pmmr = self.header_pmmr.read();
+		let txhashset = self.txhashset.read();
+		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo| {
+			utxo.get_unspent_output_at(pos)
+		})
+	}
+
 	/// Validate the tx against the current UTXO set.
 	pub fn validate_tx(&self, tx: &Transaction) -> Result<(), Error> {
 		let header_pmmr = self.header_pmmr.read();
@@ -1376,7 +1385,6 @@ impl Chain {
 
 		Ok(Some((kernel, header.height, mmr_index)))
 	}
-
 	/// Gets the block header in which a given kernel mmr index appears in the txhashset.
 	pub fn get_header_for_kernel_index(
 		&self,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -477,11 +477,13 @@ where
 		let output_pmmr =
 			ReadonlyPMMR::at(&trees.output_pmmr_h.backend, trees.output_pmmr_h.last_pos);
 		let header_pmmr = ReadonlyPMMR::at(&handle.backend, handle.last_pos);
+		let rproof_pmmr =
+			ReadonlyPMMR::at(&trees.rproof_pmmr_h.backend, trees.rproof_pmmr_h.last_pos);
 
 		// Create a new batch here to pass into the utxo_view.
 		// Discard it (rollback) after we finish with the utxo_view.
 		let batch = trees.commit_index.batch()?;
-		let utxo = UTXOView::new(output_pmmr, header_pmmr, &batch);
+		let utxo = UTXOView::new(output_pmmr, header_pmmr, rproof_pmmr, &batch);
 		res = inner(&utxo);
 	}
 	res
@@ -856,6 +858,7 @@ impl<'a> Extension<'a> {
 		UTXOView::new(
 			self.output_pmmr.readonly_pmmr(),
 			header_ext.pmmr.readonly_pmmr(),
+			self.rproof_pmmr.readonly_pmmr(),
 			self.batch,
 		)
 	}


### PR DESCRIPTION
Simplify the API v1 output endpoint. We now always return a single object called OutputPrintable instead of different object when it is by id or by height.
Add method `get_unspent_output_at_pos`.

Before:

```
[
  {
    "commit": "08392e391abc679f6a66478fab4febb783d11904fc9b32cdeabf442ff6026f4baa",
    "height": 375611,
    "mmr_index": 4102967
  }
]
```

After:
```
[
  {
    "output_type": "Transaction",
    "commit": "08392e391abc679f6a66478fab4febb783d11904fc9b32cdeabf442ff6026f4baa",
    "spent": false,
    "proof": "1e93a916bccf08746147c9310954c720140faab878c73558f9a515ef1db314b57affa22d080fc8c0bbb8efa578089bd38025ac347f423648b71adf19bf93416c0cb98805a9eb9e27403621201fa47c89b4b44c864edc8c9123d8890d6194aeb0e13ad0a99d87b265ef79c7940b6d237c6da0b7cdc87badfca921d0598f33c09a3c9f72f3e909afb75d1e06334ab3f0c8a23374f7101d7bd03906f393cc9b1a4de04b561ca6750bffa4c2fbc94f8c8874e289e908665f3d25fdc8fd1707d90e135c640c590b20f00d57f96251dbe84a1cadad8fd06fc4f1556b0da934c5a096eed9788b96464399ce49aeabedf66f8685e6dacef0df781512313fe67e49c27ab47b9c7ee8c2f8d7810d9ec354113da563999e357d754d25750a22dfc10fe9f5482689aee0ac24e64ca48c9639564e6324160591a9ebb8320e13842856f6022ee8361d15f8f1d618a654f9c7fa012e3ba51e188418fdd89b16ae1fd6390051090497810131de7b15898d811bd35efb3ed9f6629ed56f7c25d4aeb669c7dc76077926ac70a1805d0390c0cd13de626034517772d87c43289d9c8ee665fa62837f9b9fc47a9a9e5aff421c4c7c5c5150645e74855cc437bbd9381fbf504dbf22c8c1296c34df202d921b1ba539c113d49247c698d53f7115ee8a202cfb4d15017b9a027a8f51d57b2582eb976bb60593a17e3534b97711c038256e83d801b0b4100c5312ae559e87782687c53861718dbf6367962fe5fbef77ceed9c799df25e2a4f9a795963d2e86f4c09c3c45da87e98c2b4aaabb47a4457d639371ea10ce7649c6434a825115e6452e7f241ddeb15b76145d8c682c6efe185b1cb0467e2b3964fa149a4c4865de58ad5b18edaa93670040e0e9ab997f56d585b07cd58379edb9dc5773e37ed809441ee28b48635b9aaf97d1456e753be6d822d5ee724059afa67ab1e97",
    "proof_hash": "a51aa12fba6316518368f045de5b4658cea859d6da386900e646d0445c5254bb",
    "block_height": 375611,
    "merkle_proof": null,
    "mmr_index": 4102967
  }
]
```

