### PR TITLE
cleanup HeaderVersion, "newtype" no need for constructor

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -141,17 +141,17 @@ pub fn header_version(height: u64) -> HeaderVersion {
 	match chain_type {
 		global::ChainTypes::Floonet => {
 			if height < FLOONET_FIRST_HARD_FORK {
-				(HeaderVersion::new(1))
+				(HeaderVersion(1))
 			} else if height < FLOONET_SECOND_HARD_FORK {
-				(HeaderVersion::new(2))
+				(HeaderVersion(2))
 			} else if height < 3 * HARD_FORK_INTERVAL {
-				(HeaderVersion::new(3))
+				(HeaderVersion(3))
 			} else {
-				HeaderVersion::new(hf_interval)
+				HeaderVersion(hf_interval)
 			}
 		}
 		// everything else just like mainnet
-		_ => HeaderVersion::new(hf_interval),
+		_ => HeaderVersion(hf_interval),
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -185,13 +185,6 @@ impl Default for HeaderVersion {
 	}
 }
 
-impl HeaderVersion {
-	/// Constructor taking the provided version.
-	pub fn new(version: u16) -> HeaderVersion {
-		HeaderVersion(version)
-	}
-}
-
 impl From<HeaderVersion> for u16 {
 	fn from(v: HeaderVersion) -> u16 {
 		v.0

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -176,20 +176,20 @@ where
 	match chain_type {
 		// Mainnet has Cuckaroo(d)29 for AR and Cuckatoo31+ for AF
 		ChainTypes::Mainnet if edge_bits > 29 => new_cuckatoo_ctx(edge_bits, proof_size, max_sols),
-		ChainTypes::Mainnet if valid_header_version(height, HeaderVersion::new(3)) => {
+		ChainTypes::Mainnet if valid_header_version(height, HeaderVersion(3)) => {
 			new_cuckaroom_ctx(edge_bits, proof_size)
 		}
-		ChainTypes::Mainnet if valid_header_version(height, HeaderVersion::new(2)) => {
+		ChainTypes::Mainnet if valid_header_version(height, HeaderVersion(2)) => {
 			new_cuckarood_ctx(edge_bits, proof_size)
 		}
 		ChainTypes::Mainnet => new_cuckaroo_ctx(edge_bits, proof_size),
 
 		// Same for Floonet
 		ChainTypes::Floonet if edge_bits > 29 => new_cuckatoo_ctx(edge_bits, proof_size, max_sols),
-		ChainTypes::Floonet if valid_header_version(height, HeaderVersion::new(3)) => {
+		ChainTypes::Floonet if valid_header_version(height, HeaderVersion(3)) => {
 			new_cuckaroom_ctx(edge_bits, proof_size)
 		}
-		ChainTypes::Floonet if valid_header_version(height, HeaderVersion::new(2)) => {
+		ChainTypes::Floonet if valid_header_version(height, HeaderVersion(2)) => {
 			new_cuckarood_ctx(edge_bits, proof_size)
 		}
 		ChainTypes::Floonet => new_cuckaroo_ctx(edge_bits, proof_size),

--- a/core/tests/consensus.rs
+++ b/core/tests/consensus.rs
@@ -623,134 +623,89 @@ fn hard_forks() {
 	{
 		global::set_mining_mode(global::ChainTypes::Mainnet);
 		assert_eq!(global::is_floonet(), false);
-		assert!(valid_header_version(0, HeaderVersion::new(1)));
-		assert!(valid_header_version(10, HeaderVersion::new(1)));
-		assert!(!valid_header_version(10, HeaderVersion::new(2)));
-		assert!(valid_header_version(
-			YEAR_HEIGHT / 2 - 1,
-			HeaderVersion::new(1)
-		));
-		assert!(valid_header_version(YEAR_HEIGHT / 2, HeaderVersion::new(2)));
-		assert!(valid_header_version(
-			YEAR_HEIGHT / 2 + 1,
-			HeaderVersion::new(2)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT / 2,
-			HeaderVersion::new(1)
-		));
-		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion::new(1)));
+		assert!(valid_header_version(0, HeaderVersion(1)));
+		assert!(valid_header_version(10, HeaderVersion(1)));
+		assert!(!valid_header_version(10, HeaderVersion(2)));
+		assert!(valid_header_version(YEAR_HEIGHT / 2 - 1, HeaderVersion(1)));
+		assert!(valid_header_version(YEAR_HEIGHT / 2, HeaderVersion(2)));
+		assert!(valid_header_version(YEAR_HEIGHT / 2 + 1, HeaderVersion(2)));
+		assert!(!valid_header_version(YEAR_HEIGHT / 2, HeaderVersion(1)));
+		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion(1)));
 
-		assert!(valid_header_version(YEAR_HEIGHT - 1, HeaderVersion::new(2)));
-		assert!(valid_header_version(YEAR_HEIGHT, HeaderVersion::new(3)));
-		assert!(valid_header_version(YEAR_HEIGHT + 1, HeaderVersion::new(3)));
-		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion::new(2)));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(2)
-		));
+		assert!(valid_header_version(YEAR_HEIGHT - 1, HeaderVersion(2)));
+		assert!(valid_header_version(YEAR_HEIGHT, HeaderVersion(3)));
+		assert!(valid_header_version(YEAR_HEIGHT + 1, HeaderVersion(3)));
+		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion(2)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(2)));
 		// v4 not active yet
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(4)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(3)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(2)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(1)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 2,
-			HeaderVersion::new(3)
-		));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(4)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(3)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(2)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(1)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 2, HeaderVersion(3)));
 		assert!(!valid_header_version(
 			YEAR_HEIGHT * 3 / 2 + 1,
-			HeaderVersion::new(3)
+			HeaderVersion(3)
 		));
 	}
 	// Tests for floonet chain type.
 	{
 		global::set_mining_mode(global::ChainTypes::Floonet);
 		assert_eq!(global::is_floonet(), true);
-		assert!(valid_header_version(0, HeaderVersion::new(1)));
-		assert!(valid_header_version(10, HeaderVersion::new(1)));
-		assert!(!valid_header_version(10, HeaderVersion::new(2)));
+		assert!(valid_header_version(0, HeaderVersion(1)));
+		assert!(valid_header_version(10, HeaderVersion(1)));
+		assert!(!valid_header_version(10, HeaderVersion(2)));
 		assert!(valid_header_version(
 			FLOONET_FIRST_HARD_FORK - 1,
-			HeaderVersion::new(1)
+			HeaderVersion(1)
 		));
 		assert!(valid_header_version(
 			FLOONET_FIRST_HARD_FORK,
-			HeaderVersion::new(2)
+			HeaderVersion(2)
 		));
 		assert!(valid_header_version(
 			FLOONET_FIRST_HARD_FORK + 1,
-			HeaderVersion::new(2)
+			HeaderVersion(2)
 		));
 		assert!(!valid_header_version(
 			FLOONET_FIRST_HARD_FORK,
-			HeaderVersion::new(1)
+			HeaderVersion(1)
 		));
-		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion::new(1)));
+		assert!(!valid_header_version(YEAR_HEIGHT, HeaderVersion(1)));
 		assert!(valid_header_version(
 			FLOONET_SECOND_HARD_FORK - 1,
-			HeaderVersion::new(2)
+			HeaderVersion(2)
 		));
 		assert!(valid_header_version(
 			FLOONET_SECOND_HARD_FORK,
-			HeaderVersion::new(3)
+			HeaderVersion(3)
 		));
 		assert!(valid_header_version(
 			FLOONET_SECOND_HARD_FORK + 1,
-			HeaderVersion::new(3)
+			HeaderVersion(3)
 		));
 		assert!(!valid_header_version(
 			FLOONET_SECOND_HARD_FORK,
-			HeaderVersion::new(2)
+			HeaderVersion(2)
 		));
 		assert!(!valid_header_version(
 			FLOONET_SECOND_HARD_FORK,
-			HeaderVersion::new(1)
+			HeaderVersion(1)
 		));
 
