### PR TITLE
cleanup HeaderVersion::default()

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -179,12 +179,6 @@ impl Hashed for HeaderEntry {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct HeaderVersion(pub u16);
 
-impl Default for HeaderVersion {
-	fn default() -> HeaderVersion {
-		HeaderVersion(1)
-	}
-}
-
 impl From<HeaderVersion> for u16 {
 	fn from(v: HeaderVersion) -> u16 {
 		v.0
@@ -239,7 +233,7 @@ impl DefaultHashable for BlockHeader {}
 impl Default for BlockHeader {
 	fn default() -> BlockHeader {
 		BlockHeader {
-			version: HeaderVersion::default(),
+			version: HeaderVersion::new(0),
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
 			prev_hash: ZERO_HASH,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -233,7 +233,7 @@ impl DefaultHashable for BlockHeader {}
 impl Default for BlockHeader {
 	fn default() -> BlockHeader {
 		BlockHeader {
-			version: HeaderVersion::new(0),
+			version: HeaderVersion::new(1),
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
 			prev_hash: ZERO_HASH,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -233,7 +233,7 @@ impl DefaultHashable for BlockHeader {}
 impl Default for BlockHeader {
 	fn default() -> BlockHeader {
 		BlockHeader {
-			version: HeaderVersion::new(1),
+			version: HeaderVersion(1),
 			height: 0,
 			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
 			prev_hash: ZERO_HASH,

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -211,7 +211,7 @@ fn serialize_deserialize_header_version() {
 	ser::serialize_default(&mut vec1, &1_u16).expect("serialization failed");
 
 	let mut vec2 = Vec::new();
-	ser::serialize_default(&mut vec2, &HeaderVersion::default()).expect("serialization failed");
+	ser::serialize_default(&mut vec2, &HeaderVersion(1)).expect("serialization failed");
 
 	// Check that a header_version serializes to a
 	// single u16 value with no extraneous bytes wrapping it.


### PR DESCRIPTION
HF2 changes removed our usage of a "default" header version (#3136).

The concept of a "default" header version is a little ambiguous as the valid version is dependent on block height. So this PR just makes it explicit everywhere and gets rid of the `Default` impl.

~We can now simply set the version to 0 on a default block, as we set it later to the required valid version when we set the height.~

Edit: We actually use the "default" header version when building the mainnet genesis hash on startup (same for floonet). So leaving this as `1` in the block header default constructor.

