### PR TITLE
Fix warnings

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -148,22 +148,22 @@ pub fn header_version(height: u64) -> HeaderVersion {
 		global::ChainTypes::Mainnet => HeaderVersion(hf_interval),
 		global::ChainTypes::Floonet => {
 			if height < FLOONET_FIRST_HARD_FORK {
-				(HeaderVersion(1))
+				HeaderVersion(1)
 			} else if height < FLOONET_SECOND_HARD_FORK {
-				(HeaderVersion(2))
+				HeaderVersion(2)
 			} else if height < 3 * HARD_FORK_INTERVAL {
-				(HeaderVersion(3))
+				HeaderVersion(3)
 			} else {
 				HeaderVersion(hf_interval)
 			}
 		}
 		global::ChainTypes::AutomatedTesting | global::ChainTypes::UserTesting => {
 			if height < TESTING_FIRST_HARD_FORK {
-				(HeaderVersion(1))
+				HeaderVersion(1)
 			} else if height < TESTING_SECOND_HARD_FORK {
-				(HeaderVersion(2))
+				HeaderVersion(2)
 			} else if height < 3 * HARD_FORK_INTERVAL {
-				(HeaderVersion(3))
+				HeaderVersion(3)
 			} else {
 				HeaderVersion(hf_interval)
 			}

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -333,16 +333,6 @@ impl error::Error for Error {
 			None
 		}
 	}
-
-	fn description(&self) -> &str {
-		match *self {
-			Error::CannotDeriveFromHardenedKey => "cannot derive hardened key from public key",
-			Error::Ecdsa(ref e) => error::Error::description(e),
-			Error::InvalidChildNumber(_) => "child number is invalid",
-			Error::RngError(_) => "rng error",
-			Error::MnemonicError(_) => "mnemonic error",
-		}
-	}
 }
 
 impl From<secp::Error> for Error {


### PR DESCRIPTION
Fixing some nightly warnings: removing unnecessary parentheses and removing implementation of `description()` on keychain errors, since usage of it is deprecated and we don't use it anywhere to begin with.