### PR TITLE
Fix API secret configuration options

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -261,6 +261,13 @@ impl GlobalConfig {
 		secret_path.push(API_SECRET_FILE_NAME);
 		self.members.as_mut().unwrap().server.api_secret_path =
 			Some(secret_path.to_str().unwrap().to_owned());
+		let mut foreign_secret_path = grin_home.clone();
+		foreign_secret_path.push(FOREIGN_API_SECRET_FILE_NAME);
+		self.members
+			.as_mut()
+			.unwrap()
+			.server
+			.foreign_api_secret_path = Some(foreign_secret_path.to_str().unwrap().to_owned());
 		let mut log_path = grin_home.clone();
 		log_path.push(SERVER_LOG_FILE_NAME);
 		self.members


### PR DESCRIPTION
API secret configuration options `api_secret_path` and `foreign_api_secret_path` do not work as expected.

- Default paths are always used to generate the API secrets. This PR fixes that by using the specified values of corresponding options.
- Default value of `foreign_api_secret_path` is not populated properly. This PR fixes it as well.

Fixes #3394