### PR TITLE
kernel pos index

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1107,7 +1107,7 @@ impl Chain {
 
 		// Remove historical blocks from the db unless we are running in archive mode.
 		if !self.archive_mode {
-			self.remove_historical_blocks(&header_pmmr, &mut batch)?;
+			self.remove_historical_blocks(&header_pmmr, &batch)?;
 		}
 
 		// Compact the txhashset itself (rewriting the pruned backend files).
@@ -1154,7 +1154,7 @@ impl Chain {
 	/// Get the position of the kernel if it exists in the kernel_pos index.
 	/// The index is limited to 14 days of recent kernels.
 	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<u64, Error> {
-		Ok(self.txhashset.read().get_kernel_pos(excess)?)
+		self.txhashset.read().get_kernel_pos(excess)
 	}
 
 	/// outputs by insertion index

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1090,7 +1090,7 @@ impl Chain {
 			} else {
 				global::cut_through_horizon()
 			};
-			let next_compact = tail.height.saturating_add(threshold);
+			let next_compact = tail.height.saturating_add(threshold.into());
 			if next_compact > head.height {
 				debug!(
 					"compact: skipping startup compaction (next at {})",
@@ -1152,7 +1152,7 @@ impl Chain {
 	}
 
 	/// Get the position of the kernel if it exists in the kernel_pos index.
-	/// The index is limited to 7 days of recent kernels.
+	/// The index is limited to 14 days of recent kernels.
 	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<u64, Error> {
 		Ok(self.txhashset.read().get_kernel_pos(excess)?)
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -980,8 +980,11 @@ impl Chain {
 			batch.save_body_tail(&tip)?;
 		}
 
-		// Rebuild our output_pos index in the db based on fresh UTXO set.
+		// Initialize output_pos index in the db based on current UTXO set.
 		txhashset.init_output_pos_index(&header_pmmr, &batch)?;
+
+		// Initialize the kernel_pos index for recent kernel history.
+		txhashset.init_kernel_pos_index(&header_pmmr, &batch)?;
 
 		// Commit all the changes to the db.
 		batch.commit()?;

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -131,6 +131,15 @@ impl ChainStore {
 			.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec()))
 	}
 
+	/// Get kernel_pos and block height from index.
+	pub fn get_kernel_pos_height(&self, excess: &Commitment) -> Result<(u64, u64), Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec())),
+			|| format!("Kernel pos for excess commit: {:?}", excess),
+		)
+	}
+
 	/// Builds a new batch to be used with this store.
 	pub fn batch(&self) -> Result<Batch<'_>, Error> {
 		Ok(Batch {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -134,10 +134,12 @@ impl ChainStore {
 	/// Get kernel_pos and block height from index.
 	/// Returns a vec of possible (pos, height) entries in the MMR.
 	/// Returns an empty vec if no entries found.
-	pub fn get_kernel_pos_height(&self, excess: &Commitment) -> Result<Vec<(u64, u64)>, Error> {
-		self.db
-			.get_ser(&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec()))
-			.map(|x| x.unwrap_or(vec![]))
+	pub fn get_kernel_pos_height(&self, excess: &Commitment) -> Result<(u64, u64), Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec())),
+			|| format!("Kernel position for: {:?}", excess),
+		)
 	}
 
 	/// Builds a new batch to be used with this store.
@@ -292,29 +294,25 @@ impl<'a> Batch<'a> {
 		pos: u64,
 		height: u64,
 	) -> Result<(), Error> {
-		let new_value = (pos, height);
-		let mut entry = self.get_kernel_pos_height(excess)?;
-		let idx = entry.binary_search(&new_value).unwrap_or_else(|x| x);
-		entry.insert(idx, new_value);
 		self.db.put_ser(
 			&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec())[..],
-			&entry,
+			&(pos, height),
 		)
 	}
 
 	/// Iterator over the kernel_pos index.
