### PR TITLE
Increase IO_TIMEOUT to allow nodes on high-latency connections to sync

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -38,7 +38,7 @@ use std::{
 	thread::{self, JoinHandle},
 };
 
-const IO_TIMEOUT: Duration = Duration::from_millis(1000);
+const IO_TIMEOUT: Duration = Duration::from_millis(10000);
 
 /// A trait to be implemented in order to receive messages from the
 /// connection. Allows providing an optional response.


### PR DESCRIPTION
Commit d3dbafa80b "Use blocking IO in P2P to reduce CPU load" (merged into v2.1.0) introduced the constant IO_TIMEOUT, setting it to 1 second.

On nodes with high-latency connections, this short timeout causes the txhashset archive download during step 2 of the IBD process to invariably fail before it completes.  Since there's no mechanism for resuming a failed download, this means the node gets stuck at this stage and never syncs.

Increasing IO_TIMEOUT to 10 seconds solves the issue on my node; others might suggest a more optimal value for the constant.
