### PR TITLE
our TCP listener is nonblocking so we *must* set the accepted stream to blocking explicitly

### DIFF
--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -84,6 +84,14 @@ impl Server {
 
 			match listener.accept() {
 				Ok((stream, peer_addr)) => {
+					// We want out TCP stream to be in blocking mode.
+					// The TCP listener is in nonblocking mode so we *must* explicitly
+					// move the accepted TCP stream into blocking mode (or all kinds of
+					// bad things can and will happen).
+					// A nonblocking TCP listener will accept nonblocking TCP streams which
+					// we do not want.
+					stream.set_nonblocking(false)?;
+
 					let peer_addr = PeerAddr(peer_addr);
 
 					if self.check_undesirable(&stream) {


### PR DESCRIPTION
A nonblocking TCP listener will accept nonblocking TCP streams by default.
This is __very surprising__ to put it mildly.

We were creating nonblocking streams when accepting inbound connections from peers, but creating blocking streams when connecting to outbound peers.
Which made this problem _really_ hard to debug and _really_ hard to track down.

You can see this if you add debug logging in try_break! when matching on `WouldBlock`. On _some_ connections we were seeing these scroll by at a rapid rate, but not all connections. 
It turns out it was only on inbound connections. 

So you can only reproduce the issue on a public node, or locally with a couple of nodes on localhost.

This probably explains all kinds of weird connection related problems.

One example: if we request a txhashset from a public node and we are an _inbound_ connection from the perspective of that node then the nonblocking stream is going to prevent that node from reliably sending the full txhashset attachment back un-corrupted.

