### PR TITLE
refactor apply_inputs and support converting block for v2 compatibility

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -685,7 +685,7 @@ impl Chain {
 				let prev_root = header_extension.root()?;
 
 				// Apply the latest block to the chain state via the extension.
-				extension.apply_block(b, batch)?;
+				extension.apply_block(b, header_extension, batch)?;
 
 				Ok((prev_root, extension.roots()?, extension.sizes()))
 			})?;
@@ -1644,7 +1644,8 @@ fn setup_head(
 				};
 			}
 			txhashset::extending(header_pmmr, txhashset, &mut batch, |ext, batch| {
-				ext.extension.apply_block(&genesis, batch)
+				ext.extension
+					.apply_block(&genesis, ext.header_extension, batch)
 			})?;
 
 			// Save the block_sums to the db for use later.

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -295,10 +295,9 @@ impl Chain {
 			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
 				let previous_header = batch.get_previous_header(&block.header)?;
 				pipe::rewind_and_apply_fork(&previous_header, ext, batch)?;
-				let inputs: Vec<_> = block.inputs().into();
 				ext.extension
 					.utxo_view(ext.header_extension)
-					.validate_inputs(&inputs, batch)
+					.validate_inputs(block.inputs(), batch)
 			})?;
 		let outputs: Vec<_> = outputs.into_iter().map(|(out, _)| out).collect();
 		Ok(Block {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -18,12 +18,12 @@ use crate::core::consensus;
 use crate::core::core::hash::Hashed;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::Committed;
-use crate::core::core::{Block, BlockHeader, BlockSums};
+use crate::core::core::{Block, BlockHeader, BlockSums, OutputIdentifier};
 use crate::core::pow;
 use crate::error::{Error, ErrorKind};
 use crate::store;
 use crate::txhashset;
-use crate::types::{Options, Tip};
+use crate::types::{CommitPos, Options, Tip};
 use crate::util::RwLock;
 use grin_store;
 use std::sync::Arc;
@@ -600,11 +600,12 @@ pub fn rewind_and_apply_fork(
 	Ok(fork_point)
 }
 
-fn validate_utxo(
+/// Validate block inputs against utxo.
+pub fn validate_utxo(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
-) -> Result<(), Error> {
+) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
 	let extension = &ext.extension;
 	let header_extension = &ext.header_extension;
 	extension

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -589,7 +589,7 @@ pub fn rewind_and_apply_fork(
 }
 
 /// Validate block inputs against utxo.
-pub fn validate_utxo(
+fn validate_utxo(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -442,7 +442,8 @@ fn apply_block_to_txhashset(
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
 ) -> Result<(), Error> {
-	ext.extension.apply_block(block, batch)?;
+	ext.extension
+		.apply_block(block, ext.header_extension, batch)?;
 	ext.extension.validate_roots(&block.header)?;
 	ext.extension.validate_sizes(&block.header)?;
 	Ok(())

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -125,7 +125,7 @@ impl ChainStore {
 	/// Get PMMR pos for the given output commitment.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		match self.get_output_pos_height(commit)? {
-			Some((pos, _)) => Ok(pos),
+			Some(pos) => Ok(pos.pos),
 			None => Err(Error::NotFoundErr(format!(
 				"Output position for: {:?}",
 				commit
@@ -134,7 +134,7 @@ impl ChainStore {
 	}
 
 	/// Get PMMR pos and block height for the given output commitment.
-	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<(u64, u64)>, Error> {
+	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<CommitPos>, Error> {
 		self.db.get_ser(&to_key(OUTPUT_POS_PREFIX, commit))
 	}
 
@@ -258,14 +258,9 @@ impl<'a> Batch<'a> {
 	}
 
 	/// Save output_pos and block height to index.
-	pub fn save_output_pos_height(
-		&self,
-		commit: &Commitment,
-		pos: u64,
-		height: u64,
-	) -> Result<(), Error> {
+	pub fn save_output_pos_height(&self, commit: &Commitment, pos: CommitPos) -> Result<(), Error> {
 		self.db
-			.put_ser(&to_key(OUTPUT_POS_PREFIX, commit)[..], &(pos, height))
+			.put_ser(&to_key(OUTPUT_POS_PREFIX, commit)[..], &pos)
 	}
 
 	/// Delete the output_pos index entry for a spent output.
@@ -290,7 +285,7 @@ impl<'a> Batch<'a> {
 	/// Get output_pos from index.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		match self.get_output_pos_height(commit)? {
-			Some((pos, _)) => Ok(pos),
+			Some(pos) => Ok(pos.pos),
 			None => Err(Error::NotFoundErr(format!(
 				"Output position for: {:?}",
 				commit
@@ -299,7 +294,7 @@ impl<'a> Batch<'a> {
 	}
 
 	/// Get output_pos and block height from index.
-	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<(u64, u64)>, Error> {
+	pub fn get_output_pos_height(&self, commit: &Commitment) -> Result<Option<CommitPos>, Error> {
 		self.db.get_ser(&to_key(OUTPUT_POS_PREFIX, commit))
 	}
 

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -56,8 +56,7 @@ impl<'a> UTXOView<'a> {
 		for output in block.outputs() {
 			self.validate_output(output, batch)?;
 		}
-		let inputs: Vec<_> = block.inputs().into();
-		self.validate_inputs(&inputs, batch)
+		self.validate_inputs(block.inputs(), batch)
 	}
 
 	/// Validate a transaction against the current UTXO set.
@@ -71,23 +70,26 @@ impl<'a> UTXOView<'a> {
 		for output in tx.outputs() {
 			self.validate_output(output, batch)?;
 		}
-		let inputs: Vec<_> = tx.inputs().into();
-		self.validate_inputs(&inputs, batch)
+		self.validate_inputs(tx.inputs(), batch)
 	}
 
 	/// Validate the provided inputs.
-	/// Returns a vec of output identifier corresponding to outputs
+	/// Returns a vec of output identifiers corresponding to outputs
 	/// that would be spent by the provided inputs.
 	pub fn validate_inputs(
 		&self,
-		inputs: &[Input],
+		inputs: Inputs,
 		batch: &Batch<'_>,
 	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
-		let outputs_spent: Result<Vec<_>, Error> = inputs
-			.iter()
-			.map(|input| self.validate_input(input, batch))
-			.collect();
-		outputs_spent
+		match inputs {
+			Inputs::FeaturesAndCommit(inputs) => {
+				let outputs_spent: Result<Vec<_>, Error> = inputs
+					.iter()
+					.map(|input| self.validate_input(input, batch))
+					.collect();
+				outputs_spent
+			}
+		}
 	}
 
 	// Input is valid if it is spending an (unspent) output

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -57,11 +57,7 @@ impl<'a> UTXOView<'a> {
 			self.validate_output(output, batch)?;
 		}
 		let inputs: Vec<_> = block.inputs().into();
-		let outputs_spent: Result<Vec<_>, Error> = inputs
-			.iter()
-			.map(|input| self.validate_input(input, batch))
-			.collect();
-		outputs_spent
+		self.validate_inputs(&inputs, batch)
 	}
 
 	/// Validate a transaction against the current UTXO set.
@@ -76,6 +72,17 @@ impl<'a> UTXOView<'a> {
 			self.validate_output(output, batch)?;
 		}
 		let inputs: Vec<_> = tx.inputs().into();
+		self.validate_inputs(&inputs, batch)
+	}
+
+	/// Validate the provided inputs.
+	/// Returns a vec of output identifier corresponding to outputs
+	/// that would be spent by the provided inputs.
+	pub fn validate_inputs(
+		&self,
+		inputs: &[Input],
+		batch: &Batch<'_>,
+	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
 		let outputs_spent: Result<Vec<_>, Error> = inputs
 			.iter()
 			.map(|input| self.validate_input(input, batch))

--- a/chain/tests/test_block_known.rs
+++ b/chain/tests/test_block_known.rs
@@ -43,7 +43,7 @@ fn check_known() {
 		let res = chain.process_block(latest.clone(), chain::Options::NONE);
 		assert_eq!(
 			res.unwrap_err().kind(),
-			ErrorKind::Unfit("already known in head".to_string()).into()
+			ErrorKind::Unfit("duplicate block".to_string()).into()
 		);
 	}
 
@@ -53,7 +53,7 @@ fn check_known() {
 		let res = chain.process_block(genesis.clone(), chain::Options::NONE);
 		assert_eq!(
 			res.unwrap_err().kind(),
-			ErrorKind::Unfit("already known in store".to_string()).into()
+			ErrorKind::Unfit("duplicate block".to_string()).into()
 		);
 	}
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -804,6 +804,12 @@ impl TransactionBody {
 		self
 	}
 
+	/// Fully replace inputs.
+	pub fn replace_inputs(mut self, inputs: Inputs) -> TransactionBody {
+		self.inputs = inputs;
+		self
+	}
+
 	/// Builds a new TransactionBody with the provided output added. Existing
 	/// outputs, if any, are kept intact.
 	/// Sort order is maintained.
@@ -1588,6 +1594,19 @@ impl From<Vec<Input>> for Inputs {
 	}
 }
 
+impl From<Vec<OutputIdentifier>> for Inputs {
+	fn from(outputs: Vec<OutputIdentifier>) -> Self {
+		let inputs = outputs
+			.into_iter()
+			.map(|out| Input {
+				features: out.features,
+				commit: out.commit,
+			})
+			.collect();
+		Inputs::FeaturesAndCommit(inputs)
+	}
+}
+
 impl Default for Inputs {
 	fn default() -> Self {
 		Inputs::FeaturesAndCommit(vec![])
@@ -1609,6 +1628,11 @@ impl Inputs {
 		match self {
 			Inputs::FeaturesAndCommit(inputs) => inputs.len(),
 		}
+	}
+
+	/// Empty inputs?
+	pub fn is_empty(&self) -> bool {
+		self.len() == 0
 	}
 
 	/// Verify inputs are sorted and unique.


### PR DESCRIPTION
Refactor `apply_inputs()` and `validate_inputs()` to reduce duplicated code and simplify block conversion for future compatibility and v2 peer support.

Extracted some relatively isolated changes from #3385.

* `utxo_view` is now "source of truth" for identifying outputs being spent by inputs
* we now convert a block to v2 compatibility when processing new blocks
  * uses `utxo_view.validate_inputs()` to identify outputs being spent
* `apply_inputs()` now uses `utxo_view.validate_inputs()` internally
  * removed duplicate lookup code in `apply_inputs()`

We need to hook block conversion into the block processing pipeline early on, but _after_ orphan block identification. 
This required some refactoring of `chain.process_block_single()`.
Checking for orphan block is simplified with an explicit check for "previous block in db".

This is a relatively large PR but mainly refactoring with the addition of the "v2 block conversion" step (lookup features for each output being spent).

We have good test coverage of the block processing pipeline.
Testing this on mainnet also to ensure the node syncs and stays in sync.

