### PR TITLE
Pass byte slice to to_hex

### DIFF
--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -20,10 +20,8 @@
 use crate::ser::{self, Error, ProtocolVersion, Readable, Reader, Writeable, Writer};
 use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
-use std::cmp::min;
-use std::convert::AsRef;
-use std::{fmt, ops};
-use util;
+use std::{cmp::min, convert::AsRef, fmt, ops};
+use util::ToHex;
 
 /// A hash consisting of all zeroes, used as a sentinel. No known preimage.
 pub const ZERO_HASH: Hash = Hash([0; 32]);
@@ -71,11 +69,6 @@ impl Hash {
 	/// Returns a byte slice of the hash contents.
 	pub fn as_bytes(&self) -> &[u8] {
 		&self.0
-	}
-
-	/// Convert a hash to hex string format.
-	pub fn to_hex(&self) -> String {
-		util::to_hex(self.to_vec())
 	}
 
 	/// Convert hex string back to hash.

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -19,7 +19,7 @@ use crate::ser::{self, Readable, Reader, Writeable, Writer};
 use byteorder::{ByteOrder, LittleEndian};
 use siphasher::sip::SipHasher24;
 use std::cmp::{min, Ordering};
-use util;
+use util::ToHex;
 
 /// The size of a short id used to identify inputs|outputs|kernels (6 bytes)
 pub const SHORT_ID_SIZE: usize = 6;
@@ -84,6 +84,12 @@ impl ::std::fmt::Debug for ShortId {
 	}
 }
 
