### PR TITLE
cleanup inputs_mut, outputs_mut, kernels_mut fns

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -467,7 +467,7 @@ pub struct Block {
 	/// The header with metadata and commitments to the rest of the data
 	pub header: BlockHeader,
 	/// The body - inputs/outputs/kernels
-	body: TransactionBody,
+	pub body: TransactionBody,
 }
 
 impl Hashed for Block {
@@ -666,29 +666,14 @@ impl Block {
 		&self.body.inputs
 	}
 
-	/// Get inputs mutable
-	pub fn inputs_mut(&mut self) -> &mut [Input] {
-		&mut self.body.inputs
-	}
-
 	/// Get outputs
 	pub fn outputs(&self) -> &[Output] {
 		&self.body.outputs
 	}
 
-	/// Get outputs mutable
-	pub fn outputs_mut(&mut self) -> &mut [Output] {
-		&mut self.body.outputs
-	}
-
 	/// Get kernels
 	pub fn kernels(&self) -> &[TxKernel] {
 		&self.body.kernels
-	}
-
-	/// Get kernels mut
-	pub fn kernels_mut(&mut self) -> &mut [TxKernel] {
-		&mut self.body.kernels
 	}
 
 	/// Sum of all fees (inputs less outputs) in the block

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1199,29 +1199,14 @@ impl Transaction {
 		&self.body.inputs
 	}
 
-	/// Get inputs mutable
-	pub fn inputs_mut(&mut self) -> &mut [Input] {
-		&mut self.body.inputs
-	}
-
 	/// Get outputs
 	pub fn outputs(&self) -> &[Output] {
 		&self.body.outputs
 	}
 
-	/// Get outputs mutable
-	pub fn outputs_mut(&mut self) -> &mut [Output] {
-		&mut self.body.outputs
-	}
-
 	/// Get kernels
 	pub fn kernels(&self) -> &[TxKernel] {
 		&self.body.kernels
-	}
-
-	/// Get kernels mut
-	pub fn kernels_mut(&mut self) -> &mut [TxKernel] {
-		&mut self.body.kernels
 	}
 
 	/// Total fee for a transaction is the sum of fees of all kernels.

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -345,8 +345,9 @@ fn remove_coinbase_output_flag() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(&[], &keychain, &builder, &prev, &key_id);
 
-	assert!(b.outputs()[0].is_coinbase());
-	b.outputs_mut()[0].features = OutputFeatures::Plain;
+	let mut output = b.outputs()[0].clone();
+	output.features = OutputFeatures::Plain;
+	b.body.outputs = vec![output];
 
 	assert_eq!(b.verify_coinbase(), Err(Error::CoinbaseSumMismatch));
 	assert!(b
@@ -369,8 +370,9 @@ fn remove_coinbase_kernel_flag() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(&[], &keychain, &builder, &prev, &key_id);
 
-	assert!(b.kernels()[0].is_coinbase());
-	b.kernels_mut()[0].features = KernelFeatures::Plain { fee: 0 };
+	let mut kernel = b.kernels()[0].clone();
+	kernel.features = KernelFeatures::Plain { fee: 0 };
+	b.body = b.body.replace_kernel(kernel);
 
 	// Flipping the coinbase flag results in kernels not summing correctly.
 	assert_eq!(


### PR DESCRIPTION
Refactor related to #3385.

We do not need `inputs_mut()`, `outputs_mut()`, `kernels_mut()` on `Transactions` and `Block`.
The only place we modify these in place is in some tests (and these can likely be cleaned up further).