### PR TITLE
mismatch between the test dir used and the test dir cleaned up...

### DIFF
--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -48,7 +48,7 @@ fn test_coinbase_maturity() {
 
 	{
 		let chain = chain::Chain::init(
-			".grin".to_string(),
+			chain_dir.to_string(),
 			Arc::new(NoopAdapter {}),
 			genesis_block,
 			pow::verify_size,


### PR DESCRIPTION
I suspect this explains why we see `test_coinbase_maturity` randomly failing.

We run the test under `.grin` and go to great lengths to make sure we cleanup `.grin_coinbase` after we are finished...

