### PR TITLE
API: don't error on missing output

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -57,7 +57,10 @@ impl HeaderHandler {
 	}
 
 	fn get_header_for_output(&self, commit_id: String) -> Result<BlockHeaderPrintable, Error> {
-		let oid = get_output(&self.chain, &commit_id)?.1;
+		let oid = match get_output(&self.chain, &commit_id)? {
+			Some((_, o)) => o,
+			None => return Err(ErrorKind::NotFound.into()),
+		};
 		match w(&self.chain)?.get_header_for_output(&oid) {
 			Ok(header) => Ok(BlockHeaderPrintable::from_header(&header)),
 			Err(_) => Err(ErrorKind::NotFound.into()),
@@ -87,7 +90,10 @@ impl HeaderHandler {
 			return Ok(hash);
 		}
 		if let Some(commit) = commit {
-			let oid = get_output_v2(&self.chain, &commit, false, false)?.1;
+			let oid = match get_output_v2(&self.chain, &commit, false, false)? {
+				Some((_, o)) => o,
+				None => return Err(ErrorKind::NotFound.into()),
+			};
 			match w(&self.chain)?.get_header_for_output(&oid) {
 				Ok(header) => return Ok(header.hash()),
 				Err(_) => return Err(ErrorKind::NotFound.into()),
@@ -169,7 +175,10 @@ impl BlockHandler {
 			return Ok(hash);
 		}
 		if let Some(commit) = commit {
-			let oid = get_output_v2(&self.chain, &commit, false, false)?.1;
+			let oid = match get_output_v2(&self.chain, &commit, false, false)? {
+				Some((_, o)) => o,
+				None => return Err(ErrorKind::NotFound.into()),
+			};
 			match w(&self.chain)?.get_header_for_output(&oid) {
 				Ok(header) => return Ok(header.hash()),
 				Err(_) => return Err(ErrorKind::NotFound.into()),

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -109,8 +109,10 @@ pub struct OutputHandler {
 
 impl OutputHandler {
 	fn get_output(&self, id: &str) -> Result<Output, Error> {
-		let res = get_output(&self.chain, id)?;
-		Ok(res.0)
+		match get_output(&self.chain, id)? {
+			Some((o, _)) => Ok(o),
+			None => Err(ErrorKind::NotFound.into()),
+		}
 	}
 
 	fn get_output_v2(
@@ -118,9 +120,9 @@ impl OutputHandler {
 		id: &str,
 		include_proof: bool,
 		include_merkle_proof: bool,
-	) -> Result<OutputPrintable, Error> {
+	) -> Result<Option<OutputPrintable>, Error> {
 		let res = get_output_v2(&self.chain, id, include_proof, include_merkle_proof)?;
-		Ok(res.0)
+		Ok(res.map(|o| o.0))
 	}
 
 	pub fn get_outputs_v2(
@@ -149,8 +151,10 @@ impl OutputHandler {
 					include_proof.unwrap_or(false),
 					include_merkle_proof.unwrap_or(false),
 				) {
-					Ok(output) => outputs.push(output),
-					// do not crash here simply do not retrieve this output
+					Ok(Some(output)) => outputs.push(output),
+					Ok(None) => {
+						// Ignore outputs that are not found
+					}
 					Err(e) => error!(
 						"Failure to get output for commitment {} with error {}",
 						commit, e

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::chain;
+use crate::chain::types::CommitPos;
 use crate::core::core::{OutputFeatures, OutputIdentifier};
 use crate::rest::*;
 use crate::types::*;
@@ -29,11 +30,11 @@ pub fn w<T>(weak: &Weak<T>) -> Result<Arc<T>, Error> {
 		.ok_or_else(|| ErrorKind::Internal("failed to upgrade weak refernce".to_owned()).into())
 }
 
-/// Retrieves an output from the chain given a commit id (a tiny bit iteratively)
-pub fn get_output(
-	chain: &Weak<chain::Chain>,
+/// Internal function to retrieves an output by a given commitment
+fn retrieve_output(
+	chain: &Arc<chain::Chain>,
 	id: &str,
-) -> Result<(Output, OutputIdentifier), Error> {
+) -> Result<Option<(Commitment, CommitPos, OutputIdentifier)>, Error> {
 	let c = util::from_hex(String::from(id)).context(ErrorKind::Argument(format!(
 		"Not a valid commitment: {}",
 		id
@@ -49,28 +50,30 @@ pub fn get_output(
 		OutputIdentifier::new(OutputFeatures::Coinbase, &commit),
 	];
 
-	let chain = w(chain)?;
-
 	for x in outputs.iter() {
-		let res = chain.is_unspent(x);
-		match res {
-			Ok(output_pos) => {
-				return Ok((
-					Output::new(&commit, output_pos.height, output_pos.pos),
-					x.clone(),
-				));
-			}
-			Err(e) => {
-				trace!(
-					"get_output: err: {} for commit: {:?} with feature: {:?}",
-					e.to_string(),
-					x.commit,
-					x.features
-				);
-			}
+		match chain.is_unspent(x)? {
+			Some(output_pos) => return Ok(Some((commit, output_pos, x.clone()))),
+			None => {}
 		}
 	}
-	Err(ErrorKind::NotFound.into())
+	Ok(None)
+}
+
+/// Retrieves an output from the chain given a commit id (a tiny bit iteratively)
+pub fn get_output(
+	chain: &Weak<chain::Chain>,
+	id: &str,
+) -> Result<Option<(Output, OutputIdentifier)>, Error> {
+	let chain = w(chain)?;
+	let (commit, output_pos, identifier) = match retrieve_output(&chain, id)? {
+		Some(x) => x,
+		None => return Ok(None),
+	};
+
+	Ok(Some((
+		Output::new(&commit, output_pos.height, output_pos.pos),
+		identifier,
+	)))
 }
 
 /// Retrieves an output from the chain given a commit id (a tiny bit iteratively)
@@ -79,63 +82,27 @@ pub fn get_output_v2(
 	id: &str,
 	include_proof: bool,
 	include_merkle_proof: bool,
-) -> Result<(OutputPrintable, OutputIdentifier), Error> {
-	let c = util::from_hex(String::from(id)).context(ErrorKind::Argument(format!(
-		"Not a valid commitment: {}",
-		id
-	)))?;
-	let commit = Commitment::from_vec(c);
-
-	// We need the features here to be able to generate the necessary hash
-	// to compare against the hash in the output MMR.
-	// For now we can just try both (but this probably needs to be part of the api
-	// params)
-	let outputs = [
-		OutputIdentifier::new(OutputFeatures::Plain, &commit),
-		OutputIdentifier::new(OutputFeatures::Coinbase, &commit),
-	];
-
+) -> Result<Option<(OutputPrintable, OutputIdentifier)>, Error> {
 	let chain = w(chain)?;
+	let (_, output_pos, identifier) = match retrieve_output(&chain, id)? {
+		Some(x) => x,
+		None => return Ok(None),
+	};
 
-	for x in outputs.iter() {
-		let res = chain.is_unspent(x);
-		match res {
-			Ok(output_pos) => match chain.get_unspent_output_at(output_pos.pos) {
-				Ok(output) => {
-					let header = if include_merkle_proof && output.is_coinbase() {
-						chain.get_header_by_height(output_pos.height).ok()
-					} else {
-						None
-					};
-					match OutputPrintable::from_output(
-						&output,
-						chain.clone(),
-						header.as_ref(),
-						include_proof,
-						include_merkle_proof,
-					) {
-						Ok(output_printable) => return Ok((output_printable, x.clone())),
-						Err(e) => {
-							trace!(
-								"get_output: err: {} for commit: {:?} with feature: {:?}",
-								e.to_string(),
-								x.commit,
-								x.features
-							);
-						}
-					}
-				}
-				Err(_) => return Err(ErrorKind::NotFound.into()),
-			},
-			Err(e) => {
-				trace!(
-					"get_output: err: {} for commit: {:?} with feature: {:?}",
-					e.to_string(),
-					x.commit,
-					x.features
-				);
-			}
-		}
-	}
-	Err(ErrorKind::NotFound.into())
+	let output = chain.get_unspent_output_at(output_pos.pos)?;
+	let header = if include_merkle_proof && output.is_coinbase() {
+		chain.get_header_by_height(output_pos.height).ok()
+	} else {
+		None
+	};
+
+	let output_printable = OutputPrintable::from_output(
+		&output,
+		chain.clone(),
+		header.as_ref(),
+		include_proof,
+		include_merkle_proof,
+	)?;
+
+	Ok(Some((output_printable, identifier)))
 }

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -104,6 +104,14 @@ impl From<RouterError> for Error {
 	}
 }
 
+impl From<crate::chain::Error> for Error {
+	fn from(error: crate::chain::Error) -> Error {
+		Error {
+			inner: Context::new(ErrorKind::Internal(error.to_string())),
+		}
+	}
+}
+
 /// TLS config
 #[derive(Clone)]
 pub struct TLSConfig {

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -289,7 +289,7 @@ impl OutputPrintable {
 		};
 
 		let out_id = core::OutputIdentifier::from_output(&output);
-		let res = chain.is_unspent(&out_id)?;
+		let res = chain.get_unspent(&out_id)?;
 		let (spent, block_height) = if let Some(output_pos) = res {
 			(false, Some(output_pos.height))
 		} else {

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -289,8 +289,8 @@ impl OutputPrintable {
 		};
 
 		let out_id = core::OutputIdentifier::from_output(&output);
-		let res = chain.is_unspent(&out_id);
-		let (spent, block_height) = if let Ok(output_pos) = res {
+		let res = chain.is_unspent(&out_id)?;
+		let (spent, block_height) = if let Some(output_pos) = res {
 			(false, Some(output_pos.height))
 		} else {
 			(true, None)

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -504,7 +504,7 @@ impl Chain {
 	/// spent. This querying is done in a way that is consistent with the
 	/// current chain state, specifically the current winning (valid, most
 	/// work) fork.
-	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<CommitPos, Error> {
+	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
 		self.txhashset.read().is_unspent(output_ref)
 	}
 
@@ -1305,7 +1305,10 @@ impl Chain {
 	) -> Result<BlockHeader, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		let output_pos = txhashset.is_unspent(output_ref)?;
+		let output_pos = match txhashset.is_unspent(output_ref)? {
+			Some(o) => o,
+			None => return Err(ErrorKind::OutputNotFound.into()),
+		};
 		let hash = header_pmmr.get_header_hash_by_height(output_pos.height)?;
 		Ok(self.get_block_header(&hash)?)
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -504,8 +504,8 @@ impl Chain {
 	/// spent. This querying is done in a way that is consistent with the
 	/// current chain state, specifically the current winning (valid, most
 	/// work) fork.
-	pub fn is_unspent(&self, output_ref: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
-		self.txhashset.read().is_unspent(output_ref)
+	pub fn get_unspent(&self, output_ref: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
+		self.txhashset.read().get_unspent(output_ref)
 	}
 
 	/// Retrieves an unspent output using its PMMR position
@@ -1305,7 +1305,7 @@ impl Chain {
 	) -> Result<BlockHeader, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		let output_pos = match txhashset.is_unspent(output_ref)? {
+		let output_pos = match txhashset.get_unspent(output_ref)? {
 			Some(o) => o,
 			None => return Err(ErrorKind::OutputNotFound.into()),
 		};

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -115,16 +115,20 @@ impl ChainStore {
 
 	/// Get PMMR pos for the given output commitment.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
-		self.get_output_pos_height(commit).map(|(pos, _)| pos)
+		match self.get_output_pos_height(commit) {
+			Ok(Some((pos, _))) => Ok(pos),
+			Ok(None) => Err(Error::NotFoundErr(format!(
+				"Output position for: {:?}",
+				commit
+			))),
+			Err(e) => Err(e),
+		}
 	}
 
 	/// Get PMMR pos and block height for the given output commitment.
-	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<(u64, u64), Error> {
-		option_to_not_found(
-			self.db
-				.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec())),
-			|| format!("Output position for: {:?}", commit),
-		)
+	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<(u64, u64)>, Error> {
+		self.db
+			.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec()))
 	}
 
 	/// Builds a new batch to be used with this store.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -115,13 +115,12 @@ impl ChainStore {
 
 	/// Get PMMR pos for the given output commitment.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
-		match self.get_output_pos_height(commit) {
-			Ok(Some((pos, _))) => Ok(pos),
-			Ok(None) => Err(Error::NotFoundErr(format!(
+		match self.get_output_pos_height(commit)? {
+			Some((pos, _)) => Ok(pos),
+			None => Err(Error::NotFoundErr(format!(
 				"Output position for: {:?}",
 				commit
 			))),
-			Err(e) => Err(e),
 		}
 	}
 
@@ -278,16 +277,19 @@ impl<'a> Batch<'a> {
 
 	/// Get output_pos from index.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
-		self.get_output_pos_height(commit).map(|(pos, _)| pos)
+		match self.get_output_pos_height(commit)? {
+			Some((pos, _)) => Ok(pos),
+			None => Err(Error::NotFoundErr(format!(
+				"Output position for: {:?}",
+				commit
+			))),
+		}
 	}
 
 	/// Get output_pos and block height from index.
-	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<(u64, u64), Error> {
-		option_to_not_found(
-			self.db
-				.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec())),
-			|| format!("Output position for commit: {:?}", commit),
-		)
+	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<(u64, u64)>, Error> {
+		self.db
+			.get_ser(&to_key(OUTPUT_POS_PREFIX, &mut commit.as_ref().to_vec()))
 	}
 
 	/// Get the previous header.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -223,7 +223,7 @@ impl TxHashSet {
 	/// Check if an output is unspent.
 	/// We look in the index to find the output MMR pos.
 	/// Then we check the entry in the output MMR and confirm the hash matches.
-	pub fn is_unspent(&self, output_id: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
+	pub fn get_unspent(&self, output_id: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
 		let commit = output_id.commit;
 		match self.commit_index.get_output_pos_height(&commit) {
 			Ok(Some((pos, height))) => {

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -695,10 +695,12 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.hash(), prev_main.hash());
 		assert!(chain
 			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
-			.is_ok());
+			.unwrap()
+			.is_some());
 		assert!(chain
 			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
-			.is_err());
+			.unwrap()
+			.is_none());
 
 		// make the fork win
 		let fork_next = prepare_block(&kc, &prev_fork, &chain, 10);
@@ -714,10 +716,12 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.hash(), prev_fork.hash());
 		assert!(chain
 			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
-			.is_ok());
+			.unwrap()
+			.is_some());
 		assert!(chain
 			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
-			.is_err());
+			.unwrap()
+			.is_none());
 
 		// add 20 blocks to go past the test horizon
 		let mut prev = prev_fork;

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -694,11 +694,11 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 6);
 		assert_eq!(head.hash(), prev_main.hash());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
 			.unwrap()
 			.is_some());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
 			.unwrap()
 			.is_none());
 
@@ -715,11 +715,11 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 7);
 		assert_eq!(head.hash(), prev_fork.hash());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
 			.unwrap()
 			.is_some());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
 			.unwrap()
 			.is_none());
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -694,11 +694,11 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 6);
 		assert_eq!(head.hash(), prev_main.hash());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from(&tx2.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from(&tx2.outputs()[0]))
 			.unwrap()
 			.is_some());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from(&tx1.outputs()[0]))
+			.get_unspent(&OutputIdentifier::from(&tx1.outputs()[0]))
 			.unwrap()
 			.is_none());
 


### PR DESCRIPTION
When the wallet is querying the api for a list of commitment containing unconfirmed outputs, they show up as errors in the log like this:
```
20190614 21:37:47.937 ERROR grin_api::handlers::chain_api - Failure to get output for commitment 0951860ff6a74dc41902f08cbe7614b440af0fff2ad629d2847cd0a8c4a9211fd4 with error Not found.
20190614 21:37:47.937 ERROR grin_api::handlers::chain_api - Failure to get output for commitment 08707b918dacbc8e5e4990dc1e47ce0c28b879297f3440959953cce7954683d21f with error Not found.
20190614 21:37:47.938 ERROR grin_api::handlers::chain_api - Failure to get output for commitment 087dd75eaa1f0e43bf54f0773ccde17005683c4fd02aa9b0e19fac51727b10c74a with error Not found.
```
This is not really necessary, since it is expected behaviour that some of the commitments are not in the unspent set. Furthermore, those errors were discarded higher up in the call chain, meaning real errors were not propagated to the wallet response properly.

This PR fixes both these behaviours by changing some internal functions from `Result<.., Error>` to `Result<Option<..>, Error>`.