### PR TITLE
keep output_pos index consistent with the output MMR file

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -32,8 +32,7 @@ const BLOCK_HEADER_PREFIX: u8 = 'h' as u8;
 const BLOCK_PREFIX: u8 = 'b' as u8;
 const HEAD_PREFIX: u8 = 'H' as u8;
 const TAIL_PREFIX: u8 = 'T' as u8;
-const COMMIT_POS_PREFIX: u8 = 'c' as u8;
-const COMMIT_POS_HGT_PREFIX: u8 = 'p' as u8;
+const OUTPUT_POS_PREFIX: u8 = 'p' as u8;
 const BLOCK_INPUT_BITMAP_PREFIX: u8 = 'B' as u8;
 const BLOCK_SUMS_PREFIX: u8 = 'M' as u8;
 
@@ -112,42 +111,16 @@ impl ChainStore {
 		)
 	}
 
-	/// Get all outputs PMMR pos. (only for migration purpose)
-	pub fn get_all_output_pos(&self) -> Result<Vec<(Commitment, u64)>, Error> {
-		let mut outputs_pos = Vec::new();
-		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
-		for (k, pos) in self.db.iter::<u64>(&key)? {
-			outputs_pos.push((Commitment::from_vec(k[2..].to_vec()), pos));
-		}
-		Ok(outputs_pos)
-	}
-
 	/// Get PMMR pos for the given output commitment.
-	/// Note:
-	/// 	- Original prefix 'COMMIT_POS_PREFIX' is not used anymore for normal case, refer to #2889 for detail.
-	///		- To be compatible with the old callers, let's keep this function name but replace with new prefix 'COMMIT_POS_HGT_PREFIX'
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
-		let res: Result<Option<(u64, u64)>, Error> = self.db.get_ser(&to_key(
-			COMMIT_POS_HGT_PREFIX,
-			&mut commit.as_ref().to_vec(),
-		));
-		match res {
-			Ok(None) => Err(Error::NotFoundErr(format!(
-				"Output position for: {:?}",
-				commit
-			))),
-			Ok(Some((pos, _height))) => Ok(pos),
-			Err(e) => Err(e),
-		}
+		self.get_output_pos_height(commit).map(|(pos, _)| pos)
 	}
 
 	/// Get PMMR pos and block height for the given output commitment.
 	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<(u64, u64), Error> {
 		option_to_not_found(
-			self.db.get_ser(&to_key(
-				COMMIT_POS_HGT_PREFIX,
-				&mut commit.as_ref().to_vec(),
-			)),
+			self.db
+				.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec())),
 			|| format!("Output position for: {:?}", commit),
 		)
 	}
@@ -229,6 +202,11 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Low level function to delete by key directly.
+	pub fn delete(&self, key: &[u8]) -> Result<(), Error> {
+		self.db.delete(key)
+	}
+
 	/// Delete a full block. Does not delete any record associated with a block
 	/// header.
 	pub fn delete_block(&self, bh: &Hash) -> Result<(), Error> {
@@ -256,7 +234,7 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
-	/// Save output_pos and block height to index.
+	/// Save output pos and block height to index.
 	pub fn save_output_pos_height(
 		&self,
 		commit: &Commitment,
@@ -264,57 +242,38 @@ impl<'a> Batch<'a> {
 		height: u64,
 	) -> Result<(), Error> {
 		self.db.put_ser(
-			&to_key(COMMIT_POS_HGT_PREFIX, &mut commit.as_ref().to_vec())[..],
+			&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec())[..],
 			&(pos, height),
 		)
 	}
 
 	/// Get output_pos from index.
-	/// Note:
-	/// 	- Original prefix 'COMMIT_POS_PREFIX' is not used for normal case anymore, refer to #2889 for detail.
-	///		- To be compatible with the old callers, let's keep this function name but replace with new prefix 'COMMIT_POS_HGT_PREFIX'
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
-		let res: Result<Option<(u64, u64)>, Error> = self.db.get_ser(&to_key(
-			COMMIT_POS_HGT_PREFIX,
-			&mut commit.as_ref().to_vec(),
-		));
-		match res {
-			Ok(None) => Err(Error::NotFoundErr(format!(
-				"Output position for: {:?}",
-				commit
-			))),
-			Ok(Some((pos, _height))) => Ok(pos),
-			Err(e) => Err(e),
-		}
+		self.get_output_pos_height(commit).map(|(pos, _)| pos)
 	}
 
 	/// Get output_pos and block height from index.
 	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<(u64, u64), Error> {
 		option_to_not_found(
-			self.db.get_ser(&to_key(
-				COMMIT_POS_HGT_PREFIX,
-				&mut commit.as_ref().to_vec(),
-			)),
+			self.db
+				.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec())),
 			|| format!("Output position for commit: {:?}", commit),
 		)
 	}
 
-	/// Clear all entries from the output_pos index. (only for migration purpose)
-	pub fn clear_output_pos(&self) -> Result<(), Error> {
-		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
-		for (k, _) in self.db.iter::<u64>(&key)? {
+	/// Clear all entries from the (output_pos,height) index (must be rebuilt after).
+	pub fn clear_output_pos_height(&self) -> Result<(), Error> {
+		let key = to_key(OUTPUT_POS_PREFIX, &mut "".to_string().into_bytes());
+		for (k, _) in self.db.iter::<(u64, u64)>(&key)? {
 			self.db.delete(&k)?;
 		}
 		Ok(())
 	}
 
-	/// Clear all entries from the (output_pos,height) index (must be rebuilt after).
-	pub fn clear_output_pos_height(&self) -> Result<(), Error> {
-		let key = to_key(COMMIT_POS_HGT_PREFIX, &mut "".to_string().into_bytes());
-		for (k, _) in self.db.iter::<(u64, u64)>(&key)? {
-			self.db.delete(&k)?;
-		}
-		Ok(())
+	/// Iterator over the output_pos index.
+	pub fn output_pos_iter(&self) -> Result<SerIterator<(u64, u64)>, Error> {
+		let key = to_key(OUTPUT_POS_PREFIX, &mut "".to_string().into_bytes());
+		self.db.iter(&key)
 	}
 
 	/// Get the previous header.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -289,8 +289,8 @@ where
 		}
 	}
 
-	/// Get the hash from the underlying MMR file
-	/// (ignores the remove log).
+	/// Get the hash from the underlying MMR file, ignoring the leafset.
+	/// Some entries may have been removed from the leafset but not yet pruned from the file.
 	fn get_from_file(&self, pos: u64) -> Option<Hash> {
 		if pos > self.last_pos {
 			None

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -86,6 +86,16 @@ where
 		}
 	}
 
+	/// Get the hash from the underlying MMR file, ignoring the leafset.
+	/// Some entries may have been removed from the leafset but not yet pruned from the file.
+	pub fn get_from_file(&self, pos: u64) -> Option<Hash> {
+		if pos > self.last_pos {
+			None
+		} else {
+			self.backend.get_from_file(pos)
+		}
+	}
+
 	/// Iterator over current (unpruned, unremoved) leaf positions.
 	pub fn leaf_pos_iter(&self) -> impl Iterator<Item = u64> + '_ {
 		self.backend.leaf_pos_iter()


### PR DESCRIPTION
Resolves #3222 

* we need to support rewind so index must maintain recently removed output pos
* cleanup the output_pos index migration code (no longer needed)
* cleanup the code for the old index and consolidate
* rework duplicate code in `get_output_pos()` and `get_output_pos_height()`

TODO - 
- [ ] Still need to test this under various scenarios locally and on mainnet.
- [ ] Probably good idea to split the fix out from the cleanup?