### PR TITLE
verify_cut_through and test coverage

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -486,7 +486,8 @@ impl Chain {
 		Ok(())
 	}
 
-	fn new_ctx<'a>(
+	/// Build a new block processing context.
+	pub fn new_ctx<'a>(
 		&self,
 		opts: Options,
 		batch: store::Batch<'a>,
@@ -686,6 +687,22 @@ impl Chain {
 				.validate(&self.genesis, fast_validation, &NoStatus, &header)?;
 			Ok(())
 		})
+	}
+
+	/// Sets prev_root on a brand new block header by applying the previous header to the header MMR.
+	pub fn set_prev_root_only(&self, header: &mut BlockHeader) -> Result<(), Error> {
+		let mut header_pmmr = self.header_pmmr.write();
+		let prev_root =
+			txhashset::header_extending_readonly(&mut header_pmmr, &self.store(), |ext, batch| {
+				let prev_header = batch.get_previous_header(header)?;
+				pipe::rewind_and_apply_header_fork(&prev_header, ext, batch)?;
+				ext.root()
+			})?;
+
+		// Set the prev_root on the header.
+		header.prev_root = prev_root;
+
+		Ok(())
 	}
 
 	/// Sets the txhashset roots on a brand new block by applying the block on

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -588,7 +588,9 @@ pub fn rewind_and_apply_fork(
 	Ok(fork_point)
 }
 
-/// Validate block inputs against utxo.
+/// Validate block inputs and outputs against utxo.
+/// Every input must spend an unspent output.
+/// No duplicate outputs created.
 fn validate_utxo(
 	block: &Block,
 	ext: &mut txhashset::ExtensionPair<'_>,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -764,6 +764,38 @@ where
 	}
 }
 
+/// Start a new readonly header MMR extension.
+/// This MMR can be extended individually beyond the other (output, rangeproof and kernel) MMRs
+/// to allow headers to be validated before we receive the full block data.
+pub fn header_extending_readonly<'a, F, T>(
+	handle: &'a mut PMMRHandle<BlockHeader>,
+	store: &ChainStore,
+	inner: F,
+) -> Result<T, Error>
+where
+	F: FnOnce(&mut HeaderExtension<'_>, &Batch<'_>) -> Result<T, Error>,
+{
+	let batch = store.batch()?;
+
+	// Note: Extending either the sync_head or header_head MMR here.
+	// Use underlying MMR to determine the "head".
+	let head = match handle.head_hash() {
+		Ok(hash) => {
+			let header = batch.get_block_header(&hash)?;
+			Tip::from_header(&header)
+		}
+		Err(_) => Tip::default(),
+	};
+
+	let pmmr = PMMR::at(&mut handle.backend, handle.last_pos);
+	let mut extension = HeaderExtension::new(pmmr, head);
+	let res = inner(&mut extension, &batch);
+
+	handle.backend.discard();
+
+	res
+}
+
 /// Start a new header MMR unit of work.
 /// This MMR can be extended individually beyond the other (output, rangeproof and kernel) MMRs
 /// to allow headers to be validated before we receive the full block data.

