### PR TITLE
cleanup weird edge_bits handling in tests

### DIFF
--- a/chain/tests/chain_test_helper.rs
+++ b/chain/tests/chain_test_helper.rs
@@ -97,11 +97,7 @@ where
 
 		chain.set_txhashset_roots(&mut b).unwrap();
 
-		let edge_bits = if n == 2 {
-			global::min_edge_bits() + 1
-		} else {
-			global::min_edge_bits()
-		};
+		let edge_bits = global::min_edge_bits();
 		b.header.pow.proof.edge_bits = edge_bits;
 		pow::pow_size(
 			&mut b.header,
@@ -110,7 +106,6 @@ where
 			edge_bits,
 		)
 		.unwrap();
-		b.header.pow.proof.edge_bits = edge_bits;
 
 		let bhash = b.hash();
 		chain.process_block(b, Options::MINE).unwrap();


### PR DESCRIPTION
Looks like some legacy refactoring left some conditional stuff in place that no longer makes any sense.

This PR simply cleans this up. All chain tests still pass.