### PR TITLE
Simplify api commits

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -61,7 +61,7 @@ impl HeaderHandler {
 			Some((_, o)) => o,
 			None => return Err(ErrorKind::NotFound.into()),
 		};
-		match w(&self.chain)?.get_header_for_output(&oid) {
+		match w(&self.chain)?.get_header_for_output(oid.commitment()) {
 			Ok(header) => Ok(BlockHeaderPrintable::from_header(&header)),
 			Err(_) => Err(ErrorKind::NotFound.into()),
 		}
@@ -94,7 +94,7 @@ impl HeaderHandler {
 				Some((_, o)) => o,
 				None => return Err(ErrorKind::NotFound.into()),
 			};
-			match w(&self.chain)?.get_header_for_output(&oid) {
+			match w(&self.chain)?.get_header_for_output(oid.commitment()) {
 				Ok(header) => return Ok(header.hash()),
 				Err(_) => return Err(ErrorKind::NotFound.into()),
 			}
@@ -179,7 +179,7 @@ impl BlockHandler {
 				Some((_, o)) => o,
 				None => return Err(ErrorKind::NotFound.into()),
 			};
-			match w(&self.chain)?.get_header_for_output(&oid) {
+			match w(&self.chain)?.get_header_for_output(oid.commitment()) {
 				Ok(header) => return Ok(header.hash()),
 				Err(_) => return Err(ErrorKind::NotFound.into()),
 			}

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -291,7 +291,7 @@ impl OutputPrintable {
 		};
 
 		let out_id = core::OutputIdentifier::from(output);
-		let pos = chain.get_unspent(&out_id)?;
+		let pos = chain.get_unspent(out_id.commitment())?;
 
 		let spent = pos.is_none();
 
@@ -301,8 +301,10 @@ impl OutputPrintable {
 		// api is currently doing the right thing here:
 		// An output can be spent and then subsequently reused and the new instance unspent.
 		// This would result in a height that differs from the provided block height.
-		let output_pos = pos.map(|x| x.pos).unwrap_or(0);
-		let block_height = pos.map(|x| x.height).or(block_header.map(|x| x.height));
+		let output_pos = pos.map(|(_, x)| x.pos).unwrap_or(0);
+		let block_height = pos
+			.map(|(_, x)| x.height)
+			.or(block_header.map(|x| x.height));
 
 		let proof = if include_proof {
 			Some(output.proof_bytes().to_hex())

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -255,15 +255,17 @@ impl TxHashSet {
 	/// Check if an output is unspent.
 	/// We look in the index to find the output MMR pos.
 	/// Then we check the entry in the output MMR and confirm the hash matches.
-	pub fn get_unspent(&self, output_id: &OutputIdentifier) -> Result<Option<CommitPos>, Error> {
-		let commit = output_id.commit;
+	pub fn get_unspent(
+		&self,
+		commit: Commitment,
+	) -> Result<Option<(OutputIdentifier, CommitPos)>, Error> {
 		match self.commit_index.get_output_pos_height(&commit) {
 			Ok(Some(pos)) => {
 				let output_pmmr: ReadonlyPMMR<'_, Output, _> =
 					ReadonlyPMMR::at(&self.output_pmmr_h.backend, self.output_pmmr_h.last_pos);
 				if let Some(out) = output_pmmr.get_data(pos.pos) {
-					if out == *output_id {
-						Ok(Some(pos))
+					if out.commitment() == commit {
+						Ok(Some((out, pos)))
 					} else {
 						Ok(None)
 					}

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -696,11 +696,11 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 6);
 		assert_eq!(head.hash(), prev_main.hash());
 		assert!(chain
-			.get_unspent(&OutputIdentifier::from(&tx2.outputs()[0]))
+			.get_unspent(tx2.outputs()[0].commitment())
 			.unwrap()
 			.is_some());
 		assert!(chain
-			.get_unspent(&OutputIdentifier::from(&tx1.outputs()[0]))
+			.get_unspent(tx1.outputs()[0].commitment())
 			.unwrap()
 			.is_none());
 
@@ -717,11 +717,11 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 7);
 		assert_eq!(head.hash(), prev_fork.hash());
 		assert!(chain
-			.get_unspent(&OutputIdentifier::from(&tx2.outputs()[0]))
+			.get_unspent(tx2.outputs()[0].commitment())
 			.unwrap()
 			.is_some());
 		assert!(chain
-			.get_unspent(&OutputIdentifier::from(&tx1.outputs()[0]))
+			.get_unspent(tx1.outputs()[0].commitment())
 			.unwrap()
 			.is_none());
 
@@ -796,7 +796,7 @@ fn output_header_mappings() {
 			chain.process_block(b, chain::Options::MINE).unwrap();
 
 			let header_for_output = chain
-				.get_header_for_output(&OutputIdentifier::from(&reward_outputs[n - 1]))
+				.get_header_for_output(reward_outputs[n - 1].commitment())
 				.unwrap();
 			assert_eq!(header_for_output.height, n as u64);
 
@@ -806,7 +806,7 @@ fn output_header_mappings() {
 		// Check all output positions are as expected
 		for n in 1..15 {
 			let header_for_output = chain
-				.get_header_for_output(&OutputIdentifier::from(&reward_outputs[n - 1]))
+				.get_header_for_output(reward_outputs[n - 1].commitment())
 				.unwrap();
 			assert_eq!(header_for_output.height, n as u64);
 		}


### PR DESCRIPTION
Related to recent refactoring around support for "commit only" inputs.

This PR simplifies some internal api code, passing a commitment around to specify an unspent output rather than an output identifier.

Wallet passes a commitment only when calling `get_unspent` so we no longer need to "reverse engineer" output identifiers (both plain and coinbase) internally.

There is no change to the api itself with this PR, the changes are limited to internal implementation.


