### PR TITLE
use remove_range_closed() for clarity

### DIFF
--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -115,10 +115,8 @@ impl LeafSet {
 
 		// First remove pos from leaf_set that were
 		// added after the point we are rewinding to.
-		let marker_from = cutoff_pos;
-		let marker_to = self.bitmap.maximum() as u64;
-		let rewind_add_pos: Bitmap = ((marker_from + 1)..=marker_to).map(|x| x as u32).collect();
-		bitmap.andnot_inplace(&rewind_add_pos);
+		let to_remove = ((cutoff_pos + 1) as u32)..bitmap.maximum();
+		bitmap.remove_range_closed(to_remove);
 
 		// Then add back output pos to the leaf_set
 		// that were removed.
@@ -136,10 +134,8 @@ impl LeafSet {
 	pub fn rewind(&mut self, cutoff_pos: u64, rewind_rm_pos: &Bitmap) {
 		// First remove pos from leaf_set that were
 		// added after the point we are rewinding to.
-		let marker_from = cutoff_pos;
-		let marker_to = self.bitmap.maximum() as u64;
-		let rewind_add_pos: Bitmap = ((marker_from + 1)..=marker_to).map(|x| x as u32).collect();
-		self.bitmap.andnot_inplace(&rewind_add_pos);
+		let to_remove = ((cutoff_pos + 1) as u32)..self.bitmap.maximum();
+		self.bitmap.remove_range_closed(to_remove);
 
 		// Then add back output pos to the leaf_set
 		// that were removed.


### PR DESCRIPTION
We can use `remove_range_closed()` and avoid needing to jump through hoops with `andnot_inplace()` when rewinding the leafset bitmap.

This is purely a refactor and does not change behavior in any way.

