### PR TITLE
Less cloning and pattern simplifications

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -26,7 +26,7 @@ use grin_store as store;
 use grin_store::{option_to_not_found, to_key, Error, SerIterator};
 use std::sync::Arc;
 
-const STORE_SUBPATH: &'static str = "chain";
+const STORE_SUBPATH: &str = "chain";
 
 const BLOCK_HEADER_PREFIX: u8 = 'h' as u8;
 const BLOCK_PREFIX: u8 = 'b' as u8;

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -149,7 +149,7 @@ impl BitmapAccumulator {
 		let chunk_pos = pmmr::insertion_to_pmmr_index(chunk_idx + 1);
 		let rewind_pos = chunk_pos.saturating_sub(1);
 		pmmr.rewind(rewind_pos, &Bitmap::create())
-			.map_err(|e| ErrorKind::Other(e))?;
+			.map_err(ErrorKind::Other)?;
 		Ok(())
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -67,7 +67,7 @@ impl<T: PMMRable> PMMRHandle<T> {
 		fs::create_dir_all(path.clone())?;
 		let path_str = path
 			.to_str()
-			.ok_or_else(|| Error::from(ErrorKind::Other("invalid file path".to_owned())))?;
+			.ok_or_else(|| ErrorKind::Other("invalid file path".to_owned()))?;
 		let backend = PMMRBackend::new(path_str.to_string(), prunable, version, header)?;
 		let last_pos = backend.unpruned_size();
 		Ok(PMMRHandle { backend, last_pos })
@@ -864,7 +864,7 @@ impl<'a> Committed for Extension<'a> {
 
 	fn kernels_committed(&self) -> Vec<Commitment> {
 		let mut commitments = vec![];
-		for n in 1..=self.kernel_pmmr.unpruned_size() {
+		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
 			if pmmr::is_leaf(n) {
 				if let Some(kernel) = self.kernel_pmmr.get_data(n) {
 					commitments.push(kernel.excess());
@@ -1307,12 +1307,12 @@ impl<'a> Extension<'a> {
 		let mut kern_count = 0;
 		let total_kernels = pmmr::n_leaves(self.kernel_pmmr.unpruned_size());
 		let mut tx_kernels: Vec<TxKernel> = Vec::with_capacity(KERNEL_BATCH_SIZE);
-		for n in 1..=self.kernel_pmmr.unpruned_size() {
+		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
 			if pmmr::is_leaf(n) {
 				let kernel = self
 					.kernel_pmmr
 					.get_data(n)
-					.ok_or_else(|| Error::from(ErrorKind::TxKernelNotFound))?;
+					.ok_or_else(|| ErrorKind::TxKernelNotFound)?;
 				tx_kernels.push(kernel);
 			}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -36,13 +36,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-const TXHASHSET_SUBDIR: &'static str = "txhashset";
+const TXHASHSET_SUBDIR: &str = "txhashset";
 
-const OUTPUT_SUBDIR: &'static str = "output";
-const RANGE_PROOF_SUBDIR: &'static str = "rangeproof";
-const KERNEL_SUBDIR: &'static str = "kernel";
+const OUTPUT_SUBDIR: &str = "output";
+const RANGE_PROOF_SUBDIR: &str = "rangeproof";
+const KERNEL_SUBDIR: &str = "kernel";
 
-const TXHASHSET_ZIP: &'static str = "txhashset_snapshot";
+const TXHASHSET_ZIP: &str = "txhashset_snapshot";
 
 /// Convenience wrapper around a single prunable MMR backend.
 pub struct PMMRHandle<T: PMMRable> {
@@ -65,9 +65,9 @@ impl<T: PMMRable> PMMRHandle<T> {
 	) -> Result<PMMRHandle<T>, Error> {
 		let path = Path::new(root_dir).join(sub_dir).join(file_name);
 		fs::create_dir_all(path.clone())?;
-		let path_str = path.to_str().ok_or(Error::from(ErrorKind::Other(
-			"invalid file path".to_owned(),
-		)))?;
+		let path_str = path
+			.to_str()
+			.ok_or_else(|| Error::from(ErrorKind::Other("invalid file path".to_owned())))?;
 		let backend = PMMRBackend::new(path_str.to_string(), prunable, version, header)?;
 		let last_pos = backend.unpruned_size();
 		Ok(PMMRHandle { backend, last_pos })
@@ -82,7 +82,7 @@ impl PMMRHandle<BlockHeader> {
 		if let Some(entry) = header_pmmr.get_data(pos) {
 			Ok(entry.hash())
 		} else {
-			Err(ErrorKind::Other(format!("get header hash by height")).into())
+			Err(ErrorKind::Other("get header hash by height".to_string()).into())
 		}
 	}
 
@@ -90,14 +90,14 @@ impl PMMRHandle<BlockHeader> {
 	/// Find the last leaf pos based on MMR size and return its header hash.
 	pub fn head_hash(&self) -> Result<Hash, Error> {
 		if self.last_pos == 0 {
-			return Err(ErrorKind::Other(format!("MMR empty, no head")).into());
+			return Err(ErrorKind::Other("MMR empty, no head".to_string()).into());
 		}
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.last_pos);
 		let leaf_pos = pmmr::bintree_rightmost(self.last_pos);
 		if let Some(entry) = header_pmmr.get_data(leaf_pos) {
 			Ok(entry.hash())
 		} else {
-			Err(ErrorKind::Other(format!("failed to find head hash")).into())
+			Err(ErrorKind::Other("failed to find head hash".to_string()).into())
 		}
 	}
 }
@@ -200,7 +200,7 @@ impl TxHashSet {
 				commit_index,
 			})
 		} else {
-			Err(ErrorKind::TxHashSetErr(format!("failed to open kernel PMMR")).into())
+			Err(ErrorKind::TxHashSetErr("failed to open kernel PMMR".to_string()).into())
 		}
 	}
 
@@ -236,14 +236,14 @@ impl TxHashSet {
 							height: block_height,
 						})
 					} else {
-						Err(ErrorKind::TxHashSetErr(format!("txhashset hash mismatch")).into())
+						Err(ErrorKind::TxHashSetErr("txhashset hash mismatch".to_string()).into())
 					}
 				} else {
 					Err(ErrorKind::OutputNotFound.into())
 				}
 			}
 			Err(grin_store::Error::NotFoundErr(_)) => Err(ErrorKind::OutputNotFound.into()),
-			Err(e) => Err(ErrorKind::StoreErr(e, format!("txhashset unspent check")).into()),
+			Err(e) => Err(ErrorKind::StoreErr(e, "txhashset unspent check".to_string()).into()),
 		}
 	}
 
@@ -739,7 +739,7 @@ impl<'a> HeaderExtension<'a> {
 		if let Some(hash) = self.get_header_hash(pos) {
 			Ok(batch.get_block_header(&hash)?)
 		} else {
-			Err(ErrorKind::Other(format!("get header by height")).into())
+			Err(ErrorKind::Other("get header by height".to_string()).into())
 		}
 	}
 
@@ -751,13 +751,13 @@ impl<'a> HeaderExtension<'a> {
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {
 		if header.height > self.head.height {
-			return Err(ErrorKind::Other(format!("not on current chain, out beyond")).into());
+			return Err(ErrorKind::Other("not on current chain, out beyond".to_string()).into());
 		}
 		let chain_header = self.get_header_by_height(header.height, batch)?;
 		if chain_header.hash() == header.hash() {
 			Ok(())
 		} else {
-			Err(ErrorKind::Other(format!("not on current chain")).into())
+			Err(ErrorKind::Other("not on current chain".to_string()).into())
 		}
 	}
 
@@ -864,7 +864,7 @@ impl<'a> Committed for Extension<'a> {
 
 	fn kernels_committed(&self) -> Vec<Commitment> {
 		let mut commitments = vec![];
-		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
+		for n in 1..=self.kernel_pmmr.unpruned_size() {
 			if pmmr::is_leaf(n) {
 				if let Some(kernel) = self.kernel_pmmr.get_data(n) {
 					commitments.push(kernel.excess());
@@ -966,7 +966,7 @@ impl<'a> Extension<'a> {
 			if let Some(hash) = self.output_pmmr.get_hash(pos) {
 				if hash != input.hash_with_index(pos - 1) {
 					return Err(
-						ErrorKind::TxHashSetErr(format!("output pmmr hash mismatch")).into(),
+						ErrorKind::TxHashSetErr("output pmmr hash mismatch".to_string()).into(),
 					);
 				}
 			}
@@ -978,7 +978,7 @@ impl<'a> Extension<'a> {
 				Ok(true) => {
 					self.rproof_pmmr
 						.prune(pos)
-						.map_err(|e| ErrorKind::TxHashSetErr(e))?;
+						.map_err(ErrorKind::TxHashSetErr)?;
 					Ok(pos)
 				}
 				Ok(false) => Err(ErrorKind::AlreadySpent(commit).into()),
@@ -1016,13 +1016,13 @@ impl<'a> Extension<'a> {
 		{
 			if self.output_pmmr.unpruned_size() != self.rproof_pmmr.unpruned_size() {
 				return Err(
-					ErrorKind::Other(format!("output vs rproof MMRs different sizes")).into(),
+					ErrorKind::Other("output vs rproof MMRs different sizes".to_string()).into(),
 				);
 			}
 
 			if output_pos != rproof_pos {
 				return Err(
-					ErrorKind::Other(format!("output vs rproof MMRs different pos")).into(),
+					ErrorKind::Other("output vs rproof MMRs different pos".to_string()).into(),
 				);
 			}
 		}
@@ -1067,10 +1067,10 @@ impl<'a> Extension<'a> {
 		let header = batch.get_block_header(&self.head.last_block_h)?;
 		self.output_pmmr
 			.snapshot(&header)
-			.map_err(|e| ErrorKind::Other(e))?;
+			.map_err(ErrorKind::Other)?;
 		self.rproof_pmmr
 			.snapshot(&header)
-			.map_err(|e| ErrorKind::Other(e))?;
+			.map_err(ErrorKind::Other)?;
 		Ok(())
 	}
 
@@ -1244,7 +1244,7 @@ impl<'a> Extension<'a> {
 
 		if self.head.height == 0 {
 			let zero_commit = secp_static::commit_to_zero_value();
-			return Ok((zero_commit.clone(), zero_commit.clone()));
+			return Ok((zero_commit, zero_commit));
 		}
 
 		// The real magicking happens here. Sum of kernel excesses should equal
@@ -1307,12 +1307,12 @@ impl<'a> Extension<'a> {
 		let mut kern_count = 0;
 		let total_kernels = pmmr::n_leaves(self.kernel_pmmr.unpruned_size());
 		let mut tx_kernels: Vec<TxKernel> = Vec::with_capacity(KERNEL_BATCH_SIZE);
-		for n in 1..self.kernel_pmmr.unpruned_size() + 1 {
+		for n in 1..=self.kernel_pmmr.unpruned_size() {
 			if pmmr::is_leaf(n) {
 				let kernel = self
 					.kernel_pmmr
 					.get_data(n)
-					.ok_or::<Error>(ErrorKind::TxKernelNotFound.into())?;
+					.ok_or_else(|| Error::from(ErrorKind::TxKernelNotFound))?;
 				tx_kernels.push(kernel);
 			}
 
@@ -1379,7 +1379,7 @@ impl<'a> Extension<'a> {
 		}
 
 		// remaining part which not full of 1000 range proofs
-		if proofs.len() > 0 {
+		if !proofs.is_empty() {
 			Output::batch_verify_proofs(&commits, &proofs)?;
 			commits.clear();
 			proofs.clear();
@@ -1509,7 +1509,7 @@ pub fn zip_write(
 	header: &BlockHeader,
 ) -> Result<(), Error> {
 	debug!("zip_write on path: {:?}", root_dir);
-	let txhashset_path = root_dir.clone().join(TXHASHSET_SUBDIR);
+	let txhashset_path = root_dir.join(TXHASHSET_SUBDIR);
 	fs::create_dir_all(&txhashset_path)?;
 
 	// Explicit list of files to extract from our zip archive.
@@ -1531,12 +1531,9 @@ pub fn txhashset_replace(from: PathBuf, to: PathBuf) -> Result<(), Error> {
 	clean_txhashset_folder(&to);
 
 	// rename the 'from' folder as the 'to' folder
-	if let Err(e) = fs::rename(
-		from.clone().join(TXHASHSET_SUBDIR),
-		to.clone().join(TXHASHSET_SUBDIR),
-	) {
+	if let Err(e) = fs::rename(from.join(TXHASHSET_SUBDIR), to.join(TXHASHSET_SUBDIR)) {
 		error!("hashset_replace fail on {}. err: {}", TXHASHSET_SUBDIR, e);
-		Err(ErrorKind::TxHashSetErr(format!("txhashset replacing fail")).into())
+		Err(ErrorKind::TxHashSetErr("txhashset replacing fail".to_string()).into())
 	} else {
 		Ok(())
 	}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -136,7 +136,7 @@ impl<'a> UTXOView<'a> {
 
 			// Find the "cutoff" pos in the output MMR based on the
 			// header from 1,000 blocks ago.
-			let cutoff_height = height.checked_sub(global::coinbase_maturity()).unwrap_or(0);
+			let cutoff_height = height.saturating_sub(global::coinbase_maturity());
 			let cutoff_header = self.get_header_by_height(cutoff_height, batch)?;
 			let cutoff_pos = cutoff_header.output_mmr_size;
 
@@ -168,7 +168,7 @@ impl<'a> UTXOView<'a> {
 			let header = batch.get_block_header(&hash)?;
 			Ok(header)
 		} else {
-			Err(ErrorKind::Other(format!("get header by height")).into())
+			Err(ErrorKind::Other("get header by height".to_string()).into())
 		}
 	}
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -174,7 +174,7 @@ pub fn header_version(height: u64) -> HeaderVersion {
 /// Check whether the block version is valid at a given height, implements
 /// 6 months interval scheduled hard forks for the first 2 years.
 pub fn valid_header_version(height: u64, version: HeaderVersion) -> bool {
-	return height < 3 * HARD_FORK_INTERVAL && version == header_version(height);
+	height < 3 * HARD_FORK_INTERVAL && version == header_version(height)
 }
 
 /// Number of blocks used to calculate difficulty adjustments

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -67,7 +67,7 @@ impl<H: Hashed> ShortIdentifiable for H {
 }
 
 /// Short id for identifying inputs/outputs/kernels
-#[derive(Clone, Serialize, Deserialize, Hash)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ShortId([u8; 6]);
 
 impl DefaultHashable for ShortId {}

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -302,7 +302,7 @@ where
 	/// Walks all unpruned nodes in the MMR and revalidate all parent hashes
 	pub fn validate(&self) -> Result<(), String> {
 		// iterate on all parent nodes
-		for n in 1..(self.last_pos + 1) {
+		for n in 1..=self.last_pos {
 			let height = bintree_postorder_height(n);
 			if height > 0 {
 				if let Some(hash) = self.get_hash(n) {
@@ -346,7 +346,7 @@ where
 			return;
 		}
 		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
-		for n in start..(sz / 8 + 1) {
+		for n in start..=sz / 8 {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();
 			for m in (n * 8)..(n + 1) * 8 {
@@ -380,7 +380,7 @@ where
 			return;
 		}
 		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
-		for n in start..(sz / 8 + 1) {
+		for n in start..=sz / 8 {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();
 			for m in (n * 8)..(n + 1) * 8 {

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -302,7 +302,7 @@ where
 	/// Walks all unpruned nodes in the MMR and revalidate all parent hashes
 	pub fn validate(&self) -> Result<(), String> {
 		// iterate on all parent nodes
-		for n in 1..self.last_pos + 1 {
+		for n in 1..(self.last_pos + 1) {
 			let height = bintree_postorder_height(n);
 			if height > 0 {
 				if let Some(hash) = self.get_hash(n) {

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -302,7 +302,7 @@ where
 	/// Walks all unpruned nodes in the MMR and revalidate all parent hashes
 	pub fn validate(&self) -> Result<(), String> {
 		// iterate on all parent nodes
-		for n in 1..=self.last_pos {
+		for n in 1..self.last_pos + 1 {
 			let height = bintree_postorder_height(n);
 			if height > 0 {
 				if let Some(hash) = self.get_hash(n) {
@@ -346,7 +346,7 @@ where
 			return;
 		}
 		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
-		for n in start..=sz / 8 {
+		for n in start..(sz / 8 + 1) {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();
 			for m in (n * 8)..(n + 1) * 8 {
@@ -380,7 +380,7 @@ where
 			return;
 		}
 		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
-		for n in start..=sz / 8 {
+		for n in start..(sz / 8 + 1) {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();
 			for m in (n * 8)..(n + 1) * 8 {

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -347,7 +347,7 @@ where
 		let mut last_ts = last_n.last().unwrap().timestamp;
 		for _ in n..needed_block_count {
 			last_ts = last_ts.saturating_sub(last_ts_delta);
-			last_n.push(HeaderInfo::from_ts_diff(last_ts, last_diff.clone()));
+			last_n.push(HeaderInfo::from_ts_diff(last_ts, last_diff));
 		}
 	}
 	last_n.reverse();

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -235,7 +235,7 @@ where
 
 	// Store the kernel offset (k2) on the tx.
 	// Commitments will sum correctly when accounting for the offset.
-	tx.offset = k2.clone();
+	tx.offset = k2;
 
 	// Set the kernel on the tx.
 	let tx = tx.replace_kernel(kern);

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -668,7 +668,7 @@ mod tests {
 			let commit = keychain.commit(amount, &id, switch).unwrap();
 
 			// Generate proof with ProofBuilder..
-			let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
+			let proof = create(&keychain, &builder, amount, &id, switch, commit, None).unwrap();
 			// ..and rewind with child ViewKey
 			let rewind = rewind(keychain.secp(), &child_view_key, commit, None, proof);
 

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -163,9 +163,8 @@ where
 			&self.rewind_hash
 		};
 		let res = blake2b(32, &commit.0, hash);
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
-			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
-		})
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
+			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e)).into())
 	}
 }
 
@@ -279,9 +278,8 @@ where
 
 	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.root_hash);
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
-			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
-		})
+		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
+			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e)).into())
 	}
 }
 
@@ -365,9 +363,8 @@ where
 impl ProofBuild for ViewKey {
 	fn rewind_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.rewind_hash);
-		SecretKey::from_slice(secp, res.as_bytes()).map_err(|e| {
-			ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e).to_string()).into()
-		})
+		SecretKey::from_slice(secp, res.as_bytes())
+			.map_err(|e| ErrorKind::RangeProof(format!("Unable to create nonce: {:?}", e)).into())
 	}
 
 	fn private_nonce(&self, _secp: &Secp256k1, _commit: &Commitment) -> Result<SecretKey, Error> {
@@ -452,17 +449,8 @@ mod tests {
 		let id = ExtKeychain::derive_key_id(3, rng.gen(), rng.gen(), rng.gen(), 0);
 		let switch = SwitchCommitmentType::Regular;
 		let commit = keychain.commit(amount, &id, &switch).unwrap();
-		let proof = create(
-			&keychain,
-			&builder,
-			amount,
-			&id,
-			&switch,
-			commit.clone(),
-			None,
-		)
-		.unwrap();
-		assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
+		let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
+		assert!(verify(&keychain.secp(), commit, proof, None).is_ok());
 		let rewind = rewind(keychain.secp(), &builder, commit, None, proof).unwrap();
 		assert!(rewind.is_some());
 		let (r_amount, r_id, r_switch) = rewind.unwrap();
@@ -482,18 +470,9 @@ mod tests {
 		let commit_a = {
 			let switch = SwitchCommitmentType::Regular;
 			let commit = keychain.commit(amount, &id, &switch).unwrap();
-			let proof = create(
-				&keychain,
-				&builder,
-				amount,
-				&id,
-				&switch,
-				commit.clone(),
-				None,
-			)
-			.unwrap();
-			assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
-			let rewind = rewind(keychain.secp(), &builder, commit.clone(), None, proof).unwrap();
+			let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
+			assert!(verify(&keychain.secp(), commit, proof, None).is_ok());
+			let rewind = rewind(keychain.secp(), &builder, commit, None, proof).unwrap();
 			assert!(rewind.is_some());
 			let (r_amount, r_id, r_switch) = rewind.unwrap();
 			assert_eq!(r_amount, amount);
@@ -505,18 +484,9 @@ mod tests {
 		let commit_b = {
 			let switch = SwitchCommitmentType::None;
 			let commit = keychain.commit(amount, &id, &switch).unwrap();
-			let proof = create(
-				&keychain,
-				&builder,
-				amount,
-				&id,
-				&switch,
-				commit.clone(),
-				None,
-			)
-			.unwrap();
-			assert!(verify(&keychain.secp(), commit.clone(), proof.clone(), None).is_ok());
-			let rewind = rewind(keychain.secp(), &builder, commit.clone(), None, proof).unwrap();
+			let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
+			assert!(verify(&keychain.secp(), commit, proof, None).is_ok());
+			let rewind = rewind(keychain.secp(), &builder, commit, None, proof).unwrap();
 			assert!(rewind.is_some());
 			let (r_amount, r_id, r_switch) = rewind.unwrap();
 			assert_eq!(r_amount, amount);
@@ -583,18 +553,9 @@ mod tests {
 		let commit = keychain.commit(amount, &id, &switch).unwrap();
 
 		// Generate proof with ProofBuilder..
-		let proof = create(
-			&keychain,
-			&builder,
-			amount,
-			&id,
-			&switch,
-			commit.clone(),
-			None,
-		)
-		.unwrap();
+		let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
 		// ..and rewind with ViewKey
-		let rewind = rewind(keychain.secp(), &view_key, commit.clone(), None, proof);
+		let rewind = rewind(keychain.secp(), &view_key, commit, None, proof);
 
 		assert!(rewind.is_ok());
 		let rewind = rewind.unwrap();
@@ -628,18 +589,9 @@ mod tests {
 		let commit = keychain.commit(amount, &id, &switch).unwrap();
 
 		// Generate proof with ProofBuilder..
-		let proof = create(
-			&keychain,
-			&builder,
-			amount,
-			&id,
-			&switch,
-			commit.clone(),
-			None,
-		)
-		.unwrap();
+		let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
 		// ..and rewind with ViewKey
-		let rewind = rewind(keychain.secp(), &view_key, commit.clone(), None, proof);
+		let rewind = rewind(keychain.secp(), &view_key, commit, None, proof);
 
 		assert!(rewind.is_ok());
 		let rewind = rewind.unwrap();
@@ -680,24 +632,9 @@ mod tests {
 			let commit = keychain.commit(amount, &id, &switch).unwrap();
 
 			// Generate proof with ProofBuilder..
-			let proof = create(
-				&keychain,
-				&builder,
-				amount,
-				&id,
-				&switch,
-				commit.clone(),
-				None,
-			)
-			.unwrap();
+			let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
 			// ..and rewind with child ViewKey
-			let rewind = rewind(
-				keychain.secp(),
-				&child_view_key,
-				commit.clone(),
-				None,
-				proof,
-			);
+			let rewind = rewind(keychain.secp(), &child_view_key, commit, None, proof);
 
 			assert!(rewind.is_ok());
 			let rewind = rewind.unwrap();
@@ -731,24 +668,9 @@ mod tests {
 			let commit = keychain.commit(amount, &id, &switch).unwrap();
 
 			// Generate proof with ProofBuilder..
-			let proof = create(
-				&keychain,
-				&builder,
-				amount,
-				&id,
-				&switch,
-				commit.clone(),
-				None,
-			)
-			.unwrap();
+			let proof = create(&keychain, &builder, amount, &id, &switch, commit, None).unwrap();
 			// ..and rewind with child ViewKey
-			let rewind = rewind(
-				keychain.secp(),
-				&child_view_key,
-				commit.clone(),
-				None,
-				proof,
-			);
+			let rewind = rewind(keychain.secp(), &child_view_key, commit, None, proof);
 
 			assert!(rewind.is_ok());
 			let rewind = rewind.unwrap();

--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -173,10 +173,10 @@ mod test {
 	#[test]
 	fn cuckaroo19_vectors() {
 		let mut ctx = new_impl::<u64>(19, 42);
-		ctx.params.siphash_keys = V1_19_HASH.clone();
-		assert!(ctx.verify(&Proof::new(V1_19_SOL.to_vec().clone())).is_ok());
+		ctx.params.siphash_keys = V1_19_HASH;
+		assert!(ctx.verify(&Proof::new(V1_19_SOL.to_vec())).is_ok());
 		ctx.params.siphash_keys = V2_19_HASH.clone();
-		assert!(ctx.verify(&Proof::new(V2_19_SOL.to_vec().clone())).is_ok());
+		assert!(ctx.verify(&Proof::new(V2_19_SOL.to_vec())).is_ok());
 		assert!(ctx.verify(&Proof::zero(42)).is_err());
 	}
 

--- a/core/src/pow/cuckarood.rs
+++ b/core/src/pow/cuckarood.rs
@@ -175,16 +175,12 @@ mod test {
 	#[test]
 	fn cuckarood19_29_vectors() {
 		let mut ctx19 = new_impl::<u64>(19, 42);
-		ctx19.params.siphash_keys = V1_19_HASH.clone();
-		assert!(ctx19
-			.verify(&Proof::new(V1_19_SOL.to_vec().clone()))
-			.is_ok());
+		ctx19.params.siphash_keys = V1_19_HASH;
+		assert!(ctx19.verify(&Proof::new(V1_19_SOL.to_vec())).is_ok());
 		assert!(ctx19.verify(&Proof::zero(42)).is_err());
 		let mut ctx29 = new_impl::<u64>(29, 42);
-		ctx29.params.siphash_keys = V2_29_HASH.clone();
-		assert!(ctx29
-			.verify(&Proof::new(V2_29_SOL.to_vec().clone()))
-			.is_ok());
+		ctx29.params.siphash_keys = V2_29_HASH;
+		assert!(ctx29.verify(&Proof::new(V2_29_SOL.to_vec())).is_ok());
 		assert!(ctx29.verify(&Proof::zero(42)).is_err());
 	}
 

--- a/core/src/pow/cuckaroom.rs
+++ b/core/src/pow/cuckaroom.rs
@@ -168,16 +168,12 @@ mod test {
 	#[test]
 	fn cuckaroom19_29_vectors() {
 		let mut ctx19 = new_impl::<u64>(19, 42);
-		ctx19.params.siphash_keys = V1_19_HASH.clone();
-		assert!(ctx19
-			.verify(&Proof::new(V1_19_SOL.to_vec().clone()))
-			.is_ok());
+		ctx19.params.siphash_keys = V1_19_HASH;
+		assert!(ctx19.verify(&Proof::new(V1_19_SOL.to_vec())).is_ok());
 		assert!(ctx19.verify(&Proof::zero(42)).is_err());
 		let mut ctx29 = new_impl::<u64>(29, 42);
-		ctx29.params.siphash_keys = V2_29_HASH.clone();
-		assert!(ctx29
-			.verify(&Proof::new(V2_29_SOL.to_vec().clone()))
-			.is_ok());
+		ctx29.params.siphash_keys = V2_29_HASH;
+		assert!(ctx29.verify(&Proof::new(V2_29_SOL.to_vec())).is_ok());
 		assert!(ctx29.verify(&Proof::zero(42)).is_err());
 	}
 

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -409,7 +409,7 @@ mod test {
 	{
 		let mut ctx = CuckatooContext::<u32>::new_impl(29, 42, 10).unwrap();
 		ctx.set_header_nonce([0u8; 80].to_vec(), Some(20), false)?;
-		assert!(ctx.verify(&Proof::new(V1_29.to_vec().clone())).is_ok());
+		assert!(ctx.verify(&Proof::new(V1_29.to_vec())).is_ok());
 		Ok(())
 	}
 
@@ -419,7 +419,7 @@ mod test {
 	{
 		let mut ctx = CuckatooContext::<u32>::new_impl(31, 42, 10).unwrap();
 		ctx.set_header_nonce([0u8; 80].to_vec(), Some(99), false)?;
-		assert!(ctx.verify(&Proof::new(V1_31.to_vec().clone())).is_ok());
+		assert!(ctx.verify(&Proof::new(V1_31.to_vec())).is_ok());
 		Ok(())
 	}
 
@@ -431,11 +431,11 @@ mod test {
 		let mut header = [0u8; 80];
 		header[0] = 1u8;
 		ctx.set_header_nonce(header.to_vec(), Some(20), false)?;
-		assert!(!ctx.verify(&Proof::new(V1_29.to_vec().clone())).is_ok());
+		assert!(!ctx.verify(&Proof::new(V1_29.to_vec())).is_ok());
 		header[0] = 0u8;
 		ctx.set_header_nonce(header.to_vec(), Some(20), false)?;
-		assert!(ctx.verify(&Proof::new(V1_29.to_vec().clone())).is_ok());
-		let mut bad_proof = V1_29.clone();
+		assert!(ctx.verify(&Proof::new(V1_29.to_vec())).is_ok());
+		let mut bad_proof = V1_29;
 		bad_proof[0] = 0x48a9e1;
 		assert!(!ctx.verify(&Proof::new(bad_proof.to_vec())).is_ok());
 		Ok(())

--- a/core/src/pow/siphash.rs
+++ b/core/src/pow/siphash.rs
@@ -61,7 +61,7 @@ pub fn siphash_block(v: &[u64; 4], nonce: u64, rot_e: u8, xor_all: bool) -> u64 
 	for i in xor_from..SIPHASH_BLOCK_SIZE {
 		xor ^= nonce_hash[i as usize];
 	}
-	return xor;
+	xor
 }
 
 /// Implements siphash 2-4 specialized for a 4 u64 array key and a u64 nonce

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -96,7 +96,7 @@ impl Difficulty {
 	}
 
 	/// Converts the difficulty into a u64
-	pub fn to_num(&self) -> u64 {
+	pub fn to_num(self) -> u64 {
 		self.num
 	}
 }
@@ -389,7 +389,7 @@ impl Proof {
 	}
 }
 
-fn extract_bits(bits: &Vec<u8>, bit_start: usize, bit_count: usize, read_from: usize) -> u64 {
+fn extract_bits(bits: &[u8], bit_start: usize, bit_count: usize, read_from: usize) -> u64 {
 	let mut buf: [u8; 8] = [0; 8];
 	buf.copy_from_slice(&bits[read_from..read_from + 8]);
 	if bit_count == 64 {
@@ -400,7 +400,7 @@ fn extract_bits(bits: &Vec<u8>, bit_start: usize, bit_count: usize, read_from: u
 	u64::from_le_bytes(buf) >> skip_bits & bit_mask
 }
 
-fn read_number(bits: &Vec<u8>, bit_start: usize, bit_count: usize) -> u64 {
+fn read_number(bits: &[u8], bit_start: usize, bit_count: usize) -> u64 {
 	if bit_count == 0 {
 		return 0;
 	}

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -1261,7 +1261,7 @@ where
 			}
 		}
 	}
-	const VARIANTS: &'static [&'static str] = &[
+	const VARIANTS: &'static [&str] = &[
 		"NotFound",
 		"PermissionDenied",
 		"ConnectionRefused",

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -47,7 +47,7 @@ fn too_large_block() {
 	let max_out = global::max_block_weight() / BLOCK_OUTPUT_WEIGHT;
 
 	let mut pks = vec![];
-	for n in 0..(max_out + 1) {
+	for n in 0..=max_out {
 		pks.push(ExtKeychain::derive_key_id(1, n as u32, 0, 0, 0));
 	}
 
@@ -100,7 +100,7 @@ fn block_with_cut_through() {
 
 	// spending tx2 - reuse key_id2
 
-	let mut btx3 = txspend1i1o(5, &keychain, &builder, key_id2.clone(), key_id3);
+	let mut btx3 = txspend1i1o(5, &keychain, &builder, key_id2, key_id3);
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(
@@ -135,7 +135,7 @@ fn empty_block_with_coinbase_is_valid() {
 		.outputs()
 		.iter()
 		.filter(|out| out.is_coinbase())
-		.map(|o| o.clone())
+		.cloned()
 		.collect::<Vec<_>>();
 	assert_eq!(coinbase_outputs.len(), 1);
 
@@ -143,7 +143,7 @@ fn empty_block_with_coinbase_is_valid() {
 		.kernels()
 		.iter()
 		.filter(|out| out.is_coinbase())
-		.map(|o| o.clone())
+		.cloned()
 		.collect::<Vec<_>>();
 	assert_eq!(coinbase_kernels.len(), 1);
 
@@ -494,11 +494,7 @@ fn same_amount_outputs_copy_range_proof() {
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		vec![&mut Transaction::new(
-			ins.clone(),
-			outs.clone(),
-			kernels.clone(),
-		)],
+		vec![&mut Transaction::new(ins.clone(), outs, kernels.clone())],
 		&keychain,
 		&builder,
 		&prev,
@@ -551,11 +547,7 @@ fn wrong_amount_range_proof() {
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		vec![&mut Transaction::new(
-			ins.clone(),
-			outs.clone(),
-			kernels.clone(),
-		)],
+		vec![&mut Transaction::new(ins.clone(), outs, kernels.clone())],
 		&keychain,
 		&builder,
 		&prev,
@@ -598,7 +590,7 @@ fn validate_header_proof() {
 	assert!(BlockHeader::from_pre_pow_and_proof(
 		"0xaf1678".to_string(),
 		b.header.pow.nonce,
-		b.header.pow.proof.clone(),
+		b.header.pow.proof,
 	)
 	.is_err());
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -47,7 +47,7 @@ fn too_large_block() {
 	let max_out = global::max_block_weight() / BLOCK_OUTPUT_WEIGHT;
 
 	let mut pks = vec![];
-	for n in 0..=max_out {
+	for n in 0..(max_out + 1) {
 		pks.push(ExtKeychain::derive_key_id(1, n as u32, 0, 0, 0));
 	}
 

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -137,7 +137,7 @@ impl PMMRable for TestElem {
 	type E = Self;
 
 	fn as_elmt(&self) -> Self::E {
-		self.clone()
+		*self
 	}
 
 	fn elmt_size() -> Option<u16> {

--- a/core/tests/consensus_automated.rs
+++ b/core/tests/consensus_automated.rs
@@ -118,7 +118,7 @@ fn next_target_adjustment() {
 	// We should never drop below minimum
 	hi.difficulty = Difficulty::zero();
 	assert_eq!(
-		next_difficulty(1, repeat(90, hi.clone(), just_enough, None)).difficulty,
+		next_difficulty(1, repeat(90, hi, just_enough, None)).difficulty,
 		Difficulty::min()
 	);
 }
@@ -132,7 +132,7 @@ fn repeat(interval: u64, diff: HeaderInfo, len: u64, cur_time: Option<u64>) -> V
 	};
 	// watch overflow here, length shouldn't be ridiculous anyhow
 	assert!(len < std::usize::MAX as u64);
-	let diffs = vec![diff.difficulty.clone(); len as usize];
+	let diffs = vec![diff.difficulty; len as usize];
 	let times = (0..(len as usize)).map(|n| n * interval as usize).rev();
 	let pairs = times.zip(diffs.iter());
 	pairs
@@ -140,7 +140,7 @@ fn repeat(interval: u64, diff: HeaderInfo, len: u64, cur_time: Option<u64>) -> V
 			HeaderInfo::new(
 				diff.block_hash,
 				cur_time + t as u64,
-				d.clone(),
+				*d,
 				diff.secondary_scaling,
 				diff.is_secondary,
 			)

--- a/core/tests/consensus_mainnet.rs
+++ b/core/tests/consensus_mainnet.rs
@@ -193,7 +193,7 @@ fn add_block_repeated(
 	chain_sim: Vec<(HeaderInfo, DiffStats)>,
 	iterations: usize,
 ) -> Vec<(HeaderInfo, DiffStats)> {
-	let mut return_chain = chain_sim.clone();
+	let mut return_chain = chain_sim;
 	for _ in 0..iterations {
 		return_chain = add_block(interval, return_chain.clone());
 	}
@@ -203,7 +203,7 @@ fn add_block_repeated(
 // Prints the contents of the iterator and its difficulties.. useful for
 // tweaking
 fn print_chain_sim(chain_sim: Vec<(HeaderInfo, DiffStats)>) {
-	let mut chain_sim = chain_sim.clone();
+	let mut chain_sim = chain_sim;
 	chain_sim.reverse();
 	let mut last_time = 0;
 	let mut first = true;
@@ -233,7 +233,7 @@ fn print_chain_sim(chain_sim: Vec<(HeaderInfo, DiffStats)>) {
 			stats.earliest_ts,
 			stats.ts_delta,
 		);
-		let mut sb = stats.last_blocks.clone();
+		let mut sb = stats.last_blocks;
 		sb.reverse();
 		for i in sb {
 			println!("   {}", i);
@@ -282,7 +282,7 @@ fn adjustment_scenarios() {
 	let chain_sim = add_block_repeated(60, chain_sim, just_enough as usize);
 	let chain_sim = add_block_repeated(600, chain_sim, 60);
 
-	println!("");
+	println!();
 	println!("*********************************************************");
 	println!("Scenario 3) Sudden drop in hashpower");
 	println!("*********************************************************");
@@ -294,7 +294,7 @@ fn adjustment_scenarios() {
 	let chain_sim = add_block_repeated(60, chain_sim, just_enough as usize);
 	let chain_sim = add_block_repeated(10, chain_sim, 10);
 
-	println!("");
+	println!();
 	println!("*********************************************************");
 	println!("Scenario 4) Sudden increase in hashpower");
 	println!("*********************************************************");
@@ -308,7 +308,7 @@ fn adjustment_scenarios() {
 	let chain_sim = add_block_repeated(60, chain_sim, 20);
 	let chain_sim = add_block_repeated(10, chain_sim, 10);
 
-	println!("");
+	println!();
 	println!("*********************************************************");
 	println!("Scenario 5) Oscillations in hashpower");
 	println!("*********************************************************");

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -41,7 +41,7 @@ fn some_peak_map() {
 fn bench_peak_map() {
 	let nano_to_millis = 1.0 / 1_000_000.0;
 
-	let increments = vec![1000_000u64, 10_000_000u64, 100_000_000u64];
+	let increments = vec![1_000_000u64, 10_000_000u64, 100_000_000u64];
 
 	for v in increments {
 		let start = Utc::now().timestamp_nanos();
@@ -374,7 +374,7 @@ fn pmmr_get_last_n_insertions() {
 
 	// test when empty
 	let res = pmmr.readonly_pmmr().get_last_n_insertions(19);
-	assert!(res.len() == 0);
+	assert!(res.is_empty());
 
 	pmmr.push(&elems[0]).unwrap();
 	let res = pmmr.readonly_pmmr().get_last_n_insertions(19);

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -46,7 +46,7 @@ fn test_verifier_cache_rangeproofs() {
 	// Check our output is not verified according to the cache.
 	{
 		let mut cache = cache.write();
-		let unverified = cache.filter_rangeproof_unverified(&vec![out]);
+		let unverified = cache.filter_rangeproof_unverified(&[out]);
 		assert_eq!(unverified, vec![out]);
 	}
 
@@ -59,7 +59,7 @@ fn test_verifier_cache_rangeproofs() {
 	// Check it shows as verified according to the cache.
 	{
 		let mut cache = cache.write();
-		let unverified = cache.filter_rangeproof_unverified(&vec![out]);
+		let unverified = cache.filter_rangeproof_unverified(&[out]);
 		assert_eq!(unverified, vec![]);
 	}
 }

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -382,7 +382,7 @@ impl ExtendedPrivKey {
 		passphrase: &str,
 		is_floo: bool,
 	) -> Result<ExtendedPrivKey, Error> {
-		let seed = mnemonic::to_seed(mnemonic, passphrase).map_err(|e| Error::MnemonicError(e))?;
+		let seed = mnemonic::to_seed(mnemonic, passphrase).map_err(Error::MnemonicError)?;
 		let mut hasher = BIP32GrinHasher::new(is_floo);
 		let key = ExtendedPrivKey::new_master(secp, &mut hasher, &seed)?;
 		Ok(key)
@@ -460,9 +460,7 @@ impl ExtendedPrivKey {
 		// Do SHA256 of just the ECDSA pubkey
 		let sha2_res = hasher.sha_256(&pk.public_key.serialize_vec(&secp, true)[..]);
 		// do RIPEMD160
-		let ripemd_res = hasher.ripemd_160(&sha2_res);
-		// Return
-		ripemd_res
+		hasher.ripemd_160(&sha2_res)
 	}
 
 	/// Returns the first four bytes of the identifier
@@ -567,9 +565,7 @@ impl ExtendedPubKey {
 		// Do SHA256 of just the ECDSA pubkey
 		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(secp, true)[..]);
 		// do RIPEMD160
-		let ripemd_res = hasher.ripemd_160(&sha2_res);
-		// Return
-		ripemd_res
+		hasher.ripemd_160(&sha2_res)
 	}
 
 	/// Returns the first four bytes of the identifier

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -166,14 +166,14 @@ impl Keychain for ExtKeychain {
 		let keys = blind_sum
 			.positive_blinding_factors
 			.iter()
-			.filter_map(|b| b.secret_key(&self.secp).ok().clone())
+			.filter_map(|b| b.secret_key(&self.secp).ok())
 			.collect::<Vec<SecretKey>>();
 		pos_keys.extend(keys);
 
 		let keys = blind_sum
 			.negative_blinding_factors
 			.iter()
-			.filter_map(|b| b.secret_key(&self.secp).ok().clone())
+			.filter_map(|b| b.secret_key(&self.secp).ok())
 			.collect::<Vec<SecretKey>>();
 		neg_keys.extend(keys);
 
@@ -265,7 +265,7 @@ mod test {
 
 		// adding secret keys 1 and 2 to give secret key 3
 		let mut skey3 = skey1.clone();
-		let _ = skey3.add_assign(&keychain.secp, &skey2).unwrap();
+		skey3.add_assign(&keychain.secp, &skey2).unwrap();
 
 		// create commitments for secret keys 1, 2 and 3
 		// all committing to the value 0 (which is what we do for tx_kernels)
@@ -276,7 +276,7 @@ mod test {
 		// now sum commitments for keys 1 and 2
 		let sum = keychain
 			.secp
-			.commit_sum(vec![commit_1.clone(), commit_2.clone()], vec![])
+			.commit_sum(vec![commit_1, commit_2], vec![])
 			.unwrap();
 
 		// confirm the commitment for key 3 matches the sum of the commitments 1 and 2

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -124,7 +124,7 @@ pub fn from_entropy(entropy: &[u8]) -> Result<String, Error> {
 
 	let mut hash = [0; 32];
 	let mut sha2sum = Sha256::default();
-	sha2sum.input(&(*entropy));
+	sha2sum.input(entropy);
 	hash.copy_from_slice(sha2sum.result().as_slice());
 
 	let checksum = (hash[0] >> 8 - checksum_bits) & mask;

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -112,7 +112,7 @@ pub fn to_entropy(mnemonic: &str) -> Result<Vec<u8>, Error> {
 }
 
 /// Converts entropy to a mnemonic
-pub fn from_entropy(entropy: &Vec<u8>) -> Result<String, Error> {
+pub fn from_entropy(entropy: &[u8]) -> Result<String, Error> {
 	let sizes: [usize; 5] = [16, 20, 24, 28, 32];
 	let length = entropy.len();
 	if !sizes.contains(&length) {
@@ -124,7 +124,7 @@ pub fn from_entropy(entropy: &Vec<u8>) -> Result<String, Error> {
 
 	let mut hash = [0; 32];
 	let mut sha2sum = Sha256::default();
-	sha2sum.input(&entropy.clone());
+	sha2sum.input(&(*entropy));
 	hash.copy_from_slice(sha2sum.result().as_slice());
 
 	let checksum = (hash[0] >> 8 - checksum_bits) & mask;
@@ -149,7 +149,7 @@ pub fn from_entropy(entropy: &Vec<u8>) -> Result<String, Error> {
 
 	let words: Vec<String> = indexes.iter().map(|x| WORDS[*x as usize].clone()).collect();
 	let mnemonic = words.join(" ");
-	Ok(mnemonic.to_owned())
+	Ok(mnemonic)
 }
 
 /// Converts a nemonic and a passphrase into a seed

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -163,7 +163,7 @@ impl Identifier {
 		let mut p = ExtKeychainPath::from_identifier(&self);
 		if p.depth > 0 {
 			p.path[p.depth as usize - 1] = ChildNumber::from(0);
-			p.depth = p.depth - 1;
+			p.depth -= 1;
 		}
 		Identifier::from_path(&p)
 	}
@@ -176,7 +176,7 @@ impl Identifier {
 	}
 
 	pub fn to_bytes(&self) -> [u8; IDENTIFIER_SIZE] {
-		self.0.clone()
+		self.0
 	}
 
 	pub fn from_pubkey(secp: &Secp256k1, pubkey: &PublicKey) -> Identifier {
@@ -308,7 +308,7 @@ impl BlindingFactor {
 			// and secp lib checks this
 			Ok(secp::key::ZERO_KEY)
 		} else {
-			secp::key::SecretKey::from_slice(secp, &self.0).map_err(|e| Error::Secp(e))
+			secp::key::SecretKey::from_slice(secp, &self.0).map_err(Error::Secp)
 		}
 	}
 
@@ -579,7 +579,7 @@ mod test {
 		// split a key, sum the split keys and confirm the sum matches the original key
 		let mut skey_sum = split.blind_1.secret_key(&secp).unwrap();
 		let skey_2 = split.blind_2.secret_key(&secp).unwrap();
-		let _ = skey_sum.add_assign(&secp, &skey_2).unwrap();
+		skey_sum.add_assign(&secp, &skey_2).unwrap();
 		assert_eq!(skey_in, skey_sum);
 	}
 
@@ -592,7 +592,7 @@ mod test {
 		let skey_zero = ZERO_KEY;
 
 		let mut skey_out = skey_in.clone();
-		let _ = skey_out.add_assign(&secp, &skey_zero).unwrap();
+		skey_out.add_assign(&secp, &skey_zero).unwrap();
 
 		assert_eq!(skey_in, skey_out);
 	}

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -123,7 +123,7 @@ impl ViewKey {
 	{
 		let (secret_key, chain_code) = self.ckd_pub_tweak(secp, hasher, i)?;
 
-		let mut public_key = self.public_key.clone();
+		let mut public_key = self.public_key;
 		public_key.add_exp_assign(secp, &secret_key)?;
 
 		let switch_public_key = match &self.switch_public_key {

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -40,7 +40,7 @@ pub fn from_hex(hex_str: String) -> Result<Vec<u8>, num::ParseIntError> {
 	let hex_trim = if &hex_str[..2] == "0x" {
 		hex_str[2..].to_owned()
 	} else {
-		hex_str.clone()
+		hex_str
 	};
 	split_n(&hex_trim.trim()[..], 2)
 		.iter()

--- a/util/src/rate_counter.rs
+++ b/util/src/rate_counter.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::convert::TryInto;
 /// Utility to track the rate of data transfers
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 struct Entry {
 	bytes: u64,
@@ -103,8 +104,8 @@ impl RateCounter {
 // turns out getting the millisecs since epoch in Rust isn't as easy as it
 // could be
 fn millis_since_epoch() -> u64 {
-	let since_epoch = SystemTime::now()
-		.duration_since(SystemTime::UNIX_EPOCH)
-		.unwrap_or_else(|_| Duration::new(0, 0));
-	since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_millis())
+	match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+		Ok(since_epoch) => since_epoch.as_millis().try_into().unwrap_or(0),
+		Err(_) => 0,
+	}
 }

--- a/util/src/rate_counter.rs
+++ b/util/src/rate_counter.rs
@@ -104,8 +104,9 @@ impl RateCounter {
 // turns out getting the millisecs since epoch in Rust isn't as easy as it
 // could be
 fn millis_since_epoch() -> u64 {
-	match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-		Ok(since_epoch) => since_epoch.as_millis().try_into().unwrap_or(0),
-		Err(_) => 0,
-	}
+	SystemTime::now()
+		.duration_since(SystemTime::UNIX_EPOCH)
+		.map_or(0, |since_epoch| {
+			since_epoch.as_millis().try_into().unwrap_or(0)
+		})
 }

--- a/util/src/rate_counter.rs
+++ b/util/src/rate_counter.rs
@@ -106,7 +106,6 @@ impl RateCounter {
 fn millis_since_epoch() -> u64 {
 	SystemTime::now()
 		.duration_since(SystemTime::UNIX_EPOCH)
-		.map_or(0, |since_epoch| {
-			since_epoch.as_millis().try_into().unwrap_or(0)
-		})
+		.map(|since_epoch| since_epoch.as_millis().try_into().unwrap_or(0))
+		.unwrap_or(0)
 }

--- a/util/src/rate_counter.rs
+++ b/util/src/rate_counter.rs
@@ -105,6 +105,6 @@ impl RateCounter {
 fn millis_since_epoch() -> u64 {
 	let since_epoch = SystemTime::now()
 		.duration_since(SystemTime::UNIX_EPOCH)
-		.unwrap_or(Duration::new(0, 0));
+		.unwrap_or_else(|_| Duration::new(0, 0));
 	since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_millis())
 }

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -52,7 +52,7 @@ pub fn create_zip(dst_file: &File, src_dir: &Path, files: Vec<PathBuf>) -> io::R
 /// Extract a set of files from the provided zip archive.
 pub fn extract_files(from_archive: File, dest: &Path, files: Vec<PathBuf>) -> io::Result<()> {
 	let dest: PathBuf = PathBuf::from(dest);
-	let files: Vec<_> = files.iter().cloned().collect();
+	let files: Vec<_> = files.to_vec();
 	let res = thread::spawn(move || {
 		let mut archive = zip_rs::ZipArchive::new(from_archive).expect("archive file exists");
 		for x in files {

--- a/util/tests/file.rs
+++ b/util/tests/file.rs
@@ -39,7 +39,7 @@ fn write_files(dir_name: String, root: &Path) -> io::Result<()> {
 	file.write_all(b"Hello, world!")?;
 	let mut file = File::create(root.join(dir_name.clone() + "/bar.txt"))?;
 	file.write_all(b"Goodbye, world!")?;
-	let mut file = File::create(root.join(dir_name.clone() + "/sub/lorem"))?;
+	let mut file = File::create(root.join(dir_name + "/sub/lorem"))?;
 	file.write_all(b"Lorem ipsum dolor sit amet, consectetur adipiscing elit")?;
 	Ok(())
 }


### PR DESCRIPTION
Relatively large PR. 
- Reduce the number of cloning that we do.
- Replace `!format` by `to_string()` when possible.
- Remove needless return and variable allocation.
- Other simplifications