### PR TITLE
add tx pool kernel counts to tui status page

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -446,6 +446,12 @@ impl Pool {
 		self.entries.len()
 	}
 
+	/// Number of transaction kernels in the pool.
+	/// This may differ from the size (number of transactions) due to tx aggregation.
+	pub fn kernel_count(&self) -> usize {
+		self.entries.iter().map(|x| x.tx.kernels().len()).sum()
+	}
+
 	/// Is the pool empty?
 	pub fn is_empty(&self) -> bool {
 		self.entries.is_empty()

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -85,8 +85,12 @@ pub struct ChainStats {
 pub struct TxStats {
 	/// Number of transactions in the transaction pool
 	pub tx_pool_size: usize,
+	/// Number of transaction kernels in the transaction pool
+	pub tx_pool_kernels: usize,
 	/// Number of transactions in the stem pool
 	pub stem_pool_size: usize,
+	/// Number of transaction kernels in the stem pool
+	pub stem_pool_kernels: usize,
 }
 /// Struct to return relevant information about stratum workers
 #[derive(Clone, Serialize, Debug)]

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -475,17 +475,22 @@ impl Server {
 			.map(|p| PeerStats::from_peer(&p))
 			.collect();
 
-		let (tx_pool_size, stem_pool_size) = {
-			let tx_pool_lock = self.tx_pool.try_read();
-			match tx_pool_lock {
-				Some(l) => (l.txpool.entries.len(), l.stempool.entries.len()),
-				None => (0, 0),
+		let tx_stats = {
+			let pool = self.tx_pool.try_read();
+			match pool {
+				Some(pool) => TxStats {
+					tx_pool_size: pool.txpool.size(),
+					tx_pool_kernels: pool.txpool.kernel_count(),
+					stem_pool_size: pool.stempool.size(),
+					stem_pool_kernels: pool.stempool.kernel_count(),
+				},
+				None => TxStats {
+					tx_pool_size: 0,
+					tx_pool_kernels: 0,
+					stem_pool_size: 0,
+					stem_pool_kernels: 0,
+				},
 			}
-		};
-
-		let tx_stats = TxStats {
-			tx_pool_size,
-			stem_pool_size,
 		};
 
 		let head = self.chain.head_header()?;

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -108,7 +108,7 @@ impl TUIStatusListener for TUIStatusView {
 				)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
-						.child(TextView::new("Transaction Pool Size:         "))
+						.child(TextView::new("Transaction Pool Size:        "))
 						.child(TextView::new("0").with_id("tx_pool_size"))
 						.child(TextView::new(" ("))
 						.child(TextView::new("0").with_id("tx_pool_kernels"))

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -108,13 +108,19 @@ impl TUIStatusListener for TUIStatusView {
 				)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
-						.child(TextView::new("Transaction Pool Size:        "))
-						.child(TextView::new("  ").with_id("tx_pool_size")),
+						.child(TextView::new("Transaction Pool Size:         "))
+						.child(TextView::new("0").with_id("tx_pool_size"))
+						.child(TextView::new(" ("))
+						.child(TextView::new("0").with_id("tx_pool_kernels"))
+						.child(TextView::new(")")),
 				)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
 						.child(TextView::new("Stem Pool Size:               "))
-						.child(TextView::new("  ").with_id("stem_pool_size")),
+						.child(TextView::new("0").with_id("stem_pool_size"))
+						.child(TextView::new(" ("))
+						.child(TextView::new("0").with_id("stem_pool_kernels"))
+						.child(TextView::new(")")),
 				)
 				.child(
 					LinearLayout::new(Orientation::Horizontal).child(TextView::new(
@@ -306,6 +312,12 @@ impl TUIStatusListener for TUIStatusView {
 		});
 		c.call_on_id("stem_pool_size", |t: &mut TextView| {
 			t.set_content(stats.tx_stats.stem_pool_size.to_string());
+		});
+		c.call_on_id("tx_pool_kernels", |t: &mut TextView| {
+			t.set_content(stats.tx_stats.tx_pool_kernels.to_string());
+		});
+		c.call_on_id("stem_pool_kernels", |t: &mut TextView| {
+			t.set_content(stats.tx_stats.stem_pool_kernels.to_string());
 		});
 		/*c.call_on_id("basic_mining_config_status", |t: &mut TextView| {
 			t.set_content(basic_mining_config_status);


### PR DESCRIPTION
We added tx pool size to the tui status page previously.
This PR adds the kernel count in addition to this.
This provides a rough approximation of how much tx aggregation is occurring by comparing pool size (in transactions) to the size in kernels.
