### PR TITLE
P2P replace DNS panic with map_err

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -181,9 +181,9 @@ impl<'de> Visitor<'de> for PeerAddrs {
 				Ok(ip) => peers.push(PeerAddr(ip)),
 				// If that fails it's probably a DNS record
 				Err(_) => {
-					let socket_addrs = entry
-						.to_socket_addrs()
-						.unwrap_or_else(|_| panic!("Unable to resolve DNS: {}", entry));
+					let socket_addrs = entry.to_socket_addrs().map_err(|_| {
+						serde::de::Error::custom(format!("Unable to resolve DNS: {}", entry))
+					})?;
 					peers.append(&mut socket_addrs.map(PeerAddr).collect());
 				}
 			}


### PR DESCRIPTION
Replace panic on DNS resolution error with map_err to bubble up error to the caller.

Results in more descriptive error message to the user, node still crashes for non-IPv4/6 `PeerAddrs` local config entries.

Closes #3382 

