### PR TITLE
Fix return code in peers API

### DIFF
--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -157,9 +157,7 @@ impl Handler for PeerHandler {
 					format!("unban failed: {:?}", e),
 				),
 			},
-			_ => return response(StatusCode::BAD_REQUEST, "invalid command"),
-		};
-
-		response(StatusCode::OK, "{}")
+			_ => response(StatusCode::BAD_REQUEST, "invalid command"),
+		}
 	}
 }


### PR DESCRIPTION
Rust compiler found this issue, we were preparing a response and the dropping it and returning a default one