-		assert!(!valid_header_version(
-			YEAR_HEIGHT - 1,
-			HeaderVersion::new(2)
-		));
-		assert!(valid_header_version(YEAR_HEIGHT - 1, HeaderVersion::new(3)));
-		assert!(valid_header_version(YEAR_HEIGHT, HeaderVersion::new(3)));
-		assert!(valid_header_version(YEAR_HEIGHT + 1, HeaderVersion::new(3)));
+		assert!(!valid_header_version(YEAR_HEIGHT - 1, HeaderVersion(2)));
+		assert!(valid_header_version(YEAR_HEIGHT - 1, HeaderVersion(3)));
+		assert!(valid_header_version(YEAR_HEIGHT, HeaderVersion(3)));
+		assert!(valid_header_version(YEAR_HEIGHT + 1, HeaderVersion(3)));
 		// v4 not active yet
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(4)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(3)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(2)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 3 / 2,
-			HeaderVersion::new(1)
-		));
-		assert!(!valid_header_version(
-			YEAR_HEIGHT * 2,
-			HeaderVersion::new(3)
-		));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(4)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(3)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(2)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 3 / 2, HeaderVersion(1)));
+		assert!(!valid_header_version(YEAR_HEIGHT * 2, HeaderVersion(3)));
 		assert!(!valid_header_version(
 			YEAR_HEIGHT * 3 / 2 + 1,
-			HeaderVersion::new(3)
+			HeaderVersion(3)
 		));
 	}
 }


### PR DESCRIPTION
`HeaderVersion` follows the "newtype" pattern and wraps single field.

We don't need a constructor and can create these directly, which removes a bunch of line noise.

So instead of `HeaderVersion::new(3)` will can simply do `HeaderVersion(3)`.