-	pub fn kernel_pos_iter(&self) -> Result<SerIterator<Vec<(u64, u64)>>, Error> {
+	pub fn kernel_pos_iter(&self) -> Result<SerIterator<(u64, u64)>, Error> {
 		let key = to_key(KERNEL_POS_PREFIX, &mut "".to_string().into_bytes());
 		self.db.iter(&key)
 	}
 
 	/// Get kernel_pos and block height from index.
-	/// Returns a vec of possible (pos, height) entries in the MMR.
-	/// Returns an empty vec if no entries found.
-	pub fn get_kernel_pos_height(&self, excess: &Commitment) -> Result<Vec<(u64, u64)>, Error> {
-		self.db
-			.get_ser(&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec()))
-			.map(|x| x.unwrap_or(vec![]))
+	pub fn get_kernel_pos_height(&self, excess: &Commitment) -> Result<(u64, u64), Error> {
+		option_to_not_found(
+			self.db
+				.get_ser(&to_key(KERNEL_POS_PREFIX, &mut excess.as_ref().to_vec())),
+			|| format!("Kernel pos for excess: {:?}", excess),
+		)
 	}
 
 	/// Get output_pos from index.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -348,20 +348,13 @@ impl TxHashSet {
 		Ok(self.commit_index.get_output_pos(&commit)?)
 	}
 
-	/// TODO - This needs to be a multi-step process.
-	/// TODO - Rename this.
-	/// First we need to look the entry up in the index.
-	/// This entry will be a vec of (pos, height).
-	/// The entry may be an empty vec.
-	/// We then need to filter this vec by height (discounting anything beyond current head)
-	/// and then actually look the kernels up, filtering out any that do not align with the index.
-	///
 	/// Get the position of the kernel if it exists in the kernel_pos index.
 	/// The index is limited to 14 days of recent kernels.
-	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<Vec<(TxKernel, u64)>, Error> {
-		let pos = self.commit_index.get_kernel_pos_height(&excess);
-		// .map(|entry| entry)?;
-		Ok(pos)
+	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<u64, Error> {
+		Ok(self
+			.commit_index
+			.get_kernel_pos_height(&excess)
+			.map(|x| x.1)?)
 	}
 
 	/// build a new merkle proof for the given position.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -483,6 +483,9 @@ impl TxHashSet {
 		Ok(())
 	}
 
