### PR TITLE
Fixing get_unspent_outputs documentation

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -454,7 +454,7 @@ pub trait ForeignRpc: Sync + Send {
 	{
 		"jsonrpc": "2.0",
 		"method": "get_unspent_outputs",
-		"params": [1, 2, null, true],
+		"params": [1, null, 2, true],
 		"id": 1
 	}
 	# "#


### PR DESCRIPTION
params[1] is the (optional) end_index. params[2] is the (required) max number of outputs to return. The documentation mixed up those 2.