### PR TITLE
TUI peer sort order

### DIFF
--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -103,14 +103,33 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			curr_sum.cmp(&other_sum)
 		};
 
+		fn cmp_order_alternative(order: Ordering, curr: &PeerStats, other: &PeerStats) -> Ordering {
+			if order == Ordering::Equal {
+				return curr.addr.cmp(&other.addr);
+			}
+			order
+		}
+
 		match column {
 			PeerColumn::Address => self.addr.cmp(&other.addr),
-			PeerColumn::State => self.state.cmp(&other.state),
-			PeerColumn::UsedBandwidth => cmp_used_bandwidth(&self, &other),
-			PeerColumn::TotalDifficulty => self.total_difficulty.cmp(&other.total_difficulty),
-			PeerColumn::Direction => self.direction.cmp(&other.direction),
-			PeerColumn::Version => self.version.cmp(&other.version),
-			PeerColumn::UserAgent => self.user_agent.cmp(&other.user_agent),
+			PeerColumn::State => cmp_order_alternative(self.state.cmp(&other.state), &self, &other),
+			PeerColumn::UsedBandwidth => {
+				cmp_order_alternative(cmp_used_bandwidth(&self, &other), &self, &other)
+			}
+			PeerColumn::TotalDifficulty => cmp_order_alternative(
+				self.total_difficulty.cmp(&other.total_difficulty),
+				&self,
+				&other,
+			),
+			PeerColumn::Direction => {
+				cmp_order_alternative(self.direction.cmp(&other.direction), &self, &other)
+			}
+			PeerColumn::Version => {
+				cmp_order_alternative(self.version.cmp(&other.version), &self, &other)
+			}
+			PeerColumn::UserAgent => {
+				cmp_order_alternative(self.user_agent.cmp(&other.user_agent), &self, &other)
+			}
 		}
 	}
 }

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -103,33 +103,19 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			curr_sum.cmp(&other_sum)
 		};
 
-		fn cmp_order_alternative(order: Ordering, curr: &PeerStats, other: &PeerStats) -> Ordering {
-			if order == Ordering::Equal {
-				return curr.addr.cmp(&other.addr);
-			}
-			order
-		}
+		let sort_by_addr = || self.addr.cmp(&other.addr);
 
 		match column {
-			PeerColumn::Address => self.addr.cmp(&other.addr),
-			PeerColumn::State => cmp_order_alternative(self.state.cmp(&other.state), &self, &other),
-			PeerColumn::UsedBandwidth => {
-				cmp_order_alternative(cmp_used_bandwidth(&self, &other), &self, &other)
-			}
-			PeerColumn::TotalDifficulty => cmp_order_alternative(
-				self.total_difficulty.cmp(&other.total_difficulty),
-				&self,
-				&other,
-			),
-			PeerColumn::Direction => {
-				cmp_order_alternative(self.direction.cmp(&other.direction), &self, &other)
-			}
-			PeerColumn::Version => {
-				cmp_order_alternative(self.version.cmp(&other.version), &self, &other)
-			}
-			PeerColumn::UserAgent => {
-				cmp_order_alternative(self.user_agent.cmp(&other.user_agent), &self, &other)
-			}
+			PeerColumn::Address => sort_by_addr(),
+			PeerColumn::State => self.state.cmp(&other.state).then(sort_by_addr()),
+			PeerColumn::UsedBandwidth => cmp_used_bandwidth(&self, &other).then(sort_by_addr()),
+			PeerColumn::TotalDifficulty => self
+				.total_difficulty
+				.cmp(&other.total_difficulty)
+				.then(sort_by_addr()),
+			PeerColumn::Direction => self.direction.cmp(&other.direction).then(sort_by_addr()),
+			PeerColumn::Version => self.version.cmp(&other.version).then(sort_by_addr()),
+			PeerColumn::UserAgent => self.user_agent.cmp(&other.user_agent).then(sort_by_addr()),
 		}
 	}
 }


### PR DESCRIPTION
Potential fix for: https://github.com/mimblewimble/grin/issues/3182

When TUI peers are sorted by a specific column the results are not consistent and change on each refresh. This PR introduces a fallback using the address column whenever specific cmp values are equal.  

I tested this on floonet terminal and the peers display consistently.  I am new to rust so any feedback is welcome. 
