### PR TITLE
servers: fix possible deadlock

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -342,10 +342,11 @@ impl Handler {
 			bh.pow.write_pre_pow(&mut writer).unwrap();
 		}
 		let pre_pow = header_buf.to_hex();
+		let current_state = self.current_state.read();
 		let job_template = JobTemplate {
 			height: bh.height,
-			job_id: (self.current_state.read().current_block_versions.len() - 1) as u64,
-			difficulty: self.current_state.read().minimum_share_difficulty,
+			job_id: (current_state.current_block_versions.len() - 1) as u64,
+			difficulty: current_state.minimum_share_difficulty,
 			pre_pow,
 		};
 		return job_template;


### PR DESCRIPTION
* Description:
This PR fixes a possible deadlock bug in stratumserver.
There are two Read locks on `self.current_state` in `build_block_template()` at L347 and L348.
The first Read lock is not released before calling the second lock. 
The lock `self.current_state` is a `parking_lot::RwLock`.
According to the doc of `parking_lot::RwLock`:
[“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”](https://amanieu.github.io/parking_lot/parking_lot/struct.RwLock.html)
Therefore, a deadlock may happen when a write lock interleaves the two read locks. 

* How I fix:
Use one read lock instead of two.

* Other Concerns:
I notice that `bh` is also computed from `self.current_state`.
Suppose that thread-A computes `bh`, 
thread-B changes `self.current_state`,
then thread-A computes `job_template`. Is this interleaving okay?