### PR TITLE
Use multiple LMDB dbs (tables)

### DIFF
--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -22,7 +22,7 @@ use crate::core::core::pmmr::{self, Backend, ReadonlyPMMR, RewindablePMMR, PMMR}
 use crate::core::core::{Block, BlockHeader, Input, Output, OutputIdentifier, TxKernel};
 use crate::core::ser::{PMMRable, ProtocolVersion};
 use crate::error::{Error, ErrorKind};
-use crate::store::{Batch, ChainStore};
+use crate::store::{Batch, ChainStore, OUTPUT_POS};
 use crate::txhashset::bitmap_accumulator::BitmapAccumulator;
 use crate::txhashset::{RewindableKernelView, UTXOView};
 use crate::types::{CommitPos, OutputRoots, Tip, TxHashSetRoots, TxHashsetWriteStatus};
@@ -402,7 +402,7 @@ impl TxHashSet {
 					}
 				}
 			}
-			batch.delete(&key)?;
+			batch.delete(OUTPUT_POS, &key)?;
 			removed_count += 1;
 		}
 		debug!(

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -22,7 +22,7 @@ use crate::core::core::pmmr::{self, Backend, ReadonlyPMMR, RewindablePMMR, PMMR}
 use crate::core::core::{Block, BlockHeader, Input, Output, OutputIdentifier, TxKernel};
 use crate::core::ser::{PMMRable, ProtocolVersion};
 use crate::error::{Error, ErrorKind};
-use crate::store::{Batch, ChainStore, OUTPUT_POS};
+use crate::store::{table, Batch, ChainStore};
 use crate::txhashset::bitmap_accumulator::BitmapAccumulator;
 use crate::txhashset::{RewindableKernelView, UTXOView};
 use crate::types::{CommitPos, OutputRoots, Tip, TxHashSetRoots, TxHashsetWriteStatus};
@@ -402,7 +402,7 @@ impl TxHashSet {
 					}
 				}
 			}
-			batch.delete(OUTPUT_POS, &key)?;
+			batch.delete(table::OUTPUT_POSITIONS, &key)?;
 			removed_count += 1;
 		}
 		debug!(

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -21,7 +21,7 @@ use rand::thread_rng;
 
 use crate::core::ser::{self, Readable, Reader, Writeable, Writer};
 use crate::types::{Capabilities, PeerAddr, ReasonForBan};
-use grin_store::{self, option_to_not_found, to_key, Error};
+use grin_store::{self, option_to_not_found, Error};
 
 const ENV_NAME: &str = "peer";
 const PEER: &str = "peers";
@@ -152,7 +152,7 @@ impl PeerStore {
 	) -> Result<Vec<PeerData>, Error> {
 		let mut peers = self
 			.db
-			.iter::<PeerData>(PEER, b"")?
+			.iter::<_, PeerData>(PEER, &[b' '])?
 			.map(|(_, v)| v)
 			.filter(|p| p.flags == state && p.capabilities.contains(cap))
 			.collect::<Vec<_>>();
@@ -165,7 +165,7 @@ impl PeerStore {
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
 		Ok(self
 			.db
-			.iter::<PeerData>(PEER, b"")?
+			.iter::<_, PeerData>(PEER, &[b' '])?
 			.map(|(_, v)| v)
 			.collect::<Vec<_>>())
 	}
@@ -176,7 +176,7 @@ impl PeerStore {
 		let batch = self.db.batch()?;
 
 		let mut peer = option_to_not_found(
-			batch.get_ser::<PeerData>(PEER, &peer_key(peer_addr)[..]),
+			batch.get_ser::<_, PeerData>(PEER, &peer_key(peer_addr)[..]),
 			|| format!("Peer at address: {}", peer_addr),
 		)?;
 		peer.flags = new_state;

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -67,18 +67,18 @@ fn setup(test_dir: &str) {
 fn lmdb_allocate() -> Result<(), store::Error> {
 	let test_dir = "test_output/lmdb_allocate";
 	setup(test_dir);
+	let db = "test";
 	// Allocate more than the initial chunk, ensuring
 	// the DB resizes underneath
 	{
-		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
+		let store = store::Store::new(test_dir, Some("test1"), vec![db], None)?;
 
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
 			let chunk = PhatChunkStruct::new();
-			let key_val = format!("phat_chunk_set_1_{}", i);
+			let key = format!("phat_chunk_set_1_{}", i);
 			let batch = store.batch()?;
-			let key = store::to_key(b'P', &key_val);
-			batch.put_ser(&key, &chunk)?;
+			batch.put_ser(db, &key, &chunk)?;
 			batch.commit()?;
 		}
 	}
@@ -87,14 +87,13 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 	println!("***********************************");
 	// Open env again and keep adding
 	{
-		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
+		let store = store::Store::new(test_dir, Some("test1"), vec![db], None)?;
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
 			println!("Allocating chunk: {}", i);
 			let chunk = PhatChunkStruct::new();
-			let key_val = format!("phat_chunk_set_2_{}", i);
+			let key = format!("phat_chunk_set_2_{}", i);
 			let batch = store.batch()?;
-			let key = store::to_key(b'P', &key_val);
-			batch.put_ser(&key, &chunk)?;
+			batch.put_ser(db, &key, &chunk)?;
 			batch.commit()?;
 		}
 	}


### PR DESCRIPTION
LMDB is a key-value DB, so each operation uses a key. We currently always allocate a key in the heap, which leads to millions of allocations which could be avoided.

We use one table per DB (there are 2 dbs - `chain` and `peers`), which is quite unusual, so we have to use prefixes to emulate table functionality. For example we store a few different types of entities in `chain` db - blocks, headers etc. To store or retrieve a block we call a function `to_key` which generates a key for a particular block `b/block-hash`. LMDB expects keys as byte slices, so we could use a reference to block's hash to store or retrieve it, but we need to allocate a `Vec` to add the prefix.

In our defense LMDB terms are confusing, db is called `environment`, table is called `database`, so we have 1 env and 1 db per a domain (chain, p2p). What we really want is 1 env + many db (tables), so in this case we can use already allocated data (block/header hash, commit etc) directly as keys.

This PR introduces multi db (aka multi tables) support to sufficiently reduce number of allocations and simplify the code a bit. This is also saner design, each entity type should have its own table.

This is a WIP, I susppose a bit unstable version, supports only sync from the scratch. Each singleton (head, tail etc) is saved into its own table, which is overkill, it should use one table for all such values. We also need to implement db migration and solve an UX problem - what options a user should have after migration is done - eg remove the old db, keep it for a potential downgrade, move it to backup etc.