+impl AsRef<[u8]> for ShortId {
+	fn as_ref(&self) -> &[u8] {
+		self.0.as_ref()
+	}
+}
+
 impl Readable for ShortId {
 	fn read(reader: &mut dyn Reader) -> Result<ShortId, ser::Error> {
 		let v = reader.read_fixed_bytes(SHORT_ID_SIZE)?;
@@ -106,11 +112,6 @@ impl ShortId {
 		let copy_size = min(SHORT_ID_SIZE, bytes.len());
 		hash[..copy_size].copy_from_slice(&bytes[..copy_size]);
 		ShortId(hash)
-	}
-
-	/// Hex string representation of a short_id
-	pub fn to_hex(&self) -> String {
-		util::to_hex(self.0.to_vec())
 	}
 
 	/// Reconstructs a switch commit hash from a hex string.

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -18,7 +18,7 @@ use crate::core::hash::Hash;
 use crate::core::pmmr;
 use crate::ser;
 use crate::ser::{PMMRIndexHashable, Readable, Reader, Writeable, Writer};
-use util;
+use util::ToHex;
 
 /// Merkle proof errors.
 #[derive(Clone, Debug, PartialEq)]
@@ -79,7 +79,7 @@ impl MerkleProof {
 	pub fn to_hex(&self) -> String {
 		let mut vec = Vec::new();
 		ser::serialize_default(&mut vec, &self).expect("serialization failed");
-		util::to_hex(vec)
+		vec.to_hex()
 	}
 
 	/// Convert hex string representation back to a Merkle proof instance

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -30,11 +30,11 @@ use std::cmp::{max, min};
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::{error, fmt};
-use util;
 use util::secp;
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::static_secp_instance;
 use util::RwLock;
+use util::ToHex;
 
 /// Various tx kernel variants.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -1469,6 +1469,11 @@ impl Output {
 		self.proof
 	}
 
+	/// Get range proof as byte slice
+	pub fn proof_bytes(&self) -> &[u8] {
+		&self.proof.proof[..]
+	}
+
 	/// Validates the range proof using the commitment
 	pub fn verify_proof(&self) -> Result<(), Error> {
 		let secp = static_secp_instance();
@@ -1523,14 +1528,11 @@ impl OutputIdentifier {
 			commit: self.commit,
 		}
 	}
+}
 
-	/// convert an output_identifier to hex string format.
-	pub fn to_hex(&self) -> String {
-		format!(
-			"{:b}{}",
-			self.features as u8,
-			util::to_hex(self.commit.0.to_vec()),
-		)
+impl ToHex for OutputIdentifier {
+	fn to_hex(&self) -> String {
+		format!("{:b}{}", self.features as u8, self.commit.to_hex())
 	}
 }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -273,6 +273,7 @@ mod test {
 	use super::*;
 	use crate::core::hash::Hashed;
 	use crate::ser::{self, ProtocolVersion};
+	use util::ToHex;
 
 	#[test]
 	fn floonet_genesis_hash() {

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -17,13 +17,13 @@
 use keychain::BlindingFactor;
 use serde::{Deserialize, Deserializer, Serializer};
 use util::secp::pedersen::{Commitment, RangeProof};
-use util::{from_hex, to_hex};
+use util::{from_hex, ToHex};
 
 /// Serializes a secp PublicKey to and from hex
 pub mod pubkey_serde {
 	use serde::{Deserialize, Deserializer, Serializer};
 	use util::secp::key::PublicKey;
-	use util::{from_hex, static_secp_instance, to_hex};
+	use util::{from_hex, static_secp_instance, ToHex};
 
 	///
 	pub fn serialize<S>(key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
@@ -32,7 +32,7 @@ pub mod pubkey_serde {
 	{
 		let static_secp = static_secp_instance();
 		let static_secp = static_secp.lock();
-		serializer.serialize_str(&to_hex(key.serialize_vec(&static_secp, true).to_vec()))
+		serializer.serialize_str(&key.serialize_vec(&static_secp, true).to_hex())
 	}
 
 	///
@@ -56,7 +56,7 @@ pub mod pubkey_serde {
 pub mod option_sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
 	use serde::de::Error;
-	use util::{from_hex, secp, static_secp_instance, to_hex};
+	use util::{from_hex, secp, static_secp_instance, ToHex};
 
 	///
 	pub fn serialize<S>(sig: &Option<secp::Signature>, serializer: S) -> Result<S::Ok, S::Error>
@@ -67,7 +67,7 @@ pub mod option_sig_serde {
 		let static_secp = static_secp.lock();
 		match sig {
 			Some(sig) => {
-				serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec()))
+				serializer.serialize_str(&(&sig.serialize_compact(&static_secp)[..]).to_hex())
 			}
 			None => serializer.serialize_none(),
 		}
@@ -99,7 +99,7 @@ pub mod option_sig_serde {
 pub mod option_seckey_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
 	use serde::de::Error;
-	use util::{from_hex, secp, static_secp_instance, to_hex};
+	use util::{from_hex, secp, static_secp_instance, ToHex};
 
 	///
 	pub fn serialize<S>(
@@ -110,7 +110,7 @@ pub mod option_seckey_serde {
 		S: Serializer,
 	{
 		match key {
-			Some(key) => serializer.serialize_str(&to_hex(key.0.to_vec())),
+			Some(key) => serializer.serialize_str(&key.0.to_hex()),
 			None => serializer.serialize_none(),
 		}
 	}
@@ -141,7 +141,7 @@ pub mod option_seckey_serde {
 pub mod sig_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
 	use serde::de::Error;
-	use util::{from_hex, secp, static_secp_instance, to_hex};
+	use util::{from_hex, secp, static_secp_instance, ToHex};
 
 	///
 	pub fn serialize<S>(sig: &secp::Signature, serializer: S) -> Result<S::Ok, S::Error>
@@ -150,7 +150,7 @@ pub mod sig_serde {
 	{
 		let static_secp = static_secp_instance();
 		let static_secp = static_secp.lock();
-		serializer.serialize_str(&to_hex(sig.serialize_compact(&static_secp).to_vec()))
+		serializer.serialize_str(&(&sig.serialize_compact(&static_secp)[..]).to_hex())
 	}
 
 	///
@@ -176,7 +176,7 @@ pub mod option_commitment_serde {
 	use crate::serde::{Deserialize, Deserializer, Serializer};
 	use serde::de::Error;
 	use util::secp::pedersen::Commitment;
-	use util::{from_hex, to_hex};
+	use util::{from_hex, ToHex};
 
 	///
 	pub fn serialize<S>(commit: &Option<Commitment>, serializer: S) -> Result<S::Ok, S::Error>
@@ -184,7 +184,7 @@ pub mod option_commitment_serde {
 		S: Serializer,
 	{
 		match commit {
-			Some(c) => serializer.serialize_str(&to_hex(c.0.to_vec())),
+			Some(c) => serializer.serialize_str(&c.to_hex()),
 			None => serializer.serialize_none(),
 		}
 	}
@@ -242,7 +242,7 @@ where
 	T: AsRef<[u8]>,
 	S: Serializer,
 {
-	serializer.serialize_str(&to_hex(bytes.as_ref().to_vec()))
+	serializer.serialize_str(&bytes.to_hex())
 }
 
 /// Used to ensure u64s are serialised in json

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -19,7 +19,7 @@ use crate::pow::{PoWContext, Proof};
 use byteorder::{BigEndian, WriteBytesExt};
 use croaring::Bitmap;
 use std::mem;
-use util;
+use util::ToHex;
 
 struct Graph<T>
 where
@@ -224,7 +224,7 @@ where
 	pub fn sipkey_hex(&self, index: usize) -> Result<String, Error> {
 		let mut rdr = vec![];
 		rdr.write_u64::<BigEndian>(self.params.siphash_keys[index])?;
-		Ok(util::to_hex(rdr))
+		Ok(rdr.to_hex())
 	}
 
 	/// Return number of bytes used by the graph

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -32,8 +32,7 @@ use grin_core as core;
 use grin_core::global::ChainTypes;
 use keychain::{BlindingFactor, ExtKeychain, Keychain};
 use std::sync::Arc;
-use util::secp;
-use util::RwLock;
+use util::{secp, RwLock, ToHex};
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 	Arc::new(RwLock::new(LruVerifierCache::new()))
@@ -576,7 +575,7 @@ fn validate_header_proof() {
 		b.header.write_pre_pow(&mut writer).unwrap();
 		b.header.pow.write_pre_pow(&mut writer).unwrap();
 	}
-	let pre_pow = util::to_hex(header_buf);
+	let pre_pow = header_buf.to_hex();
 
 	let reconstructed = BlockHeader::from_pre_pow_and_proof(
 		pre_pow,

--- a/etc/gen_gen/src/bin/gen_gen.rs
+++ b/etc/gen_gen/src/bin/gen_gen.rs
@@ -29,7 +29,7 @@ use grin_chain as chain;
 use grin_core as core;
 use grin_miner_plugin as plugin;
 use grin_store as store;
-use grin_util as util;
+use grin_util::{self as util, ToHex};
 use grin_wallet as wallet;
 
 use grin_core::core::hash::Hashed;
@@ -216,7 +216,7 @@ fn update_genesis_rs(gen: &core::core::Block) {
 		"excess".to_string(),
 		format!(
 			"Commitment::from_vec(util::from_hex({:x?}.to_string()).unwrap())",
-			util::to_hex(gen.kernels()[0].excess.0.to_vec())
+			gen.kernels()[0].excess.to_hex())
 		),
 	));
 	replacements.push((

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -172,7 +172,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::{from_entropy, to_entropy, to_seed};
-	use crate::util::{from_hex, to_hex};
+	use crate::util::{from_hex, ToHex};
 	use rand::{thread_rng, Rng};
 
 	struct Test<'a> {
@@ -311,7 +311,7 @@ mod tests {
 		let tests = tests();
 		for t in tests.iter() {
 			assert_eq!(
-				to_hex(to_seed(t.mnemonic, "TREZOR").unwrap().to_vec()),
+				(&to_seed(t.mnemonic, "TREZOR").unwrap()[..]).to_hex(),
 				t.seed.to_string()
 			);
 			assert_eq!(

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -27,12 +27,12 @@ use crate::blake2::blake2b::blake2b;
 use crate::extkey_bip32::{self, ChildNumber};
 use serde::{de, ser}; //TODO: Convert errors to use ErrorKind
 
-use crate::util;
 use crate::util::secp::constants::SECRET_KEY_SIZE;
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::secp::pedersen::Commitment;
 use crate::util::secp::{self, Message, Secp256k1, Signature};
 use crate::util::static_secp_instance;
+use crate::util::ToHex;
 use zeroize::Zeroize;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -195,10 +195,6 @@ impl Identifier {
 		Ok(Identifier::from_bytes(&bytes))
 	}
 
-	pub fn to_hex(&self) -> String {
-		util::to_hex(self.0.to_vec())
-	}
-
 	pub fn to_bip_32_string(&self) -> String {
 		let p = ExtKeychainPath::from_identifier(&self);
 		let mut retval = String::from("m");
@@ -286,10 +282,6 @@ impl BlindingFactor {
 
 	pub fn zero() -> BlindingFactor {
 		BlindingFactor::from_secret_key(secp::key::ZERO_KEY)
-	}
-
-	pub fn to_hex(&self) -> String {
-		util::to_hex(self.0.to_vec())
 	}
 
 	pub fn from_hex(hex: &str) -> Result<BlindingFactor, Error> {

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -25,6 +25,7 @@ use crate::core::core;
 use crate::core::core::hash::Hashed;
 use crate::p2p::types::PeerAddr;
 use futures::TryFutureExt;
+use grin_util::ToHex;
 use hyper::client::HttpConnector;
 use hyper::header::HeaderValue;
 use hyper::Client;

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -42,7 +42,7 @@ use crate::core::{pow, ser};
 use crate::keychain;
 use crate::mining::mine_block;
 use crate::pool;
-use crate::util;
+use crate::util::ToHex;
 
 type Tx = mpsc::UnboundedSender<String>;
 
@@ -342,7 +342,7 @@ impl Handler {
 			bh.write_pre_pow(&mut writer).unwrap();
 			bh.pow.write_pre_pow(&mut writer).unwrap();
 		}
-		let pre_pow = util::to_hex(header_buf);
+		let pre_pow = header_buf.to_hex();
 		let job_template = JobTemplate {
 			height: bh.height,
 			job_id: (self.current_state.read().current_block_versions.len() - 1) as u64,

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -19,12 +19,24 @@
 use std::fmt::Write;
 
 /// Encode the provided bytes into a hex string
-pub fn to_hex(bytes: Vec<u8>) -> String {
-	let mut s = String::new();
+fn to_hex(bytes: &[u8]) -> String {
+	let mut s = String::with_capacity(bytes.len() * 2);
 	for byte in bytes {
-		write!(&mut s, "{:02x}", byte).expect("Unable to write");
+		write!(&mut s, "{:02x}", byte).expect("Unable to write hex");
 	}
 	s
+}
+
+/// Convert to hex
+pub trait ToHex {
+	/// convert to hex
+	fn to_hex(&self) -> String;
+}
+
+impl<T: AsRef<[u8]>> ToHex for T {
+	fn to_hex(&self) -> String {
+		to_hex(self.as_ref())
+	}
 }
 
 /// Decode a hex string into bytes.
@@ -46,9 +58,16 @@ mod test {
 
 	#[test]
 	fn test_to_hex() {
-		assert_eq!(to_hex(vec![0, 0, 0, 0]), "00000000");
-		assert_eq!(to_hex(vec![10, 11, 12, 13]), "0a0b0c0d");
-		assert_eq!(to_hex(vec![0, 0, 0, 255]), "000000ff");
+		assert_eq!(vec![0, 0, 0, 0].to_hex(), "00000000");
+		assert_eq!(vec![10, 11, 12, 13].to_hex(), "0a0b0c0d");
+		assert_eq!([0, 0, 0, 255].to_hex(), "000000ff");
+	}
+
+	#[test]
+	fn test_to_hex_trait() {
+		assert_eq!(vec![0, 0, 0, 0].to_hex(), "00000000");
+		assert_eq!(vec![10, 11, 12, 13].to_hex(), "0a0b0c0d");
+		assert_eq!([0, 0, 0, 255].to_hex(), "000000ff");
 	}
 
 	#[test]


### PR DESCRIPTION
Currently we pass a `Vec`. This requires an extra allocation and copy of all elements if a caller doesn't have a `Vec` already, which is at least 95% of cases.
Another, a smaller issue, we have a function `util::to_hex` and some structs implement `to_hex()` on top of it, so we have a mix of it in the code. This PR introduces a trait and a blanket impl for `AsRef<[u8]>` which brings a uniform API (`obj.to_hex()`). One unfortunate case is arrays of size bigger than 32 - Rust doesn't implement `AsRef` for them so it requires an ugly hack `(&array[..]).to_hex().`
