### PR TITLE
orphan check needs to handle fast sync "edge case"

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -342,8 +342,12 @@ impl Chain {
 
 	// Check if the provided block is an orphan.
 	// If block is an orphan add it to our orphan block pool for deferred processing.
+	// If this is the "next" block immediately following current head then not an orphan.
+	// Or if we have the previous full block then not an orphan.
 	fn check_orphan(&self, block: &Block, opts: Options) -> Result<(), Error> {
-		if self.block_exists(block.header.prev_hash)? {
+		let head = self.head()?;
+		let is_next = block.header.prev_hash == head.last_block_h;
+		if is_next || self.block_exists(block.header.prev_hash)? {
 			return Ok(());
 		}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -103,9 +103,8 @@ pub fn process_block(
 	// want to do this now and not later during header validation.
 	validate_pow_only(&b.header, ctx)?;
 
-	// Get previous header from the db and check we have the corresponding full block.
+	// Get previous header from the db.
 	let prev = prev_header_store(&b.header, &mut ctx.batch)?;
-	ctx.batch.block_exists(&prev.hash())?;
 
 	// Process the header for the block.
 	// Note: We still want to process the full block if we have seen this header before


### PR DESCRIPTION
Resolves #3417

We moved the "is_orphan" check earlier in the block processing pipeline.
As part of this refactoring we made an incorrect assumption about always having the previous block.
This check needs to handle the "edge case" during initial fast sync where we have no previous full block and only have the txhashset state at the horizon.

This is not the first time we have unintentionally broken block sync in this way and is unlikely to be the last.
We _always_ have the previous full block _except_ during fast sync > 1 week.

