### PR TITLE
[WIP] chore: add snapcraft.yml for first deployment of snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,12 @@ parts:
       - clang
       - libncurses5-dev
       - libncursesw5-dev
+  wallet:
+    plugin: rust
+    source: https://github.com/mimblewimble/grin-wallet.git
+    source-tag: v2.1.0
+    build-packages:
+      - clang
 
 apps:
   grin:
@@ -24,4 +30,7 @@ apps:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     command: bin/grin
+    plugs: [network, network-bind]
+  wallet:
+    command: bin/grin-wallet
     plugs: [network, network-bind]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: grin
+version: v2.1.1
+summary: Minimal implementation of the Mimblewimble protocol
+description: |
+  https://grin.mw/
+
+epoch: 2
+confinement: strict
+grade: stable
+base: core18
+parts:
+  grin:
+    plugin: rust
+    source: https://github.com/mimblewimble/grin.git
+    source-tag: v2.1.1
+    build-packages:
+      - clang
+      - libncurses5-dev
+      - libncursesw5-dev
+
+apps:
+  grin:
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    command: bin/grin
+    plugs: [network, network-bind]


### PR DESCRIPTION
This is the config file for the snap https://snapcraft.io/grin

Can we update the versions in here when we release? There is tool (snapcraft) for building and publishing the snap based on this config. I can run manually for now, but it should be done in the CI pipeline.