### PR TITLE
Fix miminum share difficulty in Stratum Server

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -568,8 +568,7 @@ impl Handler {
 
 					current_hash = latest_hash;
 					// set the minimum acceptable share difficulty for this block
-					state.minimum_share_difficulty =
-						cmp::min(config.minimum_share_difficulty, state.current_difficulty);
+					state.minimum_share_difficulty = config.minimum_share_difficulty;
 
 					// set a new deadline for rebuilding with fresh transactions
 					deadline = Utc::now().timestamp() + config.attempt_time_per_block as i64;


### PR DESCRIPTION
Fix https://github.com/mimblewimble/grin/issues/2629.
Please see original issue for context. Basically that was a comparison between unscaled and scaled diff which doesn't relay work. This issue simplify this. 
The minimum share difficulty is simply the one provided in the configuration.