### PR TITLE
fix(TUI): selected column and row of table are now preserved during update

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -193,6 +193,24 @@ pub struct PeerStats {
 	pub received_bytes_per_sec: u64,
 }
 
+impl PartialEq for PeerStats {
+	fn eq(&self, other: &PeerStats) -> bool {
+		*self.addr == other.addr
+	}
+}
+
+impl PartialEq for WorkerStats {
+	fn eq(&self, other: &WorkerStats) -> bool {
+		*self.id == other.id
+	}
+}
+
+impl PartialEq for DiffBlock {
+	fn eq(&self, other: &DiffBlock) -> bool {
+		self.block_height == other.block_height
+	}
+}
+
 impl StratumStats {
 	/// Calculate network hashrate
 	pub fn network_hashrate(&self, height: u64) -> f64 {

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -33,7 +33,7 @@ use crate::tui::table::{TableView, TableViewItem};
 use crate::tui::types::TUIStatusListener;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-enum PeerColumn {
+pub enum PeerColumn {
 	Address,
 	State,
 	UsedBandwidth,


### PR DESCRIPTION
Currently if you move around a TUI table (e.g. peers) with the arrow keys your selection is reset every time the table is updated with a call to set_items(). This change is to preserve the selected row and column which should make is easier to monitor a selected peer for example.