### PR TITLE
fix: for TUI status try to acquire read lock on pmmr_header but if no…

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1216,6 +1216,18 @@ impl Chain {
 			.map_err(|e| ErrorKind::StoreErr(e, "chain tail".to_owned()).into())
 	}
 
+	/// Tip (head) of the header chain if read lock can be acquired right now.
+	pub fn try_header_head(&self) -> Result<Option<Tip>, Error> {
+		match self.header_pmmr.try_read() {
+			Some(lock) => {
+				let hash = lock.head_hash()?;
+				let header = self.store.get_block_header(&hash)?;
+				Ok(Some(Tip::from_header(&header)))
+			}
+			None => Ok(None),
+		}
+	}
+
 	/// Tip (head) of the header chain.
 	pub fn header_head(&self) -> Result<Tip, Error> {
 		let hash = self.header_pmmr.read().head_hash()?;

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -53,7 +53,7 @@ pub struct ServerStats {
 	/// Chain head
 	pub chain_stats: ChainStats,
 	/// sync header head
-	pub header_stats: ChainStats,
+	pub header_stats: Option<ChainStats>,
 	/// Whether we're currently syncing
 	pub sync_status: SyncStatus,
 	/// Handle to current stratum server stats

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -506,17 +506,17 @@ impl Server {
 			total_difficulty: head.total_difficulty(),
 		};
 
-		let header_tip = self.chain.try_header_head()?;
-		let header_stats = if let Some(tip) = header_tip {
-			let header = self.chain.get_block_header(&tip.hash())?;
-			Some(ChainStats {
-				latest_timestamp: header.timestamp,
-				height: header.height,
-				last_block_h: header.prev_hash,
-				total_difficulty: header.total_difficulty(),
-			})
-		} else {
-			None
+		let header_stats = match self.chain.try_header_head()? {
+			Some(tip) => {
+				let header = self.chain.get_block_header(&tip.hash())?;
+				Some(ChainStats {
+					latest_timestamp: header.timestamp,
+					height: header.height,
+					last_block_h: header.prev_hash,
+					total_difficulty: header.total_difficulty(),
+				})
+			}
+			_ => None,
 		};
 
 		let disk_usage_bytes = WalkDir::new(&self.config.db_root)

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -506,13 +506,17 @@ impl Server {
 			total_difficulty: head.total_difficulty(),
 		};
 
-		let header_tip = self.chain.header_head()?;
-		let header = self.chain.get_block_header(&header_tip.hash())?;
-		let header_stats = ChainStats {
-			latest_timestamp: header.timestamp,
-			height: header.height,
-			last_block_h: header.prev_hash,
-			total_difficulty: header.total_difficulty(),
+		let header_tip = self.chain.try_header_head()?;
+		let header_stats = if let Some(tip) = header_tip {
+			let header = self.chain.get_block_header(&tip.hash())?;
+			Some(ChainStats {
+				latest_timestamp: header.timestamp,
+				height: header.height,
+				last_block_h: header.prev_hash,
+				total_difficulty: header.total_difficulty(),
+			})
+		} else {
+			None
 		};
 
 		let disk_usage_bytes = WalkDir::new(&self.config.db_root)

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -295,18 +295,20 @@ impl TUIStatusListener for TUIStatusView {
 		c.call_on_id("chain_timestamp", |t: &mut TextView| {
 			t.set_content(stats.chain_stats.latest_timestamp.to_string());
 		});
-		c.call_on_id("basic_header_tip_hash", |t: &mut TextView| {
-			t.set_content(stats.header_stats.last_block_h.to_string() + "...");
-		});
-		c.call_on_id("basic_header_chain_height", |t: &mut TextView| {
-			t.set_content(stats.header_stats.height.to_string());
-		});
-		c.call_on_id("basic_header_total_difficulty", |t: &mut TextView| {
-			t.set_content(stats.header_stats.total_difficulty.to_string());
-		});
-		c.call_on_id("basic_header_timestamp", |t: &mut TextView| {
-			t.set_content(stats.header_stats.latest_timestamp.to_string());
-		});
+		if let Some(header_stats) = &stats.header_stats {
+			c.call_on_id("basic_header_tip_hash", |t: &mut TextView| {
+				t.set_content(header_stats.last_block_h.to_string() + "...");
+			});
+			c.call_on_id("basic_header_chain_height", |t: &mut TextView| {
+				t.set_content(header_stats.height.to_string());
+			});
+			c.call_on_id("basic_header_total_difficulty", |t: &mut TextView| {
+				t.set_content(header_stats.total_difficulty.to_string());
+			});
+			c.call_on_id("basic_header_timestamp", |t: &mut TextView| {
+				t.set_content(header_stats.latest_timestamp.to_string());
+			});
+		}
 		c.call_on_id("tx_pool_size", |t: &mut TextView| {
 			t.set_content(stats.tx_stats.tx_pool_size.to_string());
 		});


### PR DESCRIPTION
TUI status is currently broken when syncing the chain. It stops responding and does not show the percentage validation status of the txhashset. This is because during validation there is long lived write lock on pmmr_header. So when we try to get a read lock to update the status it blocks.

This fix adds a try_header_head() function which might return a Tip or not if the lock is not available right away. For TUI status this is okay as we can just update based on the available information and do not need to block.