### PR TITLE
simplify when block_sums and spent_index are added to the db

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -957,7 +957,7 @@ impl Chain {
 				// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 				batch.save_block_sums(
 					&header.hash(),
-					&BlockSums {
+					BlockSums {
 						utxo_sum,
 						kernel_sum,
 					},
@@ -1480,7 +1480,7 @@ fn setup_head(
 						// Save the block_sums to the db for use later.
 						batch.save_block_sums(
 							&header.hash(),
-							&BlockSums {
+							BlockSums {
 								utxo_sum,
 								kernel_sum,
 							},
@@ -1542,7 +1542,7 @@ fn setup_head(
 			})?;
 
 			// Save the block_sums to the db for use later.
-			batch.save_block_sums(&genesis.hash(), &sums)?;
+			batch.save_block_sums(&genesis.hash(), sums)?;
 
 			info!("init: saved genesis: {:?}", genesis.hash());
 		}

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -156,9 +156,10 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 		Ok(())
 	})?;
 
-	// Add the validated block to the db along with the corresponding block_sums.
-	// We do this even if we have not increased the total cumulative work
-	// so we can maintain multiple (in progress) forks.
+	// Add the validated block to the db.
+	// Note we do this in the outer batch, not the child batch from the extension
+	// as we only commit the child batch if the extension increases total work.
+	// We want to save the block to the db regardless.
 	add_block(b, &ctx.batch)?;
 
 	// If we have no "tail" then set it now.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -23,7 +23,7 @@ use crate::core::pow;
 use crate::error::{Error, ErrorKind};
 use crate::store;
 use crate::txhashset;
-use crate::types::{CommitPos, Options, Tip};
+use crate::types::{Options, Tip};
 use crate::util::RwLock;
 use grin_store;
 use std::sync::Arc;
@@ -121,7 +121,7 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 	let ref mut header_pmmr = &mut ctx.header_pmmr;
 	let ref mut txhashset = &mut ctx.txhashset;
 	let ref mut batch = &mut ctx.batch;
-	let (block_sums, spent) = txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
+	txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
 		rewind_and_apply_fork(&prev, ext, batch)?;
 
 		// Check any coinbase being spent have matured sufficiently.
@@ -137,13 +137,12 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 		// we can verify_kernel_sums across the full UTXO sum and full kernel sum
 		// accounting for inputs/outputs/kernels in this new block.
 		// We know there are no double-spends etc. if this verifies successfully.
-		// Remember to save these to the db later on (regardless of extension rollback)
-		let block_sums = verify_block_sums(b, batch)?;
+		verify_block_sums(b, batch)?;
 
 		// Apply the block to the txhashset state.
 		// Validate the txhashset roots and sizes against the block header.
 		// Block is invalid if there are any discrepencies.
-		let spent = apply_block_to_txhashset(b, ext, batch)?;
+		apply_block_to_txhashset(b, ext, batch)?;
 
 		// If applying this block does not increase the work on the chain then
 		// we know we have not yet updated the chain to produce a new chain head.
@@ -154,13 +153,13 @@ pub fn process_block(b: &Block, ctx: &mut BlockContext<'_>) -> Result<Option<Tip
 			ext.extension.force_rollback();
 		}
 
-		Ok((block_sums, spent))
+		Ok(())
 	})?;
 
 	// Add the validated block to the db along with the corresponding block_sums.
 	// We do this even if we have not increased the total cumulative work
 	// so we can maintain multiple (in progress) forks.
