### PR TITLE
further tweaks to block_accepted logs for clarity

### DIFF
--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -448,19 +448,23 @@ impl ChainAdapter for NoopAdapter {
 pub enum BlockStatus {
 	/// Block is the "next" block, updating the chain head.
 	Next {
-		/// Previous chain head.
-		prev_head: Tip,
+		/// Previous block (previous chain head).
+		prev: Tip,
 	},
 	/// Block does not update the chain head and is a fork.
 	Fork {
-		/// Previous chain head.
-		prev_head: Tip,
+		/// Previous block on this fork.
+		prev: Tip,
+		/// Current chain head.
+		head: Tip,
 		/// Fork point for rewind.
 		fork_point: Tip,
 	},
 	/// Block updates the chain head via a (potentially disruptive) "reorg".
 	/// Previous block was not our previous chain head.
 	Reorg {
+		/// Previous block on this fork.
+		prev: Tip,
 		/// Previous chain head.
 		prev_head: Tip,
 		/// Fork point for rewind.

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -385,6 +385,7 @@ fn mine_reorg() {
 		assert_eq!(
 			*adapter.last_status.read(),
 			Some(BlockStatus::Reorg {
+				prev: Tip::from_header(&fork_head),
 				prev_head: head,
 				fork_point: Tip::from_header(&fork_point)
 			})

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -119,13 +119,16 @@ impl ChainEvents for EventLogger {
 	fn on_block_accepted(&self, block: &core::Block, status: BlockStatus) {
 		match status {
 			BlockStatus::Reorg {
+				prev,
 				prev_head,
 				fork_point,
 			} => {
 				warn!(
-					"block_accepted (REORG!): {} at {}, (prev_head: {} at {}, fork_point: {} at {}, depth: {})",
+					"block_accepted (REORG!): {} at {}, (prev: {} at {}, prev_head: {} at {}, fork_point: {} at {}, depth: {})",
 					block.hash(),
 					block.header.height,
+					prev.hash(),
+					prev.height,
 					prev_head.hash(),
 					prev_head.height,
 					fork_point.hash(),
@@ -134,27 +137,30 @@ impl ChainEvents for EventLogger {
 				);
 			}
 			BlockStatus::Fork {
-				prev_head,
+				prev,
+				head,
 				fork_point,
 			} => {
 				debug!(
-					"block_accepted (fork?): {} at {}, (prev_head: {} at {}, fork_point: {} at {}, depth: {})",
+					"block_accepted (fork?): {} at {}, (prev: {} at {}, head: {} at {}, fork_point: {} at {}, depth: {})",
 					block.hash(),
 					block.header.height,
-					prev_head.hash(),
-					prev_head.height,
+					prev.hash(),
+					prev.height,
+					head.hash(),
+					head.height,
 					fork_point.hash(),
 					fork_point.height,
 					block.header.height.saturating_sub(fork_point.height + 1),
 				);
 			}
-			BlockStatus::Next { prev_head } => {
+			BlockStatus::Next { prev } => {
 				debug!(
-					"block_accepted (head+): {} at {} (prev_head: {} at {})",
+					"block_accepted (head+): {} at {} (prev: {} at {})",
 					block.hash(),
 					block.header.height,
-					prev_head.hash(),
-					prev_head.height,
+					prev.hash(),
+					prev.height,
 				);
 			}
 		}

--- a/servers/src/common/hooks.rs
+++ b/servers/src/common/hooks.rs
@@ -133,7 +133,7 @@ impl ChainEvents for EventLogger {
 					prev_head.height,
 					fork_point.hash(),
 					fork_point.height,
-					block.header.height.saturating_sub(fork_point.height + 1),
+					prev_head.height.saturating_sub(fork_point.height),
 				);
 			}
 			BlockStatus::Fork {
@@ -151,7 +151,7 @@ impl ChainEvents for EventLogger {
 					head.height,
 					fork_point.hash(),
 					fork_point.height,
-					block.header.height.saturating_sub(fork_point.height + 1),
+					head.height.saturating_sub(fork_point.height),
 				);
 			}
 			BlockStatus::Next { prev } => {
@@ -290,8 +290,13 @@ impl ChainEvents for WebHook {
 		};
 
 		// Add additional `depth` field to the JSON in case of reorg
-		let payload = if let BlockStatus::Reorg { fork_point, .. } = status {
-			let depth = block.header.height.saturating_sub(fork_point.height + 1);
+		let payload = if let BlockStatus::Reorg {
+			fork_point,
+			prev_head,
+			..
+		} = status
+		{
+			let depth = prev_head.height.saturating_sub(fork_point.height);
 			json!({
 				"hash": block.header.hash().to_hex(),
 				"status": status_str,


### PR DESCRIPTION
`next` logs - 
* `prev`

`fork` logs - 
* `prev`
* `head`
* `fork_point`
* `depth`

`reorg` logs - 
* `prev`
* `prev_head`
* `fork_point`
* `depth`

Related #3376 

These `block_accepted` logs are now self-sufficient and we can potentially parse them and build a full view of the chain and associated forks. Each block accepted logs the previous block and information about the chain head (and if it was updated due to reorg).

