### PR TITLE
Block input bitmap rework

### DIFF
--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -56,7 +56,7 @@ pub fn get_output(
 		match res {
 			Ok(output_pos) => {
 				return Ok((
-					Output::new(&commit, output_pos.height, output_pos.position),
+					Output::new(&commit, output_pos.height, output_pos.pos),
 					x.clone(),
 				));
 			}
@@ -100,7 +100,7 @@ pub fn get_output_v2(
 	for x in outputs.iter() {
 		let res = chain.is_unspent(x);
 		match res {
-			Ok(output_pos) => match chain.get_unspent_output_at(output_pos.position) {
+			Ok(output_pos) => match chain.get_unspent_output_at(output_pos.pos) {
 				Ok(output) => {
 					let header = if include_merkle_proof && output.is_coinbase() {
 						chain.get_header_by_height(output_pos.height).ok()

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -199,6 +199,15 @@ impl Chain {
 			&mut txhashset,
 		)?;
 
+		// Initialize the output_pos index based on UTXO set.
+		// This is fast as we only look for stale and missing entries
+		// and do not need to rebuild the entire index.
+		{
+			let batch = store.batch()?;
+			txhashset.init_output_pos_index(&header_pmmr, &batch)?;
+			batch.commit()?;
+		}
+
 		let chain = Chain {
 			db_root,
 			store,
@@ -972,7 +981,7 @@ impl Chain {
 		}
 
 		// Rebuild our output_pos index in the db based on fresh UTXO set.
-		txhashset.init_output_pos_index(&header_pmmr, &mut batch)?;
+		txhashset.init_output_pos_index(&header_pmmr, &batch)?;
 
 		// Commit all the changes to the db.
 		batch.commit()?;
@@ -1014,7 +1023,7 @@ impl Chain {
 	fn remove_historical_blocks(
 		&self,
 		header_pmmr: &txhashset::PMMRHandle<BlockHeader>,
-		batch: &mut store::Batch<'_>,
+		batch: &store::Batch<'_>,
 	) -> Result<(), Error> {
 		if self.archive_mode {
 			return Ok(());
@@ -1088,7 +1097,7 @@ impl Chain {
 		// Take a write lock on the txhashet and start a new writeable db batch.
 		let header_pmmr = self.header_pmmr.read();
 		let mut txhashset = self.txhashset.write();
-		let mut batch = self.store.batch()?;
+		let batch = self.store.batch()?;
 
 		// Compact the txhashset itself (rewriting the pruned backend files).
 		{
@@ -1099,13 +1108,16 @@ impl Chain {
 			let horizon_hash = header_pmmr.get_header_hash_by_height(horizon_height)?;
 			let horizon_header = batch.get_block_header(&horizon_hash)?;
 
-			txhashset.compact(&horizon_header, &mut batch)?;
+			txhashset.compact(&horizon_header, &batch)?;
 		}
 
 		// If we are not in archival mode remove historical blocks from the db.
 		if !self.archive_mode {
-			self.remove_historical_blocks(&header_pmmr, &mut batch)?;
+			self.remove_historical_blocks(&header_pmmr, &batch)?;
 		}
+
+		// Make sure our output_pos index is consistent with the UTXO set.
+		txhashset.init_output_pos_index(&header_pmmr, &batch)?;
 
 		// Commit all the above db changes.
 		batch.commit()?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,7 +30,7 @@ use crate::store;
 use crate::txhashset;
 use crate::txhashset::{PMMRHandle, TxHashSet};
 use crate::types::{
-	BlockStatus, ChainAdapter, NoStatus, Options, OutputPos, Tip, TxHashsetWriteStatus,
+	BlockStatus, ChainAdapter, CommitPos, NoStatus, Options, Tip, TxHashsetWriteStatus,
 };
 use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::util::RwLock;
@@ -504,7 +504,7 @@ impl Chain {
 	/// spent. This querying is done in a way that is consistent with the
 	/// current chain state, specifically the current winning (valid, most
 	/// work) fork.
-	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<OutputPos, Error> {
+	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<CommitPos, Error> {
 		self.txhashset.read().is_unspent(output_ref)
 	}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -30,7 +30,7 @@ use crate::store;
 use crate::txhashset;
 use crate::txhashset::{PMMRHandle, TxHashSet};
 use crate::types::{
-	BlockStatus, ChainAdapter, NoStatus, Options, OutputMMRPosition, Tip, TxHashsetWriteStatus,
+	BlockStatus, ChainAdapter, NoStatus, Options, OutputPos, Tip, TxHashsetWriteStatus,
 };
 use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::util::RwLock;
@@ -495,9 +495,8 @@ impl Chain {
 	/// spent. This querying is done in a way that is consistent with the
 	/// current chain state, specifically the current winning (valid, most
 	/// work) fork.
-	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<OutputMMRPosition, Error> {
-		let txhashset = self.txhashset.read();
-		txhashset.is_unspent(output_ref)
+	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<OutputPos, Error> {
+		self.txhashset.read().is_unspent(output_ref)
 	}
 
 	/// Retrieves an unspent output using its PMMR position
@@ -1510,6 +1509,7 @@ fn setup_head(
 			// We will update this later once we have the correct header_root.
 			batch.save_block_header(&genesis.header)?;
 			batch.save_block(&genesis)?;
+			batch.save_spent_index(&genesis.hash(), &vec![])?;
 			batch.save_body_head(&Tip::from_header(&genesis.header))?;
 
 			if !genesis.kernels().is_empty() {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -23,7 +23,7 @@ use crate::core::pow;
 use crate::error::{Error, ErrorKind};
 use crate::store;
 use crate::txhashset;
-use crate::types::{Options, OutputPos, Tip};
+use crate::types::{CommitPos, Options, Tip};
 use crate::util::RwLock;
 use grin_store;
 use std::sync::Arc;
@@ -431,7 +431,7 @@ fn apply_block_to_txhashset(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
-) -> Result<Vec<OutputPos>, Error> {
+) -> Result<Vec<CommitPos>, Error> {
 	let spent = ext.extension.apply_block(block, batch)?;
 	ext.extension.validate_roots(&block.header)?;
 	ext.extension.validate_sizes(&block.header)?;
@@ -444,7 +444,7 @@ fn apply_block_to_txhashset(
 fn add_block(
 	b: &Block,
 	block_sums: &BlockSums,
-	spent: &Vec<OutputPos>,
+	spent: &Vec<CommitPos>,
 	batch: &store::Batch<'_>,
 ) -> Result<(), Error> {
 	batch.save_block(b)?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -23,7 +23,7 @@ use crate::core::pow;
 use crate::error::{Error, ErrorKind};
 use crate::store;
 use crate::txhashset;
-use crate::types::{Options, Tip};
+use crate::types::{Options, OutputPos, Tip};
 use crate::util::RwLock;
 use grin_store;
 use std::sync::Arc;
@@ -121,7 +121,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 	let ref mut header_pmmr = &mut ctx.header_pmmr;
 	let ref mut txhashset = &mut ctx.txhashset;
 	let ref mut batch = &mut ctx.batch;
-	let block_sums = txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
+	let (block_sums, spent) = txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
 		rewind_and_apply_fork(&prev, ext, batch)?;
 
 		// Check any coinbase being spent have matured sufficiently.
@@ -143,22 +143,24 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 		// Apply the block to the txhashset state.
 		// Validate the txhashset roots and sizes against the block header.
 		// Block is invalid if there are any discrepencies.
-		apply_block_to_txhashset(b, ext, batch)?;
+		let spent = apply_block_to_txhashset(b, ext, batch)?;
 
 		// If applying this block does not increase the work on the chain then
 		// we know we have not yet updated the chain to produce a new chain head.
+		// We discard the "child" batch used in this extension (original ctx batch still active).
+		// We discard any MMR modifications applied in this extension.
 		let head = batch.head()?;
 		if !has_more_work(&b.header, &head) {
 			ext.extension.force_rollback();
 		}
 
-		Ok(block_sums)
+		Ok((block_sums, spent))
 	})?;
 
 	// Add the validated block to the db along with the corresponding block_sums.
 	// We do this even if we have not increased the total cumulative work
 	// so we can maintain multiple (in progress) forks.
-	add_block(b, &block_sums, &ctx.batch)?;
+	add_block(b, &block_sums, &spent, &ctx.batch)?;
 
 	// If we have no "tail" then set it now.
 	if ctx.batch.tail().is_err() {
@@ -429,20 +431,25 @@ fn apply_block_to_txhashset(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
-) -> Result<(), Error> {
-	ext.extension.apply_block(block, batch)?;
+) -> Result<Vec<OutputPos>, Error> {
+	let spent = ext.extension.apply_block(block, batch)?;
 	ext.extension.validate_roots(&block.header)?;
 	ext.extension.validate_sizes(&block.header)?;
-	Ok(())
+	Ok(spent)
 }
 
-/// Officially adds the block to our chain.
+/// Officially adds the block to our chain (possibly on a losing fork).
+/// Adds the associated block_sums and spent_index as well.
 /// Header must be added separately (assume this has been done previously).
-fn add_block(b: &Block, block_sums: &BlockSums, batch: &store::Batch<'_>) -> Result<(), Error> {
-	batch
-		.save_block(b)
-		.map_err(|e| ErrorKind::StoreErr(e, "pipe save block".to_owned()))?;
+fn add_block(
+	b: &Block,
+	block_sums: &BlockSums,
+	spent: &Vec<OutputPos>,
+	batch: &store::Batch<'_>,
+) -> Result<(), Error> {
+	batch.save_block(b)?;
 	batch.save_block_sums(&b.hash(), block_sums)?;
+	batch.save_spent_index(&b.hash(), spent)?;
 	Ok(())
 }
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -19,7 +19,7 @@ use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::{Block, BlockHeader, BlockSums};
 use crate::core::pow::Difficulty;
 use crate::core::ser::ProtocolVersion;
-use crate::types::{OutputPos, Tip};
+use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
 use croaring::Bitmap;
 use grin_store as store;
@@ -190,7 +190,7 @@ impl<'a> Batch<'a> {
 
 	/// We maintain a "spent" index for each full block to allow the output_pos
 	/// to be easily reverted during rewind.
-	pub fn save_spent_index(&self, h: &Hash, spent: &Vec<OutputPos>) -> Result<(), Error> {
+	pub fn save_spent_index(&self, h: &Hash, spent: &Vec<CommitPos>) -> Result<(), Error> {
 		self.db
 			.put_ser(&to_key(BLOCK_SPENT_PREFIX, &mut h.to_vec())[..], spent)?;
 		Ok(())
@@ -349,7 +349,7 @@ impl<'a> Batch<'a> {
 
 	/// Get the "spent index" from the db for the specified block.
 	/// If we need to rewind a block then we use this to "unspend" the spent outputs.
-	pub fn get_spent_index(&self, bh: &Hash) -> Result<Vec<OutputPos>, Error> {
+	pub fn get_spent_index(&self, bh: &Hash) -> Result<Vec<CommitPos>, Error> {
 		option_to_not_found(
 			self.db
 				.get_ser(&to_key(BLOCK_SPENT_PREFIX, &mut bh.to_vec())),

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -258,6 +258,14 @@ impl<'a> Batch<'a> {
 			.delete(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec()))
 	}
 
+	/// When using the output_pos iterator we have access to the index keys but not the
+	/// original commitment that the key is constructed from. So we need a way of comparing
+	/// a key with another commitment without reconstructing the commitment from the key bytes.
+	pub fn is_match_output_pos_key(&self, key: &[u8], commit: &Commitment) -> bool {
+		let commit_key = to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec());
+		commit_key == key
+	}
+
 	/// Iterator over the output_pos index.
 	pub fn output_pos_iter(&self) -> Result<SerIterator<(u64, u64)>, Error> {
 		let key = to_key(OUTPUT_POS_PREFIX, &mut "".to_string().into_bytes());

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -395,12 +395,15 @@ impl TxHashSet {
 			ReadonlyPMMR::at(&self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 
 		// Iterate over the current output_pos index, removing any entries that
-		// do not point to to the correct output.
+		// do not point to to the expected output.
 		let mut removed_count = 0;
 		for (key, (pos, _)) in batch.output_pos_iter()? {
 			if let Some(out) = output_pmmr.get_data(pos) {
 				if let Ok(pos_via_mmr) = batch.get_output_pos(&out.commitment()) {
-					if pos == pos_via_mmr {
+					// If the pos matches and the index key matches the commitment
+					// then keep the entry, other we want to clean it up.
+					if pos == pos_via_mmr && batch.is_match_output_pos_key(&key, &out.commitment())
+					{
 						continue;
 					}
 				}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1599,8 +1599,6 @@ pub fn clean_txhashset_folder(root_dir: &PathBuf) {
 	}
 }
 
-/// TODO - suspect this can be simplified *significantly*.
-///
 /// Given a block header to rewind to and the block header at the
 /// head of the current chain state, we need to calculate the positions
 /// of all inputs (spent outputs) we need to "undo" during a rewind.
@@ -1614,7 +1612,6 @@ fn input_pos_to_rewind(
 	let mut bitmap = Bitmap::create();
 	let mut current = head_header.clone();
 	while current.height > block_header.height {
-		// TODO - read the spent index here and explicitly fallback to input bitmap.
 		if let Ok(block_bitmap) = batch.get_block_input_bitmap(&current.hash()) {
 			bitmap.or_inplace(&block_bitmap);
 		}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -25,7 +25,7 @@ use crate::error::{Error, ErrorKind};
 use crate::store::{Batch, ChainStore};
 use crate::txhashset::bitmap_accumulator::BitmapAccumulator;
 use crate::txhashset::{RewindableKernelView, UTXOView};
-use crate::types::{OutputMMRPosition, OutputRoots, Tip, TxHashSetRoots, TxHashsetWriteStatus};
+use crate::types::{OutputPos, OutputRoots, Tip, TxHashSetRoots, TxHashsetWriteStatus};
 use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::util::{file, secp_static, zip};
 use croaring::Bitmap;
@@ -223,17 +223,18 @@ impl TxHashSet {
 	/// Check if an output is unspent.
 	/// We look in the index to find the output MMR pos.
 	/// Then we check the entry in the output MMR and confirm the hash matches.
-	pub fn is_unspent(&self, output_id: &OutputIdentifier) -> Result<OutputMMRPosition, Error> {
-		match self.commit_index.get_output_pos_height(&output_id.commit) {
-			Ok((pos, block_height)) => {
+	pub fn is_unspent(&self, output_id: &OutputIdentifier) -> Result<OutputPos, Error> {
+		let commit = output_id.commit;
+		match self.commit_index.get_output_pos_height(&commit) {
+			Ok((pos, height)) => {
 				let output_pmmr: ReadonlyPMMR<'_, Output, _> =
 					ReadonlyPMMR::at(&self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 				if let Some(hash) = output_pmmr.get_hash(pos) {
 					if hash == output_id.hash_with_index(pos - 1) {
-						Ok(OutputMMRPosition {
-							output_mmr_hash: hash,
-							position: pos,
-							height: block_height,
+						Ok(OutputPos {
+							pos,
+							height,
+							commit,
 						})
 					} else {
 						Err(ErrorKind::TxHashSetErr("txhashset hash mismatch".to_string()).into())
@@ -367,7 +368,6 @@ impl TxHashSet {
 
 		let head_header = batch.head_header()?;
 
-		// TODO - What to do with this?
 		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, batch)?;
 
 		debug!("txhashset: check_compact output mmr backend...");
@@ -379,9 +379,6 @@ impl TxHashSet {
 		self.rproof_pmmr_h
 			.backend
 			.check_compact(horizon_header.output_mmr_size, &rewind_rm_pos)?;
-
-		debug!("txhashset: compact height pos index...");
-		self.compact_height_pos_index(batch)?;
 
 		debug!("txhashset: ... compaction finished");
 
@@ -429,32 +426,6 @@ impl TxHashSet {
 		debug!(
 			"init_height_pos_index: {} UTXOs, took {}s",
 			total_outputs,
-			now.elapsed().as_secs(),
-		);
-		Ok(())
-	}
-
-	fn compact_height_pos_index(&self, batch: &Batch<'_>) -> Result<(), Error> {
-		let now = Instant::now();
-		let output_pmmr =
-			ReadonlyPMMR::at(&self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
-		let last_pos = output_pmmr.unpruned_size();
-
-		let deleted = batch
-			.output_pos_iter()?
-			.filter(|(_, (pos, _))| {
-				// Note we use get_from_file() here as we want to ensure we have an entry
-				// in the index for *every* output still in the file, not just the "unspent"
-				// outputs. This is because we need to support rewind to handle fork/reorg.
-				// Rewind may "unspend" recently spent, but not yet pruned outputs, and the
-				// index must be consistent in this situation.
-				*pos <= last_pos && output_pmmr.get_from_file(*pos).is_none()
-			})
-			.map(|(key, _)| batch.delete(&key))
-			.count();
-		debug!(
-			"compact_output_pos_index: deleted {} entries from the index, took {}s",
-			deleted,
 			now.elapsed().as_secs(),
 		);
 		Ok(())
@@ -925,18 +896,28 @@ impl<'a> Extension<'a> {
 	}
 
 	/// Apply a new block to the current txhashet extension (output, rangeproof, kernel MMRs).
-	pub fn apply_block(&mut self, b: &Block, batch: &Batch<'_>) -> Result<(), Error> {
+	pub fn apply_block(&mut self, b: &Block, batch: &Batch<'_>) -> Result<Vec<OutputPos>, Error> {
 		let mut affected_pos = vec![];
+		let mut spent = vec![];
 
 		for out in b.outputs() {
 			let pos = self.apply_output(out, batch)?;
 			affected_pos.push(pos);
+
+			// TODO - we do *not* want to actually add to batch here?
+			// if we are processing a fork we want this batch to rollback.
 			batch.save_output_pos_height(&out.commitment(), pos, b.header.height)?;
 		}
 
 		for input in b.inputs() {
-			let pos = self.apply_input(input, batch)?;
-			affected_pos.push(pos);
+			let spent_pos = self.apply_input(input, batch)?;
+			affected_pos.push(spent_pos.pos);
+
+			// TODO - we do *not* want to actually add to batch here?
+			// if processing a fork we want this batch to rollback.
+			batch.delete_output_pos_height(&spent_pos.commit)?;
+
+			spent.push(spent_pos);
 		}
 
 		for kernel in b.kernels() {
@@ -949,7 +930,7 @@ impl<'a> Extension<'a> {
 		// Update the head of the extension to reflect the block we just applied.
 		self.head = Tip::from_header(&b.header);
 
-		Ok(())
+		Ok(spent)
 	}
 
 	fn apply_to_bitmap_accumulator(&mut self, output_pos: &[u64]) -> Result<(), Error> {
@@ -971,10 +952,9 @@ impl<'a> Extension<'a> {
 		)
 	}
 
-	fn apply_input(&mut self, input: &Input, batch: &Batch<'_>) -> Result<u64, Error> {
+	fn apply_input(&mut self, input: &Input, batch: &Batch<'_>) -> Result<OutputPos, Error> {
 		let commit = input.commitment();
-		let pos_res = batch.get_output_pos(&commit);
-		if let Ok(pos) = pos_res {
+		if let Ok((pos, height)) = batch.get_output_pos_height(&commit) {
 			// First check this input corresponds to an existing entry in the output MMR.
 			if let Some(hash) = self.output_pmmr.get_hash(pos) {
 				if hash != input.hash_with_index(pos - 1) {
@@ -992,7 +972,11 @@ impl<'a> Extension<'a> {
 					self.rproof_pmmr
 						.prune(pos)
 						.map_err(ErrorKind::TxHashSetErr)?;
-					Ok(pos)
+					Ok(OutputPos {
+						pos,
+						height,
+						commit,
+					})
 				}
 				Ok(false) => Err(ErrorKind::AlreadySpent(commit).into()),
 				Err(e) => Err(ErrorKind::TxHashSetErr(e).into()),
@@ -1108,11 +1092,7 @@ impl<'a> Extension<'a> {
 
 		if head_header.height <= header.height {
 			// Nothing to rewind but we do want to truncate the MMRs at header for consistency.
-			self.rewind_mmrs_to_pos(
-				header.output_mmr_size,
-				header.kernel_mmr_size,
-				&Bitmap::create(),
-			)?;
+			self.rewind_mmrs_to_pos(header.output_mmr_size, header.kernel_mmr_size, &vec![])?;
 			self.apply_to_bitmap_accumulator(&[header.output_mmr_size])?;
 		} else {
 			let mut current = head_header;
@@ -1138,23 +1118,43 @@ impl<'a> Extension<'a> {
 		header: &BlockHeader,
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {
-		let input_bitmap = batch.get_block_input_bitmap(&header.hash())?;
+		let spent = batch.get_spent_index(&header.hash());
+
+		let spent_pos: Vec<_> = if let Ok(ref spent) = spent {
+			spent.iter().map(|x| x.pos).collect()
+		} else {
+			warn!(
+				"rewind_single_block: fallback to legacy input bitmap for block {} at {}",
+				header.hash(),
+				header.height
+			);
+			let bitmap = batch.get_block_input_bitmap(&header.hash())?;
+			bitmap.iter().map(|x| x.into()).collect()
+		};
 
 		if header.height == 0 {
-			self.rewind_mmrs_to_pos(0, 0, &Bitmap::create())?;
+			self.rewind_mmrs_to_pos(0, 0, &spent_pos)?;
 		} else {
 			let prev = batch.get_previous_header(&header)?;
-			self.rewind_mmrs_to_pos(prev.output_mmr_size, prev.kernel_mmr_size, &input_bitmap)?;
+			self.rewind_mmrs_to_pos(prev.output_mmr_size, prev.kernel_mmr_size, &spent_pos)?;
 		}
 
 		// Update our BitmapAccumulator based on affected outputs.
 		// We want to "unspend" every rewound spent output.
 		// Treat last_pos as an affected output to ensure we rebuild far enough back.
-		let mut affected_pos: Vec<_> = input_bitmap.iter().map(|x| x.into()).collect();
+		let mut affected_pos = spent_pos.clone();
 		affected_pos.push(self.output_pmmr.last_pos);
 		self.apply_to_bitmap_accumulator(&affected_pos)?;
 
-		// TODO - we need to update the output_pos index here to reflect rewound state.
+		// Update output_pos based on "unspending" all spent pos from this block.
+		// This is necessary to ensure the output_pos index correclty reflects a
+		// reused output commitment. For example an output at pos 1, spent, reused at pos 2.
+		// The output_pos index should be updated to reflect the old pos 1 when unspent.
+		if let Ok(spent) = spent {
+			for x in spent {
+				batch.save_output_pos_height(&x.commit, x.pos, x.height)?;
+			}
+		}
 
 		Ok(())
 	}
@@ -1165,13 +1165,14 @@ impl<'a> Extension<'a> {
 		&mut self,
 		output_pos: u64,
 		kernel_pos: u64,
-		rewind_rm_pos: &Bitmap,
+		spent_pos: &[u64],
 	) -> Result<(), Error> {
+		let bitmap: Bitmap = spent_pos.into_iter().map(|x| *x as u32).collect();
 		self.output_pmmr
-			.rewind(output_pos, rewind_rm_pos)
+			.rewind(output_pos, &bitmap)
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		self.rproof_pmmr
-			.rewind(output_pos, rewind_rm_pos)
+			.rewind(output_pos, &bitmap)
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		self.kernel_pmmr
 			.rewind(kernel_pos, &Bitmap::create())
@@ -1610,40 +1611,14 @@ fn input_pos_to_rewind(
 	head_header: &BlockHeader,
 	batch: &Batch<'_>,
 ) -> Result<Bitmap, Error> {
-	if head_header.height <= block_header.height {
-		return Ok(Bitmap::create());
-	}
-
-	// Batching up the block input bitmaps, and running fast_or() on every batch of 256 bitmaps.
-	// so to avoid maintaining a huge vec of bitmaps.
-	let bitmap_fast_or = |b_res, block_input_bitmaps: &mut Vec<Bitmap>| -> Option<Bitmap> {
-		if let Some(b) = b_res {
-			block_input_bitmaps.push(b);
-			if block_input_bitmaps.len() < 256 {
-				return None;
-			}
-		}
-		let bitmap = Bitmap::fast_or(&block_input_bitmaps.iter().collect::<Vec<&Bitmap>>());
-		block_input_bitmaps.clear();
-		block_input_bitmaps.push(bitmap.clone());
-		Some(bitmap)
-	};
-
-	let mut block_input_bitmaps: Vec<Bitmap> = vec![];
-
+	let mut bitmap = Bitmap::create();
 	let mut current = head_header.clone();
-	while current.hash() != block_header.hash() {
-		if current.height < 1 {
-			break;
-		}
-
-		// I/O should be minimized or eliminated here for most
-		// rewind scenarios.
-		if let Ok(b_res) = batch.get_block_input_bitmap(&current.hash()) {
-			bitmap_fast_or(Some(b_res), &mut block_input_bitmaps);
+	while current.height > block_header.height {
+		// TODO - read the spent index here and explicitly fallback to input bitmap.
+		if let Ok(block_bitmap) = batch.get_block_input_bitmap(&current.hash()) {
+			bitmap.or_inplace(&block_bitmap);
 		}
 		current = batch.get_previous_header(&current)?;
 	}
-
-	bitmap_fast_or(None, &mut block_input_bitmaps).ok_or_else(|| ErrorKind::Bitmap.into())
+	Ok(bitmap)
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -259,18 +259,6 @@ impl OutputRoots {
 	}
 }
 
-/// Minimal struct representing an output commitment at a known position (and block height)
-/// in an MMR.
-#[derive(Debug)]
-pub struct OutputPos {
-	/// MMR position
-	pub pos: u64,
-	/// Block height
-	pub height: u64,
-	/// Output commitment
-	pub commit: Commitment,
-}
-
 /// Minimal struct representing a known MMR position and associated block height.
 #[derive(Debug)]
 pub struct CommitPos {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -271,24 +271,27 @@ pub struct OutputPos {
 	pub commit: Commitment,
 }
 
-impl Readable for OutputPos {
-	fn read(reader: &mut dyn Reader) -> Result<OutputPos, ser::Error> {
+/// Minimal struct representing a known MMR position and associated block height.
+#[derive(Debug)]
+pub struct CommitPos {
+	/// MMR position
+	pub pos: u64,
+	/// Block height
+	pub height: u64,
+}
+
+impl Readable for CommitPos {
+	fn read(reader: &mut dyn Reader) -> Result<CommitPos, ser::Error> {
 		let pos = reader.read_u64()?;
 		let height = reader.read_u64()?;
-		let commit = Commitment::read(reader)?;
-		Ok(OutputPos {
-			pos,
-			height,
-			commit,
-		})
+		Ok(CommitPos { pos, height })
 	}
 }
 
-impl Writeable for OutputPos {
+impl Writeable for CommitPos {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		writer.write_u64(self.pos)?;
 		writer.write_u64(self.height)?;
-		self.commit.write(writer)?;
 		Ok(())
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 use crate::core::core::hash::{Hash, Hashed, ZERO_HASH};
 use crate::core::core::{Block, BlockHeader, HeaderVersion};
 use crate::core::pow::Difficulty;
-use crate::core::ser::{self, PMMRIndexHashable};
+use crate::core::ser::{self, PMMRIndexHashable, Readable, Reader, Writeable, Writer};
 use crate::error::{Error, ErrorKind};
+use crate::util::secp::pedersen::Commitment;
 use crate::util::RwLock;
 
 bitflags! {
@@ -258,16 +259,38 @@ impl OutputRoots {
 	}
 }
 
-/// A helper to hold the output pmmr position of the txhashset in order to keep them
-/// readable.
+/// Minimal struct representing an output commitment at a known position (and block height)
+/// in an MMR.
 #[derive(Debug)]
-pub struct OutputMMRPosition {
-	/// The hash at the output position in the MMR.
-	pub output_mmr_hash: Hash,
+pub struct OutputPos {
 	/// MMR position
-	pub position: u64,
+	pub pos: u64,
 	/// Block height
 	pub height: u64,
+	/// Output commitment
+	pub commit: Commitment,
+}
+
+impl Readable for OutputPos {
+	fn read(reader: &mut dyn Reader) -> Result<OutputPos, ser::Error> {
+		let pos = reader.read_u64()?;
+		let height = reader.read_u64()?;
+		let commit = Commitment::read(reader)?;
+		Ok(OutputPos {
+			pos,
+			height,
+			commit,
+		})
+	}
+}
+
+impl Writeable for OutputPos {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_u64(self.pos)?;
+		writer.write_u64(self.height)?;
+		self.commit.write(writer)?;
+		Ok(())
+	}
 }
 
 /// The tip of a fork. A handle to the fork ancestry from its leaf in the

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -398,6 +398,7 @@ fn mine_reorg() {
 
 #[test]
 fn mine_forks() {
+	clean_output_dir(".grin2");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	{
 		let chain = init_chain(".grin2", pow::mine_genesis_block().unwrap());
@@ -445,6 +446,7 @@ fn mine_forks() {
 
 #[test]
 fn mine_losing_fork() {
+	clean_output_dir(".grin3");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let kc = ExtKeychain::from_random_seed(false).unwrap();
 	{
@@ -481,6 +483,7 @@ fn mine_losing_fork() {
 
 #[test]
 fn longer_fork() {
+	clean_output_dir(".grin4");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let kc = ExtKeychain::from_random_seed(false).unwrap();
 	// to make it easier to compute the txhashset roots in the test, we
@@ -525,11 +528,9 @@ fn longer_fork() {
 
 #[test]
 fn spend_in_fork_and_compact() {
+	clean_output_dir(".grin6");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	util::init_test_logger();
-	// Cleanup chain directory
-	clean_output_dir(".grin6");
-
 	{
 		let chain = init_chain(".grin6", pow::mine_genesis_block().unwrap());
 		let prev = chain.head_header().unwrap();

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -527,6 +527,84 @@ fn longer_fork() {
 }
 
 #[test]
+fn spend_rewind_spend() {
+	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	util::init_test_logger();
+	clean_output_dir(".grin_spend_rewind_spend");
+
+	{
+		let chain = init_chain(
+			".grin_spend_rewind_spend",
+			pow::mine_genesis_block().unwrap(),
+		);
+		let prev = chain.head_header().unwrap();
+		let kc = ExtKeychain::from_random_seed(false).unwrap();
+		let pb = ProofBuilder::new(&kc);
+
+		let mut head = prev;
+
+		// mine the first block and keep track of the block_hash
+		// so we can spend the coinbase later
+		let b = prepare_block_key_idx(&kc, &head, &chain, 2, 1);
+		let out_id = OutputIdentifier::from_output(&b.outputs()[0]);
+		assert!(out_id.features.is_coinbase());
+		head = b.header.clone();
+		chain
+			.process_block(b.clone(), chain::Options::SKIP_POW)
+			.unwrap();
+
+		// now mine three further blocks
+		for n in 3..6 {
+			let b = prepare_block(&kc, &head, &chain, n);
+			head = b.header.clone();
+			chain.process_block(b, chain::Options::SKIP_POW).unwrap();
+		}
+
+		// Make a note of this header as we will rewind back to here later.
+		let rewind_to = head.clone();
+
+		let key_id_coinbase = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+		let key_id30 = ExtKeychainPath::new(1, 30, 0, 0, 0).to_identifier();
+
+		let tx1 = build::transaction(
+			KernelFeatures::Plain { fee: 20000 },
+			vec![
+				build::coinbase_input(consensus::REWARD, key_id_coinbase.clone()),
+				build::output(consensus::REWARD - 20000, key_id30.clone()),
+			],
+			&kc,
+			&pb,
+		)
+		.unwrap();
+
+		let b = prepare_block_tx(&kc, &head, &chain, 6, vec![&tx1]);
+		head = b.header.clone();
+		chain
+			.process_block(b.clone(), chain::Options::SKIP_POW)
+			.unwrap();
+		chain.validate(false).unwrap();
+
+		// Now mine another block, reusing the private key for the coinbase we just spent.
+		{
+			let b = prepare_block_key_idx(&kc, &head, &chain, 7, 1);
+			chain.process_block(b, chain::Options::SKIP_POW).unwrap();
+		}
+
+		// Now mine a competing block also spending the same coinbase output from earlier.
+		// Rewind back prior to the tx that spends it to "unspend" it.
+		{
+			let b = prepare_block_tx(&kc, &rewind_to, &chain, 6, vec![&tx1]);
+			chain
+				.process_block(b.clone(), chain::Options::SKIP_POW)
+				.unwrap();
+			chain.validate(false).unwrap();
+		}
+	}
+
+	clean_output_dir(".grin_spend_rewind_spend");
+}
+
+#[test]
 fn spend_in_fork_and_compact() {
 	clean_output_dir(".grin6");
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
@@ -731,15 +809,31 @@ fn output_header_mappings() {
 	clean_output_dir(".grin_header_for_output");
 }
 
+// Use diff as both diff *and* key_idx for convenience (deterministic private key for test blocks)
 fn prepare_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
 where
 	K: Keychain,
 {
-	let mut b = prepare_block_nosum(kc, prev, diff, vec![]);
+	let key_idx = diff as u32;
+	prepare_block_key_idx(kc, prev, chain, diff, key_idx)
+}
+
+fn prepare_block_key_idx<K>(
+	kc: &K,
+	prev: &BlockHeader,
+	chain: &Chain,
+	diff: u64,
+	key_idx: u32,
+) -> Block
+where
+	K: Keychain,
+{
+	let mut b = prepare_block_nosum(kc, prev, diff, key_idx, vec![]);
 	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
+// Use diff as both diff *and* key_idx for convenience (deterministic private key for test blocks)
 fn prepare_block_tx<K>(
 	kc: &K,
 	prev: &BlockHeader,
@@ -750,17 +844,38 @@ fn prepare_block_tx<K>(
 where
 	K: Keychain,
 {
-	let mut b = prepare_block_nosum(kc, prev, diff, txs);
+	let key_idx = diff as u32;
+	prepare_block_tx_key_idx(kc, prev, chain, diff, key_idx, txs)
+}
+
+fn prepare_block_tx_key_idx<K>(
+	kc: &K,
+	prev: &BlockHeader,
+	chain: &Chain,
+	diff: u64,
+	key_idx: u32,
+	txs: Vec<&Transaction>,
+) -> Block
+where
+	K: Keychain,
+{
+	let mut b = prepare_block_nosum(kc, prev, diff, key_idx, txs);
 	chain.set_txhashset_roots(&mut b).unwrap();
 	b
 }
 
-fn prepare_block_nosum<K>(kc: &K, prev: &BlockHeader, diff: u64, txs: Vec<&Transaction>) -> Block
+fn prepare_block_nosum<K>(
+	kc: &K,
+	prev: &BlockHeader,
+	diff: u64,
+	key_idx: u32,
+	txs: Vec<&Transaction>,
+) -> Block
 where
 	K: Keychain,
 {
 	let proof_size = global::proofsize();
-	let key_id = ExtKeychainPath::new(1, diff as u32, 0, 0, 0).to_identifier();
+	let key_id = ExtKeychainPath::new(1, key_idx, 0, 0, 0).to_identifier();
 
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
 	let reward =


### PR DESCRIPTION
Resolves #3235.
Extracted the "undo list" concept from the kernel index exploration (#3228) and took advantage of it for outputs (where undo == unspend during rewind).

This allows the `output_pos` index (quick lookup of output pos by output commitment) to more closely track the current utxo set in a transactional manner.
We now keep the `output_pos` index updated when applying new blocks _and_ when rewinding existing blocks under a fork scenario.

This eliminates the edge-case of needing to account for "false positive" results in the index.
We still do not treat the `output_pos` as authoritative but there are currently believed to be no cases where it will temporarily diverge from the set of unspent output pos.

We rebuild (via optimized `init`) the output_pos_index on - 
  1. startup, to ensure the node starts up in a consistent state
  1. compact (once outputs are removed and pruned/compacted we no longer need to keep them in the index)
  1. during fast sync, after receiving txhashset from a peer

We log discrepencies between the index and set of outputs during index rebuild.
This should give us some insight into whether our assumptions are correct here.
If we are comfortable that we can begin treating this index as authoritative then we will only need to rebuild the index on sync (3) above.

This PR is a relatively large change in terms of code changes. But conceptually it is pretty straightforward.

* Update `output_pos` index when we call `apply_block()`
  * add new index entries for new outputs
  * remove index entries for spent outputs
* Update `output_pos` on rewind (per block)
  * remove "future" outputs that no longer exist
  * re-add "unspent" entries to the index based on per-block "spent_index" (aka undo list)
* Store a spent_index per block when we store the associated block in the db 

We used to do something similar but not exactly the same - 
* we stored a bitmap of spent pos per block
  * this allowed us to rewind the utxo set itself, but not the associated index
* we did not undo these in the index itself when rewinding
  * this led to false positives when reading the index, so we always went to the PMMR to corroborate what the index said (if index was inconsistent with PMMR then treat as spent)

The majority of the code change involves breaking the `rewind` functionality out to do it per iteratively block. Before we could simply take the union of all the per-block bitmaps. This has been reworked to rewind block by block to take advantage of our ability to rewind the index itself.

----

We were originally hoping to get the `kernel_index` impl into `3.1.0` but this was not possible given the timing of the `3.1.0` release. This PR gives us a way of confirming the approach works on the existing `output_pos` index.

