### PR TITLE
Reduce number of allocations in to_key calls

### DIFF
--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -154,7 +154,7 @@ impl PeerStore {
 	) -> Result<Vec<PeerData>, Error> {
 		let mut peers = self
 			.db
-			.iter::<PeerData>(&to_key(PEER_PREFIX, &mut "".to_string().into_bytes()))?
+			.iter::<PeerData>(&to_key(PEER_PREFIX, ""))?
 			.map(|(_, v)| v)
 			.filter(|p| p.flags == state && p.capabilities.contains(cap))
 			.collect::<Vec<_>>();
@@ -165,7 +165,7 @@ impl PeerStore {
 	/// List all known peers
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
-		let key = to_key(PEER_PREFIX, &mut "".to_string().into_bytes());
+		let key = to_key(PEER_PREFIX, "");
 		Ok(self
 			.db
 			.iter::<PeerData>(&key)?
@@ -221,5 +221,5 @@ impl PeerStore {
 
 // Ignore the port unless ip is loopback address.
 fn peer_key(peer_addr: PeerAddr) -> Vec<u8> {
-	to_key(PEER_PREFIX, &mut peer_addr.as_key().into_bytes())
+	to_key(PEER_PREFIX, &peer_addr.as_key())
 }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -44,20 +44,22 @@ use byteorder::{BigEndian, WriteBytesExt};
 pub use crate::lmdb::*;
 
 /// Build a db key from a prefix and a byte vector identifier.
-pub fn to_key(prefix: u8, k: &mut Vec<u8>) -> Vec<u8> {
+pub fn to_key<K: AsRef<[u8]>>(prefix: u8, k: K) -> Vec<u8> {
+	let k = k.as_ref();
 	let mut res = Vec::with_capacity(k.len() + 2);
 	res.push(prefix);
 	res.push(SEP);
-	res.append(k);
+	res.extend_from_slice(k);
 	res
 }
 
 /// Build a db key from a prefix and a byte vector identifier and numeric identifier
-pub fn to_key_u64(prefix: u8, k: &mut Vec<u8>, val: u64) -> Vec<u8> {
+pub fn to_key_u64<K: AsRef<[u8]>>(prefix: u8, k: K, val: u64) -> Vec<u8> {
+	let k = k.as_ref();
 	let mut res = Vec::with_capacity(k.len() + 10);
 	res.push(prefix);
 	res.push(SEP);
-	res.append(k);
+	res.extend_from_slice(k);
 	res.write_u64::<BigEndian>(val).unwrap();
 	res
 }

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -75,9 +75,9 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
 			let chunk = PhatChunkStruct::new();
-			let mut key_val = format!("phat_chunk_set_1_{}", i).as_bytes().to_vec();
+			let key_val = format!("phat_chunk_set_1_{}", i);
 			let batch = store.batch()?;
-			let key = store::to_key(b'P', &mut key_val);
+			let key = store::to_key(b'P', &key_val);
 			batch.put_ser(&key, &chunk)?;
 			batch.commit()?;
 		}
@@ -91,9 +91,9 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
 			let chunk = PhatChunkStruct::new();
-			let mut key_val = format!("phat_chunk_set_2_{}", i).as_bytes().to_vec();
+			let key_val = format!("phat_chunk_set_2_{}", i);
 			let batch = store.batch()?;
-			let key = store::to_key(b'P', &mut key_val);
+			let key = store::to_key(b'P', &key_val);
 			batch.put_ser(&key, &chunk)?;
 			batch.commit()?;
 		}


### PR DESCRIPTION
We have to make an extra allocation per db get request because key generation function to_key takes `Vec`. Taking byte slice (`AsRef<[u8]>` to be precise) also simplifies the code a bit.
