### PR TITLE
fix: panic in TUI table selected item. focus is zero indexed

### DIFF
--- a/src/bin/tui/table.rs
+++ b/src/bin/tui/table.rs
@@ -502,7 +502,7 @@ impl<T: TableViewItem<H> + PartialEq, H: Eq + Hash + Copy + Clone + 'static> Tab
 	/// Returns the index of the currently selected item within the underlying
 	/// storage vector.
 	pub fn item(&self) -> Option<usize> {
-		if self.items.is_empty() || self.focus > self.rows_to_items.len() {
+		if self.items.is_empty() || self.focus >= self.rows_to_items.len() {
 			None
 		} else {
 			Some(self.rows_to_items[self.focus])


### PR DESCRIPTION
Additional fix for #3160 
Focus is zero indexed so should not be equal to the length of rows.