### PR TITLE
make cut_through more useful by returning both cut-through and non-cut-through elements

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -573,7 +573,7 @@ impl Block {
 		}
 
 		// apply cut-through to our tx inputs and outputs
-		let (inputs, outputs) = transaction::cut_through(&mut inputs, &mut outputs)?;
+		let (inputs, outputs, _, _) = transaction::cut_through(&mut inputs, &mut outputs)?;
 
 		let mut outputs = outputs.to_vec();
 		let mut kernels = kernels.to_vec();


### PR DESCRIPTION
Refactor `cut_through()` to return both cut-through and non-cut-through elements.

This makes `cut_through()` significantly more flexible as we can use it to identify not just the inputs/outputs that remain after applying cut-through but also the inputs/outputs what are cut-through in the process.

We can now use `cut-through()` to compare two transactions and identify the "overlap" between them. 
This corresponds to 0-confirmation output spends.
By extension we can compare a transaction to the current txpool and identify the same "overlap" of outputs _not yet_ in the utxo that would be spent (cut-through).

