### PR TITLE
explicit str, rustc 1.34.0 doesn't seem to pick this up otherwise

### DIFF
--- a/src/bin/tui/logs.rs
+++ b/src/bin/tui/logs.rs
@@ -89,7 +89,7 @@ impl View for LogBufferView {
 		let mut i = 0;
 		for entry in self.buffer.iter().take(printer.size.y) {
 			printer.with_color(LogBufferView::color(entry.level), |p| {
-				let log_message = StyledString::plain(&entry.log);
+				let log_message = StyledString::plain(entry.log.as_str());
 				let mut rows: Vec<Row> = LinesIterator::new(&log_message, printer.size.x).collect();
 				rows.reverse(); // So stack traces are in the right order.
 				for row in rows {


### PR DESCRIPTION
Potential fix for issue reference: https://github.com/mimblewimble/grin/issues/3190

As outlined by user in the issue I was unable to build new TUI logger code in older versions of rust (ie. 1.34.0), rustc does not seem to be able to properly convert the entry.log String variable referenced. 

```
   Compiling grin v3.1.0-beta.1 (/home/cadwgan/grin_dev/grin)
error[E0277]: the trait bound `std::string::String: std::convert::From<&std::string::String>` is not satisfied
  --> src/bin/tui/logs.rs:92:23
   |
92 |                 let log_message = StyledString::plain(&entry.log as &String);
   |                                   ^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&std::string::String>` is not implemented for `std::string::String`
   |
   = help: the following implementations were found:
             <std::string::String as std::convert::From<&'a str>>
             <std::string::String as std::convert::From<std::borrow::Cow<'a, str>>>
             <std::string::String as std::convert::From<std::boxed::Box<str>>>
   = note: required because of the requirements on the impl of `std::convert::Into<std::string::String>` for `&std::string::String`
   = note: required by `cursive::utils::markup::<impl cursive::utils::span::SpannedString<cursive::theme::style::Style>>::plain`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `grin`.
```

After casting with as_str(), I built the code in both 1.34.0 and 1.37.0.  Tried node out on floonet and the log panel is outputting node logs. 

```
Compiling grin v3.1.0-beta.1 (/home/cadwgan/grin_dev/grin)
    Finished dev [unoptimized + debuginfo] target(s) in 9.27s
```
