### PR TITLE
use saturating_sub() to avoid a negative value causing an overflow panic (tui logs)

### DIFF
--- a/src/bin/tui/logs.rs
+++ b/src/bin/tui/logs.rs
@@ -94,7 +94,7 @@ impl View for LogBufferView {
 				rows.reverse(); // So stack traces are in the right order.
 				for row in rows {
 					for span in row.resolve(&log_message) {
-						p.print((0, p.size.y - 1 - i), span.content);
+						p.print((0, p.size.y.saturating_sub(i + 1)), span.content);
 						i += 1;
 					}
 				}


### PR DESCRIPTION
Resolves #3138

Q) What's actually causing this though?