### PR TITLE
Remove hashmap as disclosure contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,10 +34,9 @@ and [details](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/82e0
 guidelines. More information is available about the
 [expected timelines for the full disclosure cycle](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/82e08d2736ea9dbe43484a3317e4bce214163bd0#standard-disclosure-timelines).
 
-For all security related issues, Grin has 3 main points of contact:
+For all security related issues, Grin has 2 main points of contact:
 
 * Daniel Lehnberg, daniel.lehnberg at protonmail.com [PGP key](https://github.com/mimblewimble/grin-security/blob/master/keys/lehnberg.asc)
-* hashmap, hashmap.dev at protonmail.com [PGP key](https://github.com/mimblewimble/grin-security/blob/master/keys/hashmap.asc)
 * John Woeltz, joltz at protonmail.com [PGP key](https://github.com/mimblewimble/grin-security/blob/master/keys/j01tz.asc)
 
 Send all communications PGP encrypted to all parties.


### PR DESCRIPTION
This change removes @hashmap as a disclosure contact in the disclosure policy in SECURITY.md, as he is no longer active nor available to participate for now. 

It is important to keep the security team and the associated disclosure contacts active to reduce unnecessary information leakage and to ensure that security-related requests are noticed and receive prompt responses. I hope to see him back in the future, thanks for the great work @hashmap!
