### PR TITLE
explicit read_timeout and write_timeout during hand/shake

### DIFF
--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -35,8 +35,20 @@ const NONCES_CAP: usize = 100;
 /// 10 should be enough since most of servers don't have more than 10 IP addresses.
 const ADDRS_CAP: usize = 10;
 
-/// The read_timeout and write_timeout for initial hand/shake messages.
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(2_000);
+/// The initial Hand message should come in immediately after the connection is initiated.
+/// But for consistency use the same timeout for reading both Hand and Shake messages.
+const HAND_READ_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+/// We need to allow time for the peer to receive our Hand message and send back a Shake reply.
+const SHAKE_READ_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+/// Fail fast when trying to write a Hand message to the tcp stream.
+/// If we cannot write it within a couple of seconds then something has likely gone wrong.
+const HAND_WRITE_TIMEOUT: Duration = Duration::from_millis(2_000);
+
+/// Fail fast when trying to write a Shake message to the tcp stream.
+/// If we cannot write it within a couple of seconds then something has likely gone wrong.
+const SHAKE_WRITE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
 /// Handles the handshake negotiation when two peers connect and decides on
 /// protocol.
@@ -89,8 +101,9 @@ impl Handshake {
 	) -> Result<PeerInfo, Error> {
 		// Set explicit timeouts on the tcp stream for hand/shake messages.
 		// Once the peer is up and running we will set new values for these.
-		let _ = conn.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
-		let _ = conn.set_write_timeout(Some(HANDSHAKE_TIMEOUT));
+		// We initiate this connection, writing a Hand message and read a Shake reply.
+		let _ = conn.set_write_timeout(Some(HAND_WRITE_TIMEOUT));
+		let _ = conn.set_read_timeout(Some(SHAKE_READ_TIMEOUT));
 
 		// prepare the first part of the handshake
 		let nonce = self.next_nonce();
@@ -159,8 +172,9 @@ impl Handshake {
 	) -> Result<PeerInfo, Error> {
 		// Set explicit timeouts on the tcp stream for hand/shake messages.
 		// Once the peer is up and running we will set new values for these.
-		let _ = conn.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
-		let _ = conn.set_write_timeout(Some(HANDSHAKE_TIMEOUT));
+		// We accept an inbound connection, reading a Hand then writing a Shake reply.
+		let _ = conn.set_read_timeout(Some(HAND_READ_TIMEOUT));
+		let _ = conn.set_write_timeout(Some(SHAKE_WRITE_TIMEOUT));
 
 		let hand: Hand = read_message(conn, self.protocol_version, Type::Hand)?;
 


### PR DESCRIPTION
Resolves #3248.

We were blocking indefinitely on the initial hand/shake.
Once the peer is up and running for broadcast we will replace these timeout values with the existing settings for msg header and body reads and msg writes.

without these timeouts we see `peer_connect` threads stuck, blocked indefinitely waiting for `read_exact` on connections that may have closed suddenly.