### PR TITLE
drop msg if sync_sender buffer is full (do not close peer connection)

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -18,8 +18,6 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::path::PathBuf;
-
-use std::sync::mpsc;
 use std::sync::Arc;
 
 use chrono::prelude::*;
@@ -104,11 +102,6 @@ impl From<chain::Error> for Error {
 impl From<io::Error> for Error {
 	fn from(e: io::Error) -> Error {
 		Error::Connection(e)
-	}
-}
-impl<T> From<mpsc::TrySendError<T>> for Error {
-	fn from(e: mpsc::TrySendError<T>) -> Error {
-		Error::Send(e.to_string())
 	}
 }
 


### PR DESCRIPTION
Resolves #3162.

We do not necessarily want to treat a "sending on a full channel" as an error serious enough to warrant closing the peer connection.
There are various scenarios where the `sync_sender` buffer can fill up with "yet to be sent" msgs. One example is during a long running txhashset download.

This PR splits out the error handling during `try_send`. A `Disconnected` will propagate up and cause the caller to close the peer connection. A `Full` will simply cause us to drop the msg and continue.

The assumption here is that if the buffer filling up is a symptom of a more serious issue with the peer connection this will be handled at the peer level, closing the connection as necessary. It is not the responsibility of the msg queue to identify and handle this.


