### PR TITLE
Tests: remove unused crate

### DIFF
--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -26,7 +26,6 @@ use crate::core::core::{
 };
 use crate::core::libtx::build::{self, input, output};
 use crate::core::libtx::ProofBuilder;
-use crate::core::pow::Proof;
 use crate::core::{global, ser};
 use chrono::Duration;
 use grin_core as core;


### PR DESCRIPTION
Simply remove unused crate `use crate::core::pow::Proof;` (tests only).