### PR TITLE
[DNM] vm image name is case sensitive (and potentially fails silently)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
     - template: '.ci/release.yml'
 - job: macos
   pool:
-    vmImage: macos-10.14
+    vmImage: macOS-10.14
   strategy:
     matrix:
       test:


### PR DESCRIPTION
Just checking something related to the vm image name.

Related - 

https://chromium.googlesource.com/external/github.com/numpy/numpy/+/refs/tags/v1.16.0rc2/azure-pipelines.yml

```
- job: macOS
--
  | pool:
  | # NOTE: at time of writing, there is a danger
  | # that using an invalid vmIMage string for macOS
  | # image silently redirects to a Windows build on Azure;
  | # for now, use the only image name officially present in
  | # the docs even though i.e., numba uses another in their
  | # azure config for mac os -- Microsoft has indicated
  | # they will patch this issue
  | vmIMage: macOS-10.13


```