### PR TITLE
sync_all() on leaf_set and prune_list

### DIFF
--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -171,10 +171,8 @@ impl LeafSet {
 		self.bitmap.run_optimize();
 
 		// Write the updated bitmap file to disk.
-		save_via_temp_file(&self.path, ".tmp", |w| {
-			let mut w = BufWriter::new(w);
-			w.write_all(&self.bitmap.serialize())?;
-			w.flush()
+		save_via_temp_file(&self.path, ".tmp", |file| {
+			file.write_all(&self.bitmap.serialize())
 		})?;
 
 		// Make sure our backup in memory is up to date.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -21,7 +21,7 @@
 //! must be shifted the appropriate amount when reading from the hash and data
 //! files.
 
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use croaring::Bitmap;
@@ -114,10 +114,8 @@ impl PruneList {
 
 		// Write the updated bitmap file to disk.
 		if let Some(ref path) = self.path {
-			save_via_temp_file(path, ".tmp", |w| {
-				let mut w = BufWriter::new(w);
-				w.write_all(&self.bitmap.serialize())?;
-				w.flush()
+			save_via_temp_file(path, ".tmp", |file| {
+				file.write_all(&self.bitmap.serialize())
 			})?;
 		}
 


### PR DESCRIPTION
4.0.0 has a dedicated branch now. Opening this up against master.

----

We should call `sync_all()` (aka `fsync`) when writing the leaf_set (and prune_list) with `save_via_temp_file`.

Renaming a file without first calling `fsync` is not safe.
See https://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe

Also avoid removing the original file before renaming the temp file as this kind of defeats the atomicity of the "temp file and rename" approach.

Related #3352 (fsync rabbit hole).


