### PR TITLE
keep output and rangeproof mmrs together

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -526,16 +526,16 @@ where
 {
 	let res: Result<T, Error>;
 	{
+		let header_pmmr = ReadonlyPMMR::at(&handle.backend, handle.last_pos);
 		let output_pmmr =
 			ReadonlyPMMR::at(&trees.output_pmmr_h.backend, trees.output_pmmr_h.last_pos);
-		let header_pmmr = ReadonlyPMMR::at(&handle.backend, handle.last_pos);
 		let rproof_pmmr =
 			ReadonlyPMMR::at(&trees.rproof_pmmr_h.backend, trees.rproof_pmmr_h.last_pos);
 
 		// Create a new batch here to pass into the utxo_view.
 		// Discard it (rollback) after we finish with the utxo_view.
 		let batch = trees.commit_index.batch()?;
-		let utxo = UTXOView::new(output_pmmr, header_pmmr, rproof_pmmr);
+		let utxo = UTXOView::new(header_pmmr, output_pmmr, rproof_pmmr);
 		res = inner(&utxo, &batch);
 	}
 	res
@@ -919,8 +919,8 @@ impl<'a> Extension<'a> {
 	/// and the provided header extension.
 	pub fn utxo_view(&'a self, header_ext: &'a HeaderExtension<'a>) -> UTXOView<'a> {
 		UTXOView::new(
-			self.output_pmmr.readonly_pmmr(),
 			header_ext.pmmr.readonly_pmmr(),
+			self.output_pmmr.readonly_pmmr(),
 			self.rproof_pmmr.readonly_pmmr(),
 		)
 	}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -26,21 +26,21 @@ use grin_store::pmmr::PMMRBackend;
 
 /// Readonly view of the UTXO set (based on output MMR).
 pub struct UTXOView<'a> {
-	output_pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 	header_pmmr: ReadonlyPMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
+	output_pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 	rproof_pmmr: ReadonlyPMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 }
 
 impl<'a> UTXOView<'a> {
 	/// Build a new UTXO view.
 	pub fn new(
-		output_pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 		header_pmmr: ReadonlyPMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
+		output_pmmr: ReadonlyPMMR<'a, Output, PMMRBackend<Output>>,
 		rproof_pmmr: ReadonlyPMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 	) -> UTXOView<'a> {
 		UTXOView {
-			output_pmmr,
 			header_pmmr,
+			output_pmmr,
 			rproof_pmmr,
 		}
 	}


### PR DESCRIPTION
Minor cleanup around the ordering of the fields in the utxo view.

The header pmmr in the middle felt awkward -  

```
	UTXOView::new(
		self.output_pmmr.readonly_pmmr(),
		header_ext.pmmr.readonly_pmmr(),
		self.rproof_pmmr.readonly_pmmr(),
	)
```