### PR TITLE
Update dockerfiles with rust 1.45 and Debian Buster

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,7 +1,7 @@
 # Multistage docker build, requires docker 17.05
 
 # builder stage
-FROM rust:1.35 as builder
+FROM rust:1.45 as builder
 
 RUN set -ex && \
     apt-get update && \
@@ -23,7 +23,7 @@ COPY . .
 RUN cargo build --release
 
 # runtime stage
-FROM debian:9.4
+FROM debian:10
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales openssl
 

--- a/etc/Dockerfile.floonet
+++ b/etc/Dockerfile.floonet
@@ -1,7 +1,7 @@
 # Multistage docker build, requires docker 17.05
 
 # builder stage
-FROM rust:1.35 as builder
+FROM rust:1.45 as builder
 
 RUN set -ex && \
     apt-get update && \
@@ -23,7 +23,7 @@ COPY . .
 RUN cargo build --release
 
 # runtime stage
-FROM debian:9.4
+FROM debian:10
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales openssl
 


### PR DESCRIPTION
Dockerfile was not working.
- Rust 1.35 -> 1.45
- Debian 9.4 -> 10