### PR TITLE
[WIP] reopen header_pmmr every time, no lock required

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -320,8 +320,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 		let max_height = self.chain().header_head()?.height;
 
-		let header_pmmr = self.chain().header_pmmr();
-		let header_pmmr = header_pmmr.read();
+		let header_pmmr = self.chain().header_pmmr()?;
+		// let header_pmmr = header_pmmr.read();
 
 		// looks like we know one, getting as many following headers as allowed
 		let hh = header.height;
@@ -509,8 +509,8 @@ impl NetToChainAdapter {
 
 	// Find the first locator hash that refers to a known header on our main chain.
 	fn find_common_header(&self, locator: &[Hash]) -> Option<BlockHeader> {
-		let header_pmmr = self.chain().header_pmmr();
-		let header_pmmr = header_pmmr.read();
+		let header_pmmr = self.chain().header_pmmr().unwrap();
+		// let header_pmmr = header_pmmr.read();
 
 		for hash in locator {
 			if let Ok(header) = self.chain().get_block_header(&hash) {

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -502,8 +502,8 @@ impl Server {
 			total_difficulty: head.total_difficulty(),
 		};
 
-		let header_stats = match self.chain.try_header_head(read_timeout)? {
-			Some(head) => self.chain.get_block_header(&head.hash()).map(|header| {
+		let header_stats = match self.chain.header_head() {
+			Ok(head) => self.chain.get_block_header(&head.hash()).map(|header| {
 				Some(ChainStats {
 					latest_timestamp: header.timestamp,
 					height: header.height,

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -189,11 +189,10 @@ impl SyncRunner {
 			// Does not appear to be deadlock as it does resolve itself eventually.
 			// So as a workaround we try_header_head with a relatively short timeout and simply
 			// retry the syncer loop.
-			let maybe_header_head =
-				unwrap_or_restart_loop!(self.chain.try_header_head(time::Duration::from_secs(1)));
-			let header_head = unwrap_or_restart_loop!(
-				maybe_header_head.ok_or("failed to obtain lock for try_header_head")
-			);
+			let header_head = unwrap_or_restart_loop!(self.chain.header_head());
+			// let header_head = unwrap_or_restart_loop!(
+			// 	maybe_header_head.ok_or("failed to obtain lock for try_header_head")
+			// );
 
 			// run each sync stage, each of them deciding whether they're needed
 			// except for state sync that only runs if body sync return true (means txhashset is needed)

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -316,10 +316,12 @@ impl<T: PMMRable> PMMRBackend<T> {
 
 	/// Syncs all files to disk. A call to sync is required to ensure all the
 	/// data has been successfully written to disk.
+	/// Flush the data file before the hash file to ensure we always have data where
+	/// we expect it as unpruned_size is based off hash size.
 	pub fn sync(&mut self) -> io::Result<()> {
 		Ok(())
-			.and(self.hash_file.flush())
 			.and(self.data_file.flush())
+			.and(self.hash_file.flush())
 			.and(self.sync_leaf_set())
 			.map_err(|e| {
 				io::Error::new(


### PR DESCRIPTION
Turns out it is really fast to open the header pmmr as it is non-prunable and fixed size.
It is just backed by two mmap'd files (data and hash files).
These are both strictly append-only. There is a possible edge case where we may truncate and rewrite data during a reorg but the size of the file will never decrease.

Every time we accept a new block header we add the block header to the data file and the hash to the hash file along with any necessary parent hashes.

So rather than jumping through a bunch of hoops trying to manage the `RwLock` around it across multiple peer threads and the syncer thread we can just reopen it based on the data on disk each time.

Getting rid of the `RwLock` intuitively feels wrong. But if we only ever append a new header to the data file and one or more hashes to the hash file then we can safely read the files off disk (via mmap) at _any time_ regardless of any other "readers" or "writers".

And the OS lets us do this really efficiently via mmap as the pages remain cached in memory across multiple reads of the file, without needing to maintain a reference to the file. We can simply mmap the file repeatedly and we do not start with an empty cache each time, the data is _already_ memory mapped if the file has not changed on disk.

So we can open the header PMMR and read the `header_head` lock free.
Then we can open the header PMMR and append a new header to it, lock free.
Then if we open it again we will read the new `header_head`, again lock free.

We are basically being optimistic and assume the data will _always_ be consistent and in a readable state. And the append-only semantics of the MMR backend files allow this.
This would be expensive if we were reopening and rereading the backend files each time but `mmap` makes this efficient to do repeatedly.

