### PR TITLE
pass ref to chain around

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -133,14 +133,14 @@ impl BlockHandler {
 	) -> Result<BlockPrintable, Error> {
 		let chain = w(&self.chain)?;
 		let block = chain.get_block(h).context(ErrorKind::NotFound)?;
-		BlockPrintable::from_block(&block, chain, include_proof, include_merkle_proof)
+		BlockPrintable::from_block(&block, &chain, include_proof, include_merkle_proof)
 			.map_err(|_| ErrorKind::Internal("chain error".to_owned()).into())
 	}
 
 	fn get_compact_block(&self, h: &Hash) -> Result<CompactBlockPrintable, Error> {
 		let chain = w(&self.chain)?;
 		let block = chain.get_block(h).context(ErrorKind::NotFound)?;
-		CompactBlockPrintable::from_compact_block(&block.into(), chain)
+		CompactBlockPrintable::from_compact_block(&block.into(), &chain)
 			.map_err(|_| ErrorKind::Internal("chain error".to_owned()).into())
 	}
 

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -189,7 +189,7 @@ impl OutputHandler {
 				.map(|x| {
 					OutputPrintable::from_output(
 						x,
-						chain.clone(),
+						&chain,
 						None,
 						include_proof.unwrap_or(false),
 						false,
@@ -248,13 +248,7 @@ impl OutputHandler {
 			.iter()
 			.filter(|output| commitments.is_empty() || commitments.contains(&output.commit))
 			.map(|output| {
-				OutputPrintable::from_output(
-					output,
-					chain.clone(),
-					Some(&header),
-					include_proof,
-					true,
-				)
+				OutputPrintable::from_output(output, &chain, Some(&header), include_proof, true)
 			})
 			.collect::<Result<Vec<_>, _>>()
 			.context(ErrorKind::Internal("cain error".to_owned()))?;
@@ -289,7 +283,7 @@ impl OutputHandler {
 			.map(|output| {
 				OutputPrintable::from_output(
 					output,
-					chain.clone(),
+					&chain,
 					Some(&header),
 					include_rproof,
 					include_merkle_proof,

--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -47,7 +47,8 @@ pub struct TxHashSetHandler {
 impl TxHashSetHandler {
 	// gets roots
 	fn get_roots(&self) -> Result<TxHashSet, Error> {
-		let res = TxHashSet::from_head(w(&self.chain)?).context(ErrorKind::Internal(
+		let chain = w(&self.chain)?;
+		let res = TxHashSet::from_head(&chain).context(ErrorKind::Internal(
 			"failed to read roots from txhashset".to_owned(),
 		))?;
 		Ok(res)
@@ -55,20 +56,20 @@ impl TxHashSetHandler {
 
 	// gets last n outputs inserted in to the tree
 	fn get_last_n_output(&self, distance: u64) -> Result<Vec<TxHashSetNode>, Error> {
-		Ok(TxHashSetNode::get_last_n_output(w(&self.chain)?, distance))
+		let chain = w(&self.chain)?;
+		Ok(TxHashSetNode::get_last_n_output(&chain, distance))
 	}
 
 	// gets last n rangeproofs inserted in to the tree
 	fn get_last_n_rangeproof(&self, distance: u64) -> Result<Vec<TxHashSetNode>, Error> {
-		Ok(TxHashSetNode::get_last_n_rangeproof(
-			w(&self.chain)?,
-			distance,
-		))
+		let chain = w(&self.chain)?;
+		Ok(TxHashSetNode::get_last_n_rangeproof(&chain, distance))
 	}
 
 	// gets last n kernels inserted in to the tree
 	fn get_last_n_kernel(&self, distance: u64) -> Result<Vec<TxHashSetNode>, Error> {
-		Ok(TxHashSetNode::get_last_n_kernel(w(&self.chain)?, distance))
+		let chain = w(&self.chain)?;
+		Ok(TxHashSetNode::get_last_n_kernel(&chain, distance))
 	}
 
 	// allows traversal of utxo set
@@ -92,7 +93,7 @@ impl TxHashSetHandler {
 			outputs: outputs
 				.2
 				.iter()
-				.map(|x| OutputPrintable::from_output(x, chain.clone(), None, true, true))
+				.map(|x| OutputPrintable::from_output(x, &chain, None, true, true))
 				.collect::<Result<Vec<_>, _>>()
 				.context(ErrorKind::Internal("chain error".to_owned()))?,
 		};

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -94,7 +94,7 @@ pub fn get_output_v2(
 
 	let output_printable = OutputPrintable::from_output(
 		&output,
-		chain,
+		&chain,
 		header.as_ref(),
 		include_proof,
 		include_merkle_proof,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use crate::chain;
 use crate::core::core::hash::Hashed;
 use crate::core::core::merkle_proof::MerkleProof;
@@ -119,7 +117,7 @@ impl TxHashSet {
 	/// A TxHashSet in the context of the api is simply the collection of PMMR roots.
 	/// We can obtain these in a lightweight way by reading them from the head of the chain.
 	/// We will have validated the roots on this header against the roots of the txhashset.
-	pub fn from_head(chain: Arc<chain::Chain>) -> Result<TxHashSet, chain::Error> {
+	pub fn from_head(chain: &chain::Chain) -> Result<TxHashSet, chain::Error> {
 		let header = chain.head_header()?;
 		Ok(TxHashSet {
 			output_root_hash: header.output_root.to_hex(),
@@ -138,7 +136,7 @@ pub struct TxHashSetNode {
 }
 
 impl TxHashSetNode {
-	pub fn get_last_n_output(chain: Arc<chain::Chain>, distance: u64) -> Vec<TxHashSetNode> {
+	pub fn get_last_n_output(chain: &chain::Chain, distance: u64) -> Vec<TxHashSetNode> {
 		let mut return_vec = Vec::new();
 		let last_n = chain.get_last_n_output(distance);
 		for x in last_n {
@@ -147,9 +145,9 @@ impl TxHashSetNode {
 		return_vec
 	}
 
-	pub fn get_last_n_rangeproof(head: Arc<chain::Chain>, distance: u64) -> Vec<TxHashSetNode> {
+	pub fn get_last_n_rangeproof(chain: &chain::Chain, distance: u64) -> Vec<TxHashSetNode> {
 		let mut return_vec = Vec::new();
-		let last_n = head.get_last_n_rangeproof(distance);
+		let last_n = chain.get_last_n_rangeproof(distance);
 		for elem in last_n {
 			return_vec.push(TxHashSetNode {
 				hash: elem.0.to_hex(),
@@ -158,9 +156,9 @@ impl TxHashSetNode {
 		return_vec
 	}
 
-	pub fn get_last_n_kernel(head: Arc<chain::Chain>, distance: u64) -> Vec<TxHashSetNode> {
+	pub fn get_last_n_kernel(chain: &chain::Chain, distance: u64) -> Vec<TxHashSetNode> {
 		let mut return_vec = Vec::new();
-		let last_n = head.get_last_n_kernel(distance);
+		let last_n = chain.get_last_n_kernel(distance);
 		for elem in last_n {
 			return_vec.push(TxHashSetNode {
 				hash: elem.0.to_hex(),
@@ -281,7 +279,7 @@ pub struct OutputPrintable {
 impl OutputPrintable {
 	pub fn from_output(
 		output: &core::Output,
-		chain: Arc<chain::Chain>,
+		chain: &chain::Chain,
 		block_header: Option<&core::BlockHeader>,
 		include_proof: bool,
 		include_merkle_proof: bool,
@@ -623,7 +621,7 @@ pub struct BlockPrintable {
 impl BlockPrintable {
 	pub fn from_block(
 		block: &core::Block,
-		chain: Arc<chain::Chain>,
+		chain: &chain::Chain,
 		include_proof: bool,
 		include_merkle_proof: bool,
 	) -> Result<BlockPrintable, chain::Error> {
@@ -677,15 +675,13 @@ impl CompactBlockPrintable {
 	/// api response
 	pub fn from_compact_block(
 		cb: &core::CompactBlock,
-		chain: Arc<chain::Chain>,
+		chain: &chain::Chain,
 	) -> Result<CompactBlockPrintable, chain::Error> {
 		let block = chain.get_block(&cb.hash())?;
 		let out_full = cb
 			.out_full()
 			.iter()
-			.map(|x| {
-				OutputPrintable::from_output(x, chain.clone(), Some(&block.header), false, true)
-			})
+			.map(|x| OutputPrintable::from_output(x, chain, Some(&block.header), false, true))
 			.collect::<Result<Vec<_>, _>>()?;
 		let kern_full = cb
 			.kern_full()
@@ -743,8 +739,7 @@ mod test {
 
 	#[test]
 	fn serialize_output_printable() {
-		let hex_output =
-			"{\
+		let hex_output = "{\
 			 \"output_type\":\"Coinbase\",\
 			 \"commit\":\"083eafae5d61a85ab07b12e1a51b3918d8e6de11fc6cde641d54af53608aa77b9f\",\
 			 \"spent\":false,\
@@ -761,8 +756,7 @@ mod test {
 
 	#[test]
 	fn serialize_output() {
-		let hex_commit =
-			"{\
+		let hex_commit = "{\
 			 \"commit\":\"083eafae5d61a85ab07b12e1a51b3918d8e6de11fc6cde641d54af53608aa77b9f\",\
 			 \"height\":0,\
 			 \"mmr_index\":0\


### PR DESCRIPTION
Cleanup related to #3400. 
We were doing a lot of passing a cloned `Arc<chain::Chain>` around when we can simply be passing `&chain::Chain`.

