### PR TITLE
fix race condition

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -219,14 +219,7 @@ pub fn sync_block_headers(
 	txhashset::header_extending(&mut ctx.header_pmmr, &mut ctx.batch, |ext, batch| {
 		rewind_and_apply_header_fork(&last_header, ext, batch)?;
 		Ok(())
-	})?;
-
-	let header_head = ctx.batch.header_head()?;
-	if has_more_work(last_header, &header_head) {
-		update_header_head(&Tip::from_header(last_header), &mut ctx.batch)?;
-	}
-
-	Ok(())
+	})
 }
 
 /// Process a block header. Update the header MMR and corresponding header_head if this header


### PR DESCRIPTION
We were actually updating the `header_head` too early, after applying headers to the sync MMR, but _before_ we actually apply the headers to the header MMR.

The process is roughly - 
* sync headers to sync MMR
* ~update header_head~ (leads to race condition)
* apply sync'd headers to header MMR
* update header_head

This PR fixes the issue by simply skipping the redundant (and incorrect) interim update.

We don't normally see this during a fast sync on mainnet or floonet as we are very likely to receive a new latest header during the sync process.

I noticed this a couple of times on usertesting while testing fast sync with NRD kernels and here the fast sync is fast and we are more likely to hit the race condition.

