### PR TITLE
fix: #3117 For backwards compatibility only capitalise first letter o…

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -296,9 +296,27 @@ impl GlobalConfig {
 	/// Write configuration to a file
 	pub fn write_to_file(&mut self, name: &str) -> Result<(), ConfigError> {
 		let conf_out = self.ser_config()?;
-		let conf_out = insert_comments(conf_out);
+		let fixed_config = GlobalConfig::fix_log_level(conf_out);
+		let conf_out = insert_comments(fixed_config);
 		let mut file = File::create(name)?;
 		file.write_all(conf_out.as_bytes())?;
 		Ok(())
 	}
+
+	// For backwards compatibility only first letter of log level should be capitalised.
+	fn fix_log_level(conf: String) -> String {
+		conf.replace("OFF", "Off")
+			.replace("TRACE", "Trace")
+			.replace("DEBUG", "Debug")
+			.replace("INFO", "Info")
+			.replace("WARN", "Warn")
+			.replace("ERROR", "Error")
+	}
+}
+
+#[test]
+fn test_fix_log_level() {
+	let config = "OFF TRACE DEBUG INFO WARN ERROR".to_string();
+	let fixed_config = GlobalConfig::fix_log_level(config);
+	assert_eq!(fixed_config, "Off Trace Debug Info Warn Error");
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -298,9 +298,9 @@ impl GlobalConfig {
 	pub fn write_to_file(&mut self, name: &str) -> Result<(), ConfigError> {
 		let conf_out = self.ser_config()?;
 		let fixed_config = GlobalConfig::fix_log_level(conf_out);
-		let conf_out = insert_comments(fixed_config);
+		let commented_config = insert_comments(fixed_config);
 		let mut file = File::create(name)?;
-		file.write_all(conf_out.as_bytes())?;
+		file.write_all(commented_config.as_bytes())?;
 		Ok(())
 	}
 


### PR DESCRIPTION
This is a bug fix #3117 that was introduced in #3064 

We apply a post config generation step that ensures only the first letter of log levels are capitalised. So that new and old code will work with newly generated config.

And we need to account for old config with "Warning" level which is not compatible with new code and must be modified to "WARN".

I've manually confirmed that v2.1.1 works with config generated from this change. And that new code works with config generated from v2.1.1.