### PR TITLE
Include height for spent outputs in get_outputs api

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -497,12 +497,9 @@ impl Chain {
 		}
 	}
 
-	/// TODO - where do we call this from? And do we need a rewind first?
-	/// For the given commitment find the unspent output and return the
-	/// associated Return an error if the output does not exist or has been
-	/// spent. This querying is done in a way that is consistent with the
-	/// current chain state, specifically the current winning (valid, most
-	/// work) fork.
+	/// Returns Ok(Some(pos)) if output is unspent.
+	/// Returns Ok(None) if output is spent.
+	/// Returns Err if something went wrong beyond not finding the output.
 	pub fn get_unspent(&self, output_ref: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
 		self.txhashset.read().get_unspent(output_ref)
 	}


### PR DESCRIPTION
`get_outputs` api returns both spent and unspent outputs. 
These are retrieved from full blocks so we know the block height for all of these.

This PR ensures spent outputs have their block_height included in the api response.

Resolves #3399.

----

Block height included in all outputs, both spent and unspent - 

```
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "Ok": [
      {
        "block_height": 793277,
        "commit": "09740105055d127b6d899681ba61bfd538b6364028f044f7a1af144fc5ee78da9f",
        "merkle_proof": null,
        "mmr_index": 0,
        "output_type": "Transaction",
        "proof": null,
        "proof_hash": "6360c4fc371aa1eda21446692ab2eda1408705a47fa90117412afe70b621df0e",
        "spent": true
      },
      {
        "block_height": 793277,
        "commit": "0970e4fd62b2a84ed618955e4608da137aee1c99472db61509c3f31bb41dc5ea28",
        "merkle_proof": null,
        "mmr_index": 7851400,
        "output_type": "Coinbase",
        "proof": null,
        "proof_hash": "9490768ffb58bf1fbdc1aab0c6797f2bad333696b59befb088a77d79a3c55a45",
        "spent": false
      },
      {
        "block_height": 793277,
        "commit": "09aa84daa93505ccd47199b1cd34e967b76577f1654246207e3b1e5bd4846ea3b3",
        "merkle_proof": null,
        "mmr_index": 0,
        "output_type": "Transaction",
        "proof": null,
        "proof_hash": "6ef952d5d96390a7abf856dd5f5963f45d1c9af89a0765663c445b9d60c2a88b",
        "spent": true
      },
      {
        "block_height": 793277,
        "commit": "08147203b217e7b0d01857d83ec50cdaa72f572d273ccd743e12c6f4a51f439dee",
        "merkle_proof": null,
        "mmr_index": 7851404,
        "output_type": "Transaction",
        "proof": null,
        "proof_hash": "371d201ac886ea9e5c8e7e17e14b0fce2229e37c7b363a930eb9ab76e1e499a5",
        "spent": false
      }
    ]
  }
}
```
