### PR TITLE
Call zip_read() from within the txhashet lock for a consistent view on the files

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1370,6 +1370,12 @@ pub fn zip_read(root_dir: String, header: &BlockHeader) -> Result<File, Error> {
 	// if file exist, just re-use it
 	let zip_file = File::open(zip_path.clone());
 	if let Ok(zip) = zip_file {
+		debug!(
+			"zip_read: {} at {}: reusing existing zip file: {:?}",
+			header.hash(),
+			header.height,
+			zip_path
+		);
 		return Ok(zip);
 	} else {
 		// clean up old zips.
@@ -1409,6 +1415,13 @@ pub fn zip_read(root_dir: String, header: &BlockHeader) -> Result<File, Error> {
 
 		temp_txhashset_path
 	};
+
+	debug!(
+		"zip_read: {} at {}: created zip file: {:?}",
+		header.hash(),
+		header.height,
+		zip_path
+	);
 
 	// open it again to read it back
 	let zip_file = File::open(zip_path.clone())?;


### PR DESCRIPTION
We were taking a lock on the txhashet, rewinding and taking a snapshot (saving leafset to disk for specific header hash). Then _releasing_ the txhashet lock and the copying the files and building the zip.

I do not see exactly how this could cause a corrupt `txhashset.zip` but it does risk all kinds of weird edge cases where we sync the txhashset files to disk (say from another thread processing a new block) in the period between releasing the lock and creating the zip.

This PR moves the `txhashset::zip_read()` call to inside the txhashet lock.

Also added some logging to get an idea of when we create new zip files and when we reuse a previously created zip file.

