### PR TITLE
use try_read_for() with timeout for tui status updates (header and pool stats)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1218,19 +1218,21 @@ impl Chain {
 
 	/// Tip (head) of the header chain if read lock can be acquired reasonably quickly.
 	/// Used by the TUI when updating stats to avoid locking the TUI up.
-	pub fn try_header_head(&self) -> Result<Option<Tip>, Error> {
-		if let Some(pmmr) = self.header_pmmr.try_read_for(Duration::from_millis(500)) {
-			let hash = pmmr.head_hash()?;
-			let header = self.store.get_block_header(&hash)?;
-			Ok(Some(Tip::from_header(&header)))
-		} else {
-			Ok(None)
-		}
+	pub fn try_header_head(&self, timeout: Duration) -> Result<Option<Tip>, Error> {
+		self.header_pmmr
+			.try_read_for(timeout)
+			.map(|ref pmmr| self.read_header_head(pmmr).map(|x| Some(x)))
+			.unwrap_or(Ok(None))
 	}
 
 	/// Tip (head) of the header chain.
 	pub fn header_head(&self) -> Result<Tip, Error> {
-		let hash = self.header_pmmr.read().head_hash()?;
+		self.read_header_head(&self.header_pmmr.read())
+	}
+
+	/// Read head from the provided PMMR handle.
+	fn read_header_head(&self, pmmr: &txhashset::PMMRHandle<BlockHeader>) -> Result<Tip, Error> {
+		let hash = pmmr.head_hash()?;
 		let header = self.store.get_block_header(&hash)?;
 		Ok(Tip::from_header(&header))
 	}

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -63,7 +63,7 @@ pub struct ServerStats {
 	/// Difficulty calculation statistics
 	pub diff_stats: DiffStats,
 	/// Transaction pool statistics
-	pub tx_stats: TxStats,
+	pub tx_stats: Option<TxStats>,
 	/// Disk usage in GB
 	pub disk_usage_gb: String,
 }

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -284,18 +284,20 @@ impl TUIStatusListener for TUIStatusView {
 				t.set_content(header_stats.latest_timestamp.to_string());
 			});
 		}
-		c.call_on_id("tx_pool_size", |t: &mut TextView| {
-			t.set_content(stats.tx_stats.tx_pool_size.to_string());
-		});
-		c.call_on_id("stem_pool_size", |t: &mut TextView| {
-			t.set_content(stats.tx_stats.stem_pool_size.to_string());
-		});
-		c.call_on_id("tx_pool_kernels", |t: &mut TextView| {
-			t.set_content(stats.tx_stats.tx_pool_kernels.to_string());
-		});
-		c.call_on_id("stem_pool_kernels", |t: &mut TextView| {
-			t.set_content(stats.tx_stats.stem_pool_kernels.to_string());
-		});
+		if let Some(tx_stats) = &stats.tx_stats {
+			c.call_on_id("tx_pool_size", |t: &mut TextView| {
+				t.set_content(tx_stats.tx_pool_size.to_string());
+			});
+			c.call_on_id("stem_pool_size", |t: &mut TextView| {
+				t.set_content(tx_stats.stem_pool_size.to_string());
+			});
+			c.call_on_id("tx_pool_kernels", |t: &mut TextView| {
+				t.set_content(tx_stats.tx_pool_kernels.to_string());
+			});
+			c.call_on_id("stem_pool_kernels", |t: &mut TextView| {
+				t.set_content(tx_stats.stem_pool_kernels.to_string());
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves #3128.

Use `try_read_for()` so we block when obtaining the read lock _but_ we only block for a short period of time.
If we do not block then we risk having the TUI fail to update when updating stats (and displaying stale stats).

https://docs.rs/lock_api/0.3.1/lock_api/struct.RwLock.html#method.try_read_for

We already use `try_read_for()` internally when reading our list of connected peers in p2p layer.

Refactored `tx_stats` to be `Option<>` so we do not revert to 0 values in the case where we are unable to obtain the read lock to update the stats. Only update stats if we have `Some` and just leave stats unchanged on `None`.

