### PR TITLE
Don't swallow errors in body_sync

### DIFF
--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -202,14 +202,8 @@ impl SyncRunner {
 						continue;
 					}
 
-					let check_run = match body_sync.check_run(&head, highest_height) {
-						Ok(v) => v,
-						Err(e) => {
-							error!("check_run failed: {:?}", e);
-							continue;
-						}
-					};
-
+					let check_run =
+						unwrap_or_restart_loop!(body_sync.check_run(&head, highest_height));
 					if check_run {
 						check_state_sync = true;
 					}


### PR DESCRIPTION
We handle them inside but it makes the code more cluttered
