### PR TITLE
Make imports in core crate more Rust 2018 idiomatic

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ workspace = ".."
 edition = "2018"
 
 [dependencies]
-blake2-rfc = "0.2"
+blake2 = { package = "blake2-rfc", version = "0.2"}
 byteorder = "1"
 croaring = "0.3.9"
 enum_primitive = "0.1"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "3.0.0-alpha.1" }
-grin_util = { path = "../util", version = "3.0.0-alpha.1" }
+keychain = { package = "grin_keychain", path = "../keychain", version = "3.0.0-alpha.1" }
+util = { package = "grin_util", path = "../util", version = "3.0.0-alpha.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -18,12 +18,11 @@
 //! enough, consensus-relevant constants and short functions should be kept
 //! here.
 
-use std::cmp::{max, min};
-
 use crate::core::block::HeaderVersion;
 use crate::core::hash::{Hash, ZERO_HASH};
 use crate::global;
 use crate::pow::Difficulty;
+use std::cmp::{max, min};
 
 /// A grin is divisible to 10^9, following the SI prefixes
 pub const GRIN_BASE: u64 = 1_000_000_000;

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -26,8 +26,7 @@ pub mod transaction;
 pub mod verifier_cache;
 
 use crate::consensus::GRIN_BASE;
-
-use crate::util::secp::pedersen::Commitment;
+use util::secp::pedersen::Commitment;
 
 pub use self::block::*;
 pub use self::block_sums::*;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -14,15 +14,6 @@
 
 //! Blocks and blockheaders
 
-use crate::util::RwLock;
-use chrono::naive::{MAX_DATE, MIN_DATE};
-use chrono::prelude::{DateTime, NaiveDateTime, Utc};
-use chrono::Duration;
-use std::collections::HashSet;
-use std::fmt;
-use std::iter::FromIterator;
-use std::sync::Arc;
-
 use crate::consensus::{self, reward, REWARD};
 use crate::core::committed::{self, Committed};
 use crate::core::compact_block::{CompactBlock, CompactBlockBody};
@@ -32,12 +23,19 @@ use crate::core::{
 	transaction, Commitment, Input, KernelFeatures, Output, Transaction, TransactionBody, TxKernel,
 	Weighting,
 };
-
 use crate::global;
-use crate::keychain::{self, BlindingFactor};
 use crate::pow::{verify_size, Difficulty, Proof, ProofOfWork};
 use crate::ser::{self, FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
-use crate::util::{secp, static_secp_instance};
+use chrono::naive::{MAX_DATE, MIN_DATE};
+use chrono::prelude::{DateTime, NaiveDateTime, Utc};
+use chrono::Duration;
+use keychain::{self, BlindingFactor};
+use std::collections::HashSet;
+use std::fmt;
+use std::iter::FromIterator;
+use std::sync::Arc;
+use util::RwLock;
+use util::{secp, static_secp_instance};
 
 /// Errors thrown by Block validation
 #[derive(Debug, Clone, Eq, PartialEq, Fail)]

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -17,8 +17,8 @@
 
 use crate::core::committed::Committed;
 use crate::ser::{self, Readable, Reader, Writeable, Writer};
-use crate::util::secp::pedersen::Commitment;
-use crate::util::secp_static;
+use util::secp::pedersen::Commitment;
+use util::secp_static;
 
 /// The output_sum and kernel_sum for a given block.
 /// This is used to validate the next block being processed by applying

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -14,13 +14,12 @@
 
 //! The Committed trait and associated errors.
 
-use crate::keychain;
-use crate::keychain::BlindingFactor;
-
-use crate::util::secp::key::SecretKey;
-use crate::util::secp::pedersen::Commitment;
-use crate::util::{secp, secp_static, static_secp_instance};
 use failure::Fail;
+use keychain;
+use keychain::BlindingFactor;
+use util::secp::key::SecretKey;
+use util::secp::pedersen::Commitment;
+use util::{secp, secp_static, static_secp_instance};
 
 /// Errors from summing and verifying kernel excesses via committed trait.
 #[derive(Debug, Clone, PartialEq, Eq, Fail, Serialize, Deserialize)]

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -14,13 +14,12 @@
 
 //! Compact Blocks.
 
-use rand::{thread_rng, Rng};
-
 use crate::core::block::{Block, BlockHeader, Error, UntrustedBlockHeader};
 use crate::core::hash::{DefaultHashable, Hashed};
 use crate::core::id::ShortIdentifiable;
 use crate::core::{Output, ShortId, TxKernel};
 use crate::ser::{self, read_multi, Readable, Reader, VerifySortedAndUnique, Writeable, Writer};
+use rand::{thread_rng, Rng};
 
 /// Container for full (full) outputs and kernels and kern_ids for a compact block.
 #[derive(Debug, Clone)]

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -17,18 +17,16 @@
 //! Primary hash function used in the protocol
 //!
 
+use crate::ser::{
+	self, AsFixedBytes, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer,
+};
+use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::min;
 use std::convert::AsRef;
 use std::ops::Add;
 use std::{fmt, ops};
-
-use crate::blake2::blake2b::Blake2b;
-
-use crate::ser::{
-	self, AsFixedBytes, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer,
-};
-use crate::util;
+use util;
 
 /// A hash consisting of all zeroes, used as a sentinel. No known preimage.
 pub const ZERO_HASH: Hash = Hash([0; 32]);
@@ -251,7 +249,7 @@ impl<D: DefaultHashable, E: DefaultHashable> DefaultHashable for (D, E) {}
 impl<D: DefaultHashable, E: DefaultHashable, F: DefaultHashable> DefaultHashable for (D, E, F) {}
 
 /// Implement Hashed trait for external types here
-impl DefaultHashable for crate::util::secp::pedersen::RangeProof {}
+impl DefaultHashable for util::secp::pedersen::RangeProof {}
 impl DefaultHashable for Vec<u8> {}
 impl DefaultHashable for u8 {}
 impl DefaultHashable for u64 {}

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -14,15 +14,12 @@
 
 //! short ids for compact blocks
 
-use std::cmp::min;
-use std::cmp::Ordering;
-
-use byteorder::{ByteOrder, LittleEndian};
-use siphasher::sip::SipHasher24;
-
 use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::ser::{self, Readable, Reader, Writeable, Writer};
-use crate::util;
+use byteorder::{ByteOrder, LittleEndian};
+use siphasher::sip::SipHasher24;
+use std::cmp::{min, Ordering};
+use util;
 
 /// The size of a short id used to identify inputs|outputs|kernels (6 bytes)
 pub const SHORT_ID_SIZE: usize = 6;

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -18,7 +18,7 @@ use crate::core::hash::Hash;
 use crate::core::pmmr;
 use crate::ser;
 use crate::ser::{PMMRIndexHashable, Readable, Reader, Writeable, Writer};
-use crate::util;
+use util;
 
 /// Merkle proof errors.
 #[derive(Clone, Debug, PartialEq)]

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -17,23 +17,23 @@
 use crate::core::hash::{DefaultHashable, Hashed};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{committed, Committed};
-use crate::keychain::{self, BlindingFactor};
 use crate::libtx::secp_ser;
 use crate::ser::{
 	self, read_multi, FixedLength, PMMRable, ProtocolVersion, Readable, Reader,
 	VerifySortedAndUnique, Writeable, Writer,
 };
-use crate::util;
-use crate::util::secp;
-use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::static_secp_instance;
-use crate::util::RwLock;
 use crate::{consensus, global};
 use enum_primitive::FromPrimitive;
+use keychain::{self, BlindingFactor};
 use std::cmp::Ordering;
 use std::cmp::{max, min};
 use std::sync::Arc;
 use std::{error, fmt};
+use util;
+use util::secp;
+use util::secp::pedersen::{Commitment, RangeProof};
+use util::static_secp_instance;
+use util::RwLock;
 
 /// Various tx kernel variants.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -1584,8 +1584,8 @@ mod test {
 	use super::*;
 	use crate::core::hash::Hash;
 	use crate::core::id::{ShortId, ShortIdentifiable};
-	use crate::keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
-	use crate::util::secp;
+	use keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
+	use util::secp;
 
 	#[test]
 	fn test_kernel_ser_deser() {

--- a/core/src/core/verifier_cache.rs
+++ b/core/src/core/verifier_cache.rs
@@ -15,10 +15,9 @@
 //! VerifierCache trait for batch verifying outputs and kernels.
 //! We pass a "caching verifier" into the block validation processing with this.
 
-use lru_cache::LruCache;
-
 use crate::core::hash::{Hash, Hashed};
 use crate::core::{Output, TxKernel};
+use lru_cache::LruCache;
 
 /// Verifier cache for caching expensive verification results.
 /// Specifically the following -

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -19,17 +19,15 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 
-use chrono::prelude::{TimeZone, Utc};
-
 use crate::core;
-use crate::pow::{Difficulty, Proof, ProofOfWork};
-use crate::util;
-use crate::util::secp::constants::SINGLE_BULLET_PROOF_SIZE;
-use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::secp::Signature;
-
 use crate::core::hash::Hash;
-use crate::keychain::BlindingFactor;
+use crate::pow::{Difficulty, Proof, ProofOfWork};
+use chrono::prelude::{TimeZone, Utc};
+use keychain::BlindingFactor;
+use util;
+use util::secp::constants::SINGLE_BULLET_PROOF_SIZE;
+use util::secp::pedersen::{Commitment, RangeProof};
+use util::secp::Signature;
 
 /// Genesis block definition for development networks. The proof of work size
 /// is small enough to mine it on the fly, so it does not contain its own

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -26,11 +26,12 @@ use crate::core::block::HeaderVersion;
 use crate::pow::{
 	self, new_cuckaroo_ctx, new_cuckarood_ctx, new_cuckatoo_ctx, EdgeType, PoWContext,
 };
+use util::RwLock;
+
 /// An enum collecting sets of parameters used throughout the
 /// code wherever mining is needed. This should allow for
 /// different sets of parameters for different purposes,
 /// e.g. CI, User testing, production values
-use crate::util::RwLock;
 /// Define these here, as they should be developer-set, not really tweakable
 /// by users
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,22 +21,18 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-use blake2_rfc as blake2;
 #[macro_use]
 extern crate enum_primitive;
-use grin_keychain as keychain;
-use grin_util as util;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
+use serde;
 #[macro_use]
 extern crate log;
 use failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate zeroize;
 #[macro_use]
 pub mod macros;
 

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -16,12 +16,11 @@
 //! This module interfaces into the underlying
 //! [Rust Aggsig library](https://github.com/mimblewimble/rust-secp256k1-zkp/blob/master/src/aggsig.rs)
 
-use crate::keychain::{BlindingFactor, Identifier, Keychain};
 use crate::libtx::error::{Error, ErrorKind};
-use crate::util::secp::key::{PublicKey, SecretKey};
-use crate::util::secp::pedersen::Commitment;
-use crate::util::secp::{self, aggsig, Message, Secp256k1, Signature};
-use grin_keychain::SwitchCommitmentType;
+use keychain::{BlindingFactor, Identifier, Keychain, SwitchCommitmentType};
+use util::secp::key::{PublicKey, SecretKey};
+use util::secp::pedersen::Commitment;
+use util::secp::{self, aggsig, Message, Secp256k1, Signature};
 
 /// Creates a new secure nonce (as a SecretKey), guaranteed to be usable during
 /// aggsig creation.
@@ -34,7 +33,6 @@ use grin_keychain::SwitchCommitmentType;
 ///
 /// ```
 /// # extern crate grin_core as core;
-/// # extern crate grin_util as util;
 /// use core::libtx::aggsig;
 /// use util::secp::{ContextFlag, Secp256k1};
 /// let secp = Secp256k1::with_caps(ContextFlag::SignOnly);
@@ -68,7 +66,6 @@ pub fn create_secnonce(secp: &Secp256k1) -> Result<SecretKey, Error> {
 ///
 /// ```
 /// # extern crate grin_core as core;
-/// # extern crate grin_util as util;
 /// # extern crate rand;
 /// use rand::thread_rng;
 /// use core::libtx::aggsig;
@@ -139,7 +136,6 @@ pub fn calculate_partial_sig(
 ///
 /// ```
 /// # extern crate grin_core as core;
-/// # extern crate grin_util as util;
 /// # extern crate rand;
 /// use rand::thread_rng;
 /// use core::libtx::aggsig;
@@ -223,9 +219,7 @@ pub fn verify_partial_sig(
 /// # Example
 ///
 /// ```
-/// # extern crate grin_util as util;
 /// # extern crate grin_core as core;
-/// # extern crate grin_keychain as keychain;
 /// use core::consensus::reward;
 /// use util::secp::key::{PublicKey, SecretKey};
 /// use util::secp::{ContextFlag, Secp256k1};
@@ -291,9 +285,7 @@ where
 /// # Example
 ///
 /// ```
-/// # extern crate grin_util as util;
 /// # extern crate grin_core as core;
-/// # extern crate grin_keychain as keychain;
 /// use core::consensus::reward;
 /// use core::libtx::{aggsig, proof};
 /// use util::secp::key::{PublicKey, SecretKey};
@@ -367,7 +359,6 @@ pub fn verify_single_from_commit(
 ///
 /// ```
 /// # extern crate grin_core as core;
-/// # extern crate grin_util as util;
 /// # extern crate rand;
 /// use rand::thread_rng;
 /// use core::libtx::aggsig;

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -32,10 +32,9 @@
 //! )
 
 use crate::core::{Input, KernelFeatures, Output, OutputFeatures, Transaction, TxKernel};
-use crate::keychain::{BlindSum, BlindingFactor, Identifier, Keychain};
 use crate::libtx::proof::{self, ProofBuild};
 use crate::libtx::{aggsig, Error};
-use grin_keychain::SwitchCommitmentType;
+use keychain::{BlindSum, BlindingFactor, Identifier, Keychain, SwitchCommitmentType};
 
 /// Context information available to transaction combinators.
 pub struct Context<'a, K, B>
@@ -247,14 +246,14 @@ where
 // Just a simple test, most exhaustive tests in the core.
 #[cfg(test)]
 mod test {
-	use crate::util::RwLock;
 	use std::sync::Arc;
+	use util::RwLock;
 
 	use super::*;
 	use crate::core::transaction::Weighting;
 	use crate::core::verifier_cache::{LruVerifierCache, VerifierCache};
-	use crate::keychain::{ExtKeychain, ExtKeychainPath};
 	use crate::libtx::ProofBuilder;
+	use keychain::{ExtKeychain, ExtKeychainPath};
 
 	fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 		Arc::new(RwLock::new(LruVerifierCache::new()))

--- a/core/src/libtx/error.rs
+++ b/core/src/libtx/error.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 //! libtx specific errors
-use failure::{Backtrace, Context, Fail};
-use std::fmt::{self, Display};
-
 use crate::core::transaction;
-use crate::keychain;
-use crate::util::secp;
+use failure::{Backtrace, Context, Fail};
+use keychain;
+use std::fmt::{self, Display};
+use util::secp;
 
 /// Lib tx error definition
 #[derive(Debug)]

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -14,15 +14,15 @@
 
 //! Rangeproof library functions
 
-use crate::blake2::blake2b::blake2b;
-use crate::keychain::extkey_bip32::BIP32GrinHasher;
-use crate::keychain::{Identifier, Keychain, SwitchCommitmentType, ViewKey};
 use crate::libtx::error::{Error, ErrorKind};
-use crate::util::secp::key::SecretKey;
-use crate::util::secp::pedersen::{Commitment, ProofMessage, RangeProof};
-use crate::util::secp::{self, Secp256k1};
-use crate::zeroize::Zeroize;
+use blake2::blake2b::blake2b;
+use keychain::extkey_bip32::BIP32GrinHasher;
+use keychain::{Identifier, Keychain, SwitchCommitmentType, ViewKey};
 use std::convert::TryFrom;
+use util::secp::key::SecretKey;
+use util::secp::pedersen::{Commitment, ProofMessage, RangeProof};
+use util::secp::{self, Secp256k1};
+use zeroize::Zeroize;
 
 /// Create a bulletproof
 pub fn create<K, B>(
@@ -440,8 +440,8 @@ impl ProofBuild for ViewKey {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::keychain::ExtKeychain;
-	use grin_keychain::ChildNumber;
+	use keychain::ChildNumber;
+	use keychain::ExtKeychain;
 	use rand::{thread_rng, Rng};
 
 	#[test]

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -16,14 +16,13 @@
 //! reward.
 use crate::consensus::reward;
 use crate::core::{KernelFeatures, Output, OutputFeatures, TxKernel};
-use crate::keychain::{Identifier, Keychain};
 use crate::libtx::error::Error;
 use crate::libtx::{
 	aggsig,
 	proof::{self, ProofBuild},
 };
-use crate::util::{secp, static_secp_instance};
-use grin_keychain::SwitchCommitmentType;
+use keychain::{Identifier, Keychain, SwitchCommitmentType};
+use util::{secp, static_secp_instance};
 
 /// output a reward output
 pub fn output<K, B>(

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -14,16 +14,16 @@
 
 //! Sane serialization & deserialization of cryptographic structs into hex
 
-use crate::keychain::BlindingFactor;
-use crate::serde::{Deserialize, Deserializer, Serializer};
-use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::{from_hex, to_hex};
+use keychain::BlindingFactor;
+use serde::{Deserialize, Deserializer, Serializer};
+use util::secp::pedersen::{Commitment, RangeProof};
+use util::{from_hex, to_hex};
 
 /// Serializes a secp PublicKey to and from hex
 pub mod pubkey_serde {
-	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::secp::key::PublicKey;
-	use crate::util::{from_hex, static_secp_instance, to_hex};
+	use serde::{Deserialize, Deserializer, Serializer};
+	use util::secp::key::PublicKey;
+	use util::{from_hex, static_secp_instance, to_hex};
 
 	///
 	pub fn serialize<S>(key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
@@ -55,8 +55,8 @@ pub mod pubkey_serde {
 /// Serializes an Option<secp::Signature> to and from hex
 pub mod option_sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
 	use serde::de::Error;
+	use util::{from_hex, secp, static_secp_instance, to_hex};
 
 	///
 	pub fn serialize<S>(sig: &Option<secp::Signature>, serializer: S) -> Result<S::Ok, S::Error>
@@ -93,14 +93,13 @@ pub mod option_sig_serde {
 			None => Ok(None),
 		})
 	}
-
 }
 
 /// Serializes an Option<secp::SecretKey> to and from hex
 pub mod option_seckey_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
 	use serde::de::Error;
+	use util::{from_hex, secp, static_secp_instance, to_hex};
 
 	///
 	pub fn serialize<S>(
@@ -141,8 +140,8 @@ pub mod option_seckey_serde {
 /// Serializes a secp::Signature to and from hex
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::{from_hex, secp, static_secp_instance, to_hex};
 	use serde::de::Error;
+	use util::{from_hex, secp, static_secp_instance, to_hex};
 
 	///
 	pub fn serialize<S>(sig: &secp::Signature, serializer: S) -> Result<S::Ok, S::Error>
@@ -175,9 +174,9 @@ pub mod sig_serde {
 /// Serializes an Option<secp::Commitment> to and from hex
 pub mod option_commitment_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
-	use crate::util::secp::pedersen::Commitment;
-	use crate::util::{from_hex, to_hex};
 	use serde::de::Error;
+	use util::secp::pedersen::Commitment;
+	use util::{from_hex, to_hex};
 
 	///
 	pub fn serialize<S>(commit: &Option<Commitment>, serializer: S) -> Result<S::Ok, S::Error>
@@ -202,7 +201,6 @@ pub mod option_commitment_serde {
 			None => Ok(None),
 		})
 	}
-
 }
 /// Creates a BlindingFactor from a hex string
 pub fn blind_from_hex<'de, D>(deserializer: D) -> Result<BlindingFactor, D::Error>
@@ -350,9 +348,9 @@ pub mod opt_string_or_u64 {
 mod test {
 	use super::*;
 	use crate::libtx::aggsig;
-	use crate::util::secp::key::{PublicKey, SecretKey};
-	use crate::util::secp::{Message, Signature};
-	use crate::util::static_secp_instance;
+	use util::secp::key::{PublicKey, SecretKey};
+	use util::secp::{Message, Signature};
+	use util::static_secp_instance;
 
 	use serde_json;
 

--- a/core/src/pow.rs
+++ b/core/src/pow.rs
@@ -28,6 +28,11 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+pub use self::common::EdgeType;
+pub use self::types::*;
+use crate::core::{Block, BlockHeader};
+use crate::genesis;
+use crate::global;
 use chrono;
 use num;
 
@@ -42,17 +47,11 @@ pub mod lean;
 mod siphash;
 mod types;
 
-use crate::core::{Block, BlockHeader};
-use crate::genesis;
-use crate::global;
-use chrono::prelude::{DateTime, NaiveDateTime, Utc};
-
-pub use self::common::EdgeType;
-pub use self::types::*;
 pub use crate::pow::cuckaroo::{new_cuckaroo_ctx, CuckarooContext};
 pub use crate::pow::cuckarood::{new_cuckarood_ctx, CuckaroodContext};
 pub use crate::pow::cuckatoo::{new_cuckatoo_ctx, CuckatooContext};
 pub use crate::pow::error::Error;
+use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 
 const MAX_SOLS: u32 = 10;
 

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -14,12 +14,11 @@
 
 //! Common types and traits for cuckoo family of solvers
 
-use crate::blake2::blake2b::blake2b;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::num::{PrimInt, ToPrimitive};
 use crate::pow::siphash::siphash24;
+use blake2::blake2b::blake2b;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt;
 use std::hash::Hash;
 use std::io::Cursor;

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -12,16 +12,14 @@
 // limitations under the License.
 
 //! Implementation of Cuckatoo Cycle designed by John Tromp.
-use std::mem;
-
-use byteorder::{BigEndian, WriteBytesExt};
-use croaring::Bitmap;
-
 use crate::global;
 use crate::pow::common::{CuckooParams, EdgeType, Link};
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::{PoWContext, Proof};
-use crate::util;
+use byteorder::{BigEndian, WriteBytesExt};
+use croaring::Bitmap;
+use std::mem;
+use util;
 
 struct Graph<T>
 where

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -12,22 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
+use crate::core::hash::{DefaultHashable, Hashed};
+use crate::global;
+use crate::pow::common::EdgeType;
+use crate::pow::error::Error;
+use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
+use rand::{thread_rng, Rng};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
 /// proof of work within a block header.
 use std::cmp::{max, min};
 use std::ops::{Add, Div, Mul, Sub};
 use std::{fmt, iter};
-
-use rand::{thread_rng, Rng};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
-use crate::consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
-use crate::core::hash::{DefaultHashable, Hashed};
-use crate::global;
-use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
-
-use crate::pow::common::EdgeType;
-use crate::pow::error::Error;
 
 /// Generic trait for a solver/verifier providing common interface into Cuckoo-family PoW
 /// Mostly used for verification, but also for test mining if necessary

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -21,20 +21,20 @@
 
 use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::global::PROTOCOL_VERSION;
-use crate::keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
-use crate::util::secp::constants::{
-	AGG_SIGNATURE_SIZE, COMPRESSED_PUBLIC_KEY_SIZE, MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE,
-	SECRET_KEY_SIZE,
-};
-use crate::util::secp::key::PublicKey;
-use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::secp::Signature;
-use crate::util::secp::{ContextFlag, Secp256k1};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+use keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
 use std::fmt::{self, Debug};
 use std::io::{self, Read, Write};
 use std::marker;
 use std::{cmp, error};
+use util::secp::constants::{
+	AGG_SIGNATURE_SIZE, COMPRESSED_PUBLIC_KEY_SIZE, MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE,
+	SECRET_KEY_SIZE,
+};
+use util::secp::key::PublicKey;
+use util::secp::pedersen::{Commitment, RangeProof};
+use util::secp::Signature;
+use util::secp::{ContextFlag, Secp256k1};
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
@@ -927,17 +927,17 @@ impl AsFixedBytes for crate::core::hash::Hash {
 		32
 	}
 }
-impl AsFixedBytes for crate::util::secp::pedersen::RangeProof {
+impl AsFixedBytes for util::secp::pedersen::RangeProof {
 	fn len(&self) -> usize {
 		self.plen
 	}
 }
-impl AsFixedBytes for crate::util::secp::Signature {
+impl AsFixedBytes for util::secp::Signature {
 	fn len(&self) -> usize {
 		64
 	}
 }
-impl AsFixedBytes for crate::util::secp::pedersen::Commitment {
+impl AsFixedBytes for util::secp::pedersen::Commitment {
 	fn len(&self) -> usize {
 		PEDERSEN_COMMITMENT_SIZE
 	}
@@ -947,7 +947,7 @@ impl AsFixedBytes for BlindingFactor {
 		SECRET_KEY_SIZE
 	}
 }
-impl AsFixedBytes for crate::keychain::Identifier {
+impl AsFixedBytes for keychain::Identifier {
 	fn len(&self) -> usize {
 		IDENTIFIER_SIZE
 	}

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -27,15 +27,13 @@ use crate::core::core::{
 use crate::core::libtx::build::{self, input, output};
 use crate::core::libtx::ProofBuilder;
 use crate::core::{global, ser};
-use crate::keychain::{BlindingFactor, ExtKeychain, Keychain};
-use crate::util::secp;
-use crate::util::RwLock;
 use chrono::Duration;
 use grin_core as core;
 use grin_core::global::ChainTypes;
-use grin_keychain as keychain;
-use grin_util as util;
+use keychain::{BlindingFactor, ExtKeychain, Keychain};
 use std::sync::Arc;
+use util::secp;
+use util::RwLock;
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 	Arc::new(RwLock::new(LruVerifierCache::new()))

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -14,7 +14,6 @@
 
 //! Common test functions
 
-use crate::keychain::{Identifier, Keychain};
 use grin_core::core::{Block, BlockHeader, KernelFeatures, Transaction};
 use grin_core::libtx::{
 	build::{self, input, output},
@@ -22,7 +21,7 @@ use grin_core::libtx::{
 	reward,
 };
 use grin_core::pow::Difficulty;
-use grin_keychain as keychain;
+use keychain::{Identifier, Keychain};
 
 // utility producing a transaction with 2 inputs and a single outputs
 pub fn tx2i1o() -> Transaction {

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -26,14 +26,12 @@ use self::core::core::{
 use self::core::libtx::build::{self, initial_tx, input, output, with_excess};
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
-use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
-use self::util::static_secp_instance;
-use self::util::RwLock;
 use crate::common::{new_block, tx1i1o, tx1i2o, tx2i1o};
 use grin_core as core;
-use grin_keychain as keychain;
-use grin_util as util;
+use keychain::{BlindingFactor, ExtKeychain, Keychain};
 use std::sync::Arc;
+use util::static_secp_instance;
+use util::RwLock;
 
 #[test]
 fn simple_tx_ser() {

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -19,9 +19,8 @@ pub mod common;
 use self::core::core::{Output, OutputFeatures};
 use self::core::libtx::proof;
 use self::core::ser;
-use self::keychain::{ExtKeychain, Keychain};
 use grin_core as core;
-use grin_keychain as keychain;
+use keychain::{ExtKeychain, Keychain};
 
 #[test]
 fn test_output_ser_deser() {

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -17,12 +17,10 @@ pub mod common;
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use self::core::core::{Output, OutputFeatures};
 use self::core::libtx::proof;
-use self::keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
-use self::util::RwLock;
 use grin_core as core;
-use grin_keychain as keychain;
-use grin_util as util;
+use keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
 use std::sync::Arc;
+use util::RwLock;
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 	Arc::new(RwLock::new(LruVerifierCache::new()))

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -25,8 +25,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 
-extern crate sha2;
-
 mod base58;
 pub mod extkey_bip32;
 pub mod mnemonic;


### PR DESCRIPTION
We use crate renaming to remove grin prefix, as  result imports for util and keychain crates start with crate::
which looks like a part of the current crate. This PR fixes it.
Also some small improvements were made.
If this approach works I'll replicate it to other crates.
