### PR TITLE
Remove unnecessary newline in Stratum message

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -634,7 +634,6 @@ fn accept_connections(listen_addr: SocketAddr, handler: Arc<Handler>) {
 
 					let write = async move {
 						while let Some(line) = rx.next().await {
-							let line = line + "\n";
 							writer
 								.send(line)
 								.await


### PR DESCRIPTION
Found out here https://github.com/mimblewimble/grin/issues/1215.
This line of code send an empty message. We don't the need the newline here.
Tested and this fix the issue.