### PR TITLE
height (header version) specific output PMMR root rules

### DIFF
--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -47,7 +47,10 @@ pub struct TxHashSetHandler {
 impl TxHashSetHandler {
 	// gets roots
 	fn get_roots(&self) -> Result<TxHashSet, Error> {
-		Ok(TxHashSet::from_head(w(&self.chain)?))
+		let res = TxHashSet::from_head(w(&self.chain)?).context(ErrorKind::Internal(
+			"failed to read roots from txhashset".to_owned(),
+		))?;
+		Ok(res)
 	}
 
 	// gets last n outputs inserted in to the tree

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -116,13 +116,13 @@ pub struct TxHashSet {
 }
 
 impl TxHashSet {
-	pub fn from_head(head: Arc<chain::Chain>) -> TxHashSet {
-		let roots = head.get_txhashset_roots();
-		TxHashSet {
-			output_root_hash: roots.output_root().to_hex(),
+	pub fn from_head(chain: Arc<chain::Chain>) -> Result<TxHashSet, chain::Error> {
+		let (roots, header) = chain.get_txhashset_roots()?;
+		Ok(TxHashSet {
+			output_root_hash: roots.output_root(&header)?.to_hex(),
 			range_proof_root_hash: roots.rproof_root.to_hex(),
 			kernel_root_hash: roots.kernel_root.to_hex(),
-		}
+		})
 	}
 }
 

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -116,12 +116,15 @@ pub struct TxHashSet {
 }
 
 impl TxHashSet {
+	/// A TxHashSet in the context of the api is simply the collection of PMMR roots.
+	/// We can obtain these in a lightweight way by reading them from the head of the chain.
+	/// We will have validated the roots on this header against the roots of the txhashset.
 	pub fn from_head(chain: Arc<chain::Chain>) -> Result<TxHashSet, chain::Error> {
-		let (roots, header) = chain.get_txhashset_roots()?;
+		let header = chain.head_header()?;
 		Ok(TxHashSet {
-			output_root_hash: roots.output_root(&header)?.to_hex(),
-			range_proof_root_hash: roots.rproof_root.to_hex(),
-			kernel_root_hash: roots.kernel_root.to_hex(),
+			output_root_hash: header.output_root.to_hex(),
+			range_proof_root_hash: header.range_proof_root.to_hex(),
+			kernel_root_hash: header.kernel_root.to_hex(),
 		})
 	}
 }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,8 +30,7 @@ use crate::store;
 use crate::txhashset;
 use crate::txhashset::{PMMRHandle, TxHashSet};
 use crate::types::{
-	BlockStatus, ChainAdapter, NoStatus, Options, OutputMMRPosition, Tip, TxHashSetRoots,
-	TxHashsetWriteStatus,
+	BlockStatus, ChainAdapter, NoStatus, Options, OutputMMRPosition, Tip, TxHashsetWriteStatus,
 };
 use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::util::RwLock;
@@ -604,7 +603,7 @@ impl Chain {
 		b.header.prev_root = prev_root;
 
 		// Set the output, rangeproof and kernel MMR roots.
-		b.header.output_root = roots.output_root(&b.header)?;
+		b.header.output_root = roots.output_root(&b.header);
 		b.header.range_proof_root = roots.rproof_root;
 		b.header.kernel_root = roots.kernel_root;
 
@@ -634,12 +633,6 @@ impl Chain {
 	pub fn get_merkle_proof_for_pos(&self, commit: Commitment) -> Result<MerkleProof, Error> {
 		let mut txhashset = self.txhashset.write();
 		txhashset.merkle_proof(commit)
-	}
-
-	/// Returns current txhashset roots along with current head header.
-	pub fn get_txhashset_roots(&self) -> Result<(TxHashSetRoots, BlockHeader), Error> {
-		let txhashset = self.txhashset.read();
-		Ok((txhashset.roots(), self.head_header()?))
 	}
 
 	/// Provides a reading view into the current kernel state.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -312,10 +312,14 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 	// First I/O cost, delayed as late as possible.
 	let prev = prev_header_store(header, &mut ctx.batch)?;
 
-	// make sure this header has a height exactly one higher than the previous
-	// header
+	// This header height must increase the height from the previous header by exactly 1.
 	if header.height != prev.height + 1 {
 		return Err(ErrorKind::InvalidBlockHeight.into());
+	}
+
+	// This header must have a valid header version for its height.
+	if !consensus::valid_header_version(header.height, header.version) {
+		return Err(ErrorKind::InvalidBlockVersion(header.version).into());
 	}
 
 	if header.timestamp <= prev.timestamp {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -238,7 +238,7 @@ impl OutputRoots {
 	pub fn root(&self, header: &BlockHeader) -> Result<Hash, Error> {
 		if !consensus::valid_header_version(header.height, header.version) {
 			Err(ErrorKind::InvalidBlockVersion(header.version).into())
-		} else if header.version < HeaderVersion::new(3) {
+		} else if header.version < HeaderVersion(3) {
 			Ok(self.output_root())
 		} else {
 			Ok(self.merged_root(header))

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -194,8 +194,8 @@ pub struct TxHashSetRoots {
 
 impl TxHashSetRoots {
 	/// Accessor for the output PMMR root (rules here are block height dependent).
-	/// We assume the header version is consistent with the block height and that this
-	/// has been validated elsewhere.
+	/// We assume the header version is consistent with the block height, validated
+	/// as part of pipe::validate_header().
 	pub fn output_root(&self, header: &BlockHeader) -> Hash {
 		self.output_roots.root(header)
 	}
@@ -236,8 +236,8 @@ pub struct OutputRoots {
 impl OutputRoots {
 	/// The root of our output PMMR. The rules here are block height specific.
 	/// We use the merged root here for header version 3 and later.
-	/// We assume the header version is consistent with the block height and that this
-	/// has been validated elsewhere.
+	/// We assume the header version is consistent with the block height, validated
+	/// as part of pipe::validate_header().
 	pub fn root(&self, header: &BlockHeader) -> Hash {
 		if header.version < HeaderVersion(3) {
 			self.output_root()

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -133,12 +133,16 @@ pub const FLOONET_FIRST_HARD_FORK: u64 = 185_040;
 /// Floonet second hard fork height, set to happen around 2019-12-19
 pub const FLOONET_SECOND_HARD_FORK: u64 = 298_080;
 
+pub const TESTING_FIRST_HARD_FORK: u64 = 3;
+pub const TESTING_SECOND_HARD_FORK: u64 = 6;
+
 /// Compute possible block version at a given height, implements
 /// 6 months interval scheduled hard forks for the first 2 years.
 pub fn header_version(height: u64) -> HeaderVersion {
 	let chain_type = global::CHAIN_TYPE.read().clone();
 	let hf_interval = (1 + height / HARD_FORK_INTERVAL) as u16;
 	match chain_type {
+		global::ChainTypes::Mainnet => HeaderVersion(hf_interval),
 		global::ChainTypes::Floonet => {
 			if height < FLOONET_FIRST_HARD_FORK {
 				(HeaderVersion(1))
@@ -149,9 +153,18 @@ pub fn header_version(height: u64) -> HeaderVersion {
 			} else {
 				HeaderVersion(hf_interval)
 			}
-		}
-		// everything else just like mainnet
-		_ => HeaderVersion(hf_interval),
+		},
+		global::ChainTypes::AutomatedTesting | global::ChainTypes::UserTesting => {
+			if height < TESTING_FIRST_HARD_FORK {
+				(HeaderVersion(1))
+			} else if height < TESTING_SECOND_HARD_FORK {
+				(HeaderVersion(2))
+			} else if height < 3 * HARD_FORK_INTERVAL {
+				(HeaderVersion(3))
+			} else {
+				HeaderVersion(hf_interval)
+			}
+		},
 	}
 }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -133,7 +133,10 @@ pub const FLOONET_FIRST_HARD_FORK: u64 = 185_040;
 /// Floonet second hard fork height, set to happen around 2019-12-19
 pub const FLOONET_SECOND_HARD_FORK: u64 = 298_080;
 
+/// AutomatedTesting and UserTesting first hard fork height.
 pub const TESTING_FIRST_HARD_FORK: u64 = 3;
+
+/// AutomatedTesting and UserTesting second hard fork height.
 pub const TESTING_SECOND_HARD_FORK: u64 = 6;
 
 /// Compute possible block version at a given height, implements
@@ -153,7 +156,7 @@ pub fn header_version(height: u64) -> HeaderVersion {
 			} else {
 				HeaderVersion(hf_interval)
 			}
-		},
+		}
 		global::ChainTypes::AutomatedTesting | global::ChainTypes::UserTesting => {
 			if height < TESTING_FIRST_HARD_FORK {
 				(HeaderVersion(1))
@@ -164,7 +167,7 @@ pub fn header_version(height: u64) -> HeaderVersion {
 			} else {
 				HeaderVersion(hf_interval)
 			}
-		},
+		}
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -176,7 +176,7 @@ impl Hashed for HeaderEntry {
 }
 
 /// Some type safety around header versioning.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize)]
 pub struct HeaderVersion(pub u16);
 
 impl From<HeaderVersion> for u16 {


### PR DESCRIPTION
This PR introduces the necessary consensus rule change to support "enable faster sync" https://github.com/mimblewimble/grin-rfcs/pull/29.

HF2 will change the meaning of the `output_root` field on block headers.
* Prior to HF2 the `output_root` is simply to root of the output PMMR.
* Post HF2 the `output_root` is a combined root of both the output PMMR and the associated "bitmap accumulator" representation of the PMMR `leafset`.

This PR introduces the following changes - 
* add block height aware `output_root` rules (base logic on validated header version)
* `pipe::validate_header()` now explicitly validates the header version for the given block height
  * this was implicit before (and not exercised at all in the tests or locally in `user_testing`)
* add testing specific fork heights for use in `user_testing` and `automated_testing` to exercise HF rules in tests
  * we now exercise HF1 at height 3 and HF2 at height 6 in tests and locally in `user_testing`

