### PR TITLE
more robust handling of min_height and max_height in get_kernel_height()

### DIFF
--- a/chain/tests/test_get_kernel_height.rs
+++ b/chain/tests/test_get_kernel_height.rs
@@ -1,0 +1,149 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use grin_util as util;
+
+mod chain_test_helper;
+
+use self::chain_test_helper::{clean_output_dir, mine_chain};
+
+#[test]
+fn test_get_kernel_height() {
+	let chain_dir = ".grin.get_kernel_height";
+	clean_output_dir(chain_dir);
+	let chain = mine_chain(chain_dir, 5);
+	assert_eq!(chain.head().unwrap().height, 4);
+
+	// check we can safely look for non-existent kernel with min_height=None, max_height=None
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				None,
+				None,
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=1, max_height=1
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(1),
+				Some(1),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=1, max_height=100
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(1),
+				Some(100),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=100, max_height=100
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(100),
+				Some(100),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=0, max_height=1
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(0),
+				Some(1),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=0, max_height=100
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(0),
+				Some(100),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=0, max_height=None
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(0),
+				None,
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=100, max_height=None
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(100),
+				None,
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=2, max_height=1
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(2),
+				Some(1),
+			)
+			.unwrap()
+	);
+
+	// check we can safely look for non-existent kernel with min_height=100, max_height=99
+	assert_eq!(
+		None,
+		chain
+			.get_kernel_height(
+				&util::secp::pedersen::Commitment::from_vec(vec![]),
+				Some(100),
+				Some(99),
+			)
+			.unwrap()
+	);
+
+	clean_output_dir(chain_dir);
+}

--- a/chain/tests/test_get_kernel_height.rs
+++ b/chain/tests/test_get_kernel_height.rs
@@ -17,6 +17,7 @@ use grin_util as util;
 mod chain_test_helper;
 
 use self::chain_test_helper::{clean_output_dir, mine_chain};
+use util::secp::pedersen::Commitment;
 
 #[test]
 fn test_get_kernel_height() {
@@ -29,11 +30,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				None,
-				None,
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), None, None)
 			.unwrap()
 	);
 
@@ -41,11 +38,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(1),
-				Some(1),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(1), Some(1))
 			.unwrap()
 	);
 
@@ -53,11 +46,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(1),
-				Some(100),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(1), Some(100))
 			.unwrap()
 	);
 
@@ -65,11 +54,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(100),
-				Some(100),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(100), Some(100))
 			.unwrap()
 	);
 
@@ -77,11 +62,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(0),
-				Some(1),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(0), Some(1))
 			.unwrap()
 	);
 
@@ -89,11 +70,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(0),
-				Some(100),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(0), Some(100))
 			.unwrap()
 	);
 
@@ -101,11 +78,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(0),
-				None,
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(0), None)
 			.unwrap()
 	);
 
@@ -113,11 +86,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(100),
-				None,
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(100), None)
 			.unwrap()
 	);
 
@@ -125,11 +94,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(2),
-				Some(1),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(2), Some(1))
 			.unwrap()
 	);
 
@@ -137,11 +102,7 @@ fn test_get_kernel_height() {
 	assert_eq!(
 		None,
 		chain
-			.get_kernel_height(
-				&util::secp::pedersen::Commitment::from_vec(vec![]),
-				Some(100),
-				Some(99),
-			)
+			.get_kernel_height(&Commitment::from_vec(vec![]), Some(100), Some(99))
 			.unwrap()
 	);
 


### PR DESCRIPTION
Resolves #3386.

The backtrace in the issue was a little misleading. 
It was not a problem with getting missing outouts, but `get_kernel_height()` not liking `min_height=0` being passed in.

* Better handling of min_height/max_height in get_kernel_height()
* Test coverage of various edge cases when looking for non-existent kernels

TBD - which versions need tagging and releasing?

* Needs porting to `4.x.x` branch.
* From the issue it looks like we may need to backport this to `3.x.x` branch also.

----

TODO - 

- [x] We should confirm this indeed fixes the issue.

