### PR TITLE
cleanup unused import

### DIFF
--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -22,7 +22,6 @@ use crate::core::core::{Block, BlockHeader, HeaderVersion};
 use crate::core::pow::Difficulty;
 use crate::core::ser::{self, PMMRIndexHashable, Readable, Reader, Writeable, Writer};
 use crate::error::{Error, ErrorKind};
-use crate::util::secp::pedersen::Commitment;
 use crate::util::RwLock;
 
 bitflags! {


### PR DESCRIPTION
1 line change to cleanup an unused import.
Related - #3236 (this was missed in this PR).

```
warning: unused import: `crate::util::secp::pedersen::Commitment`
  --> chain/src/types.rs:25:5
   |
25 | use crate::util::secp::pedersen::Commitment;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```