### PR TITLE
Fix rare panic in TUI

### DIFF
--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -69,7 +69,7 @@ impl TUIStatusView {
 					format!("Sync step 2/7: Downloading {}(MB) chain state for state sync: {}% at {:.1?}(kB/s)",
 							total_size / 1_000_000,
 							percent,
-							if dur_ms > 1.0f64 { (downloaded_size - prev_downloaded_size) as f64 / dur_ms as f64 } else { 0f64 },
+							if dur_ms > 1.0f64 { downloaded_size.saturating_sub(prev_downloaded_size) as f64 / dur_ms as f64 } else { 0f64 },
 					)
 				} else {
 					let start = start_time.timestamp_millis();


### PR DESCRIPTION
According to https://github.com/mimblewimble/grin/issues/3138#issuecomment-613357541, sometimes during IBD it could happen that the previous downloaded size is bigger than the downloaded size. This PR prevents the panic by not underflowing. It doesn't fix the underlying issue (which is that the downloaded size doesn't always increase monotonically) but since we're going to revamp the IBD anyway this fix should suffice for now.