### PR TITLE
go back to storing header_head in the db

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -240,12 +240,7 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 	// If it does not increase total_difficulty beyond our current header_head
 	// then we can (re)accept this header and process the full block (or request it).
 	// This header is on a fork and we should still accept it as the fork may eventually win.
-	let header_head = {
-		let hash = ctx.header_pmmr.head_hash()?;
-		let header = ctx.batch.get_block_header(&hash)?;
-		Tip::from_header(&header)
-	};
-
+	let header_head = ctx.batch.header_head()?;
 	if let Ok(existing) = ctx.batch.get_block_header(&header.hash()) {
 		if !has_more_work(&existing, &header_head) {
 			return Ok(());

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -215,6 +215,11 @@ pub fn sync_block_headers(
 		Ok(())
 	})?;
 
+	let header_head = ctx.batch.header_head()?;
+	if has_more_work(last_header, &header_head) {
+		update_header_head(&Tip::from_header(last_header), &mut ctx.batch)?;
+	}
+
 	Ok(())
 }
 
@@ -259,6 +264,10 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 
 	validate_header(header, ctx)?;
 	add_block_header(header, &ctx.batch)?;
+
+	if has_more_work(header, &header_head) {
+		update_header_head(&Tip::from_header(header), &mut ctx.batch)?;
+	}
 
 	Ok(())
 }
@@ -466,6 +475,19 @@ fn add_block_header(bh: &BlockHeader, batch: &store::Batch<'_>) -> Result<(), Er
 	batch
 		.save_block_header(bh)
 		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header".to_owned()))?;
+	Ok(())
+}
+
+fn update_header_head(head: &Tip, batch: &mut store::Batch<'_>) -> Result<(), Error> {
+	batch
+		.save_header_head(&head)
+		.map_err(|e| ErrorKind::StoreErr(e, "pipe save header head".to_owned()))?;
+
+	debug!(
+		"header head updated to {} at {}",
+		head.last_block_h, head.height
+	);
+
 	Ok(())
 }
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -33,6 +33,7 @@ const BLOCK_HEADER_PREFIX: u8 = b'h';
 const BLOCK_PREFIX: u8 = b'b';
 const HEAD_PREFIX: u8 = b'H';
 const TAIL_PREFIX: u8 = b'T';
+const HEADER_HEAD_PREFIX: u8 = b'G';
 const OUTPUT_POS_PREFIX: u8 = b'p';
 const BLOCK_INPUT_BITMAP_PREFIX: u8 = b'B';
 const BLOCK_SUMS_PREFIX: u8 = b'M';
