### PR TITLE
fix(TUI): Fixed panic when changing order of items in TableView

### DIFF
--- a/src/bin/tui/table.rs
+++ b/src/bin/tui/table.rs
@@ -492,7 +492,7 @@ impl<T: TableViewItem<H>, H: Eq + Hash + Copy + Clone + 'static> TableView<T, H>
 	/// Returns the index of the currently selected item within the underlying
 	/// storage vector.
 	pub fn item(&self) -> Option<usize> {
-		if self.items.is_empty() {
+		if self.items.is_empty() || self.focus > self.rows_to_items.len() {
 			None
 		} else {
 			Some(self.rows_to_items[self.focus])
@@ -604,7 +604,7 @@ impl<T: TableViewItem<H>, H: Eq + Hash + Copy + Clone + 'static> TableView<T, H>
 
 	fn sort_items(&mut self, column: H, order: Ordering) {
 		if !self.is_empty() {
-			let old_item = self.item().unwrap();
+			let old_item = self.item();
 
 			let mut rows_to_items = self.rows_to_items.clone();
 			rows_to_items.sort_by(|a, b| {
@@ -616,7 +616,7 @@ impl<T: TableViewItem<H>, H: Eq + Hash + Copy + Clone + 'static> TableView<T, H>
 			});
 			self.rows_to_items = rows_to_items;
 
-			self.set_selected_item(old_item);
+			old_item.map(|o| self.set_selected_item(o));
 		}
 	}
 


### PR DESCRIPTION
This is awkward to reproduce but can be done reliably if you get the timing right.
- Remove peers database (rm -r .grin/main/chain_data/peer/), just to force us to go looking for more.
- Select Peers tab in TUI and order peers by Address.
- Whenever the list of peers updates reorder again straight away, so the row with focus should always be at the bottom of the list.
- At some point the number of peers will go to a large number then back to 8 (if you have the default desired peers). It's at this point the panic occurs, because the focus might be on peer 15 but the new list only has 8 peers.

thread 'main' panicked at 'index out of bounds: the len is 8 but the index is 14': 
...
   6: grin::tui::table::TableView<T,H>::sort_by::haee3b0fe6388d824 (0x55986b9dd817)
   7: grin::tui::table::TableView<T,H>::set_items::h6712930b43f95168 (0x55986b9de079)

Have changed it so that sort function does not try to set_selected_item if it is outside the range of the new peers list and the panic no longer occurs.