### PR TITLE
Introduce a pause after calling Cursive.step

### DIFF
--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -29,6 +29,7 @@ use cursive::utils::markup::StyledString;
 use cursive::views::{BoxedView, CircularFocus, Dialog, LinearLayout, Panel, StackView, TextView};
 use cursive::Cursive;
 use std::sync::mpsc;
+use std::{thread, time};
 
 use crate::built_info;
 use crate::servers::Server;
@@ -187,6 +188,7 @@ impl Controller {
 	pub fn run(&mut self, server: Server) {
 		let stat_update_interval = 1;
 		let mut next_stat_update = Utc::now().timestamp() + stat_update_interval;
+		let delay = time::Duration::from_millis(50);
 		while self.ui.step() {
 			if let Some(message) = self.rx.try_iter().next() {
 				match message {
@@ -205,6 +207,7 @@ impl Controller {
 					self.ui.ui_tx.send(UIMessage::UpdateStatus(stats)).unwrap();
 				}
 			}
+			thread::sleep(delay);
 		}
 		server.stop();
 	}


### PR DESCRIPTION
Currently we call it in a loop without any delays which burns cpu cycles for little value.
On my machine I see decrease of cpu usage from 12% to 5-6% on a synced node after applying this fix.

CPU usage before:
<img width="683" alt="Screenshot 2020-05-14 at 23 00 59" src="https://user-images.githubusercontent.com/417244/81985742-ed307e00-9636-11ea-8c9a-113d140817f9.png">

After
<img width="555" alt="Screenshot 2020-05-14 at 22 58 19" src="https://user-images.githubusercontent.com/417244/81985792-020d1180-9637-11ea-8556-ccea85abd648.png">

As you can see for the same fully synced node cpu time dropped from 2.7 to 1.2 sec on 20 sec interval.