@@ -66,6 +67,13 @@ impl ChainStore {
 	/// The current chain head.
 	pub fn head(&self) -> Result<Tip, Error> {
 		option_to_not_found(self.db.get_ser(&[HEAD_PREFIX]), || "HEAD".to_owned())
+	}
+
+	/// The current header head (may differ from chain head).
+	pub fn header_head(&self) -> Result<Tip, Error> {
+		option_to_not_found(self.db.get_ser(&[HEADER_HEAD_PREFIX]), || {
+			"HEADER_HEAD".to_owned()
+		})
 	}
 
 	/// The current chain "tail" (earliest block in the store).
@@ -155,6 +163,13 @@ impl<'a> Batch<'a> {
 		option_to_not_found(self.db.get_ser(&[TAIL_PREFIX]), || "TAIL".to_owned())
 	}
 
+	/// The current header head (may differ from chain head).
+	pub fn header_head(&self) -> Result<Tip, Error> {
+		option_to_not_found(self.db.get_ser(&[HEADER_HEAD_PREFIX]), || {
+			"HEADER_HEAD".to_owned()
+		})
+	}
+
 	/// Header of the block at the head of the block chain (not the same thing as header_head).
 	pub fn head_header(&self) -> Result<BlockHeader, Error> {
 		self.get_block_header(&self.head()?.last_block_h)
@@ -168,6 +183,11 @@ impl<'a> Batch<'a> {
 	/// Save body "tail" to db.
 	pub fn save_body_tail(&self, t: &Tip) -> Result<(), Error> {
 		self.db.put_ser(&[TAIL_PREFIX], t)
+	}
+
+	/// Save header head to db.
+	pub fn save_header_head(&self, t: &Tip) -> Result<(), Error> {
+		self.db.put_ser(&[HEADER_HEAD_PREFIX], t)
 	}
 
 	/// get block

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -481,13 +481,7 @@ where
 	trace!("Starting new txhashset (readonly) extension.");
 
 	let head = batch.head()?;
-
-	// Find header head based on current header MMR (the rightmost leaf node in the MMR).
-	let header_head = {
-		let hash = handle.head_hash()?;
-		let header = batch.get_block_header(&hash)?;
-		Tip::from_header(&header)
-	};
+	let header_head = batch.header_head()?;
 
 	let res = {
 		let header_pmmr = PMMR::at(&mut handle.backend, handle.last_pos);
@@ -586,13 +580,7 @@ where
 	let bitmap_accumulator: BitmapAccumulator;
 
 	let head = batch.head()?;
-
-	// Find header head based on current header MMR (the rightmost leaf node in the MMR).
-	let header_head = {
-		let hash = header_pmmr.head_hash()?;
-		let header = batch.get_block_header(&hash)?;
-		Tip::from_header(&header)
-	};
+	let header_head = batch.header_head()?;
 
 	// create a child transaction so if the state is rolled back by itself, all
 	// index saving can be undone
@@ -671,7 +659,8 @@ where
 	// index saving can be undone
 	let child_batch = batch.child()?;
 
-	// Find chain head based on current MMR (the rightmost leaf node in the MMR).
+	// Note: Extending either the sync_head or header_head MMR here.
+	// Use underlying MMR to determine the "head".
 	let head = match handle.head_hash() {
 		Ok(hash) => {
 			let header = child_batch.get_block_header(&hash)?;

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -52,8 +52,8 @@ pub struct ServerStats {
 	pub peer_count: u32,
 	/// Chain head
 	pub chain_stats: ChainStats,
-	/// sync header head
-	pub header_stats: Option<ChainStats>,
+	/// Header head (may differ from chain head)
+	pub header_stats: ChainStats,
 	/// Whether we're currently syncing
 	pub sync_status: SyncStatus,
 	/// Handle to current stratum server stats

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -502,16 +502,13 @@ impl Server {
 			total_difficulty: head.total_difficulty(),
 		};
 
-		let header_stats = match self.chain.try_header_head(read_timeout)? {
-			Some(head) => self.chain.get_block_header(&head.hash()).map(|header| {
-				Some(ChainStats {
-					latest_timestamp: header.timestamp,
-					height: header.height,
-					last_block_h: header.prev_hash,
-					total_difficulty: header.total_difficulty(),
-				})
-			})?,
-			_ => None,
+		let header_head = self.chain.header_head()?;
+		let header = self.chain.get_block_header(&header_head.hash())?;
+		let header_stats = ChainStats {
+			latest_timestamp: header.timestamp,
+			height: header.height,
+			last_block_h: header.prev_hash,
+			total_difficulty: header.total_difficulty(),
 		};
 
 		let disk_usage_bytes = WalkDir::new(&self.config.db_root)

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -182,18 +182,7 @@ impl SyncRunner {
 			// if syncing is needed
 			let head = unwrap_or_restart_loop!(self.chain.head());
 			let tail = self.chain.tail().unwrap_or_else(|_| head.clone());
-
-			// We still do not fully understand what is blocking this but if this blocks here after
-			// we download and validate the txhashet we do not reliably proceed to block_sync,
-			// potentially blocking for an extended period of time (> 10 mins).
-			// Does not appear to be deadlock as it does resolve itself eventually.
-			// So as a workaround we try_header_head with a relatively short timeout and simply
-			// retry the syncer loop.
-			let maybe_header_head =
-				unwrap_or_restart_loop!(self.chain.try_header_head(time::Duration::from_secs(1)));
-			let header_head = unwrap_or_restart_loop!(
-				maybe_header_head.ok_or("failed to obtain lock for try_header_head")
-			);
+			let header_head = unwrap_or_restart_loop!(self.chain.header_head());
 
 			// run each sync stage, each of them deciding whether they're needed
 			// except for state sync that only runs if body sync return true (means txhashset is needed)

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -270,20 +270,18 @@ impl TUIStatusListener for TUIStatusView {
 		c.call_on_id("chain_timestamp", |t: &mut TextView| {
 			t.set_content(stats.chain_stats.latest_timestamp.to_string());
 		});
-		if let Some(header_stats) = &stats.header_stats {
-			c.call_on_id("basic_header_tip_hash", |t: &mut TextView| {
-				t.set_content(header_stats.last_block_h.to_string() + "...");
-			});
-			c.call_on_id("basic_header_chain_height", |t: &mut TextView| {
-				t.set_content(header_stats.height.to_string());
-			});
-			c.call_on_id("basic_header_total_difficulty", |t: &mut TextView| {
-				t.set_content(header_stats.total_difficulty.to_string());
-			});
-			c.call_on_id("basic_header_timestamp", |t: &mut TextView| {
-				t.set_content(header_stats.latest_timestamp.to_string());
-			});
-		}
+		c.call_on_id("basic_header_tip_hash", |t: &mut TextView| {
+			t.set_content(stats.header_stats.last_block_h.to_string() + "...");
+		});
+		c.call_on_id("basic_header_chain_height", |t: &mut TextView| {
+			t.set_content(stats.header_stats.height.to_string());
+		});
+		c.call_on_id("basic_header_total_difficulty", |t: &mut TextView| {
+			t.set_content(stats.header_stats.total_difficulty.to_string());
+		});
+		c.call_on_id("basic_header_timestamp", |t: &mut TextView| {
+			t.set_content(stats.header_stats.latest_timestamp.to_string());
+		});
 		if let Some(tx_stats) = &stats.tx_stats {
 			c.call_on_id("tx_pool_size", |t: &mut TextView| {
 				t.set_content(tx_stats.tx_pool_size.to_string());


### PR DESCRIPTION
This PR reverts the "read head from the header MMR directly" changes, simplifies `header_head` handling and maintains the `header_head` in the db.

We changed the way we handle the `header_head` in #3045. We used to maintain the header_head in the db and that PR changed it to simply read the head of the header MMR from the header MMR files directly.

The rationale for the change was to reduce the number of things we need to keep consistent (MMR file + db index).

I'm now convinced this was a bad choice and the wrong direction to go in.

The RwLock around the header MMR means we cannot read the current head without taking a read lock and this blocks if anything (block processing, header processing, sync process) currently has a write lock on the MMR.

This necessitated the whole `try_header_head()` timeout based workaround.

The fact that writing the `header_head` to the db is transactional is actually beneficial here - 
* we can read from the db regardless of what other threads are doing
* once the header_head is committed to the db we know this is good (and we are not at risk of reading inconsistent state from the non-transactional MMR files)

So being forced to keep the MMR and the db "in sync" and consistent is a _good thing_. The transactional semantics of the db means we only update the `header_head` once we commit the db transaction, vs the MMR backend files that can (and will) be inconsistent at times.

In concrete terms this will get rid of the large volume of "failed to obtain lock for try_header_head" errors during fast sync.
