### PR TITLE
Bug fix for highest_index in output API.

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -298,7 +298,7 @@ impl TxHashSet {
 
 	/// highest output insertion index available
 	pub fn highest_output_insertion_index(&self) -> u64 {
-		pmmr::n_leaves(self.output_pmmr_h.last_pos)
+		self.output_pmmr_h.last_pos
 	}
 
 	/// As above, for rangeproofs


### PR DESCRIPTION
Bug fix for the following issue: https://github.com/mimblewimble/grin/issues/3199
