### PR TITLE
Rename API V1 push_tx -> push

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -114,7 +114,7 @@ pub fn build_router(
 		"get txhashset/outputs?start_index=1&max=100".to_string(),
 		"get txhashset/merkleproof?n=1".to_string(),
 		"get pool".to_string(),
-		"post pool/push_tx".to_string(),
+		"post pool/push".to_string(),
 		"post peers/a.b.c.d:p/ban".to_string(),
 		"post peers/a.b.c.d:p/unban".to_string(),
 		"get peers/all".to_string(),
@@ -189,7 +189,7 @@ pub fn build_router(
 	router.add_route("/v1/status", Arc::new(status_handler))?;
 	router.add_route("/v1/kerneldownload", Arc::new(kernel_download_handler))?;
 	router.add_route("/v1/pool", Arc::new(pool_info_handler))?;
-	router.add_route("/v1/pool/push_tx", Arc::new(pool_push_handler))?;
+	router.add_route("/v1/pool/push", Arc::new(pool_push_handler))?;
 	router.add_route("/v1/peers/all", Arc::new(peers_all_handler))?;
 	router.add_route("/v1/peers/connected", Arc::new(peers_connected_handler))?;
 	router.add_route("/v1/peers/**", Arc::new(peer_handler))?;

--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -53,7 +53,7 @@ struct TxWrapper {
 }
 
 /// Push new transaction to our local transaction pool.
-/// POST /v1/pool/push_tx
+/// POST /v1/pool/push
 pub struct PoolPushHandler {
 	pub tx_pool: Weak<RwLock<pool::TransactionPool>>,
 }


### PR DESCRIPTION
Basically, the reverse of this:

https://github.com/mimblewimble/grin/pull/2897

For a quick reminder, this will ensure that 2.x.x wallets won't be able to operate against a 3.0.0 node, forcing everyone to upgrade the wallet as well as the node.

Hopefully this should be taken care of already in HF3 if the v1 api is removed and the 4.0 code uses the V2 node API exclusively.