### PR TITLE
Deadlock possible in check_orphans() called from txhashset_write()

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -441,7 +441,7 @@ impl Chain {
 	}
 
 	/// Check for orphans, once a block is successfully added
-	pub fn check_orphans(&self, mut height: u64) {
+	fn check_orphans(&self, mut height: u64) {
 		let initial_height = height;
 
 		// Is there an orphan in our orphans that we can now process?
@@ -998,9 +998,6 @@ impl Chain {
 		}
 
 		debug!("txhashset_write: replaced our txhashset with the new one");
-
-		// Check for any orphan blocks and process them based on the new chain state.
-		self.check_orphans(header.height + 1);
 
 		status.on_done();
 


### PR DESCRIPTION
Resolves #3130.

`txhashset_write()` takes a write lock on the `header_pmmr` and does not release this until the fn returns.

If we call `check_orphans()` and we have orphans to process then we proceed to attempt to take a subsequent write lock on the `header_pmmr` internally in the call to `process_block_single()` which deadlocks.

Taking a step back from this - it does not really make any sense to try processing "orphans" immediately after writing the new txhashset. The txhashset is full state as of 48 hours ago. We still to process 48 hours of recent full blocks before we even need to start thinking about recent orphans.

So lets just remove the call to `check_orphans()` from `txhashset_write`. And just let the full block sync catch up as necessary.

