### PR TITLE
servers, util: fix deadlock caused by conflicting lock order

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -714,11 +714,13 @@ impl WorkersList {
 	}
 	pub fn remove_worker(&self, worker_id: usize) {
 		self.update_stats(worker_id, |ws| ws.is_connected = false);
-		self.workers_list
-			.write()
+		let mut stratum_stats = self.stratum_stats.write();
+		let mut workers_list = self.workers_list.write();
+		workers_list
 			.remove(&worker_id)
 			.expect("Stratum: no such addr in map");
-		self.stratum_stats.write().num_workers = self.workers_list.read().len();
+
+		stratum_stats.num_workers = workers_list.len();
 	}
 
 	pub fn login(&self, worker_id: usize, login: String, agent: String) -> Result<(), RpcError> {

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -150,6 +150,8 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 			*tui_running_ref = true;
 		}
 
+		let mut was_init_ref = WAS_INIT.lock();
+
 		// Save current logging configuration
 		let mut config_ref = LOGGING_CONFIG.lock();
 		*config_ref = c.clone();
@@ -250,7 +252,6 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 		);
 
 		// Mark logger as initialized
-		let mut was_init_ref = WAS_INIT.lock();
 		*was_init_ref = true;
 	}
 


### PR DESCRIPTION
* Description:
This PR fixes two deadlock bugs caused by conflicting lock order in stratumserver and log.
In servers/src/mining/stratumserver.rs
`add_worker()` calls `stratum_stats.write()` before `workers_list.write()`
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/servers/src/mining/stratumserver.rs#L700-L704
`remove_worker()` calls `workers_list.read()` before `stratum_stats.write()`
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/servers/src/mining/stratumserver.rs#L721
When `add_worker()` and `remove_worker()` are called simultaneously, the following deadlock may happen:

|Thread-A|Thread-B|
|---|---|
|A.lock()||
||B.lock()|
|B.lock()//deadlock!||
||A.lock()//deadlock!|

Similarly, 
`init_logger()` calls `LOGGING_CONFIG.lock()` before `WAS_INIT.lock()`
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/util/src/logger.rs#L154
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/util/src/logger.rs#L253
`init_test_logger()` calls `WAS_INIT.lock()` before `LOGGING_CONFIG.lock()`
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/util/src/logger.rs#L261-L262
https://github.com/mimblewimble/grin/blob/c7c9a32b9b85b9e7dce3b254600972dcc6d7f683/util/src/logger.rs#L271

* How I fix:
The fix is to enforce the order of the locks.

In stratumserver.rs, I use only one write lock of `workers_list` and remove the following read lock. This is to avoid possible atomicity violation when `workers_list` is written by another thread before being read.
In logger.rs, `WAS_INIT` is lifted before `LOGGING_CONFIG` in `remove_worker` to prevent the interleaving of `init_logger()` and `init_test_logger()`.
Note that dropping the lockguard of Lock-A before calling Lock-B is also a possible solution for conflicting lock order. But I did not use it here to prevent possible atomicity violation.

* Minor suggestion:
When the critical sections of different locks may overlap, I suggest always locking in the order that they are declared to prevent such deadlocks.

There is only one thing that concerns me: 
fn `remove_worker()` calls `update_stats()` where `stratum_stats.write()` is called. Then `stratum_stats.write()` is called again. Is it okay to have the two critical sections interleaved with `remove_worker()` or `add_worker()` from another thread?
