### PR TITLE
#2149: Resolve JSON RPC 2.0 non-compliance

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -52,9 +52,17 @@ type Tx = mpsc::UnboundedSender<String>;
 // http://www.jsonrpc.org/specification
 // RPC Methods
 
+/// Represents a compliant JSON RPC 2.0 id.
+/// Valid id: Integer, String.
+#[derive(Serialize, Deserialize, Debug)]
+enum JsonId {
+	NumId(u32),
+	StrId(String),
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcRequest {
-	id: String,
+	id: JsonId,
 	jsonrpc: String,
 	method: String,
 	params: Option<Value>,
@@ -62,7 +70,7 @@ struct RpcRequest {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcResponse {
-	id: String,
+	id: JsonId,
 	jsonrpc: String,
 	method: String,
 	result: Option<Value>,
@@ -501,7 +509,7 @@ impl Handler {
 		// Issue #1159 - use a serde_json Value type to avoid extra quoting
 		let job_template_value: Value = serde_json::from_str(&job_template_json).unwrap();
 		let job_request = RpcRequest {
-			id: String::from("Stratum"),
+			id: JsonId::StrId(String::from("Stratum")),
 			jsonrpc: String::from("2.0"),
 			method: String::from("job"),
 			params: Some(job_template_value),


### PR DESCRIPTION
Currently, the JSON RPC requests and responses are not compliant with the spec as the server only accepts strings.
This change is *non-breaking* as it simply adds the ability to understand integers as expected.
Any old code continuing to only send string requests will continue to work as before.

Resolves #2149 