### PR TITLE
Fixed issues with fuzz in core.

### DIFF
--- a/core/fuzz/Cargo.lock
+++ b/core/fuzz/Cargo.lock
@@ -365,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin_core"
-version = "3.0.0-alpha.1"
+version = "3.1.0-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -374,8 +374,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.0.0-alpha.1",
- "grin_util 3.0.0-alpha.1",
+ "grin_keychain 3.1.0-beta.1",
+ "grin_util 3.1.0-beta.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -385,7 +385,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -393,19 +392,19 @@ dependencies = [
 name = "grin_core-fuzz"
 version = "0.0.3"
 dependencies = [
- "grin_core 3.0.0-alpha.1",
- "grin_keychain 3.0.0-alpha.1",
+ "grin_core 3.1.0-beta.1",
+ "grin_keychain 3.1.0-beta.1",
  "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
 ]
 
 [[package]]
 name = "grin_keychain"
-version = "3.0.0-alpha.1"
+version = "3.1.0-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.0.0-alpha.1",
+ "grin_util 3.1.0-beta.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -416,7 +415,6 @@ dependencies = [
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -437,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "3.0.0-alpha.1"
+version = "3.1.0-beta.1"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -796,18 +794,6 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1224,16 +1210,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "uuid"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,7 +1394,6 @@ dependencies = [
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -1471,7 +1446,6 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/main.rs"
 
 [[bin]]
 name = "block_read_v1"
-path = "fuzz_targets/block_read_v2.rs"
+path = "fuzz_targets/block_read_v1.rs"
 
 [[bin]]
 name = "block_read_v2"

--- a/core/fuzz/src/main.rs
+++ b/core/fuzz/src/main.rs
@@ -7,12 +7,39 @@ use std::fs::{self, File};
 use std::path::Path;
 
 fn main() {
-	generate("transaction_read", Transaction::default()).unwrap();
-	generate("block_read", Block::default()).unwrap();
-	generate("compact_block_read", CompactBlock::from(Block::default())).unwrap();
+	generate(
+		"transaction_read_v1",
+		ser::ProtocolVersion(1),
+		Transaction::default(),
+	)
+	.unwrap();
+	generate("block_read_v1", ser::ProtocolVersion(1), Block::default()).unwrap();
+	generate(
+		"compact_block_read_v1",
+		ser::ProtocolVersion(1),
+		CompactBlock::from(Block::default()),
+	)
+	.unwrap();
+	generate(
+		"transaction_read_v2",
+		ser::ProtocolVersion(2),
+		Transaction::default(),
+	)
+	.unwrap();
+	generate("block_read_v2", ser::ProtocolVersion(2), Block::default()).unwrap();
+	generate(
+		"compact_block_read_v2",
+		ser::ProtocolVersion(2),
+		CompactBlock::from(Block::default()),
+	)
+	.unwrap();
 }
 
-fn generate<W: ser::Writeable>(target: &str, obj: W) -> Result<(), ser::Error> {
+fn generate<W: ser::Writeable>(
+	target: &str,
+	version: ser::ProtocolVersion,
+	obj: W,
+) -> Result<(), ser::Error> {
 	let dir_path = Path::new("corpus").join(target);
 	if !dir_path.is_dir() {
 		fs::create_dir_all(&dir_path).map_err(|e| {
@@ -25,7 +52,7 @@ fn generate<W: ser::Writeable>(target: &str, obj: W) -> Result<(), ser::Error> {
 	if !pattern_path.exists() {
 		let mut file = File::create(&pattern_path)
 			.map_err(|e| ser::Error::IOErr("can't create a pattern file".to_owned(), e.kind()))?;
-		ser::serialize(&mut file, &obj)
+		ser::serialize(&mut file, version, &obj)
 	} else {
 		Ok(())
 	}


### PR DESCRIPTION
---
name: Fixed issues with fuzz in core.
about: Cargo fuzz returned an error and a warning. 

---

**Overview**
Using instructions at [ grin/core/fuzz/README.md](https://github.com/mimblewimble/grin/blob/8568c77d6eeb120492406b31af6d11dcefc5a25d/core/fuzz/README.md), <cargo run --bin  gen-corpus> returned an error and a warning.

**The error**
The error related to including ser::ProtocolVersion in calls to ser::serialize. 

<error[E0061]: this function takes 3 parameters but 2 parameters were supplied

  --> src/main.rs:28:3
   |
28 |         ser::serialize(&mut file, &obj)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
error: could not compile `grin_core-fuzz`.

To learn more, run the command again with --verbose.>

**The error: solution**
I added ser::ProtocolVersion where needed including appropriate protocol version numbers.

**The warning**
The warning related to block_read_v2 showing up twice in Cargo.toml:

<warning: /home/android/Documents/grin/core/fuzz/Cargo.toml: file found to be present in multiple build targets: /home/android/Documents/grin/core/fuzz/fuzz_targets/block_read_v2.rs>

**The warning: solution**
I simply corrected the version number in the block_read_v1 bin section.

**Testing**
<cargo test --all> came back clean for me.