--- a/chain/tests/process_block_cut_through.rs
+++ b/chain/tests/process_block_cut_through.rs
@@ -1,0 +1,176 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod chain_test_helper;
+
+use grin_chain as chain;
+use grin_core as core;
+use grin_keychain as keychain;
+use grin_util as util;
+
+use self::chain_test_helper::{clean_output_dir, genesis_block, init_chain};
+use crate::chain::{pipe, Chain, Options};
+use crate::core::core::verifier_cache::LruVerifierCache;
+use crate::core::core::{block, transaction};
+use crate::core::core::{Block, KernelFeatures, Transaction, Weighting};
+use crate::core::libtx::{build, reward, ProofBuilder};
+use crate::core::{consensus, global, pow};
+use crate::keychain::{ExtKeychain, ExtKeychainPath, Keychain, SwitchCommitmentType};
+use crate::util::RwLock;
+use chrono::Duration;
+use std::sync::Arc;
+
+fn build_block<K>(
+	chain: &Chain,
+	keychain: &K,
+	txs: &[Transaction],
+	skip_roots: bool,
+) -> Result<Block, chain::Error>
+where
+	K: Keychain,
+{
+	let prev = chain.head_header().unwrap();
+	let next_height = prev.height + 1;
+	let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter()?);
+	let fee = txs.iter().map(|x| x.fee()).sum();
+	let key_id = ExtKeychainPath::new(1, next_height as u32, 0, 0, 0).to_identifier();
+	let reward =
+		reward::output(keychain, &ProofBuilder::new(keychain), &key_id, fee, false).unwrap();
+
+	let mut block = Block::new(&prev, txs, next_header_info.clone().difficulty, reward)?;
+
+	block.header.timestamp = prev.timestamp + Duration::seconds(60);
+	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
+
+	// If we are skipping roots then just set the header prev_root and skip the other MMR roots.
+	// This allows us to build a header for an "invalid" block by ignoring outputs and kernels.
+	if skip_roots {
+		chain.set_prev_root_only(&mut block.header)?;
+	} else {
+		chain.set_txhashset_roots(&mut block)?;
+	}
+
+	let edge_bits = global::min_edge_bits();
+	block.header.pow.proof.edge_bits = edge_bits;
+	pow::pow_size(
+		&mut block.header,
+		next_header_info.difficulty,
+		global::proofsize(),
+		edge_bits,
+	)
+	.unwrap();
+
+	Ok(block)
+}
+
+#[test]
+fn process_block_cut_through() -> Result<(), chain::Error> {
+	let chain_dir = ".grin.cut_through";
+	global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+	util::init_test_logger();
+	clean_output_dir(chain_dir);
+
+	let keychain = ExtKeychain::from_random_seed(false)?;
+	let pb = ProofBuilder::new(&keychain);
+	let genesis = genesis_block(&keychain);
+	let chain = init_chain(chain_dir, genesis.clone());
+
+	// Mine a few empty blocks.
+	for _ in 1..6 {
+		let block = build_block(&chain, &keychain, &[], false)?;
+		chain.process_block(block, Options::MINE)?;
+	}
+
+	let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+	let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
+	let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
+
+	// Build a tx that spends a couple of early coinbase outputs and produces some new outputs.
+	// Note: We reuse key_ids resulting in an input and an output sharing the same commitment.
+	// The input is coinbase and the output is plain.
+	let tx = build::transaction(
+		KernelFeatures::Plain { fee: 0 },
+		&[
+			build::coinbase_input(consensus::REWARD, key_id1.clone()),
+			build::coinbase_input(consensus::REWARD, key_id2.clone()),
+			build::output(60_000_000_000, key_id1.clone()),
+			build::output(50_000_000_000, key_id2.clone()),
+			build::output(10_000_000_000, key_id3.clone()),
+		],
+		&keychain,
+		&pb,
+	)
+	.expect("valid tx");
+
+	// The offending commitment, reused in both an input and an output.
+	let commit = keychain.commit(60_000_000_000, &key_id1, SwitchCommitmentType::Regular)?;
+	let inputs: Vec<_> = tx.inputs().into();
+	assert!(inputs.iter().any(|input| input.commitment() == commit));
+	assert!(tx
+		.outputs()
+		.iter()
+		.any(|output| output.commitment() == commit));
+
+	let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
+
+	// Transaction is invalid due to cut-through.
+	assert_eq!(
+		tx.validate(Weighting::AsTransaction, verifier_cache.clone()),
+		Err(transaction::Error::CutThrough),
+	);
+
+	// Transaction will not validate against the chain (utxo).
+	assert_eq!(
+		chain.validate_tx(&tx).map_err(|e| e.kind()),
+		Err(chain::ErrorKind::DuplicateCommitment(commit)),
+	);
+
+	// Build a block with this single invalid transaction.
+	let block = build_block(&chain, &keychain, &[tx.clone()], true)?;
+
+	// The block is invalid due to cut-through.
+	let prev = chain.head_header()?;
+	assert_eq!(
+		block.validate(&prev.total_kernel_offset(), verifier_cache),
+		Err(block::Error::Transaction(transaction::Error::CutThrough))
+	);
+
+	// The block processing pipeline will refuse to accept the block due to "duplicate commitment".
+	// Note: The error is "Other" with a stringified backtrace and is effectively impossible to introspect here...
+	assert!(chain.process_block(block.clone(), Options::MINE).is_err());
+
+	// Now exercise the internal call to pipe::process_block() directly so we can introspect the error
+	// without it being wrapped as above.
+	{
+		let store = chain.store();
+		let header_pmmr = chain.header_pmmr();
+		let txhashset = chain.txhashset();
+
+		let mut header_pmmr = header_pmmr.write();
+		let mut txhashset = txhashset.write();
+		let batch = store.batch()?;
+
+		let mut ctx = chain.new_ctx(Options::NONE, batch, &mut header_pmmr, &mut txhashset)?;
+		let res = pipe::process_block(&block, &mut ctx).map_err(|e| e.kind());
+		assert_eq!(
+			res,
+			Err(chain::ErrorKind::InvalidBlockProof(
+				block::Error::Transaction(transaction::Error::CutThrough)
+			))
+		);
+	}
+
+	clean_output_dir(chain_dir);
+	Ok(())
+}


