### PR TITLE
Fixing misleading privacy claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Grin is an in-progress implementation of the Mimblewimble protocol. Many characteristics are still undefined but the following constitutes a first set of choices:
 
   * Clean and minimal implementation, and aiming to stay as such.
-  * Follows the MimbleWimble protocol, which provides confidential transactions and scaling advantages.
+  * Follows the Mimblewimble protocol, which provides confidential transactions and scaling advantages.
   * Cuckoo Cycle proof of work in two variants named Cuckaroo (ASIC-resistant) and Cuckatoo (ASIC-targeted).
   * Relatively fast block time: one minute.
   * Fixed block reward over time with a decreasing dilution.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Grin is an in-progress implementation of the Mimblewimble protocol. Many characteristics are still undefined but the following constitutes a first set of choices:
 
   * Clean and minimal implementation, and aiming to stay as such.
-  * Follows the Mimblewimble protocol, which provides great anonymity and scaling characteristics.
+  * Follows the MimbleWimble protocol, which provides confidential transactions and scaling advantages.
   * Cuckoo Cycle proof of work in two variants named Cuckaroo (ASIC-resistant) and Cuckatoo (ASIC-targeted).
   * Relatively fast block time: one minute.
   * Fixed block reward over time with a decreasing dilution.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Grin is an in-progress implementation of the Mimblewimble protocol. Many characteristics are still undefined but the following constitutes a first set of choices:
 
   * Clean and minimal implementation, and aiming to stay as such.
-  * Follows the Mimblewimble protocol, which provides confidential transactions and scaling advantages.
+  * Follows the Mimblewimble protocol, which provides hidden amounts and scaling advantages.
   * Cuckoo Cycle proof of work in two variants named Cuckaroo (ASIC-resistant) and Cuckatoo (ASIC-targeted).
   * Relatively fast block time: one minute.
   * Fixed block reward over time with a decreasing dilution.


### PR DESCRIPTION
It was recently pointed out that, although our privacy model was correct, our readme was misleading. This replaces the misleading claim.