### PR TITLE
Write header hash (aka checkpoint) to disk on successful txhashset extension (based on rewind point)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1427,6 +1427,18 @@ fn setup_head(
 		}
 	}
 
+	// Setup our header_head if we do not already have one.
+	// Migrating back to header_head in db and some nodes may not have one.
+	match batch.header_head() {
+		Ok(_) => {}
+		Err(NotFoundErr(_)) => {
+			let hash = header_pmmr.head_hash()?;
+			let header = batch.get_block_header(&hash)?;
+			batch.save_header_head(&Tip::from_header(&header))?;
+		}
+		Err(e) => return Err(ErrorKind::StoreErr(e, "chain init header_head".to_owned()).into()),
+	}
+
 	// Initialize with genesis if we have no chain head yet.
 	match batch.head() {
 		Ok(_) => {}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -241,6 +241,7 @@ impl TxHashSet {
 		}
 	}
 
+	/// Attempt to find the header based on the hash stored in grin.checkpoint file.
 	pub fn last_checkpoint(&self) -> Option<BlockHeader> {
 		let checkpoint = Checkpoint::open(&self.root_dir);
 		if let Some(hash) = checkpoint.last_good_header {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -243,10 +243,8 @@ impl TxHashSet {
 
 	/// Attempt to find the header based on the hash stored in grin.checkpoint file.
 	pub fn last_checkpoint(&self) -> Option<BlockHeader> {
-		let checkpoint = Checkpoint::open(&self.root_dir);
-		if let Some(hash) = checkpoint.last_good_header {
+		if let Some(hash) = Checkpoint::open(&self.root_dir).last_good_header {
 			if let Ok(header) = self.commit_index.get_block_header(&hash) {
-				debug!("last_checkpoint: {} at {}", header.hash(), header.height);
 				return Some(header);
 			}
 		}

--- a/chain/tests/test_checkpoint.rs
+++ b/chain/tests/test_checkpoint.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod chain_test_helper;
+use self::chain_test_helper::{clean_output_dir, init_chain, mine_chain};
+use grin_core::core::hash::Hashed;
+use grin_core::genesis;
+use grin_util as util;
+
+#[test]
+fn init_from_checkpoint() {
+	let chain_dir = ".grin.checkpoint";
+	util::init_test_logger();
+	clean_output_dir(chain_dir);
+
+	// mine some blocks and assert the checkpoint is *previous* block based on chain head.
+	{
+		let chain = mine_chain(chain_dir, 3);
+		let head = chain.head().unwrap();
+		let checkpoint = chain
+			.txhashset()
+			.read()
+			.last_checkpoint()
+			.map(|x| x.hash())
+			.unwrap();
+		assert_eq!(head.prev_block_h, checkpoint);
+	}
+
+	// re-init chain from disk, using the checkpoint written previously.
+	{
+		let chain = init_chain(chain_dir, genesis::genesis_dev());
+		let head = chain.head().unwrap();
+		let checkpoint = chain
+			.txhashset()
+			.read()
+			.last_checkpoint()
+			.map(|x| x.hash())
+			.unwrap();
+		assert_eq!(head.prev_block_h, checkpoint);
+	}
+
+	clean_output_dir(chain_dir);
+}

--- a/chain/tests/test_checkpoint.rs
+++ b/chain/tests/test_checkpoint.rs
@@ -17,7 +17,6 @@ use self::chain_test_helper::{clean_output_dir, init_chain, mine_chain};
 use chain::Tip;
 use grin_chain as chain;
 use grin_core::core::hash::Hashed;
-use grin_core::genesis;
 use grin_util as util;
 
 #[test]
@@ -29,6 +28,9 @@ fn init_from_checkpoint() {
 	// mine some blocks
 	// assert the checkpoint is *previous* block based on chain head
 	let chain = mine_chain(chain_dir, 3);
+	let genesis = chain
+		.get_block(&chain.get_header_by_height(0).unwrap().hash())
+		.unwrap();
 	let head = chain.head().unwrap();
 	let checkpoint = chain.txhashset().read().last_checkpoint().unwrap();
 	assert_eq!(head.prev_block_h, checkpoint.hash());
@@ -36,25 +38,27 @@ fn init_from_checkpoint() {
 
 	// re-init chain from disk
 	// using the checkpoint written previously
-	let chain = init_chain(chain_dir, genesis::genesis_dev());
+	let chain = init_chain(chain_dir, genesis.clone());
 	let head = chain.head().unwrap();
 	assert_eq!(head.prev_block_h, checkpoint.hash());
 	assert_eq!(head_orig, head);
 
 	// reset chain head to earlier state and forget about "latest" block
 	// chain head now matches checkpoint
-	let store = chain.store();
-	let batch = store.batch().unwrap();
-	let latest_block = batch.get_block(&head.last_block_h).unwrap();
-	batch
-		.save_body_head(&Tip::from_header(&checkpoint))
-		.unwrap();
-	batch.delete_block(&latest_block.hash()).unwrap();
-	batch.commit().unwrap();
+	let latest_block = chain.get_block(&head.last_block_h).unwrap();
+	{
+		let store = chain.store();
+		let batch = store.batch().unwrap();
+		batch
+			.save_body_head(&Tip::from_header(&checkpoint))
+			.unwrap();
+		batch.delete_block(&latest_block.hash()).unwrap();
+		batch.commit().unwrap();
+	}
 
 	// re-init chain from disk
 	// assert the chain head corresponds to the checkpoint itself
-	let chain = init_chain(chain_dir, genesis::genesis_dev());
+	let chain = init_chain(chain_dir, genesis.clone());
 	let head = chain.head().unwrap();
 	assert_eq!(head.last_block_h, checkpoint.hash());
 

--- a/chain/tests/test_checkpoint.rs
+++ b/chain/tests/test_checkpoint.rs
@@ -14,6 +14,8 @@
 
 mod chain_test_helper;
 use self::chain_test_helper::{clean_output_dir, init_chain, mine_chain};
+use chain::Tip;
+use grin_chain as chain;
 use grin_core::core::hash::Hashed;
 use grin_core::genesis;
 use grin_util as util;
@@ -24,31 +26,45 @@ fn init_from_checkpoint() {
 	util::init_test_logger();
 	clean_output_dir(chain_dir);
 
-	// mine some blocks and assert the checkpoint is *previous* block based on chain head.
-	{
-		let chain = mine_chain(chain_dir, 3);
-		let head = chain.head().unwrap();
-		let checkpoint = chain
-			.txhashset()
-			.read()
-			.last_checkpoint()
-			.map(|x| x.hash())
-			.unwrap();
-		assert_eq!(head.prev_block_h, checkpoint);
-	}
+	// mine some blocks
+	// assert the checkpoint is *previous* block based on chain head
+	let chain = mine_chain(chain_dir, 3);
+	let head = chain.head().unwrap();
+	let checkpoint = chain.txhashset().read().last_checkpoint().unwrap();
+	assert_eq!(head.prev_block_h, checkpoint.hash());
+	let head_orig = head.clone();
 
-	// re-init chain from disk, using the checkpoint written previously.
-	{
-		let chain = init_chain(chain_dir, genesis::genesis_dev());
-		let head = chain.head().unwrap();
-		let checkpoint = chain
-			.txhashset()
-			.read()
-			.last_checkpoint()
-			.map(|x| x.hash())
-			.unwrap();
-		assert_eq!(head.prev_block_h, checkpoint);
-	}
+	// re-init chain from disk
+	// using the checkpoint written previously
+	let chain = init_chain(chain_dir, genesis::genesis_dev());
+	let head = chain.head().unwrap();
+	assert_eq!(head.prev_block_h, checkpoint.hash());
+	assert_eq!(head_orig, head);
+
+	// reset chain head to earlier state and forget about "latest" block
+	// chain head now matches checkpoint
+	let store = chain.store();
+	let batch = store.batch().unwrap();
+	let latest_block = batch.get_block(&head.last_block_h).unwrap();
+	batch
+		.save_body_head(&Tip::from_header(&checkpoint))
+		.unwrap();
+	batch.delete_block(&latest_block.hash()).unwrap();
+	batch.commit().unwrap();
+
+	// re-init chain from disk
+	// assert the chain head corresponds to the checkpoint itself
+	let chain = init_chain(chain_dir, genesis::genesis_dev());
+	let head = chain.head().unwrap();
+	assert_eq!(head.last_block_h, checkpoint.hash());
+
+	// reprocess the "latest" block
+	// assert we are back to "latest" at head
+	let head = chain
+		.process_block(latest_block, chain::Options::NONE)
+		.unwrap()
+		.unwrap();
+	assert_eq!(head, head_orig);
 
 	clean_output_dir(chain_dir);
 }


### PR DESCRIPTION
We perform a "rewind" before processing each block (and block header).
The "happy path" where we process the _next_ block based on current chain head still "rewinds" but is optimized to be very cheap and is effectively a no-op.

We take advantage of the "rewind" to identify the "fork point" in the chain.
This fork point represents the earliest block that is subject to being rewritten in the context of processing the new block. Everything earlier than (and including this block) is immutable and the data is guaranteed not to change. Everything later than this may be rewritten to files on disk and the local db.

The immutable data _cannot_ be corrupted regardless of how abruptly the nodes shuts down. The backend files are truncated (at the fork point) then new bytes are written to them. 

This PR notes the "fork point" and stores the block header hash to disk in a file `chain_data/grin.checkpoint` in human readable hex format.

This is done every time the node processes a new block and happens prior to writing anything to disk or the local db. Anything written to disk subsequently will be ignored on startup and reprocessed, until the _next_ block is then processed.

On node startup we read the hash from the checkpoint file and rewind to this point before continuing.
In the majority of cases this will simply represent the header at `h-1` relative to the current chain head. So we end up reprocessing the latest full block. Conceptually this simply forces the node to reprocess the latest block, ensuring that any data partially written before shutdown reprocessed and fixed if corrupted.

Related - #3265 (more robust parsing of a header hash in hex form in a file on disk).