### PR TITLE
handle mpsc channel disconnect from peer_write thread

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -373,7 +373,7 @@ where
 					}
 					Err(RecvTimeoutError::Disconnected) => {
 						debug!("peer_write: mpsc channel disconnected during recv_timeout");
-						stop_handle.stop();
+						break;
 					}
 					Err(RecvTimeoutError::Timeout) => {}
 				}

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -31,6 +31,7 @@ use crate::util::{RateCounter, RwLock};
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use std::{
@@ -362,13 +363,21 @@ where
 			loop {
 				let maybe_data = retry_send.or_else(|_| send_rx.recv_timeout(CHANNEL_TIMEOUT));
 				retry_send = Err(());
-				if let Ok(data) = maybe_data {
-					let written =
-						try_break!(write_message(&mut writer, &data, writer_tracker.clone()));
-					if written.is_none() {
-						retry_send = Ok(data);
+				match maybe_data {
+					Ok(data) => {
+						let written =
+							try_break!(write_message(&mut writer, &data, writer_tracker.clone()));
+						if written.is_none() {
+							retry_send = Ok(data);
+						}
 					}
+					Err(RecvTimeoutError::Disconnected) => {
+						debug!("peer_write: mpsc channel disconnected during recv_timeout");
+						stop_handle.stop();
+					}
+					Err(RecvTimeoutError::Timeout) => {}
 				}
+
 				// check the close channel
 				if stopped.load(Ordering::Relaxed) {
 					break;
@@ -382,6 +391,7 @@ where
 					.map(|a| a.to_string())
 					.unwrap_or_else(|_| "?".to_owned())
 			);
+			let _ = writer.shutdown(Shutdown::Both);
 		})?;
 	Ok((reader_thread, writer_thread))
 }


### PR DESCRIPTION
Resolves #3237.

Handle the `RecvTimeoutError` when we call `recv_timeout()` to receive messages off the mpsc channel. Handle `Timeout` by retrying the loop but handle `Disconnected` by stopping and shutting down.

https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.recv_timeout

> If the corresponding Sender has disconnected, or it disconnects while this call is blocking, this call will wake up and return Err to indicate that no more messages can ever be received on this channel. However, since channels are buffered, messages sent before the disconnect will still be properly received.

We were also never calling `writer.shutdown(Shutdown::Both)` when the write loop terminated and I think we should be doing so (we do it for the read loop).

