### PR TITLE
Cleanup redundant AsFixedBytes and FixedLength traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test_output
 wallet_data
 wallet/db
 .idea/
+/node*

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -179,7 +179,6 @@ impl Chain {
 			"header",
 			"header_head",
 			false,
-			true,
 			ProtocolVersion(1),
 			None,
 		)?;
@@ -188,7 +187,6 @@ impl Chain {
 			"header",
 			"sync_head",
 			false,
-			true,
 			ProtocolVersion(1),
 			None,
 		)?;

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -20,7 +20,7 @@ use croaring::Bitmap;
 
 use crate::core::core::hash::{DefaultHashable, Hash};
 use crate::core::core::pmmr::{self, ReadonlyPMMR, VecBackend, PMMR};
-use crate::core::ser::{self, FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
+use crate::core::ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
 use crate::error::{Error, ErrorKind};
 
 /// The "bitmap accumulator" allows us to commit to a specific bitmap by splitting it into
@@ -215,10 +215,10 @@ impl PMMRable for BitmapChunk {
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
 	}
-}
 
-impl FixedLength for BitmapChunk {
-	const LEN: usize = Self::LEN_BYTES;
+	fn elmt_size() -> Option<u16> {
+		Some(Self::LEN_BYTES as u16)
+	}
 }
 
 impl DefaultHashable for BitmapChunk {}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -60,7 +60,6 @@ impl<T: PMMRable> PMMRHandle<T> {
 		sub_dir: &str,
 		file_name: &str,
 		prunable: bool,
-		fixed_size: bool,
 		version: ProtocolVersion,
 		header: Option<&BlockHeader>,
 	) -> Result<PMMRHandle<T>, Error> {
@@ -69,8 +68,7 @@ impl<T: PMMRable> PMMRHandle<T> {
 		let path_str = path.to_str().ok_or(Error::from(ErrorKind::Other(
 			"invalid file path".to_owned(),
 		)))?;
-		let backend =
-			PMMRBackend::new(path_str.to_string(), prunable, fixed_size, version, header)?;
+		let backend = PMMRBackend::new(path_str.to_string(), prunable, version, header)?;
 		let last_pos = backend.unpruned_size();
 		Ok(PMMRHandle { backend, last_pos })
 	}
@@ -136,7 +134,6 @@ impl TxHashSet {
 			TXHASHSET_SUBDIR,
 			OUTPUT_SUBDIR,
 			true,
-			true,
 			ProtocolVersion(1),
 			header,
 		)?;
@@ -145,7 +142,6 @@ impl TxHashSet {
 			&root_dir,
 			TXHASHSET_SUBDIR,
 			RANGE_PROOF_SUBDIR,
-			true,
 			true,
 			ProtocolVersion(1),
 			header,
@@ -162,7 +158,6 @@ impl TxHashSet {
 				TXHASHSET_SUBDIR,
 				KERNEL_SUBDIR,
 				false, // not prunable
-				false, // variable size kernel data file
 				version,
 				None,
 			)?;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -26,14 +26,14 @@ use crate::core::{
 use crate::global;
 use crate::pow::{verify_size, Difficulty, Proof, ProofOfWork};
 use crate::ser::{
-	self, deserialize_default, serialize_default, PMMRable, Readable, Reader,
-	Writeable, Writer,
+	self, deserialize_default, serialize_default, PMMRable, Readable, Reader, Writeable, Writer,
 };
 use chrono::naive::{MAX_DATE, MIN_DATE};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use chrono::Duration;
 use keychain::{self, BlindingFactor};
 use std::collections::HashSet;
+use std::convert::TryInto;
 use std::fmt;
 use std::iter::FromIterator;
 use std::sync::Arc;
@@ -168,11 +168,6 @@ impl Writeable for HeaderEntry {
 	}
 }
 
-impl HeaderEntry {
-	/// Length of a HeaderEntry in bytes.
-	pub const LEN: u16 = 32 + 8 + Difficulty::LEN + 4 + 1;
-}
-
 impl Hashed for HeaderEntry {
 	/// The hash of the underlying block.
 	fn hash(&self) -> Hash {
@@ -267,8 +262,10 @@ impl PMMRable for BlockHeader {
 		}
 	}
 
+	// Size is hash + u64 + difficulty + u32 + u8.
 	fn elmt_size() -> Option<u16> {
-		Some(HeaderEntry::LEN)
+		const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
+		Some(LEN.try_into().unwrap())
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -26,7 +26,7 @@ use crate::core::{
 use crate::global;
 use crate::pow::{verify_size, Difficulty, Proof, ProofOfWork};
 use crate::ser::{
-	self, deserialize_default, serialize_default, FixedLength, PMMRable, Readable, Reader,
+	self, deserialize_default, serialize_default, PMMRable, Readable, Reader,
 	Writeable, Writer,
 };
 use chrono::naive::{MAX_DATE, MIN_DATE};
@@ -168,8 +168,9 @@ impl Writeable for HeaderEntry {
 	}
 }
 
-impl FixedLength for HeaderEntry {
-	const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
+impl HeaderEntry {
+	/// Length of a HeaderEntry in bytes.
+	pub const LEN: u16 = 32 + 8 + Difficulty::LEN + 4 + 1;
 }
 
 impl Hashed for HeaderEntry {
@@ -264,6 +265,10 @@ impl PMMRable for BlockHeader {
 			secondary_scaling: self.pow.secondary_scaling,
 			is_secondary: self.pow.is_secondary(),
 		}
+	}
+
+	fn elmt_size() -> Option<u16> {
+		Some(HeaderEntry::LEN)
 	}
 }
 

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -51,11 +51,14 @@ impl fmt::Display for Hash {
 }
 
 impl Hash {
+	/// A hash is 32 bytes.
+	pub const LEN: usize = 32;
+
 	/// Builds a Hash from a byte vector. If the vector is too short, it will be
 	/// completed by zeroes. If it's too long, it will be truncated.
 	pub fn from_vec(v: &[u8]) -> Hash {
-		let mut h = [0; 32];
-		let copy_size = min(v.len(), 32);
+		let mut h = [0; Hash::LEN];
+		let copy_size = min(v.len(), Hash::LEN);
 		h[..copy_size].copy_from_slice(&v[..copy_size]);
 		Hash(h)
 	}

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -17,7 +17,7 @@
 //! Primary hash function used in the protocol
 //!
 
-use crate::ser::{self, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer};
+use crate::ser::{self, Error, ProtocolVersion, Readable, Reader, Writeable, Writer};
 use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::min;
@@ -50,17 +50,12 @@ impl fmt::Display for Hash {
 	}
 }
 
-impl FixedLength for Hash {
-	/// Size of a hash in bytes.
-	const LEN: usize = 32;
-}
-
 impl Hash {
 	/// Builds a Hash from a byte vector. If the vector is too short, it will be
 	/// completed by zeroes. If it's too long, it will be truncated.
 	pub fn from_vec(v: &[u8]) -> Hash {
-		let mut h = [0; Hash::LEN];
-		let copy_size = min(v.len(), Hash::LEN);
+		let mut h = [0; 32];
+		let copy_size = min(v.len(), 32);
 		h[..copy_size].copy_from_slice(&v[..copy_size]);
 		Hash(h)
 	}

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -17,9 +17,7 @@
 //! Primary hash function used in the protocol
 //!
 
-use crate::ser::{
-	self, AsFixedBytes, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer,
-};
+use crate::ser::{self, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer};
 use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::min;
@@ -196,8 +194,8 @@ impl ser::Writer for HashWriter {
 		ser::SerializationMode::Hash
 	}
 
-	fn write_fixed_bytes<T: AsFixedBytes>(&mut self, b32: &T) -> Result<(), ser::Error> {
-		self.state.update(b32.as_ref());
+	fn write_fixed_bytes<T: AsRef<[u8]>>(&mut self, bytes: T) -> Result<(), ser::Error> {
+		self.state.update(bytes.as_ref());
 		Ok(())
 	}
 

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -17,7 +17,7 @@ use crate::core::hash::{DefaultHashable, Hashed};
 use crate::global;
 use crate::pow::common::EdgeType;
 use crate::pow::error::Error;
-use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
+use crate::ser::{self, Readable, Reader, Writeable, Writer};
 use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
@@ -156,8 +156,9 @@ impl Readable for Difficulty {
 	}
 }
 
-impl FixedLength for Difficulty {
-	const LEN: usize = 8;
+impl Difficulty {
+	/// Length of a Difficulty in bytes for serialization purposes.
+	pub const LEN: u16 = 8;
 }
 
 impl Serialize for Difficulty {

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -157,8 +157,8 @@ impl Readable for Difficulty {
 }
 
 impl Difficulty {
-	/// Length of a Difficulty in bytes for serialization purposes.
-	pub const LEN: u16 = 8;
+	/// Difficulty is 8 bytes.
+	pub const LEN: usize = 8;
 }
 
 impl Serialize for Difficulty {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -817,6 +817,12 @@ impl<A: Readable, B: Readable, C: Readable, D: Readable> Readable for (A, B, C, 
 	}
 }
 
+impl Writeable for [u8; 4] {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		writer.write_bytes(self)
+	}
+}
+
 /// Trait for types that can be added to a PMMR.
 pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	/// The type of element actually stored in the MMR data file.

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -611,6 +611,7 @@ impl PMMRable for RangeProof {
 		self.clone()
 	}
 
+	// Size is length prefix (8 bytes for u64) + MAX_PROOF_SIZE.
 	fn elmt_size() -> Option<u16> {
 		Some((8 + MAX_PROOF_SIZE).try_into().unwrap())
 	}

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -23,10 +23,10 @@ use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::global::PROTOCOL_VERSION;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
+use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::io::{self, Read, Write};
-use std::marker;
-use std::{cmp, error};
+use std::{cmp, error, marker};
 use util::secp::constants::{
 	AGG_SIGNATURE_SIZE, COMPRESSED_PUBLIC_KEY_SIZE, MAX_PROOF_SIZE, PEDERSEN_COMMITMENT_SIZE,
 	SECRET_KEY_SIZE,
@@ -566,13 +566,9 @@ impl Writeable for BlindingFactor {
 
 impl Readable for BlindingFactor {
 	fn read(reader: &mut dyn Reader) -> Result<BlindingFactor, Error> {
-		let bytes = reader.read_fixed_bytes(BlindingFactor::LEN)?;
+		let bytes = reader.read_fixed_bytes(SECRET_KEY_SIZE)?;
 		Ok(BlindingFactor::from_slice(&bytes))
 	}
-}
-
-impl FixedLength for BlindingFactor {
-	const LEN: usize = SECRET_KEY_SIZE;
 }
 
 impl Writeable for Identifier {
@@ -608,24 +604,23 @@ impl Readable for RangeProof {
 	}
 }
 
-impl FixedLength for RangeProof {
-	const LEN: usize = 8 // length prefix
-		+ MAX_PROOF_SIZE;
-}
-
 impl PMMRable for RangeProof {
 	type E = Self;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
 	}
+
+	fn elmt_size() -> Option<u16> {
+		Some((8 + MAX_PROOF_SIZE).try_into().unwrap())
+	}
 }
 
 impl Readable for Signature {
 	fn read(reader: &mut dyn Reader) -> Result<Signature, Error> {
-		let a = reader.read_fixed_bytes(Signature::LEN)?;
-		let mut c = [0; Signature::LEN];
-		c[..Signature::LEN].clone_from_slice(&a[..Signature::LEN]);
+		let a = reader.read_fixed_bytes(AGG_SIGNATURE_SIZE)?;
+		let mut c = [0; AGG_SIGNATURE_SIZE];
+		c[..AGG_SIGNATURE_SIZE].clone_from_slice(&a[..AGG_SIGNATURE_SIZE]);
 		Ok(Signature::from_raw_data(&c).unwrap())
 	}
 }
@@ -636,19 +631,11 @@ impl Writeable for Signature {
 	}
 }
 
-impl FixedLength for Signature {
-	const LEN: usize = AGG_SIGNATURE_SIZE;
-}
-
-impl FixedLength for PublicKey {
-	const LEN: usize = COMPRESSED_PUBLIC_KEY_SIZE;
-}
-
 impl Writeable for PublicKey {
 	// Write the public key in compressed form
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
 		let secp = Secp256k1::with_caps(ContextFlag::None);
-		writer.write_fixed_bytes(&self.serialize_vec(&secp, true).as_ref())?;
+		writer.write_fixed_bytes(self.serialize_vec(&secp, true))?;
 		Ok(())
 	}
 }
@@ -656,7 +643,7 @@ impl Writeable for PublicKey {
 impl Readable for PublicKey {
 	// Read the public key in compressed form
 	fn read(reader: &mut dyn Reader) -> Result<Self, Error> {
-		let buf = reader.read_fixed_bytes(PublicKey::LEN)?;
+		let buf = reader.read_fixed_bytes(COMPRESSED_PUBLIC_KEY_SIZE)?;
 		let secp = Secp256k1::with_caps(ContextFlag::None);
 		let pk = PublicKey::from_slice(&secp, &buf).map_err(|_| Error::CorruptedData)?;
 		Ok(pk)
@@ -830,26 +817,17 @@ impl<A: Readable, B: Readable, C: Readable, D: Readable> Readable for (A, B, C, 
 	}
 }
 
-impl Writeable for [u8; 4] {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		writer.write_bytes(self)
-	}
-}
-
-/// Trait for types that serialize to a known fixed length.
-pub trait FixedLength {
-	/// The length in bytes
-	const LEN: usize;
-}
-
 /// Trait for types that can be added to a PMMR.
 pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	/// The type of element actually stored in the MMR data file.
 	/// This allows us to store Hash elements in the header MMR for variable size BlockHeaders.
-	type E: FixedLength + Readable + Writeable + Debug;
+	type E: Readable + Writeable + Debug;
 
 	/// Convert the pmmrable into the element to be stored in the MMR data file.
 	fn as_elmt(&self) -> Self::E;
+
+	/// Size of each element if "fixed" size. Elements are "variable" size if None.
+	fn elmt_size() -> Option<u16>;
 }
 
 /// Generic trait to ensure PMMR elements can be hashed with an index

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -26,7 +26,6 @@ use crate::core::core::{
 };
 use crate::core::libtx::build::{self, input, output};
 use crate::core::libtx::ProofBuilder;
-use crate::core::pow::Proof;
 use crate::core::{global, ser};
 use chrono::Duration;
 use grin_core as core;

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -22,7 +22,7 @@ use grin_core::libtx::{
 	reward,
 };
 use grin_core::pow::Difficulty;
-use grin_core::ser::{self, FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
+use grin_core::ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
 use keychain::{Identifier, Keychain};
 
 // utility producing a transaction with 2 inputs and a single outputs
@@ -133,15 +133,15 @@ pub struct TestElem(pub [u32; 4]);
 
 impl DefaultHashable for TestElem {}
 
-impl FixedLength for TestElem {
-	const LEN: usize = 16;
-}
-
 impl PMMRable for TestElem {
 	type E = Self;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
+	}
+
+	fn elmt_size() -> Option<u16> {
+		Some(16)
 	}
 }
 

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -21,7 +21,7 @@
 //! stream and make sure we get the right number of bytes out.
 
 use crate::core::ser;
-use crate::core::ser::{FixedLength, ProtocolVersion};
+use crate::core::ser::ProtocolVersion;
 use crate::msg::{
 	read_body, read_discard, read_header, read_item, write_message, Msg, MsgHeader,
 	MsgHeaderWrapper,

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -19,7 +19,7 @@ use crate::core::core::hash::Hash;
 use crate::core::core::BlockHeader;
 use crate::core::pow::Difficulty;
 use crate::core::ser::{
-	self, FixedLength, ProtocolVersion, Readable, Reader, StreamingReader, Writeable, Writer,
+	self, ProtocolVersion, Readable, Reader, StreamingReader, Writeable, Writer,
 };
 use crate::core::{consensus, global};
 use crate::types::{
@@ -262,6 +262,9 @@ pub struct MsgHeader {
 }
 
 impl MsgHeader {
+	// 2 magic bytes + 1 type byte + 8 bytes (msg_len)
+	pub const LEN: usize = 2 + 1 + 8;
+
 	/// Creates a new message header.
 	pub fn new(msg_type: Type, len: u64) -> MsgHeader {
 		MsgHeader {
@@ -270,11 +273,6 @@ impl MsgHeader {
 			msg_len: len,
 		}
 	}
-}
-
-impl FixedLength for MsgHeader {
-	// 2 magic bytes + 1 type byte + 8 bytes (msg_len)
-	const LEN: usize = 2 + 1 + 8;
 }
 
 impl Writeable for MsgHeader {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -24,6 +24,7 @@ use crate::leaf_set::LeafSet;
 use crate::prune_list::PruneList;
 use crate::types::{AppendOnlyFile, DataFile, SizeEntry, SizeInfo};
 use croaring::Bitmap;
+use std::convert::TryInto;
 use std::path::{Path, PathBuf};
 
 const PMMR_HASH_FILE: &str = "pmmr_hash.bin";
@@ -252,7 +253,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		};
 
 		// Hash file is always "fixed size" and we use 32 bytes per hash.
-		let hash_size_info = SizeInfo::FixedSize(32);
+		let hash_size_info = SizeInfo::FixedSize(Hash::LEN.try_into().unwrap());
 
 		let hash_file = DataFile::open(&data_dir.join(PMMR_HASH_FILE), hash_size_info, version)?;
 		let data_file = DataFile::open(&data_dir.join(PMMR_DATA_FILE), size_info, version)?;

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -19,7 +19,7 @@ use std::{io, time};
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::pmmr::{self, family, Backend};
 use crate::core::core::BlockHeader;
-use crate::core::ser::{FixedLength, PMMRable, ProtocolVersion};
+use crate::core::ser::{PMMRable, ProtocolVersion};
 use crate::leaf_set::LeafSet;
 use crate::prune_list::PruneList;
 use crate::types::{AppendOnlyFile, DataFile, SizeEntry, SizeInfo};
@@ -229,11 +229,11 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 impl<T: PMMRable> PMMRBackend<T> {
 	/// Instantiates a new PMMR backend.
+	/// If optional size is provided then treat as "fixed" size otherwise "variable" size backend.
 	/// Use the provided dir to store its files.
 	pub fn new<P: AsRef<Path>>(
 		data_dir: P,
 		prunable: bool,
-		fixed_size: bool,
 		version: ProtocolVersion,
 		header: Option<&BlockHeader>,
 	) -> io::Result<PMMRBackend<T>> {
@@ -241,8 +241,8 @@ impl<T: PMMRable> PMMRBackend<T> {
 
 		// Are we dealing with "fixed size" data elements or "variable size" data elements
 		// maintained in an associated size file?
-		let size_info = if fixed_size {
-			SizeInfo::FixedSize(T::E::LEN as u16)
+		let size_info = if let Some(fixed_size) = T::elmt_size() {
+			SizeInfo::FixedSize(fixed_size)
 		} else {
 			SizeInfo::VariableSize(Box::new(AppendOnlyFile::open(
 				data_dir.join(PMMR_SIZE_FILE),
@@ -252,7 +252,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		};
 
 		// Hash file is always "fixed size" and we use 32 bytes per hash.
-		let hash_size_info = SizeInfo::FixedSize(Hash::LEN as u16);
+		let hash_size_info = SizeInfo::FixedSize(32);
 
 		let hash_file = DataFile::open(&data_dir.join(PMMR_HASH_FILE), hash_size_info, version)?;
 		let data_file = DataFile::open(&data_dir.join(PMMR_DATA_FILE), size_info, version)?;

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -16,8 +16,7 @@ use memmap;
 use tempfile::tempfile;
 
 use crate::core::ser::{
-	self, BinWriter, FixedLength, ProtocolVersion, Readable, Reader, StreamingReader, Writeable,
-	Writer,
+	self, BinWriter, ProtocolVersion, Readable, Reader, StreamingReader, Writeable, Writer,
 };
 use std::fmt::Debug;
 use std::fs::{self, File, OpenOptions};
@@ -39,8 +38,9 @@ pub struct SizeEntry {
 	pub size: u16,
 }
 
-impl FixedLength for SizeEntry {
-	const LEN: usize = 8 + 2;
+impl SizeEntry {
+	/// Length of a size entry (8 + 2 bytes) for convenience.
+	pub const LEN: u16 = 8 + 2;
 }
 
 impl Readable for SizeEntry {

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -34,7 +34,7 @@ fn pmmr_leaf_idx_iter() {
 		let mut backend = store::pmmr::PMMRBackend::new(
 			data_dir.to_string(),
 			true,
-			false,
+			// false,
 			ProtocolVersion(1),
 			None,
 		)

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -61,14 +61,9 @@ fn pmmr_leaf_idx_iter() {
 fn pmmr_append() {
 	let (data_dir, elems) = setup("append");
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			false,
-			false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), false, ProtocolVersion(1), None)
+				.unwrap();
 
 		// adding first set of 4 elements and sync
 		let mut mmr_size = load(0, &elems[0..4], &mut backend);
@@ -153,14 +148,9 @@ fn pmmr_compact_leaf_sibling() {
 
 	// setup the mmr store with all elements
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			true,
-			false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 
@@ -235,14 +225,9 @@ fn pmmr_prune_compact() {
 
 	// setup the mmr store with all elements
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			true,
-			false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 
@@ -292,14 +277,9 @@ fn pmmr_reload() {
 
 	// set everything up with an initial backend
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			true,
-			false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
 
 		let mmr_size = load(0, &elems[..], &mut backend);
 
@@ -358,14 +338,9 @@ fn pmmr_reload() {
 		// create a new backend referencing the data files
 		// and check everything still works as expected
 		{
-			let mut backend = store::pmmr::PMMRBackend::new(
-				data_dir.to_string(),
-				true,
-				false,
-				ProtocolVersion(1),
-				None,
-			)
-			.unwrap();
+			let mut backend =
+				store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+					.unwrap();
 			assert_eq!(backend.unpruned_size(), mmr_size);
 			{
 				let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
@@ -406,7 +381,7 @@ fn pmmr_rewind() {
 	let (data_dir, elems) = setup("rewind");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, ProtocolVersion(1), None)
 				.unwrap();
 
 		// adding elements and keeping the corresponding root
@@ -523,7 +498,7 @@ fn pmmr_compact_single_leaves() {
 	let (data_dir, elems) = setup("compact_single_leaves");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, ProtocolVersion(1), None)
 				.unwrap();
 		let mmr_size = load(0, &elems[0..5], &mut backend);
 		backend.sync().unwrap();
@@ -559,7 +534,7 @@ fn pmmr_compact_entire_peak() {
 	let (data_dir, elems) = setup("compact_entire_peak");
 	{
 		let mut backend =
-			store::pmmr::PMMRBackend::new(data_dir.clone(), true, false, ProtocolVersion(1), None)
+			store::pmmr::PMMRBackend::new(data_dir.clone(), true, ProtocolVersion(1), None)
 				.unwrap();
 		let mmr_size = load(0, &elems[0..5], &mut backend);
 		backend.sync().unwrap();
@@ -615,14 +590,9 @@ fn pmmr_compact_horizon() {
 
 		let mmr_size;
 		{
-			let mut backend = store::pmmr::PMMRBackend::new(
-				data_dir.clone(),
-				true,
-				false,
-				ProtocolVersion(1),
-				None,
-			)
-			.unwrap();
+			let mut backend =
+				store::pmmr::PMMRBackend::new(data_dir.clone(), true, ProtocolVersion(1), None)
+					.unwrap();
 			mmr_size = load(0, &elems[..], &mut backend);
 			backend.sync().unwrap();
 
@@ -704,7 +674,6 @@ fn pmmr_compact_horizon() {
 			let backend = store::pmmr::PMMRBackend::<TestElem>::new(
 				data_dir.to_string(),
 				true,
-				false,
 				ProtocolVersion(1),
 				None,
 			)
@@ -725,7 +694,6 @@ fn pmmr_compact_horizon() {
 			let mut backend = store::pmmr::PMMRBackend::<TestElem>::new(
 				data_dir.to_string(),
 				true,
-				false,
 				ProtocolVersion(1),
 				None,
 			)
@@ -748,7 +716,6 @@ fn pmmr_compact_horizon() {
 			let backend = store::pmmr::PMMRBackend::<TestElem>::new(
 				data_dir.to_string(),
 				true,
-				false,
 				ProtocolVersion(1),
 				None,
 			)
@@ -781,14 +748,9 @@ fn compact_twice() {
 	// setup the mmr store with all elements
 	// Scoped to allow Windows to teardown
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			true,
-			false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
 		let mmr_size = load(0, &elems[..], &mut backend);
 		backend.sync().unwrap();
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -24,8 +24,7 @@ use croaring::Bitmap;
 use crate::core::core::hash::DefaultHashable;
 use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
-	Error, FixedLength, PMMRIndexHashable, PMMRable, ProtocolVersion, Readable, Reader, Writeable,
-	Writer,
+	Error, PMMRIndexHashable, PMMRable, ProtocolVersion, Readable, Reader, Writeable, Writer,
 };
 
 #[test]
@@ -1008,15 +1007,15 @@ struct TestElem(u32);
 
 impl DefaultHashable for TestElem {}
 
-impl FixedLength for TestElem {
-	const LEN: usize = 4;
-}
-
 impl PMMRable for TestElem {
 	type E = Self;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
+	}
+
+	fn elmt_size() -> Option<u16> {
+		Some(4)
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -31,14 +31,9 @@ use crate::core::ser::{
 fn pmmr_leaf_idx_iter() {
 	let (data_dir, elems) = setup("leaf_idx_iter");
 	{
-		let mut backend = store::pmmr::PMMRBackend::new(
-			data_dir.to_string(),
-			true,
-			// false,
-			ProtocolVersion(1),
-			None,
-		)
-		.unwrap();
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
 
 		// adding first set of 4 elements and sync
 		let mmr_size = load(0, &elems[0..5], &mut backend);


### PR DESCRIPTION
We had two relatively awkward traits `AsFixedBytes` and `FixedLength` traits that basically encapsulated a way of determining how many bytes a "fixed size" struct would serialize to.

`AsFixedBytes` basically wrapped `AsRef<u8>` and acted as a marker trait. The `len()` functon was never actually used anywhere as we always converted to a byte slice via `to_ref()` and then called `len()` on the byte slice directly. I suspect this has simply been refactored over time and ended up being unused without us realizing it.

`FixedLength` was used for the PMMR backend impl to determine how many bytes to use for each leaf entry in the PMMR. It ends up being far simpler to replace this with an `elmt_size()` fn on `PMMRable` for the few structs we actually care about maintaining in PMMRs. And call this directly when instantiating the PMMR backend.

This all came about because we spotted the following code and something felt wrong here - 

```
impl<'a> AsFixedBytes for &'a [u8] {
	fn len(&self) -> usize {
		1
	}
}
```

The length in bytes of a slice of u8 values should not be 1.
So this specific instance of `AsFixedBytes` appeared to be unused (or we had bigger problems during serialization/deserialization).

