### PR TITLE
Introduce CommitOnly variant of Inputs

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -275,9 +275,10 @@ impl Chain {
 	/// Validating the inputs against the utxo_view allows us to look the outputs up.
 	pub fn convert_block_v2(&self, block: Block) -> Result<Block, Error> {
 		debug!(
-			"convert_block_v2: {} at {}",
+			"convert_block_v2: {} at {} ({})",
 			block.header.hash(),
-			block.header.height
+			block.header.height,
+			block.inputs().version_str(),
 		);
 
 		if block.inputs().is_empty() {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -296,7 +296,7 @@ impl Chain {
 				pipe::rewind_and_apply_fork(&previous_header, ext, batch)?;
 				ext.extension
 					.utxo_view(ext.header_extension)
-					.validate_inputs(block.inputs(), batch)
+					.validate_inputs(&block.inputs(), batch)
 					.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect())
 			})?;
 		let inputs = inputs.as_slice().into();
@@ -647,7 +647,7 @@ impl Chain {
 	/// that would be spent by the inputs.
 	pub fn validate_inputs(
 		&self,
-		inputs: Inputs,
+		inputs: &Inputs,
 	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
@@ -663,7 +663,7 @@ impl Chain {
 
 	/// Verify we are not attempting to spend a coinbase output
 	/// that has not yet sufficiently matured.
-	pub fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), Error> {
+	pub fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), Error> {
 		let height = self.next_block_height()?;
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -663,12 +663,12 @@ impl Chain {
 
 	/// Verify we are not attempting to spend a coinbase output
 	/// that has not yet sufficiently matured.
-	pub fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), Error> {
+	pub fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), Error> {
 		let height = self.next_block_height()?;
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, batch| {
-			utxo.verify_coinbase_maturity(&tx.inputs(), height, batch)?;
+			utxo.verify_coinbase_maturity(inputs, height, batch)?;
 			Ok(())
 		})
 	}

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -84,12 +84,13 @@ pub fn process_block(
 	ctx: &mut BlockContext<'_>,
 ) -> Result<(Option<Tip>, BlockHeader), Error> {
 	debug!(
-		"pipe: process_block {} at {} [in/out/kern: {}/{}/{}]",
+		"pipe: process_block {} at {} [in/out/kern: {}/{}/{}] ({})",
 		b.hash(),
 		b.header.height,
 		b.inputs().len(),
 		b.outputs().len(),
 		b.kernels().len(),
+		b.inputs().version_str(),
 	);
 
 	// Read current chain head from db via the batch.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -424,7 +424,7 @@ fn verify_coinbase_maturity(
 	let header_extension = &ext.header_extension;
 	extension
 		.utxo_view(header_extension)
-		.verify_coinbase_maturity(block.inputs(), block.header.height, batch)
+		.verify_coinbase_maturity(&block.inputs(), block.header.height, batch)
 }
 
 /// Verify kernel sums across the full utxo and kernel sets based on block_sums

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -424,7 +424,7 @@ fn verify_coinbase_maturity(
 	let header_extension = &ext.header_extension;
 	extension
 		.utxo_view(header_extension)
-		.verify_coinbase_maturity(&block.inputs(), block.header.height, batch)
+		.verify_coinbase_maturity(block.inputs(), block.header.height, batch)
 }
 
 /// Verify kernel sums across the full utxo and kernel sets based on block_sums

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -206,6 +206,13 @@ impl<'a> Batch<'a> {
 	/// Save the block to the db.
 	/// Note: the block header is not saved to the db here, assumes this has already been done.
 	pub fn save_block(&self, b: &Block) -> Result<(), Error> {
+		debug!(
+			"save_block: {} at {} ({} -> v{})",
+			b.header.hash(),
+			b.header.height,
+			b.inputs().version_str(),
+			self.db.protocol_version(),
+		);
 		self.db.put_ser(&to_key(BLOCK_PREFIX, b.hash())[..], b)?;
 		Ok(())
 	}
@@ -222,7 +229,7 @@ impl<'a> Batch<'a> {
 	/// Block may have been read using a previous protocol version but we do not actually care.
 	pub fn migrate_block(&self, b: &Block, version: ProtocolVersion) -> Result<(), Error> {
 		self.db
-			.put_ser_with_version(&to_key(BLOCK_PREFIX, &mut b.hash())[..], b, version)?;
+			.put_ser_with_version(&to_key(BLOCK_PREFIX, b.hash())[..], b, version)?;
 		Ok(())
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1105,7 +1105,7 @@ impl<'a> Extension<'a> {
 		// Remove the spent outputs from the output_pos index.
 		let spent = self
 			.utxo_view(header_ext)
-			.validate_inputs(b.inputs(), batch)?;
+			.validate_inputs(&b.inputs(), batch)?;
 		for (out, pos) in &spent {
 			self.apply_input(out.commitment(), *pos)?;
 			affected_pos.push(pos.pos);

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1371,13 +1371,14 @@ impl<'a> Extension<'a> {
 		}
 
 		// Update output_pos based on "unspending" all spent pos from this block.
-		// This is necessary to ensure the output_pos index correclty reflects a
+		// This is necessary to ensure the output_pos index correctly reflects a
 		// reused output commitment. For example an output at pos 1, spent, reused at pos 2.
 		// The output_pos index should be updated to reflect the old pos 1 when unspent.
 		if let Ok(spent) = spent {
-			let inputs: Vec<_> = block.inputs().into();
-			for (input, pos) in inputs.iter().zip(spent) {
-				batch.save_output_pos_height(&input.commitment(), pos)?;
+			for pos in spent {
+				if let Some(out) = self.output_pmmr.get_data(pos.pos) {
+					batch.save_output_pos_height(&out.commitment(), pos)?;
+				}
 			}
 		}
 

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -56,7 +56,7 @@ impl<'a> UTXOView<'a> {
 		for output in block.outputs() {
 			self.validate_output(output, batch)?;
 		}
-		self.validate_inputs(block.inputs(), batch)
+		self.validate_inputs(&block.inputs(), batch)
 	}
 
 	/// Validate a transaction against the current UTXO set.
@@ -70,7 +70,7 @@ impl<'a> UTXOView<'a> {
 		for output in tx.outputs() {
 			self.validate_output(output, batch)?;
 		}
-		self.validate_inputs(tx.inputs(), batch)
+		self.validate_inputs(&tx.inputs(), batch)
 	}
 
 	/// Validate the provided inputs.
@@ -78,7 +78,7 @@ impl<'a> UTXOView<'a> {
 	/// that would be spent by the provided inputs.
 	pub fn validate_inputs(
 		&self,
-		inputs: Inputs,
+		inputs: &Inputs,
 		batch: &Batch<'_>,
 	) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
 		match inputs {
@@ -166,7 +166,7 @@ impl<'a> UTXOView<'a> {
 	/// that have not sufficiently matured.
 	pub fn verify_coinbase_maturity(
 		&self,
-		inputs: Inputs,
+		inputs: &Inputs,
 		height: u64,
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -122,7 +122,7 @@ fn test_coinbase_maturity() {
 
 		// Confirm the tx attempting to spend the coinbase output
 		// is not valid at the current block height given the current chain state.
-		match chain.verify_coinbase_maturity(&coinbase_txn) {
+		match chain.verify_coinbase_maturity(coinbase_txn.inputs()) {
 			Ok(_) => {}
 			Err(e) => match e.kind() {
 				ErrorKind::ImmatureCoinbase => {}
@@ -204,7 +204,7 @@ fn test_coinbase_maturity() {
 
 			// Confirm the tx attempting to spend the coinbase output
 			// is not valid at the current block height given the current chain state.
-			match chain.verify_coinbase_maturity(&coinbase_txn) {
+			match chain.verify_coinbase_maturity(coinbase_txn.inputs()) {
 				Ok(_) => {}
 				Err(e) => match e.kind() {
 					ErrorKind::ImmatureCoinbase => {}
@@ -254,7 +254,9 @@ fn test_coinbase_maturity() {
 
 			// Confirm the tx spending the coinbase output is now valid.
 			// The coinbase output has matured sufficiently based on current chain state.
-			chain.verify_coinbase_maturity(&coinbase_txn).unwrap();
+			chain
+				.verify_coinbase_maturity(coinbase_txn.inputs())
+				.unwrap();
 
 			let txs = &[coinbase_txn];
 			let fees = txs.iter().map(|tx| tx.fee()).sum();

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -122,7 +122,7 @@ fn test_coinbase_maturity() {
 
 		// Confirm the tx attempting to spend the coinbase output
 		// is not valid at the current block height given the current chain state.
-		match chain.verify_coinbase_maturity(coinbase_txn.inputs()) {
+		match chain.verify_coinbase_maturity(&coinbase_txn.inputs()) {
 			Ok(_) => {}
 			Err(e) => match e.kind() {
 				ErrorKind::ImmatureCoinbase => {}
@@ -204,7 +204,7 @@ fn test_coinbase_maturity() {
 
 			// Confirm the tx attempting to spend the coinbase output
 			// is not valid at the current block height given the current chain state.
-			match chain.verify_coinbase_maturity(coinbase_txn.inputs()) {
+			match chain.verify_coinbase_maturity(&coinbase_txn.inputs()) {
 				Ok(_) => {}
 				Err(e) => match e.kind() {
 					ErrorKind::ImmatureCoinbase => {}
@@ -255,7 +255,7 @@ fn test_coinbase_maturity() {
 			// Confirm the tx spending the coinbase output is now valid.
 			// The coinbase output has matured sufficiently based on current chain state.
 			chain
-				.verify_coinbase_maturity(coinbase_txn.inputs())
+				.verify_coinbase_maturity(&coinbase_txn.inputs())
 				.unwrap();
 
 			let txs = &[coinbase_txn];

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -609,7 +609,7 @@ impl Block {
 		kernels.extend_from_slice(cb.kern_full());
 
 		// Initialize a tx body and sort everything.
-		let body = TransactionBody::init(inputs, &outputs, &kernels, false)?;
+		let body = TransactionBody::init(inputs.into(), &outputs, &kernels, false)?;
 
 		// Finally return the full block.
 		// Note: we have not actually validated the block here,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -272,7 +272,7 @@ impl PMMRable for BlockHeader {
 /// Serialization of a block header
 impl Writeable for BlockHeader {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		if writer.serialization_mode() != ser::SerializationMode::Hash {
+		if !writer.serialization_mode().is_hash_mode() {
 			self.write_pre_pow(writer)?;
 		}
 		self.pow.write(writer)?;
@@ -507,8 +507,7 @@ impl Hashed for Block {
 impl Writeable for Block {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		self.header.write(writer)?;
-
-		if writer.serialization_mode() != ser::SerializationMode::Hash {
+		if !writer.serialization_mode().is_hash_mode() {
 			self.body.write(writer)?;
 		}
 		Ok(())

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1795,6 +1795,14 @@ impl Inputs {
 			Inputs::FeaturesAndCommit(inputs) => inputs.sort_unstable(),
 		}
 	}
+
+	/// For debug purposes only. Do not rely on this for anything.
+	pub fn version_str(&self) -> &str {
+		match self {
+			Inputs::CommitOnly(_) => "v3",
+			Inputs::FeaturesAndCommit(_) => "v2",
+		}
+	}
 }
 
 // Enum of various supported kernel "features".

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -2041,6 +2041,11 @@ impl OutputIdentifier {
 			proof,
 		}
 	}
+
+	/// Is this a coinbase?
+	pub fn is_coinbase(&self) -> bool {
+		self.features.is_coinbase()
+	}
 }
 
 impl ToHex for OutputIdentifier {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1557,14 +1557,6 @@ impl From<&OutputIdentifier> for Input {
 	}
 }
 
-// impl ::std::hash::Hash for Input {
-// 	fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
-// 		let mut vec = Vec::new();
-// 		ser::serialize_default(&mut vec, &self).expect("serialization failed");
-// 		::std::hash::Hash::hash(&vec, state);
-// 	}
-// }
-
 /// Implementation of Writeable for a transaction Input, defines how to write
 /// an Input as binary.
 impl Writeable for Input {
@@ -1888,14 +1880,6 @@ impl AsRef<Commitment> for Output {
 		&self.identifier.commit
 	}
 }
-
-// impl ::std::hash::Hash for Output {
-// 	fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
-// 		let mut vec = Vec::new();
-// 		ser::serialize_default(&mut vec, &self).expect("serialization failed");
-// 		::std::hash::Hash::hash(&vec, state);
-// 	}
-// }
 
 /// Implementation of Writeable for a transaction Output, defines how to write
 /// an Output as binary.

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1698,13 +1698,14 @@ impl From<&[CommitWrapper]> for Inputs {
 /// We want to preserve output features here.
 impl From<&[OutputIdentifier]> for Inputs {
 	fn from(outputs: &[OutputIdentifier]) -> Self {
-		let inputs = outputs
+		let mut inputs: Vec<_> = outputs
 			.iter()
 			.map(|out| Input {
 				features: out.features,
 				commit: out.commit,
 			})
 			.collect();
+		inputs.sort_unstable();
 		Inputs::FeaturesAndCommit(inputs)
 	}
 }

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -23,9 +23,12 @@ use crate::consensus::{
 	PROOFSIZE, SECOND_POW_EDGE_BITS, STATE_SYNC_THRESHOLD,
 };
 use crate::core::block::HeaderVersion;
-use crate::pow::{
-	self, new_cuckaroo_ctx, new_cuckarood_ctx, new_cuckaroom_ctx, new_cuckarooz_ctx,
-	new_cuckatoo_ctx, PoWContext,
+use crate::{
+	pow::{
+		self, new_cuckaroo_ctx, new_cuckarood_ctx, new_cuckaroom_ctx, new_cuckarooz_ctx,
+		new_cuckatoo_ctx, PoWContext,
+	},
+	ser::ProtocolVersion,
 };
 use std::cell::Cell;
 use util::OneTime;
@@ -42,7 +45,7 @@ use util::OneTime;
 /// Note: We also use a specific (possible different) protocol version
 /// for both the backend database and MMR data files.
 /// This defines the p2p layer protocol version for this node.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(3);
 
 /// Automated testing edge_bits
 pub const AUTOMATED_TESTING_MIN_EDGE_BITS: u8 = 10;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -69,6 +69,8 @@ pub enum Error {
 	DuplicateError,
 	/// Block header version (hard-fork schedule).
 	InvalidBlockVersion,
+	/// Unsupported protocol version
+	UnsupportedProtocolVersion,
 }
 
 impl From<io::Error> for Error {
@@ -92,6 +94,7 @@ impl fmt::Display for Error {
 			Error::TooLargeReadErr => f.write_str("too large read"),
 			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
+			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
 	}
 }
@@ -115,6 +118,7 @@ impl error::Error for Error {
 			Error::TooLargeReadErr => "too large read",
 			Error::HexError(_) => "hex error",
 			Error::InvalidBlockVersion => "invalid block version",
+			Error::UnsupportedProtocolVersion => "unsupported protocol version",
 		}
 	}
 }
@@ -126,6 +130,16 @@ pub enum SerializationMode {
 	Full,
 	/// Serialize the data that defines the object
 	Hash,
+}
+
+impl SerializationMode {
+	/// Hash mode?
+	pub fn is_hash_mode(&self) -> bool {
+		match self {
+			SerializationMode::Hash => true,
+			_ => false,
+		}
+	}
 }
 
 /// Implementations defined how different numbers and binary structures are

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -333,7 +333,7 @@ impl ProtocolVersion {
 	/// negotiation in the p2p layer. Connected peers will negotiate a suitable
 	/// protocol version for serialization/deserialization of p2p messages.
 	pub fn local() -> ProtocolVersion {
-		ProtocolVersion(PROTOCOL_VERSION)
+		PROTOCOL_VERSION
 	}
 
 	/// We need to specify a protocol version for our local database.

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -732,14 +732,13 @@ fn same_amount_outputs_copy_range_proof() {
 
 	// now we reconstruct the transaction, swapping the rangeproofs so they
 	// have the wrong privkey
-	let ins: Vec<_> = tx.inputs().into();
 	let mut outs = tx.outputs().to_vec();
 	outs[0].proof = outs[1].proof;
 
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		&[Transaction::new(&ins, &outs, tx.kernels())],
+		&[Transaction::new(tx.inputs(), &outs, tx.kernels())],
 		&keychain,
 		&builder,
 		&prev,
@@ -784,7 +783,6 @@ fn wrong_amount_range_proof() {
 	.unwrap();
 
 	// we take the range proofs from tx2 into tx1 and rebuild the transaction
-	let ins: Vec<_> = tx1.inputs().into();
 	let mut outs = tx1.outputs().to_vec();
 	outs[0].proof = tx2.outputs()[0].proof;
 	outs[1].proof = tx2.outputs()[1].proof;
@@ -792,7 +790,7 @@ fn wrong_amount_range_proof() {
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 4, 0, 0, 0);
 	let prev = BlockHeader::default();
 	let b = new_block(
-		&[Transaction::new(&ins, &outs, tx1.kernels())],
+		&[Transaction::new(tx1.inputs(), &outs, tx1.kernels())],
 		&keychain,
 		&builder,
 		&prev,

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -15,7 +15,9 @@
 //! Common test functions
 
 use grin_core::core::hash::DefaultHashable;
-use grin_core::core::{Block, BlockHeader, KernelFeatures, Transaction};
+use grin_core::core::{
+	Block, BlockHeader, KernelFeatures, OutputFeatures, OutputIdentifier, Transaction,
+};
 use grin_core::libtx::{
 	build::{self, input, output},
 	proof::{ProofBuild, ProofBuilder},
@@ -62,6 +64,24 @@ pub fn tx1i1o() -> Transaction {
 	.unwrap();
 
 	tx
+}
+
+#[allow(dead_code)]
+pub fn tx1i10_v2_compatible() -> Transaction {
+	let tx = tx1i1o();
+
+	let inputs: Vec<_> = tx.inputs().into();
+	let inputs: Vec<_> = inputs
+		.iter()
+		.map(|input| OutputIdentifier {
+			features: OutputFeatures::Plain,
+			commit: input.commitment(),
+		})
+		.collect();
+	Transaction {
+		body: tx.body.replace_inputs(inputs.as_slice().into()),
+		..tx
+	}
 }
 
 // utility producing a transaction with a single input

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -15,7 +15,7 @@
 //! Transaction integration tests
 
 pub mod common;
-use crate::common::tx1i1o;
+use crate::common::tx1i10_v2_compatible;
 use crate::core::core::transaction::{self, Error};
 use crate::core::core::verifier_cache::LruVerifierCache;
 use crate::core::core::{KernelFeatures, Output, OutputFeatures, Transaction, Weighting};
@@ -32,8 +32,10 @@ use util::RwLock;
 // This test ensures we exercise this serialization/deserialization code.
 #[test]
 fn test_transaction_json_ser_deser() {
-	let tx1 = tx1i1o();
+	let tx1 = tx1i10_v2_compatible();
+
 	let value = serde_json::to_value(&tx1).unwrap();
+	println!("{:?}", value);
 
 	assert!(value["offset"].is_string());
 	assert_eq!(value["body"]["inputs"][0]["features"], "Plain");
@@ -50,7 +52,6 @@ fn test_transaction_json_ser_deser() {
 	let tx2: Transaction = serde_json::from_value(value).unwrap();
 	assert_eq!(tx1, tx2);
 
-	let tx1 = tx1i1o();
 	let str = serde_json::to_string(&tx1).unwrap();
 	println!("{}", str);
 	let tx2: Transaction = serde_json::from_str(&str).unwrap();

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -252,23 +252,6 @@ impl Peer {
 		self.send(ban_reason_msg, msg::Type::BanReason).map(|_| ())
 	}
 
-	/// Sends the provided block to the remote peer. The request may be dropped
-	/// if the remote peer is known to already have the block.
-	pub fn send_block(&self, b: &core::Block) -> Result<bool, Error> {
-		if !self.tracking_adapter.has_recv(b.hash()) {
-			trace!("Send block {} to {}", b.hash(), self.info.addr);
-			self.send(b, msg::Type::Block)?;
-			Ok(true)
-		} else {
-			debug!(
-				"Suppress block send {} to {} (already seen)",
-				b.hash(),
-				self.info.addr,
-			);
-			Ok(false)
-		}
-	}
-
 	pub fn send_compact_block(&self, b: &core::CompactBlock) -> Result<bool, Error> {
 		if !self.tracking_adapter.has_recv(b.hash()) {
 			trace!("Send compact block {} to {}", b.hash(), self.info.addr);
@@ -540,8 +523,8 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.locate_headers(locator)
 	}
 
-	fn get_block(&self, h: Hash) -> Option<core::Block> {
-		self.adapter.get_block(h)
+	fn get_block(&self, h: Hash, peer_info: &PeerInfo) -> Option<core::Block> {
+		self.adapter.get_block(h, peer_info)
 	}
 
 	fn txhashset_read(&self, h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -667,8 +667,8 @@ impl ChainAdapter for Peers {
 		self.adapter.locate_headers(hs)
 	}
 
-	fn get_block(&self, h: Hash) -> Option<core::Block> {
-		self.adapter.get_block(h)
+	fn get_block(&self, h: Hash, peer_info: &PeerInfo) -> Option<core::Block> {
+		self.adapter.get_block(h, peer_info)
 	}
 
 	fn txhashset_read(&self, h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -15,7 +15,6 @@
 use crate::chain;
 use crate::conn::{Message, MessageHandler, Tracker};
 use crate::core::core::{self, hash::Hash, hash::Hashed, CompactBlock};
-
 use crate::msg::{
 	BanReason, GetPeerAddrs, Headers, Locator, Msg, PeerAddrs, Ping, Pong, TxHashSetArchive,
 	TxHashSetRequest, Type,
@@ -153,7 +152,7 @@ impl MessageHandler for Protocol {
 					msg.header.msg_len,
 				);
 
-				let bo = adapter.get_block(h);
+				let bo = adapter.get_block(h, &self.peer_info);
 				if let Some(b) = bo {
 					return Ok(Some(Msg::new(Type::Block, b, self.peer_info.version)?));
 				}
@@ -177,7 +176,7 @@ impl MessageHandler for Protocol {
 
 			Type::GetCompactBlock => {
 				let h: Hash = msg.body()?;
-				if let Some(b) = adapter.get_block(h) {
+				if let Some(b) = adapter.get_block(h, &self.peer_info) {
 					let cb: CompactBlock = b.into();
 					Ok(Some(Msg::new(
 						Type::CompactBlock,

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -335,7 +335,7 @@ impl ChainAdapter for DummyAdapter {
 	fn locate_headers(&self, _: &[Hash]) -> Result<Vec<core::BlockHeader>, chain::Error> {
 		Ok(vec![])
 	}
-	fn get_block(&self, _: Hash) -> Option<core::Block> {
+	fn get_block(&self, _: Hash, _: &PeerInfo) -> Option<core::Block> {
 		None
 	}
 	fn txhashset_read(&self, _h: Hash) -> Option<TxHashSetRead> {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -599,7 +599,8 @@ pub trait ChainAdapter: Sync + Send {
 	fn locate_headers(&self, locator: &[Hash]) -> Result<Vec<core::BlockHeader>, chain::Error>;
 
 	/// Gets a full block by its hash.
-	fn get_block(&self, h: Hash) -> Option<core::Block>;
+	/// Converts block to v2 compatibility if necessary (based on peer protocol version).
+	fn get_block(&self, h: Hash, peer_info: &PeerInfo) -> Option<core::Block>;
 
 	/// Provides a reading view into the current txhashset state as well as
 	/// the required indexes for a consumer to rewind to a consistant state

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -298,7 +298,11 @@ where
 		tx: Transaction,
 		extra_tx: Option<Transaction>,
 	) -> Result<Transaction, PoolError> {
-		debug!("convert_tx_v2: {}", tx.inputs().version_str());
+		debug!(
+			"convert_tx_v2: {} ({} -> v2)",
+			tx.hash(),
+			tx.inputs().version_str()
+		);
 
 		let mut inputs: Vec<_> = tx.inputs().into();
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -29,7 +29,6 @@ use grin_util as util;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use util::secp::pedersen::Commitment;
 use util::static_secp_instance;
 
 pub struct Pool<B, V>
@@ -60,28 +59,9 @@ where
 	}
 
 	/// Does the transaction pool contain an entry for the given transaction?
-	pub fn contains_tx(&self, hash: Hash) -> bool {
-		self.entries.iter().any(|x| x.tx.hash() == hash)
-	}
-
-	pub fn get_tx(&self, hash: Hash) -> Option<Transaction> {
-		self.entries
-			.iter()
-			.find(|x| x.tx.hash() == hash)
-			.map(|x| x.tx.clone())
-	}
-
-	/// Query the tx pool for an individual tx matching the given public excess.
-	/// Used for checking for duplicate NRD kernels in the txpool.
-	pub fn retrieve_tx_by_kernel_excess(&self, excess: Commitment) -> Option<Transaction> {
-		for x in &self.entries {
-			for k in x.tx.kernels() {
-				if k.excess() == excess {
-					return Some(x.tx.clone());
-				}
-			}
-		}
-		None
+	/// Transactions are compared by their kernels.
+	pub fn contains_tx(&self, tx: &Transaction) -> bool {
+		self.entries.iter().any(|x| x.tx.kernels() == tx.kernels())
 	}
 
 	/// Query the tx pool for an individual tx matching the given kernel hash.

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -329,8 +329,7 @@ where
 		// Remember to use the original kernels and kernel offset.
 		let mut outputs = tx.outputs().to_vec();
 		let (inputs, outputs, _, _) = transaction::cut_through(&mut spent[..], &mut outputs[..])?;
-		let inputs: Vec<_> = inputs.iter().map(|out| out.into()).collect();
-		let tx = Transaction::new(inputs.as_slice(), outputs, tx.kernels()).with_offset(tx.offset);
+		let tx = Transaction::new(inputs.into(), outputs, tx.kernels()).with_offset(tx.offset);
 
 		// Validate the tx to ensure our converted inputs are correct.
 		tx.validate(Weighting::AsTransaction, self.verifier_cache.clone())

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -298,6 +298,8 @@ where
 		tx: Transaction,
 		extra_tx: Option<Transaction>,
 	) -> Result<Transaction, PoolError> {
+		debug!("convert_tx_v2: {}", tx.inputs().version_str());
+
 		let mut inputs: Vec<_> = tx.inputs().into();
 
 		let agg_tx = self

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -269,6 +269,8 @@ where
 		Ok(valid_txs)
 	}
 
+	/// Lookup unspent outputs to be spent by the provided transaction.
+	/// We look for unspent outputs in the current txpool and then in the current utxo.
 	pub fn locate_spends(
 		&self,
 		tx: &Transaction,
@@ -292,7 +294,7 @@ where
 			transaction::cut_through(&mut inputs[..], &mut outputs[..])?;
 
 		// Lookup remaining outputs to be spent from the current utxo.
-		let spent_utxo = self.blockchain.validate_inputs(spent_utxo.into())?;
+		let spent_utxo = self.blockchain.validate_inputs(&spent_utxo.into())?;
 
 		Ok((spent_pool.to_vec(), spent_utxo))
 	}

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -20,7 +20,9 @@
 use self::core::core::hash::{Hash, Hashed};
 use self::core::core::id::ShortId;
 use self::core::core::verifier_cache::VerifierCache;
-use self::core::core::{transaction, Block, BlockHeader, HeaderVersion, Transaction, Weighting};
+use self::core::core::{
+	transaction, Block, BlockHeader, HeaderVersion, OutputIdentifier, Transaction, Weighting,
+};
 use self::core::global;
 use self::util::RwLock;
 use crate::pool::Pool;
@@ -88,22 +90,11 @@ where
 	// Add tx to stempool (passing in all txs from txpool to validate against).
 	fn add_to_stempool(
 		&mut self,
-		entry: PoolEntry,
+		entry: &PoolEntry,
 		header: &BlockHeader,
-	) -> Result<PoolEntry, PoolError> {
-		let txpool_agg = self.txpool.all_transactions_aggregate(None)?;
-
-		// Convert the tx to v2 looking for unspent outputs in both stempool and txpool, and utxo.
-		let src = entry.src;
-		let tx = entry.tx;
-		let tx_v2 = self.stempool.convert_tx_v2(tx, txpool_agg.clone())?;
-		let entry = PoolEntry::new(tx_v2, src);
-
-		self.stempool
-			.add_to_pool(entry.clone(), txpool_agg, header)?;
-
-		// If all is good return our pool entry with the converted tx.
-		Ok(entry)
+		extra_tx: Option<Transaction>,
+	) -> Result<(), PoolError> {
+		self.stempool.add_to_pool(entry.clone(), extra_tx, header)
 	}
 
 	fn add_to_reorg_cache(&mut self, entry: &PoolEntry) {
@@ -118,34 +109,27 @@ where
 		debug!("added tx to reorg_cache: size now {}", cache.len());
 	}
 
-	fn add_to_txpool(
-		&mut self,
-		entry: PoolEntry,
-		header: &BlockHeader,
-	) -> Result<PoolEntry, PoolError> {
-		// First deaggregate the tx based on current txpool txs.
-		let entry = if entry.tx.kernels().len() == 1 {
-			entry
+	// Deaggregate this tx against the txpool.
+	// Re-converts the tx to v2 if deaggregated.
+	// Returns the new deaggregated entry or the original entry if no deaggregation.
+	fn deaggregate_tx(&self, entry: &PoolEntry) -> Result<PoolEntry, PoolError> {
+		if entry.tx.kernels().len() == 1 {
+			Ok(entry.clone())
 		} else {
 			let tx = entry.tx.clone();
 			let txs = self.txpool.find_matching_transactions(tx.kernels());
-			if !txs.is_empty() {
-				let tx = transaction::deaggregate(tx, &txs)?;
-
-				// Validate this deaggregated tx "as tx", subject to regular tx weight limits.
-				tx.validate(Weighting::AsTransaction, self.verifier_cache.clone())?;
-
-				PoolEntry::new(tx, TxSource::Deaggregate)
+			if txs.is_empty() {
+				Ok(entry.clone())
 			} else {
-				entry
+				let tx = transaction::deaggregate(tx, &txs)?;
+				let (spent_pool, spent_utxo) = self.txpool.locate_spends(&tx, None)?;
+				let tx = self.convert_tx_v2(tx, &spent_pool, &spent_utxo)?;
+				Ok(PoolEntry::new(tx, TxSource::Deaggregate))
 			}
-		};
+		}
+	}
 
-		// Convert the deaggregated tx to v2 looking for unspent outputs in the txpool, and utxo.
-		let src = entry.src;
-		let tx_v2 = self.txpool.convert_tx_v2(entry.tx, None)?;
-		let entry = PoolEntry::new(tx_v2, src);
-
+	fn add_to_txpool(&mut self, entry: &PoolEntry, header: &BlockHeader) -> Result<(), PoolError> {
 		self.txpool.add_to_pool(entry.clone(), None, header)?;
 
 		// We now need to reconcile the stempool based on the new state of the txpool.
@@ -153,8 +137,7 @@ where
 		let txpool_agg = self.txpool.all_transactions_aggregate(None)?;
 		self.stempool.reconcile(txpool_agg, header)?;
 
-		// If all is good return our pool entry with the deaggregated and converted tx.
-		Ok(entry)
+		Ok(())
 	}
 
 	/// Verify the tx kernel variants and ensure they can all be accepted to the txpool/stempool
@@ -184,6 +167,9 @@ where
 		stem: bool,
 		header: &BlockHeader,
 	) -> Result<(), PoolError> {
+		//
+		// TODO - hash here is not sufficient as we have v2 vs. v3 txs...
+		//
 		// Quick check for duplicate txs.
 		// Our stempool is private and we do not want to reveal anything about the txs contained.
 		// If this is a stem tx and is already present in stempool then fluff by adding to txpool.
@@ -215,19 +201,47 @@ where
 		// Check the tx lock_time is valid based on current chain state.
 		self.blockchain.verify_tx_lock_height(&tx)?;
 
+		// If stem we want to account for the txpool.
+		let extra_tx = if stem {
+			self.txpool.all_transactions_aggregate(None)?
+		} else {
+			None
+		};
+
+		// Locate outputs being spent from pool and current utxo.
+		let (spent_pool, spent_utxo) = if stem {
+			self.stempool.locate_spends(&tx, extra_tx.clone())
+		} else {
+			self.txpool.locate_spends(&tx, None)
+		}?;
+
 		// Check coinbase maturity before we go any further.
-		self.blockchain.verify_coinbase_maturity(&tx)?;
+		let coinbase_inputs: Vec<_> = spent_utxo
+			.iter()
+			.filter(|x| x.is_coinbase())
+			.cloned()
+			.collect();
+		self.blockchain
+			.verify_coinbase_maturity(coinbase_inputs.as_slice().into())?;
+
+		// Convert the tx to "v2" compatibility with "features and commit" inputs.
+		let tx_v2 = self.convert_tx_v2(tx, &spent_pool, &spent_utxo)?;
+		let entry = PoolEntry::new(tx_v2, src);
 
 		// If this is a stem tx then attempt to add it to stempool.
 		// If the adapter fails to accept the new stem tx then fallback to fluff via txpool.
 		if stem {
-			let entry = self.add_to_stempool(PoolEntry::new(tx.clone(), src), header)?;
+			self.add_to_stempool(&entry, header, extra_tx)?;
 			if self.adapter.stem_tx_accepted(&entry).is_ok() {
 				return Ok(());
 			}
 		}
 
-		let entry = self.add_to_txpool(PoolEntry::new(tx, src), header)?;
+		// Deaggregate this tx against the current txpool.
+		let entry = self.deaggregate_tx(&entry)?;
+
+		// Add tx to txpool.
+		self.add_to_txpool(&entry, header)?;
 		self.add_to_reorg_cache(&entry);
 		self.adapter.tx_accepted(&entry);
 
@@ -237,6 +251,37 @@ where
 		}
 
 		Ok(())
+	}
+
+	/// Convert a transaction for v2 compatibility.
+	/// We may receive a transaction with "commit only" inputs.
+	/// We convert it to "features and commit" so we can safely relay it to v2 peers.
+	/// Conversion is done using outputs previously looked up in both the pool and the current utxo.
+	fn convert_tx_v2(
+		&self,
+		tx: Transaction,
+		spent_pool: &[OutputIdentifier],
+		spent_utxo: &[OutputIdentifier],
+	) -> Result<Transaction, PoolError> {
+		debug!(
+			"convert_tx_v2: {} ({} -> v2)",
+			tx.hash(),
+			tx.inputs().version_str(),
+		);
+
+		let mut inputs = spent_utxo.to_vec();
+		inputs.extend_from_slice(spent_pool);
+		inputs.sort_unstable();
+
+		let tx = Transaction {
+			body: tx.body.replace_inputs(inputs.as_slice().into()),
+			..tx
+		};
+
+		// Validate the tx to ensure our converted inputs are correct.
+		tx.validate(Weighting::AsTransaction, self.verifier_cache.clone())?;
+
+		Ok(tx)
 	}
 
 	// Evict a transaction from the txpool.
@@ -265,7 +310,7 @@ where
 			header.hash(),
 		);
 		for entry in entries {
-			let _ = self.add_to_txpool(entry, header);
+			let _ = self.add_to_txpool(&entry, header);
 		}
 		debug!(
 			"reconcile_reorg_cache: block: {:?} ... done.",

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -160,9 +160,6 @@ where
 		stem: bool,
 		header: &BlockHeader,
 	) -> Result<(), PoolError> {
-		//
-		// TODO - hash here is not sufficient as we have v2 vs. v3 txs...
-		//
 		// Quick check for duplicate txs.
 		// Our stempool is private and we do not want to reveal anything about the txs contained.
 		// If this is a stem tx and is already present in stempool then fluff by adding to txpool.
@@ -223,7 +220,7 @@ where
 			.cloned()
 			.collect();
 		self.blockchain
-			.verify_coinbase_maturity(coinbase_inputs.as_slice().into())?;
+			.verify_coinbase_maturity(&coinbase_inputs.as_slice().into())?;
 
 		// Convert the tx to "v2" compatibility with "features and commit" inputs.
 		let ref entry = self.convert_tx_v2(entry, &spent_pool, &spent_utxo)?;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -275,7 +275,7 @@ impl From<committed::Error> for PoolError {
 pub trait BlockChain: Sync + Send {
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.
-	fn verify_coinbase_maturity(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;
+	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), PoolError>;
 
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -275,7 +275,7 @@ impl From<committed::Error> for PoolError {
 pub trait BlockChain: Sync + Send {
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.
-	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), PoolError>;
+	fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), PoolError>;
 
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.
@@ -287,7 +287,7 @@ pub trait BlockChain: Sync + Send {
 	/// Validate inputs against the current utxo.
 	/// Returns the vec of output identifiers that would be spent
 	/// by these inputs if they can all be successfully spent.
-	fn validate_inputs(&self, inputs: Inputs) -> Result<Vec<OutputIdentifier>, PoolError>;
+	fn validate_inputs(&self, inputs: &Inputs) -> Result<Vec<OutputIdentifier>, PoolError>;
 
 	fn chain_head(&self) -> Result<BlockHeader, PoolError>;
 

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -141,10 +141,20 @@ fn test_transaction_pool_block_reconciliation() {
 	pool.reconcile_block(&block).unwrap();
 
 	assert_eq!(pool.total_size(), 4);
-	assert_eq!(pool.txpool.entries[0].tx, valid_transaction);
-	assert_eq!(pool.txpool.entries[1].tx, pool_child);
-	assert_eq!(pool.txpool.entries[2].tx, conflict_valid_child);
-	assert_eq!(pool.txpool.entries[3].tx, valid_child_valid);
+	// Compare the various txs by their kernels as entries in the pool are "v2" compatibility.
+	assert_eq!(
+		pool.txpool.entries[0].tx.kernels(),
+		valid_transaction.kernels()
+	);
+	assert_eq!(pool.txpool.entries[1].tx.kernels(), pool_child.kernels());
+	assert_eq!(
+		pool.txpool.entries[2].tx.kernels(),
+		conflict_valid_child.kernels()
+	);
+	assert_eq!(
+		pool.txpool.entries[3].tx.kernels(),
+		valid_child_valid.kernels()
+	);
 
 	// Cleanup db directory
 	clean_output_dir(db_root.into());

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -143,9 +143,9 @@ impl BlockChain for ChainAdapter {
 			.map_err(|_| PoolError::Other("failed to validate inputs".into()))
 	}
 
-	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), PoolError> {
+	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), PoolError> {
 		self.chain
-			.verify_coinbase_maturity(tx)
+			.verify_coinbase_maturity(inputs)
 			.map_err(|_| PoolError::ImmatureCoinbase)
 	}
 

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -136,14 +136,14 @@ impl BlockChain for ChainAdapter {
 		})
 	}
 
-	fn validate_inputs(&self, inputs: Inputs) -> Result<Vec<OutputIdentifier>, PoolError> {
+	fn validate_inputs(&self, inputs: &Inputs) -> Result<Vec<OutputIdentifier>, PoolError> {
 		self.chain
 			.validate_inputs(inputs)
 			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
 			.map_err(|_| PoolError::Other("failed to validate inputs".into()))
 	}
 
-	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), PoolError> {
+	fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), PoolError> {
 		self.chain
 			.verify_coinbase_maturity(inputs)
 			.map_err(|_| PoolError::ImmatureCoinbase)

--- a/pool/tests/nrd_kernel_relative_height.rs
+++ b/pool/tests/nrd_kernel_relative_height.rs
@@ -87,6 +87,12 @@ fn test_nrd_kernel_relative_height() -> Result<(), PoolError> {
 			aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 		kernel.verify().unwrap();
 
+		// Generate a 2nd NRD kernel sharing the same excess commitment but with different signature.
+		let mut kernel2 = kernel.clone();
+		kernel2.excess_sig =
+			aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
+		kernel2.verify().unwrap();
+
 		let tx1 = test_transaction_with_kernel(
 			&keychain,
 			vec![10, 20],
@@ -99,7 +105,7 @@ fn test_nrd_kernel_relative_height() -> Result<(), PoolError> {
 			&keychain,
 			vec![24],
 			vec![18],
-			kernel.clone(),
+			kernel2.clone(),
 			excess.clone(),
 		);
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -953,14 +953,14 @@ impl pool::BlockChain for PoolToChainAdapter {
 			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
 	}
 
-	fn validate_inputs(&self, inputs: Inputs) -> Result<Vec<OutputIdentifier>, pool::PoolError> {
+	fn validate_inputs(&self, inputs: &Inputs) -> Result<Vec<OutputIdentifier>, pool::PoolError> {
 		self.chain()
 			.validate_inputs(inputs)
 			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
 			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
 	}
 
-	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), pool::PoolError> {
+	fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), pool::PoolError> {
 		self.chain()
 			.verify_coinbase_maturity(inputs)
 			.map_err(|_| pool::PoolError::ImmatureCoinbase)

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -960,9 +960,9 @@ impl pool::BlockChain for PoolToChainAdapter {
 			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
 	}
 
-	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
+	fn verify_coinbase_maturity(&self, inputs: Inputs) -> Result<(), pool::PoolError> {
 		self.chain()
-			.verify_coinbase_maturity(tx)
+			.verify_coinbase_maturity(inputs)
 			.map_err(|_| pool::PoolError::ImmatureCoinbase)
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -172,6 +172,12 @@ where
 			// push the freshly hydrated block through the chain pipeline
 			match core::Block::hydrate_from(cb, &[]) {
 				Ok(block) => {
+					debug!(
+						"successfully hydrated (empty) block: {} at {} ({})",
+						block.header.hash(),
+						block.header.height,
+						block.inputs().version_str(),
+					);
 					if !self.sync_state.is_syncing() {
 						for hook in &self.hooks {
 							hook.on_block_received(&block, &peer_info.addr);
@@ -232,7 +238,12 @@ where
 					.validate(&prev.total_kernel_offset, self.verifier_cache.clone())
 					.is_ok()
 				{
-					debug!("successfully hydrated block from tx pool!");
+					debug!(
+						"successfully hydrated block: {} at {} ({})",
+						block.header.hash(),
+						block.header.height,
+						block.inputs().version_str(),
+					);
 					self.process_block(block, peer_info, chain::Options::NONE)
 				} else if self.sync_state.status() == SyncStatus::NoSync {
 					debug!("adapter: block invalid after hydration, requesting full block");

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -73,7 +73,7 @@ where
 	}
 }
 
-const DEFAULT_DB_VERSION: ProtocolVersion = ProtocolVersion(2);
+const DEFAULT_DB_VERSION: ProtocolVersion = ProtocolVersion(3);
 
 /// LMDB-backed store facilitating data access and serialization. All writes
 /// are done through a Batch abstraction providing atomicity.

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -157,9 +157,14 @@ impl Store {
 			env: self.env.clone(),
 			db: self.db.clone(),
 			name: self.name.clone(),
-			version: version,
+			version,
 			alloc_chunk_size,
 		}
+	}
+
+	/// Protocol version for the store.
+	pub fn protocol_version(&self) -> ProtocolVersion {
+		self.version
 	}
 
 	/// Opens the database environment
@@ -275,7 +280,7 @@ impl Store {
 	) -> Result<Option<T>, Error> {
 		let res: lmdb::error::Result<&[u8]> = access.get(&db, key);
 		match res.to_opt() {
-			Ok(Some(mut res)) => match ser::deserialize(&mut res, self.version) {
+			Ok(Some(mut res)) => match ser::deserialize(&mut res, self.protocol_version()) {
 				Ok(res) => Ok(Some(res)),
 				Err(e) => Err(Error::SerErr(format!("{}", e))),
 			},
@@ -310,7 +315,7 @@ impl Store {
 			cursor,
 			seek: false,
 			prefix: from.to_vec(),
-			version: self.version,
+			version: self.protocol_version(),
 			_marker: marker::PhantomData,
 		})
 	}
@@ -348,7 +353,12 @@ impl<'a> Batch<'a> {
 	/// Writes a single key and its `Writeable` value to the db.
 	/// Encapsulates serialization using the (default) version configured on the store instance.
 	pub fn put_ser<W: ser::Writeable>(&self, key: &[u8], value: &W) -> Result<(), Error> {
-		self.put_ser_with_version(key, value, self.store.version)
+		self.put_ser_with_version(key, value, self.store.protocol_version())
+	}
+
+	/// Protocol version used by this batch.
+	pub fn protocol_version(&self) -> ProtocolVersion {
+		self.store.protocol_version()
 	}
 
 	/// Writes a single key and its `Writeable` value to the db.


### PR DESCRIPTION
This PR bumps the node protocol version to to __3__.

Inputs in both transactions and blocks are serialized as follows - 

```
(Commitment)
```

Previously in protocol version 2 they were serialized as - 

```
(Features || Commitment)
```

Note that the _sorting_ of inputs is affected by this also. 

Inputs are now sorted using the following sort key -

```
Hash(Commitment)
```

Previously they were sorted with the key - 

```
Hash(Features || Commitment)
```

This affects the serialization of lists of inputs, not just individual inputs themselves. Inputs are not stored on-chain so this is not a consensus breaking change.
Outputs are unaffected by this change.

Full support for protocol version 2 peers is maintained via the existing version negotiation scheme.

Locally we store full blocks in the db in v3 format. These are converted to v2 before broadcasting to v2 peers as necessary.

Transactions are stored in the txpool (and stempool) in __v2__ format. This is to allow broadcast and relay with v2 peers in a convenient way. It is non-trivial to convert transactions v3->v2 due to possibility of one transaction spending unconfirmed outputs from another transaction in the txpool. To simplify transaction handling we maintain them in v2 format.
This will be revisited once we have wide support for v3 across the network.

Care has been taken not to introduce malleability here with backward support. Blocks and transactions in v2 format _must_ have a valid and correct features byte.

----

### Why Make This Change?

Uniqueness is enforced across the current utxo set. 
It is not valid to have two unspent outputs with the same commitment.
Spending an output is done solely by output commitment. The features bytes is entirely redundant.
Internally we want to simplify the spending logic by removing any reference to the redundant input features byte.

This is one of the outstanding wrinkles in the p2p msg format that we wish to resolve prior to the final scheduled hardfork.
This leaves open the possibility of taking advantage of the final HF to break backward compatibility, simplifying a lot of internal version handling implementation details.

----

* Introduce `CommitOnly` variant of `Inputs`
* Introduce CommitWrapper to wrap "commit only" inputs so we can sort them correctly (by hash).
* `v3` -> `v2` conversion (need to lookup outputs being spent) for backward compatibility with `v2` peers

TODO - 

- [x] v2/v3 serialization for the two `Inputs` variants.
  - [x] write "commit only" for v3
  - [x] convert "features and commit" to "commit only" for v3
  - [x] write "features and commit" for v2
  - [x] compatibility error if attempt to write "commit only" for v2
  - [x] write provided data for hash serialization mode
- [x] v2/v3 deserialization for two `Inputs` variants
  - [x] read "features and commit" for v2
  - [x] read "commit only" for v3
- [x] test coverage for v2/v3 serialization and deserialization
- [x] consider cost of maintaining backward compatibility here
  - [x] store in v3 in local db
  - [x] convert to v2 "on demand" if relaying full block to v2 peer?
- [x] bump default protocol version to 3

----

* Resolves #3378 
* Related https://github.com/mimblewimble/grin/pull/3424

----

TODO - 

- [x] grin-wallet needs some rework to support this (https://github.com/mimblewimble/grin-wallet/pull/512)