### PR TITLE
cleanup old unused code

### DIFF
--- a/chain/src/txhashset/rewindable_kernel_view.rs
+++ b/chain/src/txhashset/rewindable_kernel_view.rs
@@ -14,8 +14,6 @@
 
 //! Lightweight readonly view into kernel MMR for convenience.
 
-use std::fs::File;
-
 use crate::core::core::pmmr::RewindablePMMR;
 use crate::core::core::{BlockHeader, TxKernel};
 use crate::error::{Error, ErrorKind};
@@ -65,15 +63,5 @@ impl<'a> RewindableKernelView<'a> {
 			.into());
 		}
 		Ok(())
-	}
-
-	/// Read the "raw" kernel backend data file (via temp file for consistent view on data).
-	pub fn kernel_data_read(&self) -> Result<File, Error> {
-		let file = self
-			.pmmr
-			.backend()
-			.data_as_temp_file()
-			.map_err(|_| ErrorKind::FileReadErr("Data file woes".into()))?;
-		Ok(file)
 	}
 }

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fs::File;
-
 use croaring::Bitmap;
 
 use crate::core::hash::Hash;
@@ -67,11 +65,6 @@ pub trait Backend<T: PMMRable> {
 	/// given index (practically the index is the height of a block that
 	/// triggered removal).
 	fn remove(&mut self, position: u64) -> Result<(), String>;
-
-	/// Creates a temp file containing the contents of the underlying data file
-	/// from the backend storage. This allows a caller to see a consistent view
-	/// of the data without needing to lock the backend storage.
-	fn data_as_temp_file(&self) -> Result<File, String>;
 
 	/// Release underlying datafiles and locks
 	fn release_files(&mut self);

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::fs::File;
 
 use croaring::Bitmap;
 
@@ -73,10 +72,6 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		} else {
 			None
 		}
-	}
-
-	fn data_as_temp_file(&self) -> Result<File, String> {
-		unimplemented!()
 	}
 
 	/// Number of leaves in the MMR

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -15,7 +15,6 @@
 use crate::util::{Mutex, RwLock};
 use std::fmt;
 use std::fs::File;
-use std::io::Read;
 use std::net::{Shutdown, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -543,14 +542,6 @@ impl ChainAdapter for TrackingAdapter {
 
 	fn get_block(&self, h: Hash) -> Option<core::Block> {
 		self.adapter.get_block(h)
-	}
-
-	fn kernel_data_read(&self) -> Result<File, chain::Error> {
-		self.adapter.kernel_data_read()
-	}
-
-	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
-		self.adapter.kernel_data_write(reader)
 	}
 
 	fn txhashset_read(&self, h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -15,7 +15,6 @@
 use crate::util::RwLock;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -670,14 +669,6 @@ impl ChainAdapter for Peers {
 
 	fn get_block(&self, h: Hash) -> Option<core::Block> {
 		self.adapter.get_block(h)
-	}
-
-	fn kernel_data_read(&self) -> Result<File, chain::Error> {
-		self.adapter.kernel_data_read()
-	}
-
-	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
-		self.adapter.kernel_data_write(reader)
 	}
 
 	fn txhashset_read(&self, h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::fs::File;
-use std::io::{self, Read};
+use std::io;
 use std::net::{IpAddr, Shutdown, SocketAddr, SocketAddrV4, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -337,12 +337,6 @@ impl ChainAdapter for DummyAdapter {
 	}
 	fn get_block(&self, _: Hash) -> Option<core::Block> {
 		None
-	}
-	fn kernel_data_read(&self) -> Result<File, chain::Error> {
-		unimplemented!()
-	}
-	fn kernel_data_write(&self, _reader: &mut dyn Read) -> Result<bool, chain::Error> {
-		unimplemented!()
 	}
 	fn txhashset_read(&self, _h: Hash) -> Option<TxHashSetRead> {
 		unimplemented!()

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -15,7 +15,7 @@
 use std::convert::From;
 use std::fmt;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -600,10 +600,6 @@ pub trait ChainAdapter: Sync + Send {
 
 	/// Gets a full block by its hash.
 	fn get_block(&self, h: Hash) -> Option<core::Block>;
-
-	fn kernel_data_read(&self) -> Result<File, chain::Error>;
-
-	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error>;
 
 	/// Provides a reading view into the current txhashset state as well as
 	/// the required indexes for a consumer to rewind to a consistant state

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -17,7 +17,6 @@
 
 use crate::util::RwLock;
 use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
 use std::sync::{Arc, Weak};
 use std::thread;
@@ -362,15 +361,6 @@ where
 			Ok(b) => Some(b),
 			_ => None,
 		}
-	}
-
-	fn kernel_data_read(&self) -> Result<File, chain::Error> {
-		self.chain().kernel_data_read()
-	}
-
-	fn kernel_data_write(&self, reader: &mut dyn Read) -> Result<bool, chain::Error> {
-		self.chain().kernel_data_write(reader)?;
-		Ok(true)
 	}
 
 	/// Provides a reading view into the current txhashset state as well as

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -13,7 +13,7 @@
 
 //! Implementation of the persistent Backend for the prunable MMR tree.
 
-use std::fs::{self, File};
+use std::fs;
 use std::{io, time};
 
 use crate::core::core::hash::{Hash, Hashed};
@@ -169,12 +169,6 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		} else {
 			panic!("leaf_idx_iter not implemented for non-prunable PMMR")
 		}
-	}
-
-	fn data_as_temp_file(&self) -> Result<File, String> {
-		self.data_file
-			.as_temp_file()
-			.map_err(|_| "Failed to build temp data file".to_string())
 	}
 
 	/// Rewind the PMMR backend to the given position.

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -140,13 +140,6 @@ where
 		self.file.path()
 	}
 
-	/// Create a new tempfile containing the contents of this data file.
-	/// This allows callers to see a consistent view of the data without
-	/// locking the data file.
-	pub fn as_temp_file(&self) -> io::Result<File> {
-		self.file.as_temp_file()
-	}
-
 	/// Drop underlying file handles
 	pub fn release(&mut self) {
 		self.file.release();


### PR DESCRIPTION
Cleaned up some old legacy unused code - 

* `as_temp_file`
* `kernel_data_read`
* `kernel_data_write`

This is a holdover from an earlier unused "kernel sync".
This will be replaced in the in-progress PIBD work.

Should be safe to merge for `4.0.0` as this is unused.