### PR TITLE
use backend file when compacting the output pos index

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1109,9 +1109,6 @@ impl Chain {
 			txhashset.compact(&horizon_header, &mut batch)?;
 		}
 
-		// Rebuild our output_pos index in the db based on current UTXO set.
-		txhashset.rebuild_height_pos_index(&header_pmmr, &mut batch)?;
-
 		// If we are not in archival mode remove historical blocks from the db.
 		if !self.archive_mode {
 			self.remove_historical_blocks(&header_pmmr, &mut batch)?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -229,6 +229,11 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Low level function to delete directly by raw key.
+	pub fn delete(&self, key: &[u8]) -> Result<(), Error> {
+		self.db.delete(key)
+	}
+
 	/// Delete a full block. Does not delete any record associated with a block
 	/// header.
 	pub fn delete_block(&self, bh: &Hash) -> Result<(), Error> {
@@ -267,6 +272,12 @@ impl<'a> Batch<'a> {
 			&to_key(COMMIT_POS_HGT_PREFIX, &mut commit.as_ref().to_vec())[..],
 			&(pos, height),
 		)
+	}
+
+	/// Iterator over the output_pos index.
+	pub fn output_pos_iter(&self) -> Result<SerIterator<(u64, u64)>, Error> {
+		let key = to_key(COMMIT_POS_HGT_PREFIX, &mut "".to_string().into_bytes());
+		self.db.iter(&key)
 	}
 
 	/// Get output_pos from index.

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -86,6 +86,16 @@ where
 		}
 	}
 
+	/// Get the hash from the underlying MMR file, ignoring the leafset.
+	/// Some entries may have been removed from the leafset but not yet pruned from the file.
+	pub fn get_from_file(&self, pos: u64) -> Option<Hash> {
+		if pos > self.last_pos {
+			None
+		} else {
+			self.backend.get_from_file(pos)
+		}
+	}
+
 	/// Iterator over current (unpruned, unremoved) leaf positions.
 	pub fn leaf_pos_iter(&self) -> impl Iterator<Item = u64> + '_ {
 		self.backend.leaf_pos_iter()


### PR DESCRIPTION
Resolves #3222. 
Related #3224. 

We need to ensure the "output pos height" index is consistent with the full output MMR backend file. It is not sufficient to simply keep it consistent with the _current_ UTXO set as we need to support rewind during fork/reorg handling.

This fixes one of the outstanding scenarios that result in an `AlreadySpent` error.

Will open a separate PR for the refactor/cleanup from #3224.