### PR TITLE
Fix compiler warning 'unnecessary parentheses around type'

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1008,7 +1008,7 @@ impl<'a> Extension<'a> {
 		}
 	}
 
-	fn apply_output(&mut self, out: &Output) -> Result<(u64), Error> {
+	fn apply_output(&mut self, out: &Output) -> Result<u64, Error> {
 		let commit = out.commitment();
 
 		if let Ok(pos) = self.batch.get_output_pos(&commit) {
@@ -1229,7 +1229,7 @@ impl<'a> Extension<'a> {
 	pub fn validate_kernel_sums(
 		&self,
 		genesis: &BlockHeader,
-	) -> Result<((Commitment, Commitment)), Error> {
+	) -> Result<(Commitment, Commitment), Error> {
 		let now = Instant::now();
 
 		let head_header = self.batch.get_block_header(&self.head.last_block_h)?;
@@ -1253,7 +1253,7 @@ impl<'a> Extension<'a> {
 		genesis: &BlockHeader,
 		fast_validation: bool,
 		status: &dyn TxHashsetWriteStatus,
-	) -> Result<((Commitment, Commitment)), Error> {
+	) -> Result<(Commitment, Commitment), Error> {
 		self.validate_mmrs()?;
 		self.validate_roots()?;
 		self.validate_sizes()?;

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -124,7 +124,7 @@ pub trait Committed {
 		&self,
 		overage: i64,
 		kernel_offset: BlindingFactor,
-	) -> Result<((Commitment, Commitment)), Error> {
+	) -> Result<(Commitment, Commitment), Error> {
 		// Sum all input|output|overage commitments.
 		let utxo_sum = self.sum_commitments(overage)?;
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -110,7 +110,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Get the hash at pos.
 	/// Return None if pos is a leaf and it has been removed (or pruned or
 	/// compacted).
-	fn get_hash(&self, pos: u64) -> Option<(Hash)> {
+	fn get_hash(&self, pos: u64) -> Option<Hash> {
 		if self.prunable && pmmr::is_leaf(pos) && !self.leaf_set.includes(pos) {
 			return None;
 		}
@@ -119,7 +119,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	/// Get the data at pos.
 	/// Return None if it has been removed or if pos is not a leaf node.
-	fn get_data(&self, pos: u64) -> Option<(T::E)> {
+	fn get_data(&self, pos: u64) -> Option<T::E> {
 		if !pmmr::is_leaf(pos) {
 			return None;
 		}


### PR DESCRIPTION
Probably related to Rust 1.40.0.
Remove unnecessary parentheses such as:
```
warning: unnecessary parentheses around type
   --> store/src/pmmr.rs:113:41
    |
113 |     fn get_hash(&self, pos: u64) -> Option<(Hash)> {
    |                                            ^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default
```