### PR TITLE
cleanup unused hash_with impl

### DIFF
--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -24,7 +24,6 @@ use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::min;
 use std::convert::AsRef;
-use std::ops::Add;
 use std::{fmt, ops};
 use util;
 
@@ -37,17 +36,6 @@ pub const ZERO_HASH: Hash = Hash([0; 32]);
 pub struct Hash([u8; 32]);
 
 impl DefaultHashable for Hash {}
-
-impl Hash {
-	fn hash_with<T: Writeable>(&self, other: T) -> Hash {
-		let mut hasher = HashWriter::default();
-		ser::Writeable::write(self, &mut hasher).unwrap();
-		ser::Writeable::write(&other, &mut hasher).unwrap();
-		let mut ret = [0; 32];
-		hasher.finalize(&mut ret);
-		Hash(ret)
-	}
-}
 
 impl fmt::Debug for Hash {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -168,13 +156,6 @@ impl Writeable for Hash {
 	}
 }
 
-impl Add for Hash {
-	type Output = Hash;
-	fn add(self, other: Hash) -> Hash {
-		self.hash_with(other)
-	}
-}
-
 impl Default for Hash {
 	fn default() -> Hash {
 		ZERO_HASH
@@ -234,6 +215,7 @@ pub trait Hashed {
 /// Implementing this trait enables the default
 /// hash implementation
 pub trait DefaultHashable: Writeable {}
+
 impl<D: DefaultHashable> Hashed for D {
 	fn hash(&self) -> Hash {
 		let mut hasher = HashWriter::default();

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -345,7 +345,7 @@ impl Readable for TxKernel {
 }
 
 /// We store kernels in the kernel MMR.
-/// Note: These are "variable size" to support different kernel featuere variants.
+/// Note: These are "variable size" to support different kernel feature variants.
 impl PMMRable for TxKernel {
 	type E = Self;
 


### PR DESCRIPTION
This PR cleans up the unused impl for `hash_with(other)` and the associated `impl Add for Hash`.
I'm guessing these were used at some point with code since refactored.

Note we still have the `hash_with_index()` impl as this is different.

This was discovered while investigating how we might go about hashing "relative" tx kernels if they reference a prior kernel excess commitment, but indirectly via an MMR index.

