### PR TITLE
Refactor SyncState

### DIFF
--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -79,16 +79,11 @@ fn sync_status_to_api(sync_status: SyncStatus) -> (String, Option<serde_json::Va
 			"header_sync".to_string(),
 			Some(json!({ "current_height": current_height, "highest_height": highest_height })),
 		),
-		SyncStatus::TxHashsetDownload {
-			start_time: _,
-			prev_update_time: _,
-			update_time: _,
-			prev_downloaded_size: _,
-			downloaded_size,
-			total_size,
-		} => (
+		SyncStatus::TxHashsetDownload(stats) => (
 			"txhashset_download".to_string(),
-			Some(json!({ "downloaded_size": downloaded_size, "total_size": total_size })),
+			Some(
+				json!({ "downloaded_size": stats.downloaded_size, "total_size": stats.total_size }),
+			),
 		),
 		SyncStatus::TxHashsetRangeProofsValidation {
 			rproofs,

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -46,5 +46,6 @@ pub use crate::chain::{Chain, MAX_ORPHAN_SIZE};
 pub use crate::error::{Error, ErrorKind};
 pub use crate::store::ChainStore;
 pub use crate::types::{
-	BlockStatus, ChainAdapter, Options, SyncState, SyncStatus, Tip, TxHashsetWriteStatus,
+	BlockStatus, ChainAdapter, Options, SyncState, SyncStatus, Tip, TxHashsetDownloadStats,
+	TxHashsetWriteStatus,
 };

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -68,13 +68,9 @@ impl StateSync {
 		let mut sync_need_restart = false;
 
 		// check sync error
-		{
-			let clone = self.sync_state.sync_error();
-			if let Some(ref sync_error) = *clone.read() {
-				error!("state_sync: error = {:?}. restart fast sync", sync_error);
-				sync_need_restart = true;
-			}
-			drop(clone);
+		if let Some(ref sync_error) = *self.sync_state.sync_error() {
+			error!("state_sync: error = {:?}. restart fast sync", sync_error);
+			sync_need_restart = true;
 		}
 
 		// check peer connection status of this sync
@@ -147,14 +143,8 @@ impl StateSync {
 					}
 				}
 
-				self.sync_state.update(SyncStatus::TxHashsetDownload {
-					start_time: Utc::now(),
-					prev_update_time: Utc::now(),
-					update_time: Utc::now(),
-					prev_downloaded_size: 0,
-					downloaded_size: 0,
-					total_size: 0,
-				});
+				self.sync_state
+					.update(SyncStatus::TxHashsetDownload(Default::default()));
 			}
 		}
 		true

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -48,31 +48,20 @@ impl TUIStatusView {
 				};
 				format!("Sync step 1/7: Downloading headers: {}%", percent)
 			}
-			SyncStatus::TxHashsetDownload {
-				start_time,
-				prev_update_time,
-				update_time: _,
-				prev_downloaded_size,
-				downloaded_size,
-				total_size,
-			} => {
-				if total_size > 0 {
-					let percent = if total_size > 0 {
-						downloaded_size * 100 / total_size
-					} else {
-						0
-					};
-					let start = prev_update_time.timestamp_nanos();
+			SyncStatus::TxHashsetDownload(stat) => {
+				if stat.total_size > 0 {
+					let percent = stat.downloaded_size * 100 / stat.total_size;
+					let start = stat.prev_update_time.timestamp_nanos();
 					let fin = Utc::now().timestamp_nanos();
 					let dur_ms = (fin - start) as f64 * NANO_TO_MILLIS;
 
 					format!("Sync step 2/7: Downloading {}(MB) chain state for state sync: {}% at {:.1?}(kB/s)",
-							total_size / 1_000_000,
+							stat.total_size / 1_000_000,
 							percent,
-							if dur_ms > 1.0f64 { downloaded_size.saturating_sub(prev_downloaded_size) as f64 / dur_ms as f64 } else { 0f64 },
+							if dur_ms > 1.0f64 { stat.downloaded_size.saturating_sub(stat.prev_downloaded_size) as f64 / dur_ms as f64 } else { 0f64 },
 					)
 				} else {
-					let start = start_time.timestamp_millis();
+					let start = stat.start_time.timestamp_millis();
 					let fin = Utc::now().timestamp_millis();
 					let dur_secs = (fin - start) / 1000;
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -29,7 +29,7 @@ extern crate lazy_static;
 extern crate serde_derive;
 // Re-export so only has to be included once
 pub use parking_lot::Mutex;
-pub use parking_lot::{RwLock, RwLockReadGuard};
+pub use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 // Re-export so only has to be included once
 pub use secp256k1zkp as secp;


### PR DESCRIPTION
Method `sync_error()` return type was simplified.
`update_txhashset_download()` was  made type safe, which eliminates a runtime enum variant's  check. As a bonus matching code is shorter and simpler when we do a partial destructuing, which happens quite often.
