### PR TITLE
maintain preferred peer connections

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -416,7 +416,12 @@ impl Peers {
 	/// Iterate over the peer list and prune all peers we have
 	/// lost connection to or have been deemed problematic.
 	/// Also avoid connected peer count getting too high.
-	pub fn clean_peers(&self, max_inbound_count: usize, max_outbound_count: usize) {
+	pub fn clean_peers(
+		&self,
+		max_inbound_count: usize,
+		max_outbound_count: usize,
+		preferred_peers: &[PeerAddr],
+	) {
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up
@@ -464,12 +469,13 @@ impl Peers {
 		let excess_outgoing_count =
 			(self.peer_outbound_count() as usize).saturating_sub(max_outbound_count);
 		if excess_outgoing_count > 0 {
-			let mut addrs = self
+			let mut addrs: Vec<_> = self
 				.outgoing_connected_peers()
 				.iter()
+				.filter(|x| !preferred_peers.contains(&x.info.addr))
 				.take(excess_outgoing_count)
 				.map(|x| x.info.addr)
-				.collect::<Vec<_>>();
+				.collect();
 			rm.append(&mut addrs);
 		}
 
@@ -477,12 +483,13 @@ impl Peers {
 		let excess_incoming_count =
 			(self.peer_inbound_count() as usize).saturating_sub(max_inbound_count);
 		if excess_incoming_count > 0 {
-			let mut addrs = self
+			let mut addrs: Vec<_> = self
 				.incoming_connected_peers()
 				.iter()
+				.filter(|x| !preferred_peers.contains(&x.info.addr))
 				.take(excess_incoming_count)
 				.map(|x| x.info.addr)
-				.collect::<Vec<_>>();
+				.collect();
 			rm.append(&mut addrs);
 		}
 

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -248,13 +248,16 @@ impl Server {
 				_ => unreachable!(),
 			};
 
-			let preferred_peers = config.p2p_config.peers_preferred.clone().map(|p| p.peers);
+			let preferred_peers = match &config.p2p_config.peers_preferred {
+				Some(addrs) => addrs.peers.clone(),
+				None => vec![],
+			};
 
 			connect_thread = Some(seed::connect_and_monitor(
 				p2p_server.clone(),
 				config.p2p_config.capabilities,
 				seeder,
-				preferred_peers,
+				&preferred_peers,
 				stop_state.clone(),
 			)?);
 		}


### PR DESCRIPTION
* If we specify `preferred_peers` in config then attempt to maintain these when cleaning excess peers.
* Pass `preferred_peers` into `clean_peers()` to facilitate this.
* General cleanup passing a slice of `PeerAddr` around rather than `Option<Vec<PeerAddr>>`.

Tested on `mainnet` and "preferred peers" works a lot more robustly now...