### PR TITLE
Refactor bucket_transactions() and evict_transaction()

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -307,6 +307,15 @@ where
 		Ok(())
 	}
 
+	// Use our bucket logic to identify the best transaction for eviction and evict it.
+	// We want to avoid evicting a transaction where another transaction depends on it.
+	// We want to evict a transaction with low fee_to_weight.
+	pub fn evict_transaction(&mut self) {
+		if let Some(evictable_transaction) = self.bucket_transactions(Weighting::NoLimit).last() {
+			self.entries.retain(|x| x.tx != *evictable_transaction);
+		};
+	}
+
 	/// Buckets consist of a vec of txs and track the aggregate fee_to_weight.
 	/// We aggregate (cut-through) dependent transactions within a bucket *unless* adding a tx
 	/// would reduce the aggregate fee_to_weight, in which case we start a new bucket.
@@ -314,7 +323,7 @@ where
 	/// containing the tx it depends on.
 	/// Sorting the buckets by fee_to_weight will therefore preserve dependency ordering,
 	/// maximizing both cut-through and overall fees.
-	pub fn bucket_transactions(&self, weighting: Weighting) -> Vec<Transaction> {
+	fn bucket_transactions(&self, weighting: Weighting) -> Vec<Transaction> {
 		let mut tx_buckets: Vec<Bucket> = Vec::new();
 		let mut output_commits = HashMap::new();
 		let mut rejected = HashSet::new();

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -195,19 +195,11 @@ where
 		Ok(())
 	}
 
-	// Remove the last transaction from the flattened bucket transactions.
-	// No other tx depends on it, it has low fee_to_weight and is unlikely to participate in any cut-through.
+	// Evict a transaction from the txpool.
+	// Uses bucket logic to identify the "last" transaction.
+	// No other tx depends on it and it has low fee_to_weight.
 	pub fn evict_from_txpool(&mut self) {
-		// Get bucket transactions
-		let bucket_transactions = self.txpool.bucket_transactions(Weighting::NoLimit);
-
-		// Get last transaction and remove it
-		if let Some(evictable_transaction) = bucket_transactions.last() {
-			// Remove transaction
-			self.txpool
-				.entries
-				.retain(|x| x.tx != *evictable_transaction);
-		};
+		self.txpool.evict_transaction()
 	}
 
 	// Old txs will "age out" after 30 mins.


### PR DESCRIPTION
Investigation into https://github.com/mimblewimble/grin/pull/3318 identified some minor cleanup.

`bucket_transactions()` does not need to be `pub` if we move `evict_transaction()` to txpool.

No functional changes, just refactoring.

