### PR TITLE
3.0.x: Bug fix for highest_index in output API #3200

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -298,7 +298,7 @@ impl TxHashSet {
 
 	/// highest output insertion index available
 	pub fn highest_output_insertion_index(&self) -> u64 {
-		pmmr::n_leaves(self.output_pmmr_h.last_pos)
+		self.output_pmmr_h.last_pos
 	}
 
 	/// As above, for rangeproofs


### PR DESCRIPTION
Equivalent of https://github.com/mimblewimble/grin/pull/3200 for `current/3.0.x`.