### PR TITLE
Introduce Inputs enum variants for future commit only support

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -629,11 +629,8 @@ impl BlockPrintable {
 		include_proof: bool,
 		include_merkle_proof: bool,
 	) -> Result<BlockPrintable, chain::Error> {
-		let inputs = block
-			.inputs()
-			.iter()
-			.map(|x| x.commitment().to_hex())
-			.collect();
+		let inputs: Vec<_> = block.inputs().into();
+		let inputs = inputs.iter().map(|x| x.commitment().to_hex()).collect();
 		let outputs = block
 			.outputs()
 			.iter()

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1052,7 +1052,8 @@ impl<'a> Extension<'a> {
 		// Add spent_pos to affected_pos to update the accumulator later on.
 		// Remove the spent output from the output_pos index.
 		let mut spent = vec![];
-		for input in b.inputs() {
+		let inputs: Vec<_> = b.inputs().into();
+		for input in &inputs {
 			let pos = self.apply_input(input, batch)?;
 			affected_pos.push(pos.pos);
 			batch.delete_output_pos_height(&input.commitment())?;
@@ -1331,7 +1332,8 @@ impl<'a> Extension<'a> {
 		// reused output commitment. For example an output at pos 1, spent, reused at pos 2.
 		// The output_pos index should be updated to reflect the old pos 1 when unspent.
 		if let Ok(spent) = spent {
-			for (x, y) in block.inputs().iter().zip(spent) {
+			let inputs: Vec<_> = block.inputs().into();
+			for (x, y) in inputs.iter().zip(spent) {
 				batch.save_output_pos_height(&x.commitment(), y.pos, y.height)?;
 			}
 		}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -16,7 +16,7 @@
 
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::pmmr::{self, ReadonlyPMMR};
-use crate::core::core::{Block, BlockHeader, Input, Output, OutputIdentifier, Transaction};
+use crate::core::core::{Block, BlockHeader, Input, Inputs, Output, OutputIdentifier, Transaction};
 use crate::core::global;
 use crate::error::{Error, ErrorKind};
 use crate::store::Batch;
@@ -52,7 +52,8 @@ impl<'a> UTXOView<'a> {
 			self.validate_output(output, batch)?;
 		}
 
-		for input in block.inputs() {
+		let inputs: Vec<_> = block.inputs().into();
+		for input in &inputs {
 			self.validate_input(input, batch)?;
 		}
 		Ok(())
@@ -66,7 +67,8 @@ impl<'a> UTXOView<'a> {
 			self.validate_output(output, batch)?;
 		}
 
-		for input in tx.inputs() {
+		let inputs: Vec<_> = tx.inputs().into();
+		for input in &inputs {
 			self.validate_input(input, batch)?;
 		}
 		Ok(())
@@ -113,12 +115,13 @@ impl<'a> UTXOView<'a> {
 	/// that have not sufficiently matured.
 	pub fn verify_coinbase_maturity(
 		&self,
-		inputs: &[Input],
+		inputs: &Inputs,
 		height: u64,
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {
 		// Find the greatest output pos of any coinbase
 		// outputs we are attempting to spend.
+		let inputs: Vec<_> = inputs.into();
 		let pos = inputs
 			.iter()
 			.filter(|x| x.is_coinbase())

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -676,15 +676,14 @@ fn same_amount_outputs_copy_range_proof() {
 
 	// now we reconstruct the transaction, swapping the rangeproofs so they
 	// have the wrong privkey
-	let ins = tx.inputs();
+	let ins: Vec<_> = tx.inputs().into();
 	let mut outs = tx.outputs().to_vec();
-	let kernels = tx.kernels();
 	outs[0].proof = outs[1].proof;
 
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		&[Transaction::new(ins, &outs, kernels)],
+		&[Transaction::new(&ins, &outs, tx.kernels())],
 		&keychain,
 		&builder,
 		&prev,
@@ -729,16 +728,15 @@ fn wrong_amount_range_proof() {
 	.unwrap();
 
 	// we take the range proofs from tx2 into tx1 and rebuild the transaction
-	let ins = tx1.inputs();
+	let ins: Vec<_> = tx1.inputs().into();
 	let mut outs = tx1.outputs().to_vec();
-	let kernels = tx1.kernels();
 	outs[0].proof = tx2.outputs()[0].proof;
 	outs[1].proof = tx2.outputs()[1].proof;
 
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		&[Transaction::new(ins, &outs, kernels)],
+		&[Transaction::new(&ins, &outs, tx1.kernels())],
 		&keychain,
 		&builder,
 		&prev,

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -557,9 +557,7 @@ fn reward_empty_block() {
 
 	let b = new_block(&[], &keychain, &builder, &previous_header, &key_id);
 
-	b.cut_through()
-		.unwrap()
-		.validate(&BlindingFactor::zero(), verifier_cache())
+	b.validate(&BlindingFactor::zero(), verifier_cache())
 		.unwrap();
 }
 
@@ -578,11 +576,7 @@ fn reward_with_tx_block() {
 	let previous_header = BlockHeader::default();
 
 	let block = new_block(&[tx1], &keychain, &builder, &previous_header, &key_id);
-	block
-		.cut_through()
-		.unwrap()
-		.validate(&BlindingFactor::zero(), vc.clone())
-		.unwrap();
+	block.validate(&BlindingFactor::zero(), vc.clone()).unwrap();
 }
 
 #[test]

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -354,7 +354,8 @@ where
 			let mut insert_pos = None;
 			let mut is_rejected = false;
 
-			for input in entry.tx.inputs() {
+			let tx_inputs: Vec<_> = entry.tx.inputs().into();
+			for input in tx_inputs {
 				if rejected.contains(&input.commitment()) {
 					// Depends on a rejected tx, so reject this one.
 					is_rejected = true;
@@ -464,9 +465,11 @@ where
 		// Reject any txs where we see a matching tx kernel in the block.
 		// Also reject any txs where we see a conflicting tx,
 		// where an input is spent in a different tx.
+		let block_inputs: Vec<_> = block.inputs().into();
 		self.entries.retain(|x| {
+			let tx_inputs: Vec<_> = x.tx.inputs().into();
 			!x.tx.kernels().iter().any(|y| block.kernels().contains(y))
-				&& !x.tx.inputs().iter().any(|y| block.inputs().contains(y))
+				&& !tx_inputs.iter().any(|y| block_inputs.contains(y))
 		});
 	}
 


### PR DESCRIPTION
Refactoring extracted from #3385.

* Introduced `Inputs` wrapper for a `Vec<Input>` in preparation for a future simplified `Vec<Commitment>`
* Cleaned up `Block::hydrate_from()` taking advantage of `Inputs` and passing slices around
* `cut_through()` checks explicitly for duplicates internally to keep the logic together
* `impl PartialEq<Output> for Input` so we can compare inputs/outputs directly (input spends an output)
* cleanup errors in `cut_through()`, return `Error::CutThrough`, was `Error::AggregationError` for duplicates

