### PR TITLE
Refactor Readable trait

### DIFF
--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -233,7 +233,7 @@ impl Readable for BitmapChunk {
 	/// Reading is not currently supported, just return an empty one for now.
 	/// We store the underlying roaring bitmap externally for the bitmap accumulator
 	/// and the "hash only" backend means we never actually read these chunks.
-	fn read(_reader: &mut dyn Reader) -> Result<BitmapChunk, ser::Error> {
+	fn read<R: Reader>(_reader: &mut R) -> Result<BitmapChunk, ser::Error> {
 		Ok(BitmapChunk::new())
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -315,7 +315,7 @@ pub struct CommitPos {
 }
 
 impl Readable for CommitPos {
-	fn read(reader: &mut dyn Reader) -> Result<CommitPos, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<CommitPos, ser::Error> {
 		let pos = reader.read_u64()?;
 		let height = reader.read_u64()?;
 		Ok(CommitPos { pos, height })
@@ -387,7 +387,7 @@ impl ser::Writeable for Tip {
 }
 
 impl ser::Readable for Tip {
-	fn read(reader: &mut dyn ser::Reader) -> Result<Tip, ser::Error> {
+	fn read<R: ser::Reader>(reader: &mut R) -> Result<Tip, ser::Error> {
 		let height = reader.read_u64()?;
 		let last = Hash::read(reader)?;
 		let prev = Hash::read(reader)?;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -132,7 +132,7 @@ pub struct HeaderEntry {
 }
 
 impl Readable for HeaderEntry {
-	fn read(reader: &mut dyn Reader) -> Result<HeaderEntry, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<HeaderEntry, ser::Error> {
 		let hash = Hash::read(reader)?;
 		let timestamp = reader.read_u64()?;
 		let total_difficulty = Difficulty::read(reader)?;
@@ -192,7 +192,7 @@ impl Writeable for HeaderVersion {
 }
 
 impl Readable for HeaderVersion {
-	fn read(reader: &mut dyn Reader) -> Result<HeaderVersion, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<HeaderVersion, ser::Error> {
 		let version = reader.read_u16()?;
 		Ok(HeaderVersion(version))
 	}
@@ -280,7 +280,7 @@ impl Writeable for BlockHeader {
 	}
 }
 
-fn read_block_header(reader: &mut dyn Reader) -> Result<BlockHeader, ser::Error> {
+fn read_block_header<R: Reader>(reader: &mut R) -> Result<BlockHeader, ser::Error> {
 	let version = HeaderVersion::read(reader)?;
 	let (height, timestamp) = ser_multiread!(reader, read_u64, read_i64);
 	let prev_hash = Hash::read(reader)?;
@@ -316,7 +316,7 @@ fn read_block_header(reader: &mut dyn Reader) -> Result<BlockHeader, ser::Error>
 
 /// Deserialization of a block header
 impl Readable for BlockHeader {
-	fn read(reader: &mut dyn Reader) -> Result<BlockHeader, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<BlockHeader, ser::Error> {
 		read_block_header(reader)
 	}
 }
@@ -413,7 +413,7 @@ pub struct UntrustedBlockHeader(BlockHeader);
 
 /// Deserialization of an untrusted block header
 impl Readable for UntrustedBlockHeader {
-	fn read(reader: &mut dyn Reader) -> Result<UntrustedBlockHeader, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<UntrustedBlockHeader, ser::Error> {
 		let header = read_block_header(reader)?;
 		if header.timestamp
 			> Utc::now() + Duration::seconds(12 * (consensus::BLOCK_TIME_SEC as i64))
@@ -490,7 +490,7 @@ impl Writeable for Block {
 /// Implementation of Readable for a block, defines how to read a full block
 /// from a binary stream.
 impl Readable for Block {
-	fn read(reader: &mut dyn Reader) -> Result<Block, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Block, ser::Error> {
 		let header = BlockHeader::read(reader)?;
 		let body = TransactionBody::read(reader)?;
 		Ok(Block { header, body })
@@ -828,7 +828,7 @@ pub struct UntrustedBlock(Block);
 
 /// Deserialization of an untrusted block header
 impl Readable for UntrustedBlock {
-	fn read(reader: &mut dyn Reader) -> Result<UntrustedBlock, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<UntrustedBlock, ser::Error> {
 		// we validate header here before parsing the body
 		let header = UntrustedBlockHeader::read(reader)?;
 		let body = TransactionBody::read(reader)?;

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -41,7 +41,7 @@ impl Writeable for BlockSums {
 }
 
 impl Readable for BlockSums {
-	fn read(reader: &mut dyn Reader) -> Result<BlockSums, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<BlockSums, ser::Error> {
 		Ok(BlockSums {
 			utxo_sum: Commitment::read(reader)?,
 			kernel_sum: Commitment::read(reader)?,

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -82,7 +82,7 @@ impl CompactBlockBody {
 }
 
 impl Readable for CompactBlockBody {
-	fn read(reader: &mut dyn Reader) -> Result<CompactBlockBody, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<CompactBlockBody, ser::Error> {
 		let (out_full_len, kern_full_len, kern_id_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 
@@ -215,7 +215,7 @@ impl Writeable for CompactBlock {
 /// Implementation of Readable for a compact block, defines how to read a
 /// compact block from a binary stream.
 impl Readable for CompactBlock {
-	fn read(reader: &mut dyn Reader) -> Result<CompactBlock, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<CompactBlock, ser::Error> {
 		let header = BlockHeader::read(reader)?;
 		let nonce = reader.read_u64()?;
 		let body = CompactBlockBody::read(reader)?;
@@ -241,7 +241,7 @@ pub struct UntrustedCompactBlock(CompactBlock);
 /// Implementation of Readable for an untrusted compact block, defines how to read a
 /// compact block from a binary stream.
 impl Readable for UntrustedCompactBlock {
-	fn read(reader: &mut dyn Reader) -> Result<UntrustedCompactBlock, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<UntrustedCompactBlock, ser::Error> {
 		let header = UntrustedBlockHeader::read(reader)?;
 		let nonce = reader.read_u64()?;
 		let body = CompactBlockBody::read(reader)?;

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -138,7 +138,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 impl Readable for Hash {
-	fn read(reader: &mut dyn Reader) -> Result<Hash, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Hash, ser::Error> {
 		let v = reader.read_fixed_bytes(32)?;
 		let mut a = [0; 32];
 		a.copy_from_slice(&v[..]);

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -85,7 +85,7 @@ impl ::std::fmt::Debug for ShortId {
 }
 
 impl Readable for ShortId {
-	fn read(reader: &mut dyn Reader) -> Result<ShortId, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<ShortId, ser::Error> {
 		let v = reader.read_fixed_bytes(SHORT_ID_SIZE)?;
 		let mut a = [0; SHORT_ID_SIZE];
 		a.copy_from_slice(&v[..]);

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -47,7 +47,7 @@ impl Writeable for MerkleProof {
 }
 
 impl Readable for MerkleProof {
-	fn read(reader: &mut dyn Reader) -> Result<MerkleProof, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<MerkleProof, ser::Error> {
 		let mmr_size = reader.read_u64()?;
 		let path_len = reader.read_u64()?;
 		let mut path = Vec::with_capacity(path_len as usize);

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -133,7 +133,7 @@ impl KernelFeatures {
 	// Always read feature byte, 8 bytes for fee and 8 bytes for lock height.
 	// Fee and lock height may be unused for some kernel variants but we need
 	// to read these bytes and verify they are 0 if unused.
-	fn read_v1(reader: &mut dyn Reader) -> Result<KernelFeatures, ser::Error> {
+	fn read_v1<R: Reader>(reader: &mut R) -> Result<KernelFeatures, ser::Error> {
 		let feature_byte = reader.read_u8()?;
 		let fee = reader.read_u64()?;
 		let lock_height = reader.read_u64()?;
@@ -164,7 +164,7 @@ impl KernelFeatures {
 
 	// V2 kernels only expect bytes specific to each variant.
 	// Coinbase kernels have no associated fee and we do not serialize a fee for these.
-	fn read_v2(reader: &mut dyn Reader) -> Result<KernelFeatures, ser::Error> {
+	fn read_v2<R: Reader>(reader: &mut R) -> Result<KernelFeatures, ser::Error> {
 		let features = match reader.read_u8()? {
 			KernelFeatures::PLAIN_U8 => {
 				let fee = reader.read_u64()?;
@@ -202,7 +202,7 @@ impl Writeable for KernelFeatures {
 }
 
 impl Readable for KernelFeatures {
-	fn read(reader: &mut dyn Reader) -> Result<KernelFeatures, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<KernelFeatures, ser::Error> {
 		match reader.protocol_version().value() {
 			0..=1 => KernelFeatures::read_v1(reader),
 			2..=ProtocolVersion::MAX => KernelFeatures::read_v2(reader),
@@ -336,7 +336,7 @@ impl Writeable for TxKernel {
 }
 
 impl Readable for TxKernel {
-	fn read(reader: &mut dyn Reader) -> Result<TxKernel, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<TxKernel, ser::Error> {
 		Ok(TxKernel {
 			features: KernelFeatures::read(reader)?,
 			excess: Commitment::read(reader)?,
@@ -534,7 +534,7 @@ impl Writeable for TransactionBody {
 /// Implementation of Readable for a body, defines how to read a
 /// body from a binary stream.
 impl Readable for TransactionBody {
-	fn read(reader: &mut dyn Reader) -> Result<TransactionBody, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<TransactionBody, ser::Error> {
 		let (input_len, output_len, kernel_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 
@@ -908,7 +908,7 @@ impl Writeable for Transaction {
 /// Implementation of Readable for a transaction, defines how to read a full
 /// transaction from a binary stream.
 impl Readable for Transaction {
-	fn read(reader: &mut dyn Reader) -> Result<Transaction, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Transaction, ser::Error> {
 		let offset = BlindingFactor::read(reader)?;
 		let body = TransactionBody::read(reader)?;
 		let tx = Transaction { offset, body };
@@ -1294,7 +1294,7 @@ impl Writeable for Input {
 /// Implementation of Readable for a transaction Input, defines how to read
 /// an Input from a binary stream.
 impl Readable for Input {
-	fn read(reader: &mut dyn Reader) -> Result<Input, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Input, ser::Error> {
 		let features = OutputFeatures::read(reader)?;
 		let commit = Commitment::read(reader)?;
 		Ok(Input::new(features, commit))
@@ -1352,7 +1352,7 @@ impl Writeable for OutputFeatures {
 }
 
 impl Readable for OutputFeatures {
-	fn read(reader: &mut dyn Reader) -> Result<OutputFeatures, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<OutputFeatures, ser::Error> {
 		let features =
 			OutputFeatures::from_u8(reader.read_u8()?).ok_or(ser::Error::CorruptedData)?;
 		Ok(features)
@@ -1410,7 +1410,7 @@ impl Writeable for Output {
 /// Implementation of Readable for a transaction Output, defines how to read
 /// an Output from a binary stream.
 impl Readable for Output {
-	fn read(reader: &mut dyn Reader) -> Result<Output, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Output, ser::Error> {
 		Ok(Output {
 			features: OutputFeatures::read(reader)?,
 			commit: Commitment::read(reader)?,
@@ -1543,7 +1543,7 @@ impl Writeable for OutputIdentifier {
 }
 
 impl Readable for OutputIdentifier {
-	fn read(reader: &mut dyn Reader) -> Result<OutputIdentifier, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<OutputIdentifier, ser::Error> {
 		Ok(OutputIdentifier {
 			features: OutputFeatures::read(reader)?,
 			commit: Commitment::read(reader)?,

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -150,7 +150,7 @@ impl Writeable for Difficulty {
 }
 
 impl Readable for Difficulty {
-	fn read(reader: &mut dyn Reader) -> Result<Difficulty, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Difficulty, ser::Error> {
 		let data = reader.read_u64()?;
 		Ok(Difficulty { num: data })
 	}
@@ -249,7 +249,7 @@ impl Writeable for ProofOfWork {
 }
 
 impl Readable for ProofOfWork {
-	fn read(reader: &mut dyn Reader) -> Result<ProofOfWork, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<ProofOfWork, ser::Error> {
 		let total_difficulty = Difficulty::read(reader)?;
 		let secondary_scaling = reader.read_u32()?;
 		let nonce = reader.read_u64()?;
@@ -425,7 +425,7 @@ fn read_number(bits: &[u8], bit_start: usize, bit_count: usize) -> u64 {
 }
 
 impl Readable for Proof {
-	fn read(reader: &mut dyn Reader) -> Result<Proof, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<Proof, ser::Error> {
 		let edge_bits = reader.read_u8()?;
 		if edge_bits == 0 || edge_bits > 63 {
 			return Err(ser::Error::CorruptedData);

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -155,7 +155,7 @@ impl Writeable for TestElem {
 }
 
 impl Readable for TestElem {
-	fn read(reader: &mut dyn Reader) -> Result<TestElem, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<TestElem, ser::Error> {
 		Ok(TestElem([
 			reader.read_u32()?,
 			reader.read_u32()?,

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -25,7 +25,7 @@ use chrono::prelude::Utc;
 use rand::{thread_rng, Rng};
 use std::cmp;
 use std::fs::{self, File, OpenOptions};
-use std::io::BufWriter;
+use std::io::{BufWriter, Read};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -51,9 +51,9 @@ impl Protocol {
 }
 
 impl MessageHandler for Protocol {
-	fn consume(
+	fn consume<R: Read>(
 		&self,
-		mut msg: Message,
+		mut msg: Message<R>,
 		stopped: Arc<AtomicBool>,
 		tracker: Arc<Tracker>,
 	) -> Result<Option<Msg>, Error> {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -75,7 +75,7 @@ impl Writeable for PeerData {
 }
 
 impl Readable for PeerData {
-	fn read(reader: &mut dyn Reader) -> Result<PeerData, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<PeerData, ser::Error> {
 		let addr = PeerAddr::read(reader)?;
 		let capab = reader.read_u32()?;
 		let ua = reader.read_bytes_len_prefix()?;

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -138,7 +138,7 @@ impl Writeable for PeerAddr {
 }
 
 impl Readable for PeerAddr {
-	fn read(reader: &mut dyn Reader) -> Result<PeerAddr, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<PeerAddr, ser::Error> {
 		let v4_or_v6 = reader.read_u8()?;
 		if v4_or_v6 == 0 {
 			let ip = reader.read_fixed_bytes(4)?;

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -44,7 +44,7 @@ impl SizeEntry {
 }
 
 impl Readable for SizeEntry {
-	fn read(reader: &mut dyn Reader) -> Result<SizeEntry, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<SizeEntry, ser::Error> {
 		Ok(SizeEntry {
 			offset: reader.read_u64()?,
 			size: reader.read_u16()?,

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -35,7 +35,7 @@ impl PhatChunkStruct {
 }
 
 impl Readable for PhatChunkStruct {
-	fn read(reader: &mut dyn Reader) -> Result<PhatChunkStruct, ser::Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<PhatChunkStruct, ser::Error> {
 		let mut retval = PhatChunkStruct::new();
 		for _ in 0..TEST_ALLOC_SIZE {
 			retval.phatness = reader.read_u64()?;

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -982,7 +982,7 @@ impl Writeable for TestElem {
 	}
 }
 impl Readable for TestElem {
-	fn read(reader: &mut dyn Reader) -> Result<TestElem, Error> {
+	fn read<R: Reader>(reader: &mut R) -> Result<TestElem, Error> {
 		Ok(TestElem(reader.read_u32()?))
 	}
 }


### PR DESCRIPTION
Currently `Writable` accepts trait `Write` as a type parameter but `Readable`
takes `Read` as a trait object, which is not symmetrical and also less performant. This PR changes Readable trait and all places where it's used
