### PR TITLE
Optimization: Pass SwitchCommitment by value instead of reference

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1595,7 +1595,7 @@ mod test {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 		let commit = keychain
-			.commit(5, &key_id, &SwitchCommitmentType::Regular)
+			.commit(5, &key_id, SwitchCommitmentType::Regular)
 			.unwrap();
 
 		// just some bytes for testing ser/deser
@@ -1644,12 +1644,12 @@ mod test {
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 		let commit = keychain
-			.commit(1003, &key_id, &SwitchCommitmentType::Regular)
+			.commit(1003, &key_id, SwitchCommitmentType::Regular)
 			.unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 		let commit_2 = keychain
-			.commit(1003, &key_id, &SwitchCommitmentType::Regular)
+			.commit(1003, &key_id, SwitchCommitmentType::Regular)
 			.unwrap();
 
 		assert!(commit == commit_2);
@@ -1660,7 +1660,7 @@ mod test {
 		let keychain = ExtKeychain::from_seed(&[0; 32], false).unwrap();
 		let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 		let commit = keychain
-			.commit(5, &key_id, &SwitchCommitmentType::Regular)
+			.commit(5, &key_id, SwitchCommitmentType::Regular)
 			.unwrap();
 
 		let input = Input {

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -233,7 +233,7 @@ pub fn verify_partial_sig(
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let switch = &SwitchCommitmentType::Regular;
+/// let switch = SwitchCommitmentType::Regular;
 /// let commit = keychain.commit(value, &key_id, switch).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain);
 /// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();
@@ -264,7 +264,7 @@ pub fn sign_from_key_id<K>(
 where
 	K: Keychain,
 {
-	let skey = k.derive_key(value, key_id, &SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
+	let skey = k.derive_key(value, key_id, SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
 	let sig = aggsig::sign_single(secp, &msg, &skey, s_nonce, None, None, blind_sum, None)?;
 	Ok(sig)
 }
@@ -300,7 +300,7 @@ where
 /// let fees = 10_000;
 /// let value = reward(fees);
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-/// let switch = &SwitchCommitmentType::Regular;
+/// let switch = SwitchCommitmentType::Regular;
 /// let commit = keychain.commit(value, &key_id, switch).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain);
 /// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -69,7 +69,7 @@ where
 				let commit =
 					build
 						.keychain
-						.commit(value, &key_id, &SwitchCommitmentType::Regular)?;
+						.commit(value, &key_id, SwitchCommitmentType::Regular)?;
 				// TODO: proper support for different switch commitment schemes
 				let input = Input::new(features, commit);
 				Ok((
@@ -119,7 +119,7 @@ where
 			let (tx, sum) = acc?;
 
 			// TODO: proper support for different switch commitment schemes
-			let switch = &SwitchCommitmentType::Regular;
+			let switch = SwitchCommitmentType::Regular;
 
 			let commit = build.keychain.commit(value, &key_id, switch)?;
 

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -38,7 +38,7 @@ where
 {
 	let value = reward(fees);
 	// TODO: proper support for different switch commitment schemes
-	let switch = &SwitchCommitmentType::Regular;
+	let switch = SwitchCommitmentType::Regular;
 	let commit = keychain.commit(value, key_id, switch)?;
 
 	trace!("Block reward - Pedersen Commit is: {:?}", commit,);

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -26,7 +26,7 @@ use keychain::{ExtKeychain, Keychain};
 fn test_output_ser_deser() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let switch = &keychain::SwitchCommitmentType::Regular;
+	let switch = keychain::SwitchCommitmentType::Regular;
 	let commit = keychain.commit(5, &key_id, switch).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
 	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -32,7 +32,7 @@ fn test_verifier_cache_rangeproofs() {
 
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
-	let switch = &SwitchCommitmentType::Regular;
+	let switch = SwitchCommitmentType::Regular;
 	let commit = keychain.commit(5, &key_id, switch).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain);
 	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -100,7 +100,7 @@ impl Keychain for ExtKeychain {
 		&self,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<SecretKey, Error> {
 		let mut h = self.hasher.clone();
 		let p = id.to_path();
@@ -109,7 +109,7 @@ impl Keychain for ExtKeychain {
 			ext_key = ext_key.ckd_priv(&self.secp, &mut h, p.path[i as usize])?;
 		}
 
-		match *switch {
+		match switch {
 			SwitchCommitmentType::Regular => {
 				Ok(self.secp.blind_switch(amount, ext_key.secret_key)?)
 			}
@@ -121,7 +121,7 @@ impl Keychain for ExtKeychain {
 		&self,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<Commitment, Error> {
 		let key = self.derive_key(amount, id, switch)?;
 		let commit = self.secp.commit(amount, key)?;
@@ -136,7 +136,7 @@ impl Keychain for ExtKeychain {
 				let res = self.derive_key(
 					k.value,
 					&Identifier::from_path(&k.ext_keychain_path),
-					&k.switch,
+					k.switch,
 				);
 				if let Ok(s) = res {
 					Some(s)
@@ -153,7 +153,7 @@ impl Keychain for ExtKeychain {
 				let res = self.derive_key(
 					k.value,
 					&Identifier::from_path(&k.ext_keychain_path),
-					&k.switch,
+					k.switch,
 				);
 				if let Ok(s) = res {
 					Some(s)
@@ -186,7 +186,7 @@ impl Keychain for ExtKeychain {
 		msg: &Message,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<Signature, Error> {
 		let skey = self.derive_key(amount, id, switch)?;
 		let sig = self.secp.sign(msg, &skey)?;
@@ -220,7 +220,7 @@ mod test {
 	fn test_key_derivation() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 		let secp = keychain.secp();
-		let switch = &SwitchCommitmentType::None;
+		let switch = SwitchCommitmentType::None;
 
 		let path = ExtKeychainPath::new(1, 1, 0, 0, 0);
 		let key_id = path.to_identifier();

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -484,13 +484,13 @@ pub trait Keychain: Sync + Send + Clone {
 		&self,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<SecretKey, Error>;
 	fn commit(
 		&self,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<Commitment, Error>;
 	fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error>;
 	fn sign(
@@ -498,7 +498,7 @@ pub trait Keychain: Sync + Send + Clone {
 		msg: &Message,
 		amount: u64,
 		id: &Identifier,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<Signature, Error>;
 	fn sign_with_blinding(&self, _: &Message, _: &BlindingFactor) -> Result<Signature, Error>;
 	fn secp(&self) -> &Secp256k1;
@@ -522,9 +522,9 @@ impl TryFrom<u8> for SwitchCommitmentType {
 	}
 }
 
-impl From<&SwitchCommitmentType> for u8 {
-	fn from(switch: &SwitchCommitmentType) -> Self {
-		match *switch {
+impl From<SwitchCommitmentType> for u8 {
+	fn from(switch: SwitchCommitmentType) -> Self {
+		match switch {
 			SwitchCommitmentType::None => 0,
 			SwitchCommitmentType::Regular => 1,
 		}

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -151,11 +151,11 @@ impl ViewKey {
 		&self,
 		secp: &Secp256k1,
 		amount: u64,
-		switch: &SwitchCommitmentType,
+		switch: SwitchCommitmentType,
 	) -> Result<PublicKey, Error> {
 		let value_key = secp.commit_value(amount)?.to_pubkey(secp)?;
 		let pub_key = PublicKey::from_combination(secp, vec![&self.public_key, &value_key])?;
-		match *switch {
+		match switch {
 			SwitchCommitmentType::None => Ok(pub_key),
 			SwitchCommitmentType::Regular => {
 				// TODO: replace this whole block by a libsecp function


### PR DESCRIPTION
As the title says, this PR changes the way we pass the `SwitchCommitment` enum: by value instead of reference. 
Why? An enum is 1 byte in memory but a reference is 8 bytes.