### PR TITLE
cleanup unused macros and error

### DIFF
--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -79,38 +79,6 @@ pub fn create_siphash_keys(header: &[u8]) -> Result<[u64; 4], Error> {
 	])
 }
 
-/// Macro to clean up u64 unwrapping
-#[macro_export]
-macro_rules! to_u64 {
-	($n:expr) => {
-		$n.to_u64().ok_or(ErrorKind::IntegerCast)?
-	};
-}
-
-/// Macro to clean up u64 unwrapping as u32
-#[macro_export]
-macro_rules! to_u32 {
-	($n:expr) => {
-		$n.to_u64().ok_or(ErrorKind::IntegerCast)? as u32
-	};
-}
-
-/// Macro to clean up u64 unwrapping as usize
-#[macro_export]
-macro_rules! to_usize {
-	($n:expr) => {
-		$n.to_u64().ok_or(ErrorKind::IntegerCast)? as usize
-	};
-}
-
-/// Macro to clean up casting to edge type
-#[macro_export]
-macro_rules! to_edge {
-	($edge_type:ident, $n:expr) => {
-		$edge_type::from($n).ok_or(ErrorKind::IntegerCast)?
-	};
-}
-
 /// Utility struct to calculate commonly used Cuckoo parameters calculated
 /// from header, nonce, edge_bits, etc.
 pub struct CuckooParams {

--- a/core/src/pow/error.rs
+++ b/core/src/pow/error.rs
@@ -29,9 +29,6 @@ pub enum ErrorKind {
 	/// Verification error
 	#[fail(display = "Verification Error: {}", _0)]
 	Verification(String),
-	/// Failure to cast from/to generic integer type
-	#[fail(display = "IntegerCast")]
-	IntegerCast,
 	/// IO Error
 	#[fail(display = "IO Error")]
 	IOError,
@@ -86,14 +83,6 @@ impl From<ErrorKind> for Error {
 impl From<Context<ErrorKind>> for Error {
 	fn from(inner: Context<ErrorKind>) -> Error {
 		Error { inner }
-	}
-}
-
-impl From<fmt::Error> for Error {
-	fn from(_error: fmt::Error) -> Error {
-		Error {
-			inner: Context::new(ErrorKind::IntegerCast),
-		}
 	}
 }
 


### PR DESCRIPTION
These macros are no longer required as the conversion code was simplified and cleaned up in #3365.
Now the macros are gone we no longer need the `IntegerCast` error kind.

This PR cleans up the unused code.

