### PR TITLE
Use latest hosted agent for CI

### DIFF
--- a/.ci/install.yml
+++ b/.ci/install.yml
@@ -1,17 +1,5 @@
 steps:
   - script: |
       git apply .ci/win.patch
-      choco install -y llvm
-    displayName: Windows Install LLVM
+    displayName: Windows Apply Patch
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  - script: |
-      clang --version
-      brew uninstall llvm
-      clang --version
-    displayName: macOS Uninstall LLVM
-    condition: eq( variables['Agent.OS'], 'Darwin' )
-  - script: |
-      sudo apt-get update -yqq
-      sudo apt-get install -yqq --no-install-recommends libncursesw5-dev libclang-dev clang
-    displayName: Linux Install Dependencies
-    condition: eq( variables['Agent.OS'], 'Linux' )

--- a/.ci/install.yml
+++ b/.ci/install.yml
@@ -1,9 +1,0 @@
-steps:
-  - script: |
-      git apply .ci/win.patch
-    displayName: Windows Apply Patch
-    condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  - script: |
-      brew uninstall llvm
-    displayName: macOS Uninstall LLVM
-    condition: eq( variables['Agent.OS'], 'Darwin' )

--- a/.ci/install.yml
+++ b/.ci/install.yml
@@ -3,3 +3,7 @@ steps:
       git apply .ci/win.patch
     displayName: Windows Apply Patch
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  - script: |
+      brew uninstall llvm
+    displayName: macOS Uninstall LLVM
+    condition: eq( variables['Agent.OS'], 'Darwin' )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,6 @@ jobs:
         PLATFORM: win-x64
   steps:
     - script: |
-        git apply .ci/win.patch
         choco install -y llvm
       displayName: Windows Install Dependencies
     - template: '.ci/test.yml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
     - script: |
         sudo apt-get update -yqq
         sudo apt-get install -yqq --no-install-recommends libncursesw5-dev
-    - displayName: Linux Install Dependencies
+      displayName: Linux Install Dependencies
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: macos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,10 @@ jobs:
         CI_JOB: release
         PLATFORM: linux-amd64
   steps:
+    - script: |
+        sudo apt-get update -yqq
+        sudo apt-get install -yqq --no-install-recommends libncursesw5-dev
+    - displayName: Linux Install Dependencies
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: macos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,6 @@ jobs:
         CI_JOB: release
         PLATFORM: linux-amd64
   steps:
-    - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: macos
@@ -64,7 +63,9 @@ jobs:
         CI_JOB: release
         PLATFORM: macos
   steps:
-    - template: '.ci/install.yml'
+    - script: |
+        brew uninstall llvm
+      displayName: macOS Uninstall LLVM
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: windows
@@ -78,6 +79,9 @@ jobs:
         CI_JOB: release
         PLATFORM: win-x64
   steps:
-    - template: '.ci/install.yml'
+    - script: |
+        git apply .ci/win.patch
+        choco install -y llvm
+      displayName: Windows Install Dependencies
     - template: '.ci/test.yml'
     - template: '.ci/windows-release.yml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,7 @@ jobs:
         PLATFORM: win-x64
   steps:
     - script: |
+        git apply .ci/win.patch
         choco install -y llvm
       displayName: Windows Install Dependencies
     - template: '.ci/test.yml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       servers:
@@ -55,7 +55,7 @@ jobs:
     - template: '.ci/release.yml'
 - job: macos
   pool:
-    vmImage: macos-10.14
+    vmImage: macos-latest
   strategy:
     matrix:
       test:
@@ -69,7 +69,7 @@ jobs:
     - template: '.ci/release.yml'
 - job: windows
   pool:
-    vmImage: windows-2019
+    vmImage: windows-latest
   strategy:
     matrix:
       test:


### PR DESCRIPTION
Which are:
macOS 10.15 Catalina
Ubuntu 18.04 LTS
Windows server 2019

- Use `ubuntu-latest`, `macos-latest` and `windows-latest`.
- Remove the shared install steps.

Build should be a bit faster.

more info here:
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#software
