### PR TITLE
support explicit filtering of txs when preparing to mine

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -142,7 +142,8 @@ where
 			tx.kernels().iter().all(|x| match x.features {
 				KernelFeatures::Plain { .. } => true,
 				KernelFeatures::HeightLocked { .. } => true,
-				_ => false,
+				// Coinbase should never be present in txpool but filter them out regardless.
+				KernelFeatures::Coinbase => false,
 			})
 		});
 

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -198,12 +198,13 @@ where
 	// Remove the last transaction from the flattened bucket transactions.
 	// No other tx depends on it, it has low fee_to_weight and is unlikely to participate in any cut-through.
 	pub fn evict_from_txpool(&mut self) {
-		// Get bucket transactions
-		let bucket_transactions = self.txpool.bucket_transactions(Weighting::NoLimit);
+		// All transactions are eligible for eviction.
+		let bucket_transactions = self
+			.txpool
+			.bucket_transactions(Weighting::NoLimit, |_| true);
 
 		// Get last transaction and remove it
 		if let Some(evictable_transaction) = bucket_transactions.last() {
-			// Remove transaction
 			self.txpool
 				.entries
 				.retain(|x| x.tx != *evictable_transaction);


### PR DESCRIPTION
This PR adds functionality to explicitly filter txs (by bucket) when preparing a set of candidate transaction to mine a block.

We now explicitly filter by kernel variant, allowing buckets containing transactions with the following feature variants (and only these feature variants) - 

* Plain
* HeightLocked

HF3 will introduce the following new kernel variant (unsupported prior to HF3) - 

* NoRecentDuplicate

When we introduce the proposed NoRecentDuplicate kernel variant in HF3 we will use this new filtering logic to explicitly start allowing txs containing NoRecentDuplicate kernels to be included in a candidate block to be mined.

TODO - 

Later buckets can be dependent on earlier buckets due to fee calcs.

- [x] So we need to hook into the "reject" logic earlier to filter out invalid txs and their dependent txs.

Actually `tx_filter` closure can be used on the way in to the txpool also. The filtering logic is the same.

- [ ] Use `tx_filter` on way in to txpool/stempool also.

