### PR TITLE
[DNM] do not retry the txhashset msg send (do not retry any msg with an attachment)

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -139,6 +139,14 @@ impl Msg {
 		})
 	}
 
+	// Is it safe to retry sending this message?
+	// We do not want to retry sending a message if it includes an attachment.
+	// We may encounter an exception part way through sending the (potentially large) attachment.
+	// We do not want to retry in this case, we simply want to close the connection.
+	pub fn can_retry_send(&self) -> bool {
+		self.attachment.is_none()
+	}
+
 	pub fn add_attachment(&mut self, attachment: File) {
 		self.attachment = Some(attachment)
 	}


### PR DESCRIPTION
Related #3145.

The existing `retry_send` logic retries any msg send if `try_break!` returns `None`.
`try_break!` does some funky stuff internally squashing some exceptions but letting others propagate. `WouldBlock` and `TimedOut` are both squashed, returning `None`. 
So any msg send that times out will be retried.

This is fine for most (small) self-contained msgs but is definitely not fine for msgs that contain an attachment. For attachments we write repeatedly in a tight loop and any iteration of this loop could experience a timeout.
In situations like this we want to fail fast and not attempt to retry the msg send.

The receiver may have received a partial txhashset zip file and the _only_ thing we can do here is to close the connection to signal to the recipient that we cannot reliably send the remaining bytes of the zip file.

Do not merge yet - needs discussing. 
#3145 should be merged first.

----

We may want to rethink how we implement `write_message` to make sending the attachment more robust. But even if we do we still want to prevent msgs with attachments from being retried at the full msg level.

