### PR TITLE
[WIP] Ban peer on specific deserialization errors

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -19,7 +19,7 @@ use crate::handlers::chain_api::{ChainCompactHandler, ChainValidationHandler};
 use crate::handlers::peers_api::{PeerHandler, PeersConnectedHandler};
 use crate::handlers::server_api::StatusHandler;
 use crate::p2p::types::PeerInfoDisplay;
-use crate::p2p::{self, PeerData};
+use crate::p2p::{self, PeerAddr, PeerData};
 use crate::rest::*;
 use crate::types::Status;
 use std::net::SocketAddr;
@@ -156,7 +156,7 @@ impl Owner {
 		let peer_handler = PeerHandler {
 			peers: self.peers.clone(),
 		};
-		peer_handler.ban_peer(addr)
+		peer_handler.ban_peer(PeerAddr(addr))
 	}
 
 	/// Unbans a specific peer.
@@ -174,6 +174,6 @@ impl Owner {
 		let peer_handler = PeerHandler {
 			peers: self.peers.clone(),
 		};
-		peer_handler.unban_peer(addr)
+		peer_handler.unban_peer(PeerAddr(addr))
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,6 +69,8 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
+	/// Invalid PoW size.
+	InvalidPoWSize,
 }
 
 impl From<io::Error> for Error {
@@ -92,6 +94,7 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
+			Error::InvalidPoWSize => f.write_str("invalid PoW size"),
 		}
 	}
 }
@@ -115,6 +118,18 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
+			Error::InvalidPoWSize => "invalid PoW size",
+		}
+	}
+}
+
+impl Error {
+	/// Some errors related to deserialization are intrinsically bad
+	/// and should result in a peer being banned.
+	pub fn is_bad(&self) -> bool {
+		match *self {
+			Error::InvalidPoWSize => true,
+			_ => false,
 		}
 	}
 }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -597,6 +597,10 @@ impl NetAdapter for TrackingAdapter {
 		self.adapter.peer_difficulty(addr, diff, height)
 	}
 
+	fn ban_peer(&self, addr: PeerAddr, reason: ReasonForBan) {
+		self.adapter.ban_peer(addr, reason)
+	}
+
 	fn is_banned(&self, addr: PeerAddr) -> bool {
 		self.adapter.is_banned(addr)
 	}

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -383,6 +383,7 @@ impl NetAdapter for DummyAdapter {
 	}
 	fn peer_addrs_received(&self, _: Vec<PeerAddr>) {}
 	fn peer_difficulty(&self, _: PeerAddr, _: Difficulty, _: u64) {}
+	fn ban_peer(&self, _: PeerAddr, _: ReasonForBan) {}
 	fn is_banned(&self, _: PeerAddr) -> bool {
 		false
 	}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -650,10 +650,13 @@ pub trait NetAdapter: ChainAdapter {
 	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<PeerAddr>;
 
 	/// A list of peers has been received from one of our peers.
-	fn peer_addrs_received(&self, _: Vec<PeerAddr>);
+	fn peer_addrs_received(&self, addrs: Vec<PeerAddr>);
 
 	/// Heard total_difficulty from a connected peer (via ping/pong).
-	fn peer_difficulty(&self, _: PeerAddr, _: Difficulty, _: u64);
+	fn peer_difficulty(&self, addr: PeerAddr, difficulty: Difficulty, height: u64);
+
+	/// Peer just did something unforgiveable.
+	fn ban_peer(&self, addr: PeerAddr, reason: ReasonForBan);
 
 	/// Is this peer currently banned?
 	fn is_banned(&self, addr: PeerAddr) -> bool;

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -156,9 +156,7 @@ fn monitor_peers(
 				let interval = Utc::now().timestamp() - x.last_banned;
 				// Unban peer
 				if interval >= config.ban_window() {
-					if let Err(e) = peers.unban_peer(x.addr) {
-						error!("failed to unban peer {}: {:?}", x.addr, e);
-					}
+					peers.unban_peer(x.addr);
 					debug!(
 						"monitor_peers: unbanned {} after {} seconds",
 						x.addr, interval

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 use crate::chain::{self, SyncState, SyncStatus};
 use crate::common::types::Error;
 use crate::core::core::hash::{Hash, Hashed};
-use crate::p2p::{self, types::ReasonForBan, Peer};
+use crate::p2p::types::{NetAdapter, ReasonForBan};
+use crate::p2p::{self, Peer};
 
 pub struct HeaderSync {
 	sync_state: Arc<SyncState>,
@@ -144,12 +145,8 @@ impl HeaderSync {
 							if now > *stalling_ts + Duration::seconds(120)
 								&& header_head.total_difficulty < peer.info.total_difficulty()
 							{
-								if let Err(e) = self
-									.peers
-									.ban_peer(peer.info.addr, ReasonForBan::FraudHeight)
-								{
-									error!("failed to ban peer {}: {:?}", peer.info.addr, e);
-								}
+								self.peers
+									.ban_peer(peer.info.addr, ReasonForBan::FraudHeight);
 								info!(
 										"sync: ban a fraud peer: {}, claimed height: {}, total difficulty: {}",
 										peer.info.addr,


### PR DESCRIPTION
Currently a `CorruptedData` error during deserialization simply results in a peer connection getting dropped. 
Some errors during deserialization are more serious and should result in a peer being banned.

Specifically during header deserialization we should probably ban a peer if PoW related `verify_size()` fails.

Related #3360.

Several related cleanup/refactoring is also in this PR, revisiting the peer ban/unban impl.

* refactor ban/unban peer as errors here are not particularly useful
  * if we encounter an error when banning a peer there is not much we can do
  * it should not be an error if we attempt to unban a peer not currently banned
* move `ban_peer` to `NetAdapter` trait to make it available to `consume()` during msg parsing and deserialization

TODO - 
- [ ] expose a more serious version of `CorruptedData`
- [ ] handle this more serious version by banning the peer in `consume()`
- [ ] tests to ensure we are not deadlocking on `peers` or similar
- [ ] make `verify_size()` a bannable verification step
- [ ] investigate other "untrusted" bannable verification during deserialization

