### PR TITLE
display chain type on tui title bar

### DIFF
--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -39,6 +39,7 @@ use crate::servers::Server;
 use crate::tui::constants::{ROOT_STACK, VIEW_BASIC_STATUS, VIEW_MINING, VIEW_PEER_SYNC};
 use crate::tui::types::{TUIStatusListener, UIMessage};
 use crate::tui::{logs, menu, mining, peers, status, version};
+use grin_core::global;
 use grin_util::logger::LogEntry;
 
 pub struct UI {
@@ -98,9 +99,9 @@ impl UI {
 		let mut title_string = StyledString::new();
 		title_string.append(StyledString::styled(
 			format!(
-				"Grin Version {} (proto: {})",
+				"Grin Version {} [{:?}]",
 				built_info::PKG_VERSION,
-				Server::protocol_version()
+				global::get_chain_type()
 			),
 			Color::Dark(BaseColor::Green),
 		));


### PR DESCRIPTION
Small tweak to the tui to display chain_type on the title bar - 

<img width="422" alt="Screen Shot 2020-05-29 at 10 15 50 AM" src="https://user-images.githubusercontent.com/30642645/83243355-ae053f80-a195-11ea-9482-774114ddb351.png">

Remove the proto version from the tui as this is no longer necessary (everybody is on v2).