### PR TITLE
bump protocol version to 1000 to facilitate version deprecation

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -45,7 +45,7 @@ use util::OneTime;
 /// Note: We also use a specific (possible different) protocol version
 /// for both the backend database and MMR data files.
 /// This defines the p2p layer protocol version for this node.
-pub const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(3);
+pub const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1_000);
 
 /// Automated testing edge_bits
 pub const AUTOMATED_TESTING_MIN_EDGE_BITS: u8 = 10;


### PR DESCRIPTION
Related #3430. 

This PR introduces a "major" protocol version bump to __1000__.

https://github.com/mimblewimble/docs/wiki/P2P-Protocol#phasing-out-old-peers

> Peers with a protocol version in the range [1000-1999] should be able to interact with any peer in the range [0-2999].

This maintains full support with all prior protocol versions.
In effect we deprecate (but still continue to support) versions __0-1000__ inclusive.

As part of HF4 the proposal is to introduce an additional "major" bump to __2000__.

> Peers with a protocol version in the range [2000-2999] should be able to interact with any peer in the range [1000-3999].

This would cleanly and intentionally remove support for old deprecated versions (<1000) allowing implementation internals to be cleaned up post HF4.