+	/// Initialize the kernel_pos index.
+	/// Find the block header at the kernel index horizon (14 days of history).
+	/// Then iterate over all kernels since then and add to the index.
 	pub fn init_kernel_pos_index(
 		&self,
 		header_pmmr: &PMMRHandle<BlockHeader>,
@@ -522,6 +525,8 @@ impl TxHashSet {
 		Ok(())
 	}
 
+	/// Compact the kernel_pos index by removing any entries older than the kernel index horizon.
+	/// This will ensure we always have 14 days of kernel history in the index.
 	fn compact_kernel_pos_index(&self, batch: &Batch<'_>) -> Result<(), Error> {
 		let now = Instant::now();
 		let head_header = batch.head_header()?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -300,6 +300,7 @@ impl TxHashSet {
 			.elements_from_pmmr_index(start_index, max_count, max_index)
 	}
 
+	/// TODO - Leverage the kernel_pos as a quick way of achieving this for recent kernels.
 	/// Find a kernel with a given excess. Work backwards from `max_index` to `min_index`
 	pub fn find_kernel(
 		&self,
@@ -347,13 +348,19 @@ impl TxHashSet {
 		Ok(self.commit_index.get_output_pos(&commit)?)
 	}
 
+	/// TODO - This needs to be a multi-step process.
+	/// TODO - Rename this.
+	/// First we need to look the entry up in the index.
+	/// This entry will be a vec of (pos, height).
+	/// The entry may be an empty vec.
+	/// We then need to filter this vec by height (discounting anything beyond current head)
+	/// and then actually look the kernels up, filtering out any that do not align with the index.
+	///
 	/// Get the position of the kernel if it exists in the kernel_pos index.
-	/// The index is limited to 7 days of recent kernels.
-	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<u64, Error> {
-		let pos = self
-			.commit_index
-			.get_kernel_pos_height(&excess)
-			.map(|(pos, _)| pos)?;
+	/// The index is limited to 14 days of recent kernels.
+	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<Vec<(TxKernel, u64)>, Error> {
+		let pos = self.commit_index.get_kernel_pos_height(&excess);
+		// .map(|entry| entry)?;
 		Ok(pos)
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -346,6 +346,16 @@ impl TxHashSet {
 		Ok(self.commit_index.get_output_pos(&commit)?)
 	}
 
+	/// Get the position of the kernel if it exists in the kernel_pos index.
+	/// The index is limited to 7 days of recent kernels.
+	pub fn get_kernel_pos(&self, excess: Commitment) -> Result<u64, Error> {
+		let pos = self
+			.commit_index
+			.get_kernel_pos_height(&excess)
+			.map(|(pos, _)| pos)?;
+		Ok(pos)
+	}
+
 	/// build a new merkle proof for the given position.
 	pub fn merkle_proof(&mut self, commit: Commitment) -> Result<MerkleProof, Error> {
 		let pos = self.commit_index.get_output_pos(&commit)?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -505,7 +505,7 @@ impl TxHashSet {
 		};
 		let mut kernel_count = 0;
 		let mut current_header = cutoff_header;
-		for pos in cutoff_pos..=self.kernel_pmmr_h.last_pos {
+		for pos in cutoff_pos..(self.kernel_pmmr_h.last_pos + 1) {
 			while pos > current_header.kernel_mmr_size {
 				let next_hash = header_pmmr.get_header_hash_by_height(current_header.height + 1)?;
 				current_header = batch.get_block_header(&next_hash)?;

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -259,7 +259,7 @@ impl OutputRoots {
 }
 
 /// Minimal struct representing a known MMR position and associated block height.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CommitPos {
 	/// MMR position
 	pub pos: u64,

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -730,43 +730,7 @@ fn spend_in_fork_and_compact() {
 			prev = next.header.clone();
 			chain.process_block(next, chain::Options::SKIP_POW).unwrap();
 		}
-
 		chain.validate(false).unwrap();
-
-		{
-			let head = chain.head().unwrap();
-			let header_at_horizon = chain
-				.get_header_by_height(
-					head.height
-						.saturating_sub(global::cut_through_horizon() as u64),
-				)
-				.unwrap();
-			let block_at_horizon = chain.get_block(&header_at_horizon.hash()).unwrap();
-			let block_pre_horizon = chain.get_block(&header_at_horizon.prev_hash).unwrap();
-
-			// Chain compaction will remove all blocks earlier than the horizon.
-			chain.compact().expect("chain compaction error");
-
-			// Check the full block at the horizon is in the db but the previous block
-			// has been removed from the db as expected.
-			chain
-				.get_block(&block_at_horizon.hash())
-				.expect("block at horizon in db");
-			chain
-				.get_block(&block_pre_horizon.hash())
-				.expect_err("block pre horizon not in db");
-
-			// Check the kernels for the block still in the db are in the kernel_pos index.
-			let kernel = block_at_horizon.kernels().first().unwrap();
-			chain.get_kernel_pos(kernel.excess).unwrap();
-
-			// Check the kernels for the removed block are no longer in the kernel_pos index.
-			let kernel = block_pre_horizon.kernels().first().unwrap();
-			chain
-				.get_kernel_pos(kernel.excess)
-				.expect_err("kernel_pos should be compacted");
-		}
-
 		chain.validate(false).expect("chain validation error");
 	}
 	// Cleanup chain directory

--- a/chain/tests/test_kernel_index.rs
+++ b/chain/tests/test_kernel_index.rs
@@ -1,0 +1,115 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use self::chain::Chain;
+use self::core::core::hash::Hashed;
+use self::core::core::{Block, BlockHeader, Transaction};
+use self::core::global::ChainTypes;
+use self::core::libtx;
+use self::core::pow::Difficulty;
+use self::core::{global, pow};
+use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
+use chrono::Duration;
+use grin_chain as chain;
+use grin_core as core;
+use grin_keychain as keychain;
+use grin_util as util;
+
+mod chain_test_helper;
+
+use self::chain_test_helper::{clean_output_dir, init_chain};
+
+#[test]
+fn kernel_index_after_compaction() {
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	util::init_test_logger();
+	// Cleanup chain directory
+	let chain_dir = ".grin_kernel_idx";
+	clean_output_dir(chain_dir);
+
+	let chain = init_chain(chain_dir, pow::mine_genesis_block().unwrap());
+	let mut prev = chain.head_header().unwrap();
+	let kc = ExtKeychain::from_random_seed(false).unwrap();
+
+	// mine some blocks
+	for n in 0..30 {
+		let next = prepare_block(&kc, &prev, &chain, 10 + n);
+		prev = next.header.clone();
+		chain.process_block(next, chain::Options::SKIP_POW).unwrap();
+	}
+
+	chain.validate(false).unwrap();
+
+	{
+		let head = chain.head().unwrap();
+		let header_at_horizon = chain
+			.get_header_by_height(
+				head.height
+					.saturating_sub(global::kernel_index_horizon() as u64),
+			)
+			.unwrap();
+		let block_at_horizon = chain.get_block(&header_at_horizon.hash()).unwrap();
+		let block_pre_horizon = chain.get_block(&header_at_horizon.prev_hash).unwrap();
+
+		// Chain compaction will remove all blocks earlier than the horizon.
+		chain.compact().expect("chain compaction error");
+
+		// Kernels up to and including the horizon must be in the kernel index.
+		let kernel = block_at_horizon.kernels().first().unwrap();
+		chain.get_kernel_pos(kernel.excess).unwrap();
+
+		// Kernels beyond the horizon are no longer in the kernel index.
+		let kernel = block_pre_horizon.kernels().first().unwrap();
+		chain
+			.get_kernel_pos(kernel.excess)
+			.expect_err("kernel_pos should be compacted");
+	}
+
+	// Cleanup chain directory
+	clean_output_dir(chain_dir);
+}
+
+fn prepare_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
+where
+	K: Keychain,
+{
+	let mut b = prepare_block_nosum(kc, prev, diff, vec![]);
+	chain.set_txhashset_roots(&mut b).unwrap();
+	b
+}
+
+fn prepare_block_nosum<K>(kc: &K, prev: &BlockHeader, diff: u64, txs: Vec<&Transaction>) -> Block
+where
+	K: Keychain,
+{
+	let proof_size = global::proofsize();
+	let key_id = ExtKeychainPath::new(1, diff as u32, 0, 0, 0).to_identifier();
+
+	let fees = txs.iter().map(|tx| tx.fee()).sum();
+	let reward =
+		libtx::reward::output(kc, &libtx::ProofBuilder::new(kc), &key_id, fees, false).unwrap();
+	let mut b = match core::core::Block::new(
+		prev,
+		txs.into_iter().cloned().collect(),
+		Difficulty::from_num(diff),
+		reward,
+	) {
+		Err(e) => panic!("{:?}", e),
+		Ok(b) => b,
+	};
+	b.header.timestamp = prev.timestamp + Duration::seconds(60);
+	b.header.pow.total_difficulty = prev.total_difficulty() + Difficulty::from_num(diff);
+	b.header.pow.proof = pow::Proof::random(proof_size);
+	b
+}

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -93,6 +93,11 @@ pub const BASE_EDGE_BITS: u8 = 24;
 /// easier to reason about.
 pub const CUT_THROUGH_HORIZON: u32 = WEEK_HEIGHT as u32;
 
+/// A relative kernel lock is only applicable within a limited number of recent blocks.
+/// This is consensus critical as the lock condition will be met once this number of blocks
+/// has been exceeded and the referenced kernel "ages out".
+pub const KERNEL_RELATIVE_HEIGHT_LIMIT: u32 = WEEK_HEIGHT as u32;
+
 /// Default number of blocks in the past to determine the height where we request
 /// a txhashset (and full blocks from). Needs to be long enough to not overlap with
 /// a long reorg.

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -19,8 +19,8 @@
 use crate::consensus::{
 	graph_weight, valid_header_version, HeaderInfo, BASE_EDGE_BITS, BLOCK_TIME_SEC,
 	COINBASE_MATURITY, CUT_THROUGH_HORIZON, DAY_HEIGHT, DEFAULT_MIN_EDGE_BITS,
-	DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY, MAX_BLOCK_WEIGHT, PROOFSIZE,
-	SECOND_POW_EDGE_BITS, STATE_SYNC_THRESHOLD,
+	DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY, KERNEL_RELATIVE_HEIGHT_LIMIT, MAX_BLOCK_WEIGHT,
+	PROOFSIZE, SECOND_POW_EDGE_BITS, STATE_SYNC_THRESHOLD,
 };
 use crate::core::block::HeaderVersion;
 use crate::pow::{
@@ -66,6 +66,12 @@ pub const AUTOMATED_TESTING_CUT_THROUGH_HORIZON: u32 = 20;
 
 /// Testing cut through horizon in blocks
 pub const USER_TESTING_CUT_THROUGH_HORIZON: u32 = 70;
+
+/// Kernel index horizon for automated tests
+pub const AUTOMATED_TESTING_KERNEL_INDEX_HORIZON: u32 = 25;
+
+/// Kernel index horizon for user testing
+pub const USER_TESTING_KERNEL_INDEX_HORIZON: u32 = 2 * USER_TESTING_CUT_THROUGH_HORIZON;
 
 /// Testing state sync threshold in blocks
 pub const TESTING_STATE_SYNC_THRESHOLD: u32 = 20;
@@ -280,6 +286,17 @@ pub fn cut_through_horizon() -> u32 {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_CUT_THROUGH_HORIZON,
 		ChainTypes::UserTesting => USER_TESTING_CUT_THROUGH_HORIZON,
 		_ => CUT_THROUGH_HORIZON,
+	}
+}
+
+/// We maintain an index of "recent" kernels back to this horizon.
+/// This must be sufficient for validating an NSKR lock under rewind scenario.
+pub fn kernel_index_horizon() -> u32 {
+	let param_ref = CHAIN_TYPE.read();
+	match *param_ref {
+		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_KERNEL_INDEX_HORIZON,
+		ChainTypes::UserTesting => USER_TESTING_KERNEL_INDEX_HORIZON,
+		_ => KERNEL_RELATIVE_HEIGHT_LIMIT + CUT_THROUGH_HORIZON,
 	}
 }
 


### PR DESCRIPTION
Maintain index of "recent" kernels so we can quickly lookup a kernel MMR pos (and block height) by kernel excess commitment.

This is similar to the existing `output_pos` index.
Important difference is outputs can be removed and pruned (after being spent), kernels are never removed. But we only want to maintain an index of "recent" kernels sufficient for the proposed NSKR relative kernel locks.

Compact the kernel pos index when we compact the txhashset. We maintain 2 weeks of kernel history in the index. This covers 7 days of full block history back to the horizon (for rewind purposes) and a further 7 days of kernel history to cover the max NSKR relative kernel lock period.

Populate the index as we go when calling `apply_kernel()` during processing of new full blocks.

Add test coverage around chain compaction and interaction with the kernel pos index.

Track an "undo list" for each full block so we can rewind the kernel_pos index as required when rewinding a block.

----

We do not need to track the kernel_pos index currently as it is unused.
But we need this implemented for efficient handling of NRD kernel lookups.
Once we have the NRD kernel feature variant we can modify the kernel_pos index to only index recent NRD kernels (currently we index all recent kernels).

----

Related #3273.

If we track `kernel_pos` via the "linked list" impl then we no longer need to maintain the "undo list" per block.
We can simply pop entries off the head of the list during rewind, rewinding each kernel in the block, leaving the index in the previous state in the case of duplicates.



