### PR TITLE
fix: add shutting down dialog to TUI

### DIFF
--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -109,8 +109,9 @@ impl UI {
 		// Configure a callback (shutdown, for the first test)
 		let controller_tx_clone = grin_ui.controller_tx.clone();
 		grin_ui.cursive.add_global_callback('q', move |c| {
+			let content = StyledString::styled("Shutting down...", Color::Light(BaseColor::Yellow));
 			c.add_layer(CircularFocus::wrap_tab(Dialog::around(TextView::new(
-				"Shutting down...",
+				content,
 			))));
 			controller_tx_clone
 				.send(ControllerMessage::Shutdown)

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -26,7 +26,7 @@ use cursive::theme::{BaseColor, BorderStyle, Color, Theme};
 use cursive::traits::Boxable;
 use cursive::traits::Identifiable;
 use cursive::utils::markup::StyledString;
-use cursive::views::{LinearLayout, Panel, StackView, TextView, ViewBox};
+use cursive::views::{CircularFocus, Dialog, LinearLayout, Panel, StackView, TextView, ViewBox};
 use cursive::Cursive;
 use std::sync::mpsc;
 
@@ -108,7 +108,10 @@ impl UI {
 
 		// Configure a callback (shutdown, for the first test)
 		let controller_tx_clone = grin_ui.controller_tx.clone();
-		grin_ui.cursive.add_global_callback('q', move |_| {
+		grin_ui.cursive.add_global_callback('q', move |c| {
+			c.add_layer(CircularFocus::wrap_tab(Dialog::around(TextView::new(
+				"Shutting down...",
+			))));
 			controller_tx_clone
 				.send(ControllerMessage::Shutdown)
 				.unwrap();
@@ -174,7 +177,6 @@ impl Controller {
 				match message {
 					ControllerMessage::Shutdown => {
 						self.ui.stop();
-						println!("Shutdown in progress, please wait");
 						server.stop();
 						return;
 					}


### PR DESCRIPTION
Add dialog to let user know that server is shutting down. It appears as soon as 'q' is pressed and remains for a second or two until the process quits. This is instead of the current behaviour where the "Shutdown in progress, please wait" text appears awkwardly.
