### PR TITLE
Remove some unwraps

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -185,7 +185,9 @@ pub fn sync_block_headers(
 	if headers.is_empty() {
 		return Ok(());
 	}
-	let last_header = headers.last().expect("last header");
+	let last_header = headers
+		.last()
+		.ok_or_else(|| ErrorKind::SyncError("empty headers".to_string()))?;
 
 	// Check if we know about all these headers. If so we can accept them quickly.
 	// If they *do not* increase total work on the sync chain we are done.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -360,11 +360,11 @@ impl<'a> Batch<'a> {
 	/// Fallback to legacy block input bitmap from the db.
 	pub fn get_block_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
 		if let Ok(spent) = self.get_spent_index(bh) {
-			let bitmap = spent
+			spent
 				.into_iter()
-				.map(|x| x.pos.try_into().unwrap())
-				.collect();
-			Ok(bitmap)
+				.map(|x| x.pos.try_into())
+				.collect::<Result<Bitmap, _>>()
+				.map_err(|e| Error::SerErr(format!("Invalid spent index: {}", e)))
 		} else {
 			self.get_legacy_input_bitmap(bh)
 		}

--- a/chain/tests/chain_test_helper.rs
+++ b/chain/tests/chain_test_helper.rs
@@ -57,7 +57,7 @@ where
 	let key_id = keychain::ExtKeychain::derive_key_id(0, 1, 0, 0, 0);
 	let reward = reward::output(
 		keychain,
-		&libtx::ProofBuilder::new(keychain),
+		&libtx::ProofBuilder::new(keychain).expect("new proof builder"),
 		&key_id,
 		0,
 		false,
@@ -86,9 +86,14 @@ where
 		let prev = chain.head_header().unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 		let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-		let reward =
-			libtx::reward::output(keychain, &libtx::ProofBuilder::new(keychain), &pk, 0, false)
-				.unwrap();
+		let reward = libtx::reward::output(
+			keychain,
+			&libtx::ProofBuilder::new(keychain).expect("new proof builder"),
+			&pk,
+			0,
+			false,
+		)
+		.unwrap();
 		let mut b =
 			core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
 				.unwrap();

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -539,7 +539,7 @@ fn spend_rewind_spend() {
 		);
 		let prev = chain.head_header().unwrap();
 		let kc = ExtKeychain::from_random_seed(false).unwrap();
-		let pb = ProofBuilder::new(&kc);
+		let pb = ProofBuilder::new(&kc).expect("new proof builder");
 
 		let mut head = prev;
 
@@ -613,7 +613,7 @@ fn spend_in_fork_and_compact() {
 		let chain = init_chain(".grin6", pow::mine_genesis_block().unwrap());
 		let prev = chain.head_header().unwrap();
 		let kc = ExtKeychain::from_random_seed(false).unwrap();
-		let pb = ProofBuilder::new(&kc);
+		let pb = ProofBuilder::new(&kc).expect("new proof builder");
 
 		let mut fork_head = prev;
 
@@ -761,7 +761,7 @@ fn output_header_mappings() {
 			let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 				&pk,
 				0,
 				false,
@@ -882,8 +882,14 @@ where
 	let key_id = ExtKeychainPath::new(1, key_idx, 0, 0, 0).to_identifier();
 
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward =
-		libtx::reward::output(kc, &libtx::ProofBuilder::new(kc), &key_id, fees, false).unwrap();
+	let reward = libtx::reward::output(
+		kc,
+		&libtx::ProofBuilder::new(kc).expect("new proof builder"),
+		&key_id,
+		fees,
+		false,
+	)
+	.unwrap();
 	let mut b = match core::core::Block::new(
 		prev,
 		txs.into_iter().cloned().collect(),

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -60,7 +60,7 @@ fn test_coinbase_maturity() {
 		let prev = chain.head_header().unwrap();
 
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -144,7 +144,7 @@ fn test_coinbase_maturity() {
 			let prev = chain.head_header().unwrap();
 
 			let keychain = ExtKeychain::from_random_seed(false).unwrap();
-			let builder = ProofBuilder::new(&keychain);
+			let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 			let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
@@ -227,7 +227,7 @@ fn test_coinbase_maturity() {
 				let prev = chain.head_header().unwrap();
 
 				let keychain = ExtKeychain::from_random_seed(false).unwrap();
-				let builder = ProofBuilder::new(&keychain);
+				let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 				let pk = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 				let reward = libtx::reward::output(&keychain, &builder, &pk, 0, false).unwrap();

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -233,7 +233,7 @@ pub fn verify_partial_sig(
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 /// let switch = SwitchCommitmentType::Regular;
 /// let commit = keychain.commit(value, &key_id, switch).unwrap();
-/// let builder = proof::ProofBuilder::new(&keychain);
+/// let builder = proof::ProofBuilder::new(&keychain).expect("new proof builder");
 /// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();
 /// let output = Output {
 ///     features: OutputFeatures::Coinbase,
@@ -300,7 +300,7 @@ where
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 /// let switch = SwitchCommitmentType::Regular;
 /// let commit = keychain.commit(value, &key_id, switch).unwrap();
-/// let builder = proof::ProofBuilder::new(&keychain);
+/// let builder = proof::ProofBuilder::new(&keychain).expect("new proof builder");
 /// let rproof = proof::create(&keychain, &builder, value, &key_id, switch, commit, None).unwrap();
 /// let output = Output {
 ///     features: OutputFeatures::Coinbase,

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -262,7 +262,7 @@ mod test {
 	#[test]
 	fn blind_simple_tx() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -283,7 +283,7 @@ mod test {
 	#[test]
 	fn blind_simple_tx_with_offset() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -304,7 +304,7 @@ mod test {
 	#[test]
 	fn blind_simpler_tx() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -137,23 +137,22 @@ where
 	K: Keychain,
 {
 	/// Creates a new instance of this proof builder
-	pub fn new(keychain: &'a K) -> Self {
-		let private_root_key = keychain
-			.derive_key(0, &K::root_key_id(), SwitchCommitmentType::None)
-			.unwrap();
+	pub fn new(keychain: &'a K) -> Result<Self, Error> {
+		let private_root_key =
+			keychain.derive_key(0, &K::root_key_id(), SwitchCommitmentType::None)?;
 
 		let private_hash = blake2b(32, &[], &private_root_key.0).as_bytes().to_vec();
 
 		let public_root_key = keychain
-			.public_root_key()
+			.public_root_key()?
 			.serialize_vec(keychain.secp(), true);
 		let rewind_hash = blake2b(32, &[], &public_root_key[..]).as_bytes().to_vec();
 
-		Self {
+		Ok(Self {
 			keychain,
 			rewind_hash,
 			private_hash,
-		}
+		})
 	}
 
 	fn nonce(&self, commit: &Commitment, private: bool) -> Result<SecretKey, Error> {
@@ -459,7 +458,7 @@ mod tests {
 	fn builder() {
 		let rng = &mut thread_rng();
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let amount = rng.gen();
 		let id = ExtKeychain::derive_key_id(3, rng.gen(), rng.gen(), rng.gen(), 0);
 		// With switch commitment
@@ -500,7 +499,7 @@ mod tests {
 		/*let rng = &mut thread_rng();
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let mut hasher = keychain.hasher();
 		let view_key = ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
 		assert_eq!(builder.rewind_hash, view_key.rewind_hash);
@@ -531,7 +530,7 @@ mod tests {
 		let rng = &mut thread_rng();
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let mut hasher = keychain.hasher();
 		let view_key =
 			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
@@ -567,7 +566,7 @@ mod tests {
 		let rng = &mut thread_rng();
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let mut hasher = keychain.hasher();
 		let view_key =
 			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();
@@ -599,7 +598,7 @@ mod tests {
 		let rng = &mut thread_rng();
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 		let mut hasher = keychain.hasher();
 		let view_key =
 			ViewKey::create(&keychain, keychain.master.clone(), &mut hasher, false).unwrap();

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -43,7 +43,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 fn too_large_block() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let max_out = global::max_block_weight() / BLOCK_OUTPUT_WEIGHT;
 
 	let mut pks = vec![];
@@ -84,7 +84,7 @@ fn very_empty_block() {
 // builds a block with a tx spending another and check that cut_through occurred
 fn block_with_cut_through() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -122,7 +122,7 @@ fn block_with_cut_through() {
 #[test]
 fn empty_block_with_coinbase_is_valid() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -160,7 +160,7 @@ fn empty_block_with_coinbase_is_valid() {
 // additionally verifying the merkle_inputs_outputs also fails
 fn remove_coinbase_output_flag() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -183,7 +183,7 @@ fn remove_coinbase_output_flag() {
 // invalidates the block and specifically it causes verify_coinbase to fail
 fn remove_coinbase_kernel_flag() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -225,7 +225,7 @@ fn serialize_deserialize_header_version() {
 #[test]
 fn serialize_deserialize_block_header() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -243,7 +243,7 @@ fn serialize_deserialize_block_header() {
 fn serialize_deserialize_block() {
 	let tx1 = tx1i2o();
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
@@ -263,7 +263,7 @@ fn serialize_deserialize_block() {
 fn empty_block_serialized_size() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -276,7 +276,7 @@ fn empty_block_serialized_size() {
 fn block_single_tx_serialized_size() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -290,7 +290,7 @@ fn block_single_tx_serialized_size() {
 fn empty_compact_block_serialized_size() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -304,7 +304,7 @@ fn empty_compact_block_serialized_size() {
 fn compact_block_single_tx_serialized_size() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -319,7 +319,7 @@ fn compact_block_single_tx_serialized_size() {
 fn block_10_tx_serialized_size() {
 	global::set_mining_mode(global::ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 
 	let mut txs = vec![];
 	for _ in 0..10 {
@@ -356,7 +356,7 @@ fn block_10_tx_serialized_size() {
 fn compact_block_10_tx_serialized_size() {
 	global::set_mining_mode(ChainTypes::AutomatedTesting);
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 
 	let mut txs = vec![];
 	for _ in 0..10 {
@@ -375,7 +375,7 @@ fn compact_block_10_tx_serialized_size() {
 #[test]
 fn compact_block_hash_with_nonce() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let tx = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -406,7 +406,7 @@ fn compact_block_hash_with_nonce() {
 #[test]
 fn convert_block_to_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -430,7 +430,7 @@ fn convert_block_to_compact_block() {
 #[test]
 fn hydrate_empty_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
@@ -444,7 +444,7 @@ fn hydrate_empty_compact_block() {
 #[test]
 fn serialize_deserialize_compact_block() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let tx1 = tx1i2o();
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
@@ -471,7 +471,7 @@ fn serialize_deserialize_compact_block() {
 #[test]
 fn same_amount_outputs_copy_range_proof() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -513,7 +513,7 @@ fn same_amount_outputs_copy_range_proof() {
 #[test]
 fn wrong_amount_range_proof() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -565,7 +565,7 @@ fn wrong_amount_range_proof() {
 #[test]
 fn validate_header_proof() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -29,7 +29,7 @@ use keychain::{Identifier, Keychain};
 #[allow(dead_code)]
 pub fn tx2i1o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -47,7 +47,7 @@ pub fn tx2i1o() -> Transaction {
 #[allow(dead_code)]
 pub fn tx1i1o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 
@@ -66,7 +66,7 @@ pub fn tx1i1o() -> Transaction {
 #[allow(dead_code)]
 pub fn tx1i2o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -92,7 +92,7 @@ fn tx_double_ser_deser() {
 #[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
@@ -112,7 +112,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 #[test]
 fn build_tx_kernel() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -358,7 +358,7 @@ fn basic_transaction_deaggregation() {
 #[test]
 fn hash_output() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -413,7 +413,7 @@ fn tx_hash_diff() {
 #[test]
 fn tx_build_exchange() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -458,7 +458,7 @@ fn tx_build_exchange() {
 #[test]
 fn reward_empty_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let previous_header = BlockHeader::default();
@@ -474,7 +474,7 @@ fn reward_empty_block() {
 #[test]
 fn reward_with_tx_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -501,7 +501,7 @@ fn reward_with_tx_block() {
 #[test]
 fn simple_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -524,7 +524,7 @@ fn simple_block() {
 #[test]
 fn test_block_with_timelocked_tx() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain).expect("new proof builder");
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -28,7 +28,8 @@ fn test_output_ser_deser() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let switch = keychain::SwitchCommitmentType::Regular;
 	let commit = keychain.commit(5, &key_id, switch).unwrap();
-	let builder = proof::ProofBuilder::new(&keychain);
+	let builder = proof::ProofBuilder::new(&keychain).expect("new proof builder");
+
 	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();
 
 	let out = Output {

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -34,7 +34,7 @@ fn test_verifier_cache_rangeproofs() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let switch = SwitchCommitmentType::Regular;
 	let commit = keychain.commit(5, &key_id, switch).unwrap();
-	let builder = proof::ProofBuilder::new(&keychain);
+	let builder = proof::ProofBuilder::new(&keychain).expect("new proof builder");
 	let proof = proof::create(&keychain, &builder, 5, &key_id, switch, commit, None).unwrap();
 
 	let out = Output {

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -432,7 +432,7 @@ impl ExtendedPrivKey {
 		Ok(ExtendedPrivKey {
 			network: self.network,
 			depth: self.depth + 1,
-			parent_fingerprint: self.fingerprint(hasher),
+			parent_fingerprint: self.fingerprint(hasher)?,
 			child_number: i,
 			secret_key: sk,
 			chain_code: ChainCode::from(&result[32..]),
@@ -440,42 +440,46 @@ impl ExtendedPrivKey {
 	}
 
 	/// Returns the HASH160 of the chaincode
-	pub fn identifier<H>(&self, hasher: &mut H) -> [u8; 20]
+	pub fn identifier<H>(&self, hasher: &mut H) -> Result<[u8; 20], Error>
 	where
 		H: BIP32Hasher,
 	{
 		let secp = Secp256k1::with_caps(ContextFlag::SignOnly);
 		// Compute extended public key
-		let pk: ExtendedPubKey = ExtendedPubKey::from_private::<H>(&secp, self, hasher);
+		let pk: ExtendedPubKey = ExtendedPubKey::from_private::<H>(&secp, self, hasher)?;
 		// Do SHA256 of just the ECDSA pubkey
 		let sha2_res = hasher.sha_256(&pk.public_key.serialize_vec(&secp, true)[..]);
 		// do RIPEMD160
-		hasher.ripemd_160(&sha2_res)
+		Ok(hasher.ripemd_160(&sha2_res))
 	}
 
 	/// Returns the first four bytes of the identifier
-	pub fn fingerprint<H>(&self, hasher: &mut H) -> Fingerprint
+	pub fn fingerprint<H>(&self, hasher: &mut H) -> Result<Fingerprint, Error>
 	where
 		H: BIP32Hasher,
 	{
-		Fingerprint::from(&self.identifier(hasher)[0..4])
+		Ok(Fingerprint::from(&self.identifier(hasher)?[0..4]))
 	}
 }
 
 impl ExtendedPubKey {
 	/// Derives a public key from a private key
-	pub fn from_private<H>(secp: &Secp256k1, sk: &ExtendedPrivKey, hasher: &mut H) -> ExtendedPubKey
+	pub fn from_private<H>(
+		secp: &Secp256k1,
+		sk: &ExtendedPrivKey,
+		hasher: &mut H,
+	) -> Result<ExtendedPubKey, Error>
 	where
 		H: BIP32Hasher,
 	{
-		ExtendedPubKey {
+		Ok(ExtendedPubKey {
 			network: hasher.network_pub(),
 			depth: sk.depth,
 			parent_fingerprint: sk.parent_fingerprint,
 			child_number: sk.child_number,
-			public_key: PublicKey::from_secret_key(secp, &sk.secret_key).unwrap(),
+			public_key: PublicKey::from_secret_key(secp, &sk.secret_key)?,
 			chain_code: sk.chain_code,
-		}
+		})
 	}
 
 	/// Attempts to derive an extended public key from a path.
@@ -736,7 +740,8 @@ mod tests {
 	) {
 		let mut h = BIP32ReferenceHasher::new();
 		let mut sk = ExtendedPrivKey::new_master(secp, &mut h, seed).unwrap();
-		let mut pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
+		let mut pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h)
+			.expect("from_private");
 
 		// Check derivation convenience method for ExtendedPrivKey
 		assert_eq!(
@@ -764,7 +769,8 @@ mod tests {
 			match num {
 				ChildNumber::Normal { .. } => {
 					let pk2 = pk.ckd_pub(secp, &mut h, num).unwrap();
-					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
+					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h)
+						.expect("from_provate");
 					assert_eq!(pk, pk2);
 				}
 				ChildNumber::Hardened { .. } => {
@@ -772,7 +778,8 @@ mod tests {
 						pk.ckd_pub(secp, &mut h, num),
 						Err(Error::CannotDeriveFromHardenedKey)
 					);
-					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h);
+					pk = ExtendedPubKey::from_private::<BIP32ReferenceHasher>(secp, &sk, &mut h)
+						.expect("from_private");
 				}
 			}
 		}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -35,8 +35,9 @@ pub struct ExtKeychain {
 }
 
 impl ExtKeychain {
-	pub fn pub_root_key(&mut self) -> ExtendedPubKey {
-		ExtendedPubKey::from_private(&self.secp, &self.master, &mut self.hasher)
+	pub fn pub_root_key(&mut self) -> Result<ExtendedPubKey, Error> {
+		let key = ExtendedPubKey::from_private(&self.secp, &self.master, &mut self.hasher)?;
+		Ok(key)
 	}
 
 	pub fn hasher(&self) -> BIP32GrinHasher {
@@ -91,9 +92,10 @@ impl Keychain for ExtKeychain {
 		ExtKeychainPath::new(depth, d1, d2, d3, d4).to_identifier()
 	}
 
-	fn public_root_key(&self) -> PublicKey {
+	fn public_root_key(&self) -> Result<PublicKey, Error> {
 		let mut hasher = self.hasher.clone();
-		ExtendedPubKey::from_private(&self.secp, &self.master, &mut hasher).public_key
+		let key = ExtendedPubKey::from_private(&self.secp, &self.master, &mut hasher)?;
+		Ok(key.public_key)
 	}
 
 	fn derive_key(

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -474,7 +474,7 @@ pub trait Keychain: Sync + Send + Clone {
 	fn derive_key_id(depth: u8, d1: u32, d2: u32, d3: u32, d4: u32) -> Identifier;
 
 	/// The public root key
-	fn public_root_key(&self) -> PublicKey;
+	fn public_root_key(&self) -> Result<PublicKey, Error>;
 
 	fn derive_key(
 		&self,

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -60,13 +60,13 @@ impl ViewKey {
 			child_number,
 			public_key,
 			chain_code,
-		} = ExtendedPubKey::from_private(secp, &ext_key, hasher);
+		} = ExtendedPubKey::from_private(secp, &ext_key, hasher)?;
 
 		let mut switch_public_key = PublicKey(ffi::PublicKey(GENERATOR_PUB_J_RAW));
 		switch_public_key.mul_assign(secp, &ext_key.secret_key)?;
 		let switch_public_key = Some(switch_public_key);
 
-		let rewind_hash = Self::rewind_hash(secp, keychain.public_root_key());
+		let rewind_hash = Self::rewind_hash(secp, keychain.public_root_key()?);
 
 		Ok(Self {
 			is_floo,

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -49,7 +49,7 @@ fn test_transaction_pool_block_building() {
 				let fee = txs.iter().map(|x| x.fee()).sum();
 				let reward = libtx::reward::output(
 					&keychain,
-					&libtx::ProofBuilder::new(&keychain),
+					&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 					&key_id,
 					fee,
 					false,

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -53,7 +53,7 @@ fn test_block_building_max_weight() {
 				let fee = txs.iter().map(|x| x.fee()).sum();
 				let reward = libtx::reward::output(
 					&keychain,
-					&libtx::ProofBuilder::new(&keychain),
+					&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 					&key_id,
 					fee,
 					false,

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -47,7 +47,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 				&key_id,
 				0,
 				false,
@@ -74,7 +74,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let fees = initial_tx.fee();
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 				&key_id,
 				fees,
 				false,
@@ -175,7 +175,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let fees = block_txs.iter().map(|tx| tx.fee()).sum();
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 				&key_id,
 				fees,
 				false,

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -197,7 +197,7 @@ where
 		KernelFeatures::Plain { fee: fees as u64 },
 		tx_elements,
 		keychain,
-		&libtx::ProofBuilder::new(keychain),
+		&libtx::ProofBuilder::new(keychain).expect("new proof builder"),
 	)
 	.unwrap()
 }
@@ -232,7 +232,7 @@ where
 		KernelFeatures::Plain { fee: fees as u64 },
 		tx_elements,
 		keychain,
-		&libtx::ProofBuilder::new(keychain),
+		&libtx::ProofBuilder::new(keychain).expect("new proof builder"),
 	)
 	.unwrap()
 }

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -48,7 +48,7 @@ fn test_the_transaction_pool() {
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let reward = libtx::reward::output(
 			&keychain,
-			&libtx::ProofBuilder::new(&keychain),
+			&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 			&key_id,
 			0,
 			false,
@@ -257,7 +257,7 @@ fn test_the_transaction_pool() {
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain).expect("new proof builder"),
 				&key_id,
 				0,
 				false,

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -227,7 +227,7 @@ fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, B
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) = crate::core::libtx::reward::output(
 		&keychain,
-		&ProofBuilder::new(&keychain),
+		&ProofBuilder::new(&keychain)?,
 		&key_id,
 		block_fees.fees,
 		false,


### PR DESCRIPTION
It breaks `Keychain` and `bip32` APIs by Result-wrapping some return types.
Changes in `store.rs` and `pipe.rs` don't affect API.