### PR TITLE
Remove Writeable impl for [u8; 4]

### DIFF
--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -818,12 +818,6 @@ impl<A: Readable, B: Readable, C: Readable, D: Readable> Readable for (A, B, C, 
 	}
 }
 
-impl Writeable for [u8; 4] {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		writer.write_bytes(self)
-	}
-}
-
 /// Trait for types that can be added to a PMMR.
 pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	/// The type of element actually stored in the MMR data file.


### PR DESCRIPTION
This impl of the `Writeable` trait feels wrong and as far as I can tell its not actively used by anything.

Note we call `write_bytes()` here and not `write_fixed_bytes()`.
This will prefix the bytes themselves with a u64 to represent the size in bytes (which in this case is always a fixed 4 bytes). So we would be serializing 4 bytes as 8 bytes + 4 bytes each time.

The only place I see `[u8; 4]` being used is in the keychain crate for `ExtendedPrivKey` and `Fingerprint` but I do not see these using `Readable/Writeable` traits anywhere.

@yeastplume Do you reckon this is safe to cleanup?
Is there anywhere we may be using this?

