### PR TITLE
Use generic types instead of trait objects in tx pool

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -16,8 +16,10 @@
 
 use crate::core::core::hash::Hash;
 use crate::core::core::transaction::Transaction;
+use crate::core::core::verifier_cache::VerifierCache;
 use crate::foreign::Foreign;
 use crate::pool::PoolEntry;
+use crate::pool::{BlockChain, PoolAdapter};
 use crate::rest::ErrorKind;
 use crate::types::{
 	BlockHeaderPrintable, BlockPrintable, LocatedTxKernel, OutputListing, OutputPrintable, Tip,
@@ -738,7 +740,12 @@ pub trait ForeignRpc: Sync + Send {
 	fn push_transaction(&self, tx: Transaction, fluff: Option<bool>) -> Result<(), ErrorKind>;
 }
 
-impl ForeignRpc for Foreign {
+impl<B, P, V> ForeignRpc for Foreign<B, P, V>
+where
+	B: BlockChain,
+	P: PoolAdapter,
+	V: VerifierCache + 'static,
+{
 	fn get_header(
 		&self,
 		height: Option<u64>,

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -30,21 +30,25 @@ use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-pub struct Pool {
+pub struct Pool<B, V>
+where
+	B: BlockChain,
+	V: VerifierCache,
+{
 	/// Entries in the pool (tx + info + timer) in simple insertion order.
 	pub entries: Vec<PoolEntry>,
 	/// The blockchain
-	pub blockchain: Arc<dyn BlockChain>,
-	pub verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	pub blockchain: Arc<B>,
+	pub verifier_cache: Arc<RwLock<V>>,
 	pub name: String,
 }
 
-impl Pool {
-	pub fn new(
-		chain: Arc<dyn BlockChain>,
-		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-		name: String,
-	) -> Pool {
+impl<B, V> Pool<B, V>
+where
+	B: BlockChain,
+	V: VerifierCache + 'static,
+{
+	pub fn new(chain: Arc<B>, verifier_cache: Arc<RwLock<V>>, name: String) -> Self {
 		Pool {
 			entries: vec![],
 			blockchain: chain,

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -31,30 +31,40 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 /// Transaction pool implementation.
-pub struct TransactionPool {
+pub struct TransactionPool<B, P, V>
+where
+	B: BlockChain,
+	P: PoolAdapter,
+	V: VerifierCache,
+{
 	/// Pool Config
 	pub config: PoolConfig,
 	/// Our transaction pool.
-	pub txpool: Pool,
+	pub txpool: Pool<B, V>,
 	/// Our Dandelion "stempool".
-	pub stempool: Pool,
+	pub stempool: Pool<B, V>,
 	/// Cache of previous txs in case of a re-org.
 	pub reorg_cache: Arc<RwLock<VecDeque<PoolEntry>>>,
 	/// The blockchain
-	pub blockchain: Arc<dyn BlockChain>,
-	pub verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	pub blockchain: Arc<B>,
+	pub verifier_cache: Arc<RwLock<V>>,
 	/// The pool adapter
-	pub adapter: Arc<dyn PoolAdapter>,
+	pub adapter: Arc<P>,
 }
 
-impl TransactionPool {
+impl<B, P, V> TransactionPool<B, P, V>
+where
+	B: BlockChain,
+	P: PoolAdapter,
+	V: VerifierCache + 'static,
+{
 	/// Create a new transaction pool
 	pub fn new(
 		config: PoolConfig,
-		chain: Arc<dyn BlockChain>,
-		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-		adapter: Arc<dyn PoolAdapter>,
-	) -> TransactionPool {
+		chain: Arc<B>,
+		verifier_cache: Arc<RwLock<V>>,
+		adapter: Arc<P>,
+	) -> Self {
 		TransactionPool {
 			config,
 			txpool: Pool::new(chain.clone(), verifier_cache.clone(), "txpool".to_string()),

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -148,10 +148,14 @@ impl BlockChain for ChainAdapter {
 	}
 }
 
-pub fn test_setup(
-	chain: Arc<dyn BlockChain>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
-) -> TransactionPool {
+pub fn test_setup<B, V>(
+	chain: Arc<B>,
+	verifier_cache: Arc<RwLock<V>>,
+) -> TransactionPool<B, NoopAdapter, V>
+where
+	B: BlockChain,
+	V: VerifierCache + 'static,
+{
 	TransactionPool::new(
 		PoolConfig {
 			accept_fee_base: 0,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -41,7 +41,7 @@ use crate::common::stats::{
 };
 use crate::common::types::{Error, ServerConfig, StratumServerConfig};
 use crate::core::core::hash::Hashed;
-use crate::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
+use crate::core::core::verifier_cache::LruVerifierCache;
 use crate::core::ser::ProtocolVersion;
 use crate::core::{consensus, genesis, global, pow};
 use crate::grin::{dandelion_monitor, seed, sync};
@@ -54,6 +54,12 @@ use crate::util::file::get_first_line;
 use crate::util::{RwLock, StopState};
 use grin_util::logger::LogEntry;
 
+/// Arcified  thread-safe TransactionPool with type parameters used by server components
+pub type ServerTxPool =
+	Arc<RwLock<pool::TransactionPool<PoolToChainAdapter, PoolToNetAdapter, LruVerifierCache>>>;
+/// Arcified thread-safe LruVerifierCache
+pub type ServerVerifierCache = Arc<RwLock<LruVerifierCache>>;
+
 /// Grin server holding internal structures.
 pub struct Server {
 	/// server config
@@ -63,10 +69,10 @@ pub struct Server {
 	/// data store access
 	pub chain: Arc<chain::Chain>,
 	/// in-memory transaction pool
-	pub tx_pool: Arc<RwLock<pool::TransactionPool>>,
+	pub tx_pool: ServerTxPool,
 	/// Shared cache for verification results when
 	/// verifying rangeproof and kernel signatures.
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	verifier_cache: ServerVerifierCache,
 	/// Whether we're currently syncing
 	pub sync_state: Arc<SyncState>,
 	/// To be passed around to collect stats and info

--- a/servers/src/lib.rs
+++ b/servers/src/lib.rs
@@ -41,4 +41,4 @@ mod mining;
 
 pub use crate::common::stats::{DiffBlock, PeerStats, ServerStats, StratumStats, WorkerStats};
 pub use crate::common::types::{ServerConfig, StratumServerConfig};
-pub use crate::grin::server::Server;
+pub use crate::grin::server::{Server, ServerTxPool, ServerVerifierCache};

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -15,7 +15,6 @@
 //! Build a block to mine: gathers transactions from the pool, assembles
 //! them into a block and returns it.
 
-use crate::util::RwLock;
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use rand::{thread_rng, Rng};
 use serde_json::{json, Value};
@@ -26,13 +25,12 @@ use std::time::Duration;
 use crate::api;
 use crate::chain;
 use crate::common::types::Error;
-use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{Output, TxKernel};
 use crate::core::libtx::secp_ser;
 use crate::core::libtx::ProofBuilder;
 use crate::core::{consensus, core, global};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
-use crate::pool;
+use crate::{ServerTxPool, ServerVerifierCache};
 
 /// Fees in block to use for coinbase amount calculation
 /// (Duplicated from Grin wallet project)
@@ -71,8 +69,8 @@ pub struct CbData {
 // Warning: This call does not return until/unless a new block can be built
 pub fn get_block(
 	chain: &Arc<chain::Chain>,
-	tx_pool: &Arc<RwLock<pool::TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	tx_pool: &ServerTxPool,
+	verifier_cache: ServerVerifierCache,
 	key_id: Option<Identifier>,
 	wallet_listener_url: Option<String>,
 ) -> (core::Block, BlockFees) {
@@ -133,8 +131,8 @@ pub fn get_block(
 /// transactions from the pool.
 fn build_block(
 	chain: &Arc<chain::Chain>,
-	tx_pool: &Arc<RwLock<pool::TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	tx_pool: &ServerTxPool,
+	verifier_cache: ServerVerifierCache,
 	key_id: Option<Identifier>,
 	wallet_listener_url: Option<String>,
 ) -> Result<(core::Block, BlockFees), Error> {

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -36,13 +36,12 @@ use crate::chain::{self, SyncState};
 use crate::common::stats::{StratumStats, WorkerStats};
 use crate::common::types::StratumServerConfig;
 use crate::core::core::hash::Hashed;
-use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::Block;
 use crate::core::{pow, ser};
 use crate::keychain;
 use crate::mining::mine_block;
-use crate::pool;
 use crate::util::ToHex;
+use crate::{ServerTxPool, ServerVerifierCache};
 
 type Tx = mpsc::UnboundedSender<String>;
 
@@ -523,8 +522,8 @@ impl Handler {
 	pub fn run(
 		&self,
 		config: &StratumServerConfig,
-		tx_pool: &Arc<RwLock<pool::TransactionPool>>,
-		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+		tx_pool: &ServerTxPool,
+		verifier_cache: ServerVerifierCache,
 	) {
 		debug!("Run main loop");
 		let mut deadline: i64 = 0;
@@ -803,8 +802,8 @@ pub struct StratumServer {
 	id: String,
 	config: StratumServerConfig,
 	chain: Arc<chain::Chain>,
-	tx_pool: Arc<RwLock<pool::TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	pub tx_pool: ServerTxPool,
+	verifier_cache: ServerVerifierCache,
 	sync_state: Arc<SyncState>,
 	stratum_stats: Arc<RwLock<StratumStats>>,
 }
@@ -814,8 +813,8 @@ impl StratumServer {
 	pub fn new(
 		config: StratumServerConfig,
 		chain: Arc<chain::Chain>,
-		tx_pool: Arc<RwLock<pool::TransactionPool>>,
-		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+		tx_pool: ServerTxPool,
+		verifier_cache: ServerVerifierCache,
 		stratum_stats: Arc<RwLock<StratumStats>>,
 	) -> StratumServer {
 		StratumServer {

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -17,19 +17,17 @@
 //! header with its proof-of-work.  Any valid mined blocks are submitted to the
 //! network.
 
-use crate::util::RwLock;
 use chrono::prelude::Utc;
 use std::sync::Arc;
 
 use crate::chain;
 use crate::common::types::StratumServerConfig;
 use crate::core::core::hash::{Hash, Hashed};
-use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{Block, BlockHeader};
 use crate::core::global;
 use crate::mining::mine_block;
-use crate::pool;
 use crate::util::StopState;
+use crate::{ServerTxPool, ServerVerifierCache};
 use grin_chain::SyncState;
 use std::thread;
 use std::time::Duration;
@@ -37,8 +35,8 @@ use std::time::Duration;
 pub struct Miner {
 	config: StratumServerConfig,
 	chain: Arc<chain::Chain>,
-	tx_pool: Arc<RwLock<pool::TransactionPool>>,
-	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	tx_pool: ServerTxPool,
+	verifier_cache: ServerVerifierCache,
 	stop_state: Arc<StopState>,
 	sync_state: Arc<SyncState>,
 	// Just to hold the port we're on, so this miner can be identified
@@ -47,13 +45,13 @@ pub struct Miner {
 }
 
 impl Miner {
-	/// Creates a new Miner. Needs references to the chain state and its
+	// Creates a new Miner. Needs references to the chain state and its
 	/// storage.
 	pub fn new(
 		config: StratumServerConfig,
 		chain: Arc<chain::Chain>,
-		tx_pool: Arc<RwLock<pool::TransactionPool>>,
-		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+		tx_pool: ServerTxPool,
+		verifier_cache: ServerVerifierCache,
 		stop_state: Arc<StopState>,
 		sync_state: Arc<SyncState>,
 	) -> Miner {


### PR DESCRIPTION
Tx pool takes some parameters as trait objects. It's not an idiomatic Rust code, in this particular case we should use generic types. Trait object makes sense when we accept in runtime different concrete types which implement the trait as a value of the same field. It's not the case here. Trait objects come with a price - instead of method dispatch in compile time we have to accept runtime dispatch. My guess we did it to not clutter the code with type parameters, which is understandable but still suboptimal.

Basically the change is to replace
```
pub struct TransactionPool {
        pub blockchain: Arc<dyn BlockChain>,
	pub verifier_cache: Arc<RwLock<dyn VerifierCache>>,
	pub adapter: Arc<dyn PoolAdapter>,
        ...
}
```
with  
```
pub struct TransactionPool<B, P, V>
where
	B: BlockChain,
	P: PoolAdapter,
	V: VerifierCache,
{
     pub blockchain: Arc<B>,
     pub verifier_cache: Arc<RwLock<V>>,
     pub adapter: Arc<P>,
...
}
```

The rest is just passing type parameters to `Pool` and `TransactionPool`