### PR TITLE
Current/2.1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.3",
- "grin_chain 2.1.0-beta.3",
- "grin_config 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_servers 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_api 2.1.0-beta.4",
+ "grin_chain 2.1.0-beta.4",
+ "grin_config 2.1.0-beta.4",
+ "grin_core 2.1.0-beta.4",
+ "grin_keychain 2.1.0-beta.4",
+ "grin_p2p 2.1.0-beta.4",
+ "grin_servers 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 2.1.0-beta.4",
+ "grin_core 2.1.0-beta.4",
+ "grin_p2p 2.1.0-beta.4",
+ "grin_pool 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 2.1.0-beta.4",
+ "grin_keychain 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_servers 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 2.1.0-beta.4",
+ "grin_p2p 2.1.0-beta.4",
+ "grin_servers 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_keychain 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.0-beta.3",
+ "grin_util 2.1.0-beta.4",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 2.1.0-beta.4",
+ "grin_core 2.1.0-beta.4",
+ "grin_pool 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_chain 2.1.0-beta.4",
+ "grin_core 2.1.0-beta.4",
+ "grin_keychain 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.3",
- "grin_chain 2.1.0-beta.3",
- "grin_core 2.1.0-beta.3",
- "grin_keychain 2.1.0-beta.3",
- "grin_p2p 2.1.0-beta.3",
- "grin_pool 2.1.0-beta.3",
- "grin_store 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_api 2.1.0-beta.4",
+ "grin_chain 2.1.0-beta.4",
+ "grin_core 2.1.0-beta.4",
+ "grin_keychain 2.1.0-beta.4",
+ "grin_p2p 2.1.0-beta.4",
+ "grin_pool 2.1.0-beta.4",
+ "grin_store 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.3",
- "grin_util 2.1.0-beta.3",
+ "grin_core 2.1.0-beta.4",
+ "grin_util 2.1.0-beta.4",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.1-beta.1",
- "grin_chain 2.1.1-beta.1",
- "grin_config 2.1.1-beta.1",
- "grin_core 2.1.1-beta.1",
- "grin_keychain 2.1.1-beta.1",
- "grin_p2p 2.1.1-beta.1",
- "grin_servers 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_api 2.1.1",
+ "grin_chain 2.1.1",
+ "grin_config 2.1.1",
+ "grin_core 2.1.1",
+ "grin_keychain 2.1.1",
+ "grin_p2p 2.1.1",
+ "grin_servers 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1-beta.1",
- "grin_core 2.1.1-beta.1",
- "grin_p2p 2.1.1-beta.1",
- "grin_pool 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_chain 2.1.1",
+ "grin_core 2.1.1",
+ "grin_p2p 2.1.1",
+ "grin_pool 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1-beta.1",
- "grin_keychain 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_core 2.1.1",
+ "grin_keychain 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1-beta.1",
- "grin_p2p 2.1.1-beta.1",
- "grin_servers 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_core 2.1.1",
+ "grin_p2p 2.1.1",
+ "grin_servers 2.1.1",
+ "grin_util 2.1.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_keychain 2.1.1",
+ "grin_util 2.1.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.1-beta.1",
+ "grin_util 2.1.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1-beta.1",
- "grin_core 2.1.1-beta.1",
- "grin_pool 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_chain 2.1.1",
+ "grin_core 2.1.1",
+ "grin_pool 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1-beta.1",
- "grin_core 2.1.1-beta.1",
- "grin_keychain 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_chain 2.1.1",
+ "grin_core 2.1.1",
+ "grin_keychain 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.1-beta.1",
- "grin_chain 2.1.1-beta.1",
- "grin_core 2.1.1-beta.1",
- "grin_keychain 2.1.1-beta.1",
- "grin_p2p 2.1.1-beta.1",
- "grin_pool 2.1.1-beta.1",
- "grin_store 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_api 2.1.1",
+ "grin_chain 2.1.1",
+ "grin_core 2.1.1",
+ "grin_keychain 2.1.1",
+ "grin_p2p 2.1.1",
+ "grin_pool 2.1.1",
+ "grin_store 2.1.1",
+ "grin_util 2.1.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1-beta.1",
- "grin_util 2.1.1-beta.1",
+ "grin_core 2.1.1",
+ "grin_util 2.1.1",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0",
- "grin_chain 2.1.0",
- "grin_config 2.1.0",
- "grin_core 2.1.0",
- "grin_keychain 2.1.0",
- "grin_p2p 2.1.0",
- "grin_servers 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_api 2.1.1-beta.1",
+ "grin_chain 2.1.1-beta.1",
+ "grin_config 2.1.1-beta.1",
+ "grin_core 2.1.1-beta.1",
+ "grin_keychain 2.1.1-beta.1",
+ "grin_p2p 2.1.1-beta.1",
+ "grin_servers 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0",
- "grin_core 2.1.0",
- "grin_p2p 2.1.0",
- "grin_pool 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_chain 2.1.1-beta.1",
+ "grin_core 2.1.1-beta.1",
+ "grin_p2p 2.1.1-beta.1",
+ "grin_pool 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0",
- "grin_keychain 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_core 2.1.1-beta.1",
+ "grin_keychain 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0",
- "grin_p2p 2.1.0",
- "grin_servers 2.1.0",
- "grin_util 2.1.0",
+ "grin_core 2.1.1-beta.1",
+ "grin_p2p 2.1.1-beta.1",
+ "grin_servers 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.0",
- "grin_util 2.1.0",
+ "grin_keychain 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.0",
+ "grin_util 2.1.1-beta.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0",
- "grin_core 2.1.0",
- "grin_pool 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_chain 2.1.1-beta.1",
+ "grin_core 2.1.1-beta.1",
+ "grin_pool 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0",
- "grin_core 2.1.0",
- "grin_keychain 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_chain 2.1.1-beta.1",
+ "grin_core 2.1.1-beta.1",
+ "grin_keychain 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0",
- "grin_chain 2.1.0",
- "grin_core 2.1.0",
- "grin_keychain 2.1.0",
- "grin_p2p 2.1.0",
- "grin_pool 2.1.0",
- "grin_store 2.1.0",
- "grin_util 2.1.0",
+ "grin_api 2.1.1-beta.1",
+ "grin_chain 2.1.1-beta.1",
+ "grin_core 2.1.1-beta.1",
+ "grin_keychain 2.1.1-beta.1",
+ "grin_p2p 2.1.1-beta.1",
+ "grin_pool 2.1.1-beta.1",
+ "grin_store 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0",
- "grin_util 2.1.0",
+ "grin_core 2.1.1-beta.1",
+ "grin_util 2.1.1-beta.1",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.1",
- "grin_chain 2.1.1",
- "grin_config 2.1.1",
- "grin_core 2.1.1",
- "grin_keychain 2.1.1",
- "grin_p2p 2.1.1",
- "grin_servers 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_api 2.1.2-beta.1",
+ "grin_chain 2.1.2-beta.1",
+ "grin_config 2.1.2-beta.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_keychain 2.1.2-beta.1",
+ "grin_p2p 2.1.2-beta.1",
+ "grin_servers 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1",
- "grin_core 2.1.1",
- "grin_p2p 2.1.1",
- "grin_pool 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_chain 2.1.2-beta.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_p2p 2.1.2-beta.1",
+ "grin_pool 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1",
- "grin_keychain 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_keychain 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1",
- "grin_p2p 2.1.1",
- "grin_servers 2.1.1",
- "grin_util 2.1.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_p2p 2.1.2-beta.1",
+ "grin_servers 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.1",
- "grin_util 2.1.1",
+ "grin_keychain 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.1",
+ "grin_util 2.1.2-beta.1",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1",
- "grin_core 2.1.1",
- "grin_pool 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_chain 2.1.2-beta.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_pool 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.1",
- "grin_core 2.1.1",
- "grin_keychain 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_chain 2.1.2-beta.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_keychain 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.1",
- "grin_chain 2.1.1",
- "grin_core 2.1.1",
- "grin_keychain 2.1.1",
- "grin_p2p 2.1.1",
- "grin_pool 2.1.1",
- "grin_store 2.1.1",
- "grin_util 2.1.1",
+ "grin_api 2.1.2-beta.1",
+ "grin_chain 2.1.2-beta.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_keychain 2.1.2-beta.1",
+ "grin_p2p 2.1.2-beta.1",
+ "grin_pool 2.1.2-beta.1",
+ "grin_store 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.1",
- "grin_util 2.1.1",
+ "grin_core 2.1.2-beta.1",
+ "grin_util 2.1.2-beta.1",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,15 +666,15 @@ dependencies = [
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.4",
- "grin_chain 2.1.0-beta.4",
- "grin_config 2.1.0-beta.4",
- "grin_core 2.1.0-beta.4",
- "grin_keychain 2.1.0-beta.4",
- "grin_p2p 2.1.0-beta.4",
- "grin_servers 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_api 2.1.0",
+ "grin_chain 2.1.0",
+ "grin_config 2.1.0",
+ "grin_core 2.1.0",
+ "grin_keychain 2.1.0",
+ "grin_p2p 2.1.0",
+ "grin_servers 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,17 +685,17 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.4",
- "grin_core 2.1.0-beta.4",
- "grin_p2p 2.1.0-beta.4",
- "grin_pool 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_chain 2.1.0",
+ "grin_core 2.1.0",
+ "grin_p2p 2.1.0",
+ "grin_pool 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -726,10 +726,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.4",
- "grin_keychain 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_core 2.1.0",
+ "grin_keychain 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,13 +741,13 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.4",
- "grin_p2p 2.1.0-beta.4",
- "grin_servers 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_core 2.1.0",
+ "grin_p2p 2.1.0",
+ "grin_servers 2.1.0",
+ "grin_util 2.1.0",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,8 +766,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_keychain 2.1.0",
+ "grin_util 2.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.1.0-beta.4",
+ "grin_util 2.1.0",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,17 +806,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.4",
- "grin_core 2.1.0-beta.4",
- "grin_pool 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_chain 2.1.0",
+ "grin_core 2.1.0",
+ "grin_pool 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,17 +828,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.1.0-beta.4",
- "grin_core 2.1.0-beta.4",
- "grin_keychain 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_chain 2.1.0",
+ "grin_core 2.1.0",
+ "grin_keychain 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,19 +862,19 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.1.0-beta.4",
- "grin_chain 2.1.0-beta.4",
- "grin_core 2.1.0-beta.4",
- "grin_keychain 2.1.0-beta.4",
- "grin_p2p 2.1.0-beta.4",
- "grin_pool 2.1.0-beta.4",
- "grin_store 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_api 2.1.0",
+ "grin_chain 2.1.0",
+ "grin_core 2.1.0",
+ "grin_keychain 2.1.0",
+ "grin_p2p 2.1.0",
+ "grin_pool 2.1.0",
+ "grin_store 2.1.0",
+ "grin_util 2.1.0",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,8 +900,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.1.0-beta.4",
- "grin_util 2.1.0-beta.4",
+ "grin_core 2.1.0",
+ "grin_util 2.1.0",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 dependencies = [
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.0-beta.4" }
-grin_config = { path = "./config", version = "2.1.0-beta.4" }
-grin_chain = { path = "./chain", version = "2.1.0-beta.4" }
-grin_core = { path = "./core", version = "2.1.0-beta.4" }
-grin_keychain = { path = "./keychain", version = "2.1.0-beta.4" }
-grin_p2p = { path = "./p2p", version = "2.1.0-beta.4" }
-grin_servers = { path = "./servers", version = "2.1.0-beta.4" }
-grin_util = { path = "./util", version = "2.1.0-beta.4" }
+grin_api = { path = "./api", version = "2.1.0" }
+grin_config = { path = "./config", version = "2.1.0" }
+grin_chain = { path = "./chain", version = "2.1.0" }
+grin_core = { path = "./core", version = "2.1.0" }
+grin_keychain = { path = "./keychain", version = "2.1.0" }
+grin_p2p = { path = "./p2p", version = "2.1.0" }
+grin_servers = { path = "./servers", version = "2.1.0" }
+grin_util = { path = "./util", version = "2.1.0" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.0-beta.4" }
-grin_store = { path = "./store", version = "2.1.0-beta.4" }
+grin_chain = { path = "./chain", version = "2.1.0" }
+grin_store = { path = "./store", version = "2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.1-beta.1" }
-grin_config = { path = "./config", version = "2.1.1-beta.1" }
-grin_chain = { path = "./chain", version = "2.1.1-beta.1" }
-grin_core = { path = "./core", version = "2.1.1-beta.1" }
-grin_keychain = { path = "./keychain", version = "2.1.1-beta.1" }
-grin_p2p = { path = "./p2p", version = "2.1.1-beta.1" }
-grin_servers = { path = "./servers", version = "2.1.1-beta.1" }
-grin_util = { path = "./util", version = "2.1.1-beta.1" }
+grin_api = { path = "./api", version = "2.1.1" }
+grin_config = { path = "./config", version = "2.1.1" }
+grin_chain = { path = "./chain", version = "2.1.1" }
+grin_core = { path = "./core", version = "2.1.1" }
+grin_keychain = { path = "./keychain", version = "2.1.1" }
+grin_p2p = { path = "./p2p", version = "2.1.1" }
+grin_servers = { path = "./servers", version = "2.1.1" }
+grin_util = { path = "./util", version = "2.1.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.1-beta.1" }
-grin_store = { path = "./store", version = "2.1.1-beta.1" }
+grin_chain = { path = "./chain", version = "2.1.1" }
+grin_store = { path = "./store", version = "2.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.0-beta.3" }
-grin_config = { path = "./config", version = "2.1.0-beta.3" }
-grin_chain = { path = "./chain", version = "2.1.0-beta.3" }
-grin_core = { path = "./core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "./keychain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "./p2p", version = "2.1.0-beta.3" }
-grin_servers = { path = "./servers", version = "2.1.0-beta.3" }
-grin_util = { path = "./util", version = "2.1.0-beta.3" }
+grin_api = { path = "./api", version = "2.1.0-beta.4" }
+grin_config = { path = "./config", version = "2.1.0-beta.4" }
+grin_chain = { path = "./chain", version = "2.1.0-beta.4" }
+grin_core = { path = "./core", version = "2.1.0-beta.4" }
+grin_keychain = { path = "./keychain", version = "2.1.0-beta.4" }
+grin_p2p = { path = "./p2p", version = "2.1.0-beta.4" }
+grin_servers = { path = "./servers", version = "2.1.0-beta.4" }
+grin_util = { path = "./util", version = "2.1.0-beta.4" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.0-beta.3" }
-grin_store = { path = "./store", version = "2.1.0-beta.3" }
+grin_chain = { path = "./chain", version = "2.1.0-beta.4" }
+grin_store = { path = "./store", version = "2.1.0-beta.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.0" }
-grin_config = { path = "./config", version = "2.1.0" }
-grin_chain = { path = "./chain", version = "2.1.0" }
-grin_core = { path = "./core", version = "2.1.0" }
-grin_keychain = { path = "./keychain", version = "2.1.0" }
-grin_p2p = { path = "./p2p", version = "2.1.0" }
-grin_servers = { path = "./servers", version = "2.1.0" }
-grin_util = { path = "./util", version = "2.1.0" }
+grin_api = { path = "./api", version = "2.1.1-beta.1" }
+grin_config = { path = "./config", version = "2.1.1-beta.1" }
+grin_chain = { path = "./chain", version = "2.1.1-beta.1" }
+grin_core = { path = "./core", version = "2.1.1-beta.1" }
+grin_keychain = { path = "./keychain", version = "2.1.1-beta.1" }
+grin_p2p = { path = "./p2p", version = "2.1.1-beta.1" }
+grin_servers = { path = "./servers", version = "2.1.1-beta.1" }
+grin_util = { path = "./util", version = "2.1.1-beta.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.0" }
-grin_store = { path = "./store", version = "2.1.0" }
+grin_chain = { path = "./chain", version = "2.1.1-beta.1" }
+grin_store = { path = "./store", version = "2.1.1-beta.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.5"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "2.1.1" }
-grin_config = { path = "./config", version = "2.1.1" }
-grin_chain = { path = "./chain", version = "2.1.1" }
-grin_core = { path = "./core", version = "2.1.1" }
-grin_keychain = { path = "./keychain", version = "2.1.1" }
-grin_p2p = { path = "./p2p", version = "2.1.1" }
-grin_servers = { path = "./servers", version = "2.1.1" }
-grin_util = { path = "./util", version = "2.1.1" }
+grin_api = { path = "./api", version = "2.1.2-beta.1" }
+grin_config = { path = "./config", version = "2.1.2-beta.1" }
+grin_chain = { path = "./chain", version = "2.1.2-beta.1" }
+grin_core = { path = "./core", version = "2.1.2-beta.1" }
+grin_keychain = { path = "./keychain", version = "2.1.2-beta.1" }
+grin_p2p = { path = "./p2p", version = "2.1.2-beta.1" }
+grin_servers = { path = "./servers", version = "2.1.2-beta.1" }
+grin_util = { path = "./util", version = "2.1.2-beta.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.12", default-features = false, features = ["pancurses-backend"] }
@@ -53,5 +53,5 @@ cursive = "0.12"
 built = "0.3"
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "2.1.1" }
-grin_store = { path = "./store", version = "2.1.1" }
+grin_chain = { path = "./chain", version = "2.1.2-beta.1" }
+grin_store = { path = "./store", version = "2.1.2-beta.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_chain = { path = "../chain", version = "2.1.0" }
-grin_p2p = { path = "../p2p", version = "2.1.0" }
-grin_pool = { path = "../pool", version = "2.1.0" }
-grin_store = { path = "../store", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.1-beta.1" }
+grin_store = { path = "../store", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.1.1-beta.1" }
-grin_store = { path = "../store", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_chain = { path = "../chain", version = "2.1.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1" }
+grin_pool = { path = "../pool", version = "2.1.1" }
+grin_store = { path = "../store", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.4" }
-grin_store = { path = "../store", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_chain = { path = "../chain", version = "2.1.0" }
+grin_p2p = { path = "../p2p", version = "2.1.0" }
+grin_pool = { path = "../pool", version = "2.1.0" }
+grin_store = { path = "../store", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
+grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
+grin_pool = { path = "../pool", version = "2.1.0-beta.4" }
+grin_store = { path = "../store", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ futures = "0.1.21"
 rustls = "0.13"
 url = "1.7.0"
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_chain = { path = "../chain", version = "2.1.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1" }
-grin_pool = { path = "../pool", version = "2.1.1" }
-grin_store = { path = "../store", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.2-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.2-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.2-beta.1" }
+grin_store = { path = "../store", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
-grin_store = { path = "../store", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_keychain = { path = "../keychain", version = "2.1.0" }
+grin_store = { path = "../store", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_keychain = { path = "../keychain", version = "2.1.0" }
-grin_store = { path = "../store", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
+grin_store = { path = "../store", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
+grin_store = { path = "../store", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
-grin_store = { path = "../store", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1" }
+grin_store = { path = "../store", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ lru-cache = "0.1"
 lazy_static = "1"
 regex = "1"
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1" }
-grin_store = { path = "../store", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.2-beta.1" }
+grin_store = { path = "../store", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_servers = { path = "../servers", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_servers = { path = "../servers", version = "2.1.0-beta.4" }
+grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_servers = { path = "../servers", version = "2.1.0-beta.4" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_servers = { path = "../servers", version = "2.1.0" }
+grin_p2p = { path = "../p2p", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_servers = { path = "../servers", version = "2.1.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_servers = { path = "../servers", version = "2.1.2-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_servers = { path = "../servers", version = "2.1.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_servers = { path = "../servers", version = "2.1.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_servers = { path = "../servers", version = "2.1.0" }
-grin_p2p = { path = "../p2p", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_servers = { path = "../servers", version = "2.1.1-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_keychain = { path = "../keychain", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,8 +29,8 @@ log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 zeroize = "0.9"
 
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_keychain = { path = "../keychain", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_store = { path = "../store", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_store = { path = "../store", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
+grin_chain = { path = "../chain", version = "2.1.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.1-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_store = { path = "../store", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
-grin_chain = { path = "../chain", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_store = { path = "../store", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.0" }
+grin_pool = { path = "../pool", version = "2.1.1-beta.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_store = { path = "../store", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
+grin_pool = { path = "../pool", version = "2.1.0-beta.4" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_store = { path = "../store", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
-grin_chain = { path = "../chain", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_store = { path = "../store", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.1" }
+grin_pool = { path = "../pool", version = "2.1.2-beta.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_store = { path = "../store", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_store = { path = "../store", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
+grin_chain = { path = "../chain", version = "2.1.0" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "2.1.0-beta.4" }
+grin_pool = { path = "../pool", version = "2.1.0" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_keychain = { path = "../keychain", version = "2.1.0" }
-grin_store = { path = "../store", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
+grin_store = { path = "../store", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.0" }
+grin_chain = { path = "../chain", version = "2.1.1-beta.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
+grin_store = { path = "../store", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
+grin_chain = { path = "../chain", version = "2.1.0-beta.4" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
-grin_store = { path = "../store", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_keychain = { path = "../keychain", version = "2.1.0" }
+grin_store = { path = "../store", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
+grin_chain = { path = "../chain", version = "2.1.0" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
-grin_store = { path = "../store", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1" }
+grin_store = { path = "../store", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.4"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1" }
-grin_store = { path = "../store", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.2-beta.1" }
+grin_store = { path = "../store", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "2.1.1" }
+grin_chain = { path = "../chain", version = "2.1.2-beta.1" }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -105,21 +105,21 @@ pub struct PoolConfig {
 	/// Base fee for a transaction to be accepted by the pool. The transaction
 	/// weight is computed from its number of inputs, outputs and kernels and
 	/// multiplied by the base fee to compare to the actual transaction fee.
-	#[serde = "default_accept_fee_base"]
+	#[serde(default = "default_accept_fee_base")]
 	pub accept_fee_base: u64,
 
 	/// Maximum capacity of the pool in number of transactions
-	#[serde = "default_max_pool_size"]
+	#[serde(default = "default_max_pool_size")]
 	pub max_pool_size: usize,
 
 	/// Maximum capacity of the pool in number of transactions
-	#[serde = "default_max_stempool_size"]
+	#[serde(default = "default_max_stempool_size")]
 	pub max_stempool_size: usize,
 
 	/// Maximum total weight of transactions that can get selected to build a
 	/// block from. Allows miners to restrict the maximum weight of their
 	/// blocks.
-	#[serde = "default_mineable_max_weight"]
+	#[serde(default = "default_mineable_max_weight")]
 	pub mineable_max_weight: usize,
 }
 

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.1" }
-grin_chain = { path = "../chain", version = "2.1.1" }
-grin_core = { path = "../core", version = "2.1.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1" }
-grin_pool = { path = "../pool", version = "2.1.1" }
-grin_store = { path = "../store", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_api = { path = "../api", version = "2.1.2-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.2-beta.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.2-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.2-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.2-beta.1" }
+grin_store = { path = "../store", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.1-beta.1" }
-grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
-grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
-grin_pool = { path = "../pool", version = "2.1.1-beta.1" }
-grin_store = { path = "../store", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_api = { path = "../api", version = "2.1.1" }
+grin_chain = { path = "../chain", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1" }
+grin_pool = { path = "../pool", version = "2.1.1" }
+grin_store = { path = "../store", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.0" }
-grin_chain = { path = "../chain", version = "2.1.0" }
-grin_core = { path = "../core", version = "2.1.0" }
-grin_keychain = { path = "../keychain", version = "2.1.0" }
-grin_p2p = { path = "../p2p", version = "2.1.0" }
-grin_pool = { path = "../pool", version = "2.1.0" }
-grin_store = { path = "../store", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_api = { path = "../api", version = "2.1.1-beta.1" }
+grin_chain = { path = "../chain", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_keychain = { path = "../keychain", version = "2.1.1-beta.1" }
+grin_p2p = { path = "../p2p", version = "2.1.1-beta.1" }
+grin_pool = { path = "../pool", version = "2.1.1-beta.1" }
+grin_store = { path = "../store", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.0-beta.3" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.3" }
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.3" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.3" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.3" }
-grin_store = { path = "../store", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_api = { path = "../api", version = "2.1.0-beta.4" }
+grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
+grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
+grin_pool = { path = "../pool", version = "2.1.0-beta.4" }
+grin_store = { path = "../store", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ chrono = "0.4.4"
 tokio =  "0.1.11"
 walkdir = "2.2.9"
 
-grin_api = { path = "../api", version = "2.1.0-beta.4" }
-grin_chain = { path = "../chain", version = "2.1.0-beta.4" }
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_keychain = { path = "../keychain", version = "2.1.0-beta.4" }
-grin_p2p = { path = "../p2p", version = "2.1.0-beta.4" }
-grin_pool = { path = "../pool", version = "2.1.0-beta.4" }
-grin_store = { path = "../store", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_api = { path = "../api", version = "2.1.0" }
+grin_chain = { path = "../chain", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_keychain = { path = "../keychain", version = "2.1.0" }
+grin_p2p = { path = "../p2p", version = "2.1.0" }
+grin_pool = { path = "../pool", version = "2.1.0" }
+grin_store = { path = "../store", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.1-beta.1" }
-grin_util = { path = "../util", version = "2.1.1-beta.1" }
+grin_core = { path = "../core", version = "2.1.1" }
+grin_util = { path = "../util", version = "2.1.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.0" }
-grin_util = { path = "../util", version = "2.1.0" }
+grin_core = { path = "../core", version = "2.1.1-beta.1" }
+grin_util = { path = "../util", version = "2.1.1-beta.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.0-beta.4" }
-grin_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_core = { path = "../core", version = "2.1.0" }
+grin_util = { path = "../util", version = "2.1.0" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.0-beta.3" }
-grin_util = { path = "../util", version = "2.1.0-beta.3" }
+grin_core = { path = "../core", version = "2.1.0-beta.4" }
+grin_util = { path = "../util", version = "2.1.0-beta.4" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "2.1.1" }
-grin_util = { path = "../util", version = "2.1.1" }
+grin_core = { path = "../core", version = "2.1.2-beta.1" }
+grin_util = { path = "../util", version = "2.1.2-beta.1" }
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.1-beta.1"
+version = "2.1.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.0-beta.3"
+version = "2.1.0-beta.4"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.1"
+version = "2.1.2-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.0"
+version = "2.1.1-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "2.1.0-beta.4"
+version = "2.1.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
# This file is automatically @generated by Cargo.
# It is not intended for manual editing.
[[package]]
name = "adler32"
version = "1.0.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "aho-corasick"
version = "0.7.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ansi_term"
version = "0.11.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "antidote"
version = "1.0.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "arc-swap"
version = "0.3.11"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "argon2rs"
version = "0.2.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "array-macro"
version = "1.0.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "arrayref"
version = "0.3.5"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "arrayvec"
version = "0.3.25"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 "odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "arrayvec"
version = "0.4.10"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "atty"
version = "0.2.11"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "autocfg"
version = "0.1.4"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "backtrace"
version = "0.3.32"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "backtrace-sys 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "backtrace-sys"
version = "0.1.29"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "base64"
version = "0.9.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "bindgen"
version = "0.37.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "bitflags"
version = "0.9.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "bitflags"
version = "1.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "blake2-rfc"
version = "0.2.18"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "block-buffer"
version = "0.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "build_const"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "built"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "byte-tools"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "byteorder"
version = "1.3.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "bytes"
version = "0.4.12"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "cc"
version = "1.0.37"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "cexpr"
version = "0.2.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "cfg-if"
version = "0.1.9"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "chrono"
version = "0.4.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "clang-sys"
version = "0.23.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "clap"
version = "2.33.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "cloudabi"
version = "0.0.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "constant_time_eq"
version = "0.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "crc"
version = "1.8.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crc32fast"
version = "1.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "croaring"
version = "0.3.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "croaring-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "croaring-sys"
version = "0.3.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crossbeam-channel"
version = "0.3.8"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crossbeam-deque"
version = "0.7.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crossbeam-epoch"
version = "0.7.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crossbeam-queue"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crossbeam-utils"
version = "0.6.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "crypto-mac"
version = "0.6.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ct-logs"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ctrlc"
version = "3.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "cursive"
version = "0.12.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "enum-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "enumset 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "ncurses 5.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "darling"
version = "0.9.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "darling_core"
version = "0.9.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "darling_macro"
version = "0.9.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "difference"
version = "2.0.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "digest"
version = "0.7.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "dirs"
version = "1.0.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "dtoa"
version = "0.4.4"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "either"
version = "1.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "enum-map"
version = "0.5.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "enum-map-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "enum-map-internals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "enum-map-derive"
version = "0.4.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "enum-map-internals"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "array-macro 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "enum_primitive"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "enumset"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "enumset_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "enumset_derive"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "env_logger"
version = "0.5.13"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "failure"
version = "0.1.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "failure_derive"
version = "0.1.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
 "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "fake-simd"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "filetime"
version = "0.2.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "flate2"
version = "1.0.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "fnv"
version = "1.0.6"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "fs2"
version = "0.4.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "fuchsia-cprng"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "fuchsia-zircon"
version = "0.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "fuchsia-zircon-sys"
version = "0.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "futures"
version = "0.1.28"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "futures-cpupool"
version = "0.1.8"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "gcc"
version = "0.3.55"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "generic-array"
version = "0.9.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "git2"
version = "0.9.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "libgit2-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "glob"
version = "0.2.11"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "grin"
version = "2.1.2-beta.1"
dependencies = [
 "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_api 2.1.2-beta.1",
 "grin_chain 2.1.2-beta.1",
 "grin_config 2.1.2-beta.1",
 "grin_core 2.1.2-beta.1",
 "grin_keychain 2.1.2-beta.1",
 "grin_p2p 2.1.2-beta.1",
 "grin_servers 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_api"
version = "2.1.2-beta.1"
dependencies = [
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_chain 2.1.2-beta.1",
 "grin_core 2.1.2-beta.1",
 "grin_p2p 2.1.2-beta.1",
 "grin_pool 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-rustls 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_chain"
version = "2.1.2-beta.1"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_core 2.1.2-beta.1",
 "grin_keychain 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_config"
version = "2.1.2-beta.1"
dependencies = [
 "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_core 2.1.2-beta.1",
 "grin_p2p 2.1.2-beta.1",
 "grin_servers 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_core"
version = "2.1.2-beta.1"
dependencies = [
 "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_keychain 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_keychain"
version = "2.1.2-beta.1"
dependencies = [
 "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_util 2.1.2-beta.1",
 "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "pbkdf2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_p2p"
version = "2.1.2-beta.1"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_chain 2.1.2-beta.1",
 "grin_core 2.1.2-beta.1",
 "grin_pool 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_pool"
version = "2.1.2-beta.1"
dependencies = [
 "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_chain 2.1.2-beta.1",
 "grin_core 2.1.2-beta.1",
 "grin_keychain 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_secp256k1zkp"
version = "0.7.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_servers"
version = "2.1.2-beta.1"
dependencies = [
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_api 2.1.2-beta.1",
 "grin_chain 2.1.2-beta.1",
 "grin_core 2.1.2-beta.1",
 "grin_keychain 2.1.2-beta.1",
 "grin_p2p 2.1.2-beta.1",
 "grin_pool 2.1.2-beta.1",
 "grin_store 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_store"
version = "2.1.2-beta.1"
dependencies = [
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_core 2.1.2-beta.1",
 "grin_util 2.1.2-beta.1",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "grin_util"
version = "2.1.2-beta.1"
dependencies = [
 "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "h2"
version = "0.1.24"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "hashbrown"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "hmac"
version = "0.6.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "http"
version = "0.1.17"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "http-body"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "httparse"
version = "1.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "humansize"
version = "1.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "humantime"
version = "1.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "hyper"
version = "0.12.31"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "hyper-rustls"
version = "0.14.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ct-logs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-rustls 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "hyper-timeout"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io-timeout 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ident_case"
version = "1.0.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "idna"
version = "0.1.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "indexmap"
version = "1.0.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "iovec"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "itertools"
version = "0.7.11"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "itoa"
version = "0.4.4"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "kernel32-sys"
version = "0.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "lazy_static"
version = "1.3.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "libc"
version = "0.2.58"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "libgit2-sys"
version = "0.8.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "liblmdb-sys"
version = "0.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "libloading"
version = "0.5.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "libz-sys"
version = "1.0.25"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "linked-hash-map"
version = "0.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "lmdb-zero"
version = "0.4.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "lock_api"
version = "0.1.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "log"
version = "0.4.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "log-mdc"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "log4rs"
version = "0.8.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "lru-cache"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "maplit"
version = "1.0.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "matches"
version = "0.1.8"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "memchr"
version = "1.0.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "memchr"
version = "2.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "memmap"
version = "0.7.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "memoffset"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "miniz-sys"
version = "0.1.12"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "miniz_oxide"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "miniz_oxide_c_api"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "mio"
version = "0.6.19"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "mio-uds"
version = "0.6.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "miow"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ncurses"
version = "5.99.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "net2"
version = "0.2.33"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "nix"
version = "0.14.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "nodrop"
version = "0.1.13"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "nom"
version = "3.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num"
version = "0.1.42"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-bigint"
version = "0.1.44"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-bigint"
version = "0.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-complex"
version = "0.1.43"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-complex"
version = "0.2.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-integer"
version = "0.1.41"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-iter"
version = "0.1.39"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-rational"
version = "0.1.42"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-rational"
version = "0.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-traits"
version = "0.1.43"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num-traits"
version = "0.2.8"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "num_cpus"
version = "1.10.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "numtoa"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "odds"
version = "0.2.26"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "ordered-float"
version = "1.0.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "owning_ref"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "pancurses"
version = "0.16.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "ncurses 5.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "pdcurses-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "parking_lot"
version = "0.6.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "parking_lot"
version = "0.7.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "parking_lot_core"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "parking_lot_core"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "pbkdf2"
version = "0.2.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "pdcurses-sys"
version = "0.7.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "peeking_take_while"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "percent-encoding"
version = "1.0.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "pkg-config"
version = "0.3.14"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "podio"
version = "0.1.6"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "pretty_assertions"
version = "0.5.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "proc-macro2"
version = "0.3.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "proc-macro2"
version = "0.4.30"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "quick-error"
version = "1.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "quote"
version = "0.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "quote"
version = "0.6.12"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand"
version = "0.4.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand"
version = "0.5.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand"
version = "0.6.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_chacha"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_core"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_core"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "rand_hc"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_isaac"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_jitter"
version = "0.1.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_os"
version = "0.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_pcg"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rand_xorshift"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rdrand"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "redox_syscall"
version = "0.1.54"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "redox_termios"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "redox_users"
version = "0.3.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "regex"
version = "1.1.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "regex-syntax"
version = "0.6.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "remove_dir_all"
version = "0.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ring"
version = "0.13.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ripemd160"
version = "0.7.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rustc-demangle"
version = "0.1.15"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "rustc-serialize"
version = "0.3.24"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "rustc_version"
version = "0.2.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "rustls"
version = "0.13.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ryu"
version = "0.2.8"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "safemem"
version = "0.3.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "same-file"
version = "1.0.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "scoped-tls"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "scoped_threadpool"
version = "0.1.9"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "scopeguard"
version = "0.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "sct"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "semver"
version = "0.9.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "semver-parser"
version = "0.7.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "serde"
version = "1.0.93"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "serde-value"
version = "0.5.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "serde_derive"
version = "1.0.93"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "serde_json"
version = "1.0.39"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "serde_yaml"
version = "0.8.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "sha2"
version = "0.7.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "signal-hook"
version = "0.1.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "signal-hook-registry"
version = "1.0.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "siphasher"
version = "0.2.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "slab"
version = "0.4.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "smallvec"
version = "0.6.10"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "stable_deref_trait"
version = "1.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "string"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "strsim"
version = "0.7.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "strsim"
version = "0.8.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "supercow"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "syn"
version = "0.14.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "syn"
version = "0.15.38"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "synstructure"
version = "0.10.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
 "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tempfile"
version = "3.0.8"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "term"
version = "0.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "term_size"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "termcolor"
version = "1.0.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "termion"
version = "1.5.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "textwrap"
version = "0.11.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "thread-id"
version = "3.3.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "thread_local"
version = "0.3.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "time"
version = "0.1.42"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio"
version = "0.1.21"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-buf"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-codec"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-core"
version = "0.1.17"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-current-thread"
version = "0.1.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-executor"
version = "0.1.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-fs"
version = "0.1.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-io"
version = "0.1.12"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-io-timeout"
version = "0.3.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-reactor"
version = "0.1.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-rustls"
version = "0.7.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-service"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-sync"
version = "0.1.6"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-tcp"
version = "0.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-threadpool"
version = "0.1.14"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-timer"
version = "0.2.11"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-trace-core"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-udp"
version = "0.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "tokio-uds"
version = "0.2.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "toml"
version = "0.4.10"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "toml"
version = "0.5.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "traitobject"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "try-lock"
version = "0.2.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "typemap"
version = "0.3.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "typenum"
version = "1.10.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "ucd-util"
version = "0.1.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "unicode-bidi"
version = "0.3.4"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "unicode-normalization"
version = "0.1.8"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "unicode-segmentation"
version = "1.3.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "unicode-width"
version = "0.1.5"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "unicode-xid"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "unsafe-any"
version = "0.4.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "untrusted"
version = "0.6.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "url"
version = "1.7.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "utf8-ranges"
version = "1.0.3"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "uuid"
version = "0.6.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "vcpkg"
version = "0.2.6"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "vec_map"
version = "0.8.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "void"
version = "1.0.2"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "walkdir"
version = "2.2.9"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "want"
version = "0.2.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "webpki"
version = "0.18.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
 "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "webpki-roots"
version = "0.15.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "which"
version = "1.0.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "winapi"
version = "0.2.8"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "winapi"
version = "0.3.7"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "winapi-build"
version = "0.1.1"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "winapi-i686-pc-windows-gnu"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "winapi-util"
version = "0.1.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "winapi-x86_64-pc-windows-gnu"
version = "0.4.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "wincolor"
version = "1.0.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "winreg"
version = "0.5.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "ws2_32-sys"
version = "0.2.1"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "xi-unicode"
version = "0.1.0"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "yaml-rust"
version = "0.3.5"
source = "registry+https://github.com/rust-lang/crates.io-index"

[[package]]
name = "yaml-rust"
version = "0.4.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "zeroize"
version = "0.9.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "zeroize_derive 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "zeroize_derive"
version = "0.9.3"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
 "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
]

[[package]]
name = "zip"
version = "0.5.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
dependencies = [
 "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
]

[metadata]
"checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
"checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
"checksum array-macro 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4ff37a25fb442a1fecfd399be0dde685558bca30fb998420532889a36852d2"
"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
"checksum arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
"checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
"checksum backtrace-sys 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "12cb9f1eef1d1fc869ad5a26c9fa48516339a15e54a227a25460fc304815fdb3"
"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
"checksum bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1b25ab82877ea8fe6ce1ce1f8ac54361f0218bad900af9eb11803994bf67c221"
"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
"checksum built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7bff98465f9ff426a6e99829629b69acb0048504584934c1fb8b5822457535"
"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
"checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
"checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
"checksum croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "71152d60cec9dfdc5d9d793bccfa9ad95927372b80cd00e983db5eb2ce103e3b"
"checksum croaring-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ac84a4f975e67fc418be3911b7ca9aa74ee8a9717ca75452da7d6839421e2d67"
"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
"checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
"checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
"checksum crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7afa06d05a046c7a47c3a849907ec303504608c927f4e85f7bfff22b7180d971"
"checksum ct-logs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a4bf5107667e12bf6ce31a3a5066d67acc88942b6742117a41198734aaccaa"
"checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
"checksum cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ecc7282b5361471b607c26f44148205607e26d48a2fc65bd16e7619b1ebb78"
"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
"checksum enum-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccd9b2d5e0eb5c2ff851791e2af90ab4531b1168cfc239d1c0bf467e60ba3c89"
"checksum enum-map-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "153f6e8a8b2868e2fedf921b165f30229edcccb74d6a9bb1ccf0480ef61cd07e"
"checksum enum-map-internals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38b0bacf3ea7aba18ce84032efc3f0fa29f5c814048b742ab3e64d07d83ac3e8"
"checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
"checksum enumset 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac0a22e173f6570a7d69a2ab9e3fe79cf0dcdd0fdb162bfc932b97158f2b2a7"
"checksum enumset_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01d93b926a992a4a526c2a14e2faf734fdef5bf9d0a52ba69a2ca7d4494c284b"
"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
"checksum filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
"checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
"checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
"checksum git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "924b2e7d2986e625dcad89e8a429a7b3adee3c3d71e585f4a66c4f7e78715e31"
"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
"checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
"checksum h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "69b2a5a3092cbebbc951fe55408402e696ee2ed09019137d1800fc2c411265d2"
"checksum hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
"checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
"checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
"checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
"checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
"checksum hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)" = "6481fff8269772d4463253ca83c788104a7305cb3fb9136bc651a6211e46e03f"
"checksum hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68f2aa6b1681795bf4da8063f718cd23145aa0c9a5143d9787b345aa60d38ee4"
"checksum hyper-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16ec7c8e526ed674ce148323e1f2010f76f546fcdca99a2c721e04bc7bf5b6f7"
"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
"checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
"checksum libgit2-sys 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "941a41e23f77323b8c9d2ee118aec9ee39dfc176078c18b4757d3bad049d9ff7"
"checksum liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "feed38a3a580f60bf61aaa067b0ff4123395966839adeaf67258a9e50c4d2e49"
"checksum libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5692f82b51823e27c4118b3e5c0d98aee9be90633ebc71ad12afef380b50219"
"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
"checksum lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "13416eee745b087c22934f35f1f24da22da41ba2a5ce197143d168ce055cc58d"
"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
"checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
"checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
"checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
"checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
"checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
"checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
"checksum ncurses 5.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82"
"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
"checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
"checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
"checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
"checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
"checksum pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d3058bc37c433096b2ac7afef1c5cdfae49ede0a4ffec3dfc1df1df0959d0ff0"
"checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
"checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
"checksum pbkdf2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c09cddfbfc98de7f76931acf44460972edb4023eb14d0c6d4018800e552d8e0"
"checksum pdcurses-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "084dd22796ff60f1225d4eb6329f33afaf4c85419d51d440ab6b8c6f4529166b"
"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
"checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
"checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
"checksum proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
"checksum ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "482aa56cc68aaeccdaaff1cc5a72c247da8bbad3beb174ca5741f274c22883fb"
"checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
"checksum rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "942b71057b31981152970d57399c25f72e27a6ee0d207a669d8304cabf44705b"
"checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
"checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
"checksum sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb8f61f9e6eadd062a71c380043d28036304a4706b3c4dd001ff3387ed00745a"
"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
"checksum serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)" = "960e29cf7004b3b6e65fc5002981400eb3ccc017a08a2406940823e58e7179a9"
"checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
"checksum serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)" = "c4cce6663696bd38272e90bf34a0267e1226156c33f52d3f3915a2dd5d802085"
"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
"checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
"checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
"checksum signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7"
"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
"checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
"checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
"checksum syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)" = "37ea458a750f59ab679b47fef9b6722c586c5742f4cfe18a120bbc807e5e01fd"
"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
"checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
"checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
"checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
"checksum tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2ffcf4bcfc641413fa0f1427bf8f91dfc78f56a6559cbf50e04837ae442a87"
"checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
"checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
"checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
"checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
"checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
"checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
"checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
"checksum tokio-io-timeout 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "135ce81f15cfd7982fac684f9057a1299eebeb79e98a8a709969b9aa51123129"
"checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
"checksum tokio-rustls 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "208d62fa3e015426e3c64039d9d20adf054a3c9b4d9445560f1c41c75bef3eab"
"checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
"checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
"checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
"checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
"checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
"checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
"checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
"checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
"checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
"checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
"checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
"checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
"checksum webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "17d7967316d8411ca3b01821ee6c332bde138ba4363becdb492f12e514daa17f"
"checksum webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85d1f408918fd590908a70d36b7ac388db2edc221470333e4d6e5b598e44cabf"
"checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
"checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
"checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
"checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
"checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
"checksum zeroize_derive 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"
"checksum zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c18fc320faf909036e46ac785ea827f72e485304877faf1a3a39538d3714dbc3"