### PR TITLE
Tx conversion for v2 compatibility

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -607,12 +607,29 @@ impl Chain {
 		})
 	}
 
-	fn validate_tx_against_utxo(&self, tx: &Transaction) -> Result<(), Error> {
+	fn validate_tx_against_utxo(
+		&self,
+		tx: &Transaction,
+	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, batch| {
-			utxo.validate_tx(tx, batch)?;
-			Ok(())
+			utxo.validate_tx(tx, batch)
+		})
+	}
+
+	/// Validates inputs against the current utxo.
+	/// Each input must spend an unspent output.
+	/// Returns the vec of output identifiers and their pos of the outputs
+	/// that would be spent by the inputs.
+	pub fn validate_inputs(
+		&self,
+		inputs: Inputs,
+	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
+		let header_pmmr = self.header_pmmr.read();
+		let txhashset = self.txhashset.read();
+		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, batch| {
+			utxo.validate_inputs(inputs, batch)
 		})
 	}
 

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -19,7 +19,9 @@ use self::chain::Chain;
 use self::core::consensus;
 use self::core::core::hash::Hash;
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
-use self::core::core::{Block, BlockHeader, BlockSums, KernelFeatures, Transaction, TxKernel};
+use self::core::core::{
+	Block, BlockHeader, BlockSums, Inputs, KernelFeatures, OutputIdentifier, Transaction, TxKernel,
+};
 use self::core::genesis;
 use self::core::global;
 use self::core::libtx::{build, reward, ProofBuilder};
@@ -132,6 +134,13 @@ impl BlockChain for ChainAdapter {
 			chain::ErrorKind::NRDRelativeHeight => PoolError::NRDKernelRelativeHeight,
 			_ => PoolError::Other("failed to validate tx".into()),
 		})
+	}
+
+	fn validate_inputs(&self, inputs: Inputs) -> Result<Vec<OutputIdentifier>, PoolError> {
+		self.chain
+			.validate_inputs(inputs)
+			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
+			.map_err(|_| PoolError::Other("failed to validate inputs".into()))
 	}
 
 	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), PoolError> {

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -150,7 +150,11 @@ fn test_the_transaction_pool() {
 	// Check we can take some entries from the stempool and "fluff" them into the
 	// txpool. This also exercises multi-kernel txs.
 	{
-		let agg_tx = pool.stempool.all_transactions_aggregate().unwrap().unwrap();
+		let agg_tx = pool
+			.stempool
+			.all_transactions_aggregate(None)
+			.unwrap()
+			.unwrap();
 		assert_eq!(agg_tx.kernels().len(), 2);
 		pool.add_to_pool(test_source(), agg_tx, false, &header)
 			.unwrap();
@@ -182,6 +186,7 @@ fn test_the_transaction_pool() {
 	// that is a superset of a tx already in the pool.
 	{
 		let tx4 = test_transaction(&keychain, vec![800], vec![799]);
+
 		// tx1 and tx2 are already in the txpool (in aggregated form)
 		// tx4 is the "new" part of this aggregated tx that we care about
 		let agg_tx = transaction::aggregate(&[tx1.clone(), tx2.clone(), tx4]).unwrap();

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -30,7 +30,7 @@ use crate::common::types::{ChainValidationMode, DandelionEpoch, ServerConfig};
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::transaction::Transaction;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::core::core::{BlockHeader, BlockSums, CompactBlock};
+use crate::core::core::{BlockHeader, BlockSums, CompactBlock, Inputs, OutputIdentifier};
 use crate::core::pow::Difficulty;
 use crate::core::{core, global};
 use crate::p2p;
@@ -935,6 +935,13 @@ impl pool::BlockChain for PoolToChainAdapter {
 	fn validate_tx(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
 		self.chain()
 			.validate_tx(tx)
+			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
+	}
+
+	fn validate_inputs(&self, inputs: Inputs) -> Result<Vec<OutputIdentifier>, pool::PoolError> {
+		self.chain()
+			.validate_inputs(inputs)
+			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
 			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
 	}
 

--- a/servers/src/grin/dandelion_monitor.rs
+++ b/servers/src/grin/dandelion_monitor.rs
@@ -131,7 +131,7 @@ fn process_fluff_phase(
 	let header = tx_pool.chain_head()?;
 
 	let fluffable_txs = {
-		let txpool_tx = tx_pool.txpool.all_transactions_aggregate()?;
+		let txpool_tx = tx_pool.txpool.all_transactions_aggregate(None)?;
 		let txs: Vec<_> = all_entries.into_iter().map(|x| x.tx).collect();
 		tx_pool.stempool.validate_raw_txs(
 			&txs,


### PR DESCRIPTION
Similar to converting blocks in #3409 this PR adds functionality to convert transactions.
We may receive (not yet implemented) transactons with "commit only" inputs, but we still need to support relaying this transactions to v2 peers that expect "features and commit" inputs.
This PR looks up outputs "to be spent" via both the stempool/txpool and current utxo to find the corresponding output features.
We leverage the improved cut_through functionality from #3410 in the lookup implementation.
We also take advantage of #3411 to allow cut_through on output identifiers rather than full outputs.

All transactions and blocks are now handled in v2 compatible mode internally.
This ensures we can subsequently relay or broadcast to v2 peers correctly without additional conversion or lookup.

Note: There is _no_ v3 transactions or blocks yet. So the conversion is simply v2 -> v2 in all cases.
But we are exercising the conversion code on all blocks and transactions.

The actual v3 support will come in a subsequent PR.