-	add_block(b, &block_sums, &spent, &ctx.batch)?;
+	add_block(b, &ctx.batch)?;
 
 	// If we have no "tail" then set it now.
 	if ctx.batch.tail().is_err() {
@@ -404,7 +403,8 @@ fn verify_coinbase_maturity(
 
 /// Verify kernel sums across the full utxo and kernel sets based on block_sums
 /// of previous block accounting for the inputs|outputs|kernels of the new block.
-fn verify_block_sums(b: &Block, batch: &store::Batch<'_>) -> Result<BlockSums, Error> {
+/// Saves the new block_sums to the db via the current batch if successful.
+fn verify_block_sums(b: &Block, batch: &store::Batch<'_>) -> Result<(), Error> {
 	// Retrieve the block_sums for the previous block.
 	let block_sums = batch.get_block_sums(&b.header.prev_hash)?;
 
@@ -419,10 +419,15 @@ fn verify_block_sums(b: &Block, batch: &store::Batch<'_>) -> Result<BlockSums, E
 	let (utxo_sum, kernel_sum) =
 		(block_sums, b as &dyn Committed).verify_kernel_sums(overage, offset)?;
 
-	Ok(BlockSums {
-		utxo_sum,
-		kernel_sum,
-	})
+	batch.save_block_sums(
+		&b.hash(),
+		BlockSums {
+			utxo_sum,
+			kernel_sum,
+		},
+	)?;
+
+	Ok(())
 }
 
 /// Fully validate the block by applying it to the txhashset extension.
@@ -431,25 +436,17 @@ fn apply_block_to_txhashset(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
-) -> Result<Vec<CommitPos>, Error> {
-	let spent = ext.extension.apply_block(block, batch)?;
+) -> Result<(), Error> {
+	ext.extension.apply_block(block, batch)?;
 	ext.extension.validate_roots(&block.header)?;
 	ext.extension.validate_sizes(&block.header)?;
-	Ok(spent)
+	Ok(())
 }
 
 /// Officially adds the block to our chain (possibly on a losing fork).
-/// Adds the associated block_sums and spent_index as well.
 /// Header must be added separately (assume this has been done previously).
-fn add_block(
-	b: &Block,
-	block_sums: &BlockSums,
-	spent: &Vec<CommitPos>,
-	batch: &store::Batch<'_>,
-) -> Result<(), Error> {
+fn add_block(b: &Block, batch: &store::Batch<'_>) -> Result<(), Error> {
 	batch.save_block(b)?;
-	batch.save_block_sums(&b.hash(), block_sums)?;
-	batch.save_spent_index(&b.hash(), spent)?;
 	Ok(())
 }
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -318,7 +318,7 @@ impl<'a> Batch<'a> {
 	}
 
 	/// Save block_sums for the block.
-	pub fn save_block_sums(&self, h: &Hash, sums: &BlockSums) -> Result<(), Error> {
+	pub fn save_block_sums(&self, h: &Hash, sums: BlockSums) -> Result<(), Error> {
 		self.db
 			.put_ser(&to_key(BLOCK_SUMS_PREFIX, &mut h.to_vec())[..], &sums)
 	}

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -83,7 +83,7 @@ impl ChainAdapter {
 			utxo_sum,
 			kernel_sum,
 		};
-		batch.save_block_sums(&header.hash(), &block_sums).unwrap();
+		batch.save_block_sums(&header.hash(), block_sums).unwrap();
 
 		batch.commit().unwrap();
 


### PR DESCRIPTION
Store `spent_index` when calling `apply_block()` and `block_sums` when calling `verify_block_sums()`. 

This lets us simplify `process_block` and `add_block` and makes it a little clearer when/where these are added to the db (via the current batch). We do not need to pass the data around and return it from various fns.

Conceptually we have 2 (nested) places where we commit data to the db - 
1. We commit the block itself to the db if we process the block successfully (fork or otherwise)
1. We _only_ commit the following data iff this block also increases total work - 
    * chain head
    * various index entries

We do this via a child batch - this child batch includes the update to chain head, indices etc. and is rolled back along with the MMR changes if the block does not increase total work.
We apply everything transactionally (db + MMRs via txhashset extension) then discard this transaction.
The outer db transaction is then committed to commit the block itself to the db (unless validation failed or other error).

This PR moves the block_sums and spent_index into the child batch. This is safe to do we rebuild both for all blocks along a fork being processed. And we only make assumptions about them being present in the db for the main chain itself.

