### PR TITLE
cleanup mining stats

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -208,6 +208,10 @@ pub const AR_SCALE_DAMP_FACTOR: u64 = 13;
 pub fn graph_weight(height: u64, edge_bits: u8) -> u64 {
 	let mut xpr_edge_bits = edge_bits as u64;
 
+	if edge_bits < global::base_edge_bits() {
+		return 0;
+	}
+
 	let expiry_height = YEAR_HEIGHT;
 	if edge_bits == 31 && height >= expiry_height {
 		xpr_edge_bits = xpr_edge_bits.saturating_sub(1 + (height - expiry_height) / WEEK_HEIGHT);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -208,10 +208,6 @@ pub const AR_SCALE_DAMP_FACTOR: u64 = 13;
 pub fn graph_weight(height: u64, edge_bits: u8) -> u64 {
 	let mut xpr_edge_bits = edge_bits as u64;
 
-	if edge_bits < global::base_edge_bits() {
-		return 0;
-	}
-
 	let expiry_height = YEAR_HEIGHT;
 	if edge_bits == 31 && height >= expiry_height {
 		xpr_edge_bits = xpr_edge_bits.saturating_sub(1 + (height - expiry_height) / WEEK_HEIGHT);

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -267,7 +267,7 @@ impl Default for StratumStats {
 			num_workers: 0,
 			block_height: 0,
 			network_difficulty: 0,
-			edge_bits: 32,
+			edge_bits: 0,
 			network_hashrate: 0.0,
 			worker_stats: Vec::new(),
 		}

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -127,7 +127,7 @@ pub struct StratumStats {
 	pub block_height: u64,
 	/// current network difficulty we're working on
 	pub network_difficulty: u64,
-	/// cuckoo size of last share sumitted
+	/// cuckoo size of last share submitted
 	pub edge_bits: u16,
 	/// current network Hashrate (for edge_bits)
 	pub network_hashrate: f64,

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -266,7 +266,7 @@ impl Default for StratumStats {
 			is_running: false,
 			num_workers: 0,
 			block_height: 0,
-			network_difficulty: 1000,
+			network_difficulty: 0,
 			edge_bits: 32,
 			network_hashrate: 0.0,
 			worker_stats: Vec::new(),

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -19,7 +19,6 @@ use crate::util::RwLock;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::core::consensus::graph_weight;
 use crate::core::core::hash::Hash;
 use crate::core::ser::ProtocolVersion;
 
@@ -128,8 +127,10 @@ pub struct StratumStats {
 	pub block_height: u64,
 	/// current network difficulty we're working on
 	pub network_difficulty: u64,
-	/// cuckoo size used for mining
+	/// cuckoo size of last share sumitted
 	pub edge_bits: u16,
+	/// current network Hashrate (for edge_bits)
+	pub network_hashrate: f64,
 	/// Individual worker status
 	pub worker_stats: Vec<WorkerStats>,
 }
@@ -211,14 +212,6 @@ impl PartialEq for DiffBlock {
 	}
 }
 
-impl StratumStats {
-	/// Calculate network hashrate
-	pub fn network_hashrate(&self, height: u64) -> f64 {
-		42.0 * (self.network_difficulty as f64 / graph_weight(height, self.edge_bits as u8) as f64)
-			/ 60.0
-	}
-}
-
 impl PeerStats {
 	/// Convert from a peer directly
 	pub fn from_peer(peer: &p2p::Peer) -> PeerStats {
@@ -274,7 +267,8 @@ impl Default for StratumStats {
 			num_workers: 0,
 			block_height: 0,
 			network_difficulty: 1000,
-			edge_bits: 29,
+			edge_bits: 32,
+			network_hashrate: 0.0,
 			worker_stats: Vec::new(),
 		}
 	}

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -361,7 +361,6 @@ impl Server {
 
 	/// Start a minimal "stratum" mining service on a separate thread
 	pub fn start_stratum_server(&self, config: StratumServerConfig) {
-		let edge_bits = global::min_edge_bits();
 		let proof_size = global::proofsize();
 		let sync_state = self.sync_state.clone();
 
@@ -375,7 +374,7 @@ impl Server {
 		let _ = thread::Builder::new()
 			.name("stratum_server".to_string())
 			.spawn(move || {
-				stratum_server.run_loop(edge_bits as u32, proof_size, sync_state);
+				stratum_server.run_loop(proof_size, sync_state);
 			});
 	}
 

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -346,8 +346,8 @@ impl TUIStatusListener for TUIMiningView {
 			_ => format!("Solving Block Height:  {}", stratum_stats.block_height),
 		};
 		let stratum_edge_bits = match stratum_stats.num_workers {
-			0 => "Mining POW:            n/a".to_string(),
-			_ => format!("Mining POW:            Cuckoo{}", stratum_stats.edge_bits),
+			0 => "Latest POW submitted:  n/a".to_string(),
+			_ => format!("Latest POW submitted:  Cuckoo{}", stratum_stats.edge_bits),
 		};
 		let stratum_network_difficulty = match stratum_stats.num_workers {
 			0 => "Network Difficulty:    n/a".to_string(),

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -228,15 +228,15 @@ impl TUIMiningView {
 			)
 			.child(
 				LinearLayout::new(Orientation::Horizontal)
+					.child(TextView::new("  ").with_name("stratum_edge_bits_status")),
+			)
+			.child(
+				LinearLayout::new(Orientation::Horizontal)
 					.child(TextView::new("  ").with_name("stratum_network_difficulty_status")),
 			)
 			.child(
 				LinearLayout::new(Orientation::Horizontal)
 					.child(TextView::new("  ").with_name("stratum_network_hashrate")),
-			)
-			.child(
-				LinearLayout::new(Orientation::Horizontal)
-					.child(TextView::new("  ").with_name("stratum_edge_bits_status")),
 			);
 
 		let mining_device_view = LinearLayout::new(Orientation::Vertical)
@@ -337,21 +337,32 @@ impl TUIStatusListener for TUIMiningView {
 			},
 		);
 		let stratum_stats = stats.stratum_stats.clone();
-		let stratum_network_hashrate = format!(
-			"Network Hashrate:      {:.*}",
-			2,
-			stratum_stats.network_hashrate(stratum_stats.block_height)
-		);
 		let worker_stats = stratum_stats.worker_stats;
 		let stratum_enabled = format!("Mining server enabled: {}", stratum_stats.is_enabled);
 		let stratum_is_running = format!("Mining server running: {}", stratum_stats.is_running);
 		let stratum_num_workers = format!("Number of workers:     {}", stratum_stats.num_workers);
-		let stratum_block_height = format!("Solving Block Height:  {}", stratum_stats.block_height);
-		let stratum_network_difficulty = format!(
-			"Network Difficulty:    {}",
-			stratum_stats.network_difficulty
-		);
-		let stratum_edge_bits = format!("Cuckoo Size:           {}", stratum_stats.edge_bits);
+		let stratum_block_height = match stratum_stats.num_workers {
+			0 => "Solving Block Height:  n/a".to_string(),
+			_ => format!("Solving Block Height:  {}", stratum_stats.block_height),
+		};
+		let stratum_edge_bits = match stratum_stats.num_workers {
+			0 => "Mining POW:            n/a".to_string(),
+			_ => format!("Mining POW:            Cuckoo{}", stratum_stats.edge_bits),
+		};
+		let stratum_network_difficulty = match stratum_stats.num_workers {
+			0 => "Network Difficulty:    n/a".to_string(),
+			_ => format!(
+				"Network Difficulty:    {}",
+				stratum_stats.network_difficulty
+			),
+		};
+		let stratum_network_hashrate = match stratum_stats.num_workers {
+			0 => "Network Hashrate:      n/a".to_string(),
+			_ => format!(
+				"Network Hashrate C{}:  {:.*}",
+				stratum_stats.edge_bits, 2, stratum_stats.network_hashrate
+			),
+		};
 
 		c.call_on_name("stratum_config_status", |t: &mut TextView| {
 			t.set_content(stratum_enabled);
@@ -365,14 +376,14 @@ impl TUIStatusListener for TUIMiningView {
 		c.call_on_name("stratum_block_height_status", |t: &mut TextView| {
 			t.set_content(stratum_block_height);
 		});
+		c.call_on_name("stratum_edge_bits_status", |t: &mut TextView| {
+			t.set_content(stratum_edge_bits);
+		});
 		c.call_on_name("stratum_network_difficulty_status", |t: &mut TextView| {
 			t.set_content(stratum_network_difficulty);
 		});
 		c.call_on_name("stratum_network_hashrate", |t: &mut TextView| {
 			t.set_content(stratum_network_hashrate);
-		});
-		c.call_on_name("stratum_edge_bits_status", |t: &mut TextView| {
-			t.set_content(stratum_edge_bits);
 		});
 		let _ = c.call_on_name(
 			TABLE_MINING_STATUS,


### PR DESCRIPTION
Cleanup mining stats

1) make edge_bits dynamic (last size submitted)
2) dont show bogus stats when no miners are connected
3) move network hashrate calculation into stratum server and only call it when miners are connected, and pass the value through StratumStats object (like all the rest)
4) update a few comments

The two user visible (non-consensus) changes are:

Previously:  bogus default, or outdated stats would be shown when no miners are connected.
Now: status shows "n/a" for those stats when no miners are connected

Previously:  only stats for C31 are shown, which is no longer even mined
Now: stats are shown for the size of the last share submitted - with C32 by default (if no shares are submitted yet)

