### PR TITLE
explicit header version based on height rather than "incrementing" the version

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -185,13 +185,6 @@ impl Default for HeaderVersion {
 	}
 }
 
-// self-conscious increment function courtesy of Jasper
-impl HeaderVersion {
-	fn next(&self) -> Self {
-		Self(self.0 + 1)
-	}
-}
-
 impl HeaderVersion {
 	/// Constructor taking the provided version.
 	pub fn new(version: u16) -> HeaderVersion {
@@ -619,12 +612,9 @@ impl Block {
 			vec![],
 		)?;
 
+		// Determine the height and associated version for the new header.
 		let height = prev.height + 1;
-
-		let mut version = prev.version;
-		if !consensus::valid_header_version(height, version) {
-			version = version.next();
-		}
+		let version = consensus::header_version(height);
 
 		let now = Utc::now().timestamp();
 		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);


### PR DESCRIPTION
We can set the header version on the new header by using the new `consensus::header_version()` introduced in #3136. 

We do not need to "increment" the version. We now simply increment the height and determine the version based on the new height.

