### PR TITLE
make sure header PMMR is init correctly based on header_head from db

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1453,6 +1453,10 @@ fn setup_head(
 	// If header_head is missing in db then use head of header PMMR.
 	if let Ok(head) = batch.header_head() {
 		header_pmmr.init_head(&head)?;
+		txhashset::header_extending(header_pmmr, &mut batch, |ext, batch| {
+			let header = batch.get_block_header(&head.hash())?;
+			ext.rewind(&header)
+		})?;
 	} else {
 		let hash = header_pmmr.head_hash()?;
 		let header = batch.get_block_header(&hash)?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1449,9 +1449,11 @@ fn setup_head(
 		}
 	}
 
-	// Setup our header_head if we do not already have one.
-	// Migrating back to header_head in db and some nodes may note have one.
-	if batch.header_head().is_err() {
+	// Make sure our header PMMR is consistent with header_head from db if it exists.
+	// If header_head is missing in db then use head of header PMMR.
+	if let Ok(head) = batch.header_head() {
+		header_pmmr.init_head(&head)?;
+	} else {
 		let hash = header_pmmr.head_hash()?;
 		let header = batch.get_block_header(&hash)?;
 		batch.save_header_head(&Tip::from_header(&header))?;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -250,6 +250,11 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 		}
 	}
 
+	// We want to validate this individual header before applying it to our header PMMR.
+	validate_header(header, ctx)?;
+
+	// Apply the header to the header PMMR, making sure we put the extension in the correct state
+	// based on previous header first.
 	txhashset::header_extending(&mut ctx.header_pmmr, &mut ctx.batch, |ext, batch| {
 		rewind_and_apply_header_fork(&prev_header, ext, batch)?;
 		ext.validate_root(header)?;
@@ -260,7 +265,7 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 		Ok(())
 	})?;
 
-	validate_header(header, ctx)?;
+	// Add this new block header to the db.
 	add_block_header(header, &ctx.batch)?;
 
 	if has_more_work(header, &header_head) {


### PR DESCRIPTION
We had logic in chain init to make sure header_head was consistent with the header PMMR (in the case where it was missing from the db after migration to 3.x.x).

This PR adds logic to ensure the inverse of this - that the header PMMR is consistent with header_head from the db in the case where the header PMMR contains unwanted rightmost data.
The PMMR is append-only and there may be headers appended that we want to discard.
The `header_head` in the db is our "source of truth".

We simply (re)set the PMMR handle `last_pos` to discard data to the right.
Then we can safely "rewind" the header PMMR to the pos corresponding `header_head` from db.

----

Also tweaked the order of operations slightly when processing block headers.
We now validate the header _before_ applying it to our header PMMR (to validate the roots).
Otherwise we potentially leave the header PMMR in a bad state if the roots are valid but the header ends up being invalid for some other reason.
This is likely the reason _why_ a node gets into a bad state. We can now recover from this on startup but we want to avoid it happening in the first place.

----

Tested with sync (and staying in sync) on both `floonet` and `mainnet`.
Tested mining on `usertesting`.
@quentinlesceller tested this against `floonet` with stratum miners.