### PR DESCRIPTION
This PR makes the "cut-through" logic consistent across block validation "in isolation", aligning it with the _implicit_ "cut-through" rules applied later in the block processing pipeline.
This is related to a consensus rule but we have confirmed it does not impact existing consensus rules (see below).

This is a relatively large PR but vast majority of additional LOC is in new test coverage and greater flexibility in test setup.
The code changes themselves are minimal and limited to early block and transaction validation in `verify_cut_through()`.

----

In the block processing pipeline we `apply_block()` by iterating over the block outputs calling `apply_output()`

https://github.com/mimblewimble/grin/blob/01a300e68bd7efdccf513a813864e42bd4c9786f/chain/src/txhashset/txhashset.rs#L1125-L1127

Note that we compare the output _commitment_ and we do not allow duplicates by commitment.
We process block outputs _before_ block inputs - adding new outputs to the UTXO set before removing spent outputs.
So a block is not valid if it attempts to add an output to the UTXO set if an unspent output with that commitment already exists.

Rule 1: It is invalid to spend `C` to produce a new output `C'` if they share the same _commitment_.

When a node initially receives a block we validate it "in isolation". This happens outside of the context of the UTXO. The block is validated to ensure it is internally consistent. As part of this we verify the block is fully "cut-through", that it does not spend its own outputs.

https://github.com/mimblewimble/grin/blob/01a300e68bd7efdccf513a813864e42bd4c9786f/core/src/core/transaction.rs#L951-L970

Rule 2: It is invalid to spend `C` to produce a new output `C'` if they share the same _hash_.

Note that in both rule (1) and (2) we are verifying that the block is fully cut-through. But there is inconsistency in the way these rules are applied.

It is possible for two outputs to share the same commitment but differ in hash as we include output "features" in the data to be hashed.

https://github.com/mimblewimble/grin/blob/01a300e68bd7efdccf513a813864e42bd4c9786f/core/src/core/transaction.rs#L1472-L1478

https://github.com/mimblewimble/grin/blob/01a300e68bd7efdccf513a813864e42bd4c9786f/core/src/core/transaction.rs#L1725-L1731

We have two output features - 
* Plain
* Coinbase

So there is a form of transaction where an output of one feature variant is spent and could be replaced by a new output with the same commitment but different feature variant. This would involve spending a coinbase output and producing a plain output. In this way it would be possible to produce a block containing `C -> C'` where `C` is coinbase output and `C'` plain output, both sharing the same commitment.

The result of this inconsistency is that a block can be seen as valid (no cut-through) when validated internally, but then subsequently seen as invalid (due to cut-through) later in the block processing pipeline.

----

### Does this result in a consensus issue currently?

We have confirmed this inconsistency _does not and cannot_ lead to a consensus problem. The combination of the two cut-through checks (one explicit, one later implicit) ensures that a valid block will always be treated as valid and an invalid block always treated as invalid. We are letting invalid blocks through the pipeline further than they need to go, and catching them later in the process.

### Does fixing this risk introducing a consensus issue?

We want to make both cut-through checks consistent. A block should be caught as invalid early in the validation process. When we check for cut-through by comparing the block inputs and outputs internally we should apply the correct cut-through rules (comparing by commitment). The concern here is that we would be changing consensus sensitive code.
By making the earlier cut-through validation rule consistent with those applied later implicitly (when applying outputs to the UTXO) we are not changing the consensus rule in any way, we are simply catching an invalid block earlier.

----

The fix is relatively simple. When validating the block for cut-through we want to compare the inputs and outputs by commitment only. 

https://github.com/mimblewimble/grin/blob/6648904899bf88ca9dd07a30e17de91a8c53c442/core/src/core/transaction.rs#L990-L998

When comparing by hash we could take advantage of the enforced sort order of both inputs and outputs as they are both sorted by hash (verified during block validation). We took advantage of this to verify cut-through without needing to allocate. This is no longer possible as we need to resort the inputs and outputs by commitment only. The chosen implementation requires allocation due to this resorting but is significantly simpler and clearer as a result.

----

The remainder of this PR is test coverage for block and transaction validation.
We now have tests covering cut-through during early block and transaction validation and later during the block processing pipeline.

One area of complexity that arose during these tests is the difficulty in actually creating an invalid block without necessarily identifying it as invalid. We want to be able to create an invalid block (with cut-through) and have it accepted into the block processing pipeline. To do this it requires a valid block header.
As part of this we needed to introduce a "readonly header extension" to allow the `prev_root` on the block header to be set correctly, even in the presence of invalid inputs and outputs in the block body itself.

https://github.com/mimblewimble/grin/blob/6648904899bf88ca9dd07a30e17de91a8c53c442/chain/src/chain.rs#L692-L706

