### PR TITLE
Always return a typed structure from lmdb store

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -348,11 +348,11 @@ impl<'a> Batch<'a> {
 	}
 
 	fn get_legacy_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
-		if let Ok(Some(bytes)) = self.db.get(&to_key(BLOCK_INPUT_BITMAP_PREFIX, bh)) {
-			Ok(Bitmap::deserialize(&bytes))
-		} else {
-			Err(Error::NotFoundErr("legacy block input bitmap".to_string()))
-		}
+		option_to_not_found(
+			self.db
+				.get_with(&to_key(BLOCK_INPUT_BITMAP_PREFIX, bh), Bitmap::deserialize),
+			|| "legacy block input bitmap".to_string(),
+		)
 	}
 
 	/// Get the "spent index" from the db for the specified block.


### PR DESCRIPTION
We have a method get which returns a Vec, it's used in cases when we can't implement FromLmdbBytes or Readable on a desired type, eg when both traits and type are external for the current crate. This approach requires an extra allocation of a Vec, this PR introduces a method which accepts desirialzer as closure, which allows to desrialize in place without an intermediate heap allocation.

It's still possible to get a Vec if needed, just pass a Vec constructor to get_with.
