### PR TITLE
[DNM] Readonly PMMR backend via try_clone()

### DIFF
--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -30,6 +30,7 @@ use std::io::{self, BufWriter, Write};
 
 /// Compact (roaring) bitmap representing the set of positions of
 /// leaves that are currently unpruned in the MMR.
+#[derive(Clone)]
 pub struct LeafSet {
 	path: PathBuf,
 	bitmap: Bitmap,

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -261,6 +261,17 @@ impl<T: PMMRable> PMMRBackend<T> {
 		})
 	}
 
+	pub fn try_clone(&self) -> io::Result<PMMRBackend<T>> {
+		Ok(PMMRBackend {
+			data_dir: self.data_dir.clone(),
+			prunable: self.prunable.clone(),
+			hash_file: self.hash_file.try_clone()?,
+			data_file: self.data_file.try_clone()?,
+			leaf_set: self.leaf_set.clone(),
+			prune_list: self.prune_list.clone(),
+		})
+	}
+
 	fn is_pruned(&self, pos: u64) -> bool {
 		self.prune_list.is_pruned(pos)
 	}

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -40,6 +40,7 @@ use crate::{read_bitmap, save_via_temp_file};
 /// but positions of a node within the PMMR will not match positions in the
 /// backend storage anymore. The PruneList accounts for that mismatch and does
 /// the position translation.
+#[derive(Clone)]
 pub struct PruneList {
 	path: Option<PathBuf>,
 	/// Bitmap representing pruned root node positions.


### PR DESCRIPTION
Still WIP as we need to think through some edge cases.

One of the bottlenecks in the code today is the need to obtain a _write_ lock on the txhashset even if we only want to read from a "readonly" view of the txhashset. This is because we need a `mutable` instance of the various PMMR backends due to the way we handle "rewind" via mutability of `last_pos`.

This PR makes the PMMR backend cloneable by introducing `try_clone()` on a couple of structs, specifically the `PMMRHandle` and the backend hash file and data file. 

[tbd - describe what can be cloned and why]
* files are mmap'd and "immutable"
* leafset (what do we do with this and why?)
* prunelist is readonly during normal operation

Q) What happens here during the occasional prune operation? What happens if we are reading a cloned instance of a PMMR backend and it is pruned and compacted from beneath us?

Todo - Explain the issue of our `batch` implementation. All lmdb interaction is done via a batch, reads _and_ writes. Explain why we still have an implicit global lock around the txhashset.

