### PR TITLE
bump master to 4.0.1-alpha.1 to differentiate from 4.0.0 official tagged build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "blake2-rfc",
  "built",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "dirs",
  "grin_core",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "backtrace",
  "base64 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ term = "0.6"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_api = { path = "./api", version = "4.0.0" }
-grin_config = { path = "./config", version = "4.0.0" }
-grin_chain = { path = "./chain", version = "4.0.0" }
-grin_core = { path = "./core", version = "4.0.0" }
-grin_keychain = { path = "./keychain", version = "4.0.0" }
-grin_p2p = { path = "./p2p", version = "4.0.0" }
-grin_servers = { path = "./servers", version = "4.0.0" }
-grin_util = { path = "./util", version = "4.0.0" }
+grin_api = { path = "./api", version = "4.0.1-alpha.1" }
+grin_config = { path = "./config", version = "4.0.1-alpha.1" }
+grin_chain = { path = "./chain", version = "4.0.1-alpha.1" }
+grin_core = { path = "./core", version = "4.0.1-alpha.1" }
+grin_keychain = { path = "./keychain", version = "4.0.1-alpha.1" }
+grin_p2p = { path = "./p2p", version = "4.0.1-alpha.1" }
+grin_servers = { path = "./servers", version = "4.0.1-alpha.1" }
+grin_util = { path = "./util", version = "4.0.1-alpha.1" }
 
 [dependencies.cursive]
 version = "0.15"
@@ -50,5 +50,5 @@ features = ["pancurses-backend"]
 built = { version = "0.4", features = ["git2"]}
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "4.0.0-rc.1" }
-grin_store = { path = "./store", version = "4.0.0-rc.1" }
+grin_chain = { path = "./chain", version = "4.0.1-alpha.1" }
+grin_store = { path = "./store", version = "4.0.1-alpha.1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -31,9 +31,9 @@ rustls = "0.17"
 url = "2.1"
 bytes = "0.5"
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_chain = { path = "../chain", version = "4.0.0" }
-grin_p2p = { path = "../p2p", version = "4.0.0" }
-grin_pool = { path = "../pool", version = "4.0.0" }
-grin_store = { path = "../store", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_chain = { path = "../chain", version = "4.0.1-alpha.1" }
+grin_p2p = { path = "../p2p", version = "4.0.1-alpha.1" }
+grin_pool = { path = "../pool", version = "4.0.1-alpha.1" }
+grin_store = { path = "../store", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ chrono = "0.4.11"
 lru-cache = "0.1"
 lazy_static = "1"
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_keychain = { path = "../keychain", version = "4.0.0" }
-grin_store = { path = "../store", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_keychain = { path = "../keychain", version = "4.0.1-alpha.1" }
+grin_store = { path = "../store", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.5"
 dirs = "2.0"
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_servers = { path = "../servers", version = "4.0.0" }
-grin_p2p = { path = "../p2p", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_servers = { path = "../servers", version = "4.0.1-alpha.1" }
+grin_p2p = { path = "../p2p", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -28,8 +28,8 @@ log = "0.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 zeroize = { version = "1.1", features =["zeroize_derive"] }
 
-keychain = { package = "grin_keychain", path = "../keychain", version = "4.0.0" }
-util = { package = "grin_util", path = "../util", version = "4.0.0" }
+keychain = { package = "grin_keychain", path = "../keychain", version = "4.0.1-alpha.1" }
+util = { package = "grin_util", path = "../util", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -26,4 +26,4 @@ ripemd160 = "0.7"
 sha2 = "0.7"
 pbkdf2 = "0.2"
 
-grin_util = { path = "../util", version = "4.0.0" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -21,10 +21,10 @@ tempfile = "3.1"
 log = "0.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_store = { path = "../store", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
-grin_chain = { path = "../chain", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_store = { path = "../store", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }
+grin_chain = { path = "../chain", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "4.0.0" }
+grin_pool = { path = "../pool", version = "4.0.1-alpha.1" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -19,9 +19,9 @@ chrono = "0.4.11"
 failure = "0.1"
 failure_derive = "0.1"
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_keychain = { path = "../keychain", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_keychain = { path = "../keychain", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "4.0.0" }
+grin_chain = { path = "../chain", version = "4.0.1-alpha.1" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ tokio = {version = "0.2", features = ["full"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 walkdir = "2.3.1"
 
-grin_api = { path = "../api", version = "4.0.0" }
-grin_chain = { path = "../chain", version = "4.0.0" }
-grin_core = { path = "../core", version = "4.0.0" }
-grin_keychain = { path = "../keychain", version = "4.0.0" }
-grin_p2p = { path = "../p2p", version = "4.0.0" }
-grin_pool = { path = "../pool", version = "4.0.0" }
-grin_store = { path = "../store", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_api = { path = "../api", version = "4.0.1-alpha.1" }
+grin_chain = { path = "../chain", version = "4.0.1-alpha.1" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_keychain = { path = "../keychain", version = "4.0.1-alpha.1" }
+grin_p2p = { path = "../p2p", version = "4.0.1-alpha.1" }
+grin_pool = { path = "../pool", version = "4.0.1-alpha.1" }
+grin_store = { path = "../store", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -22,8 +22,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "4.0.0" }
-grin_util = { path = "../util", version = "4.0.0" }
+grin_core = { path = "../core", version = "4.0.1-alpha.1" }
+grin_util = { path = "../util", version = "4.0.1-alpha.1" }
 
 [dev-dependencies]
 chrono = "0.4.11"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
So we can identify `4.0.0` vs. `master` on mainnet.