### PR TITLE
migrate blocks in batches (rework db iterator impl)

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -37,12 +37,12 @@ use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::{util::RwLock, ChainStore};
 use grin_core::ser;
 use grin_store::Error::NotFoundErr;
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{collections::HashMap, io::Cursor};
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
 pub const MAX_ORPHAN_SIZE: usize = 200;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -37,12 +37,12 @@ use crate::util::secp::pedersen::{Commitment, RangeProof};
 use crate::{util::RwLock, ChainStore};
 use grin_core::ser;
 use grin_store::Error::NotFoundErr;
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{collections::HashMap, io::Cursor};
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
 pub const MAX_ORPHAN_SIZE: usize = 200;

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -265,6 +265,14 @@ impl From<io::Error> for Error {
 	}
 }
 
+impl From<ser::Error> for Error {
+	fn from(error: ser::Error) -> Error {
+		Error {
+			inner: Context::new(ErrorKind::SerErr(error)),
+		}
+	}
+}
+
 impl From<secp::Error> for Error {
 	fn from(e: secp::Error) -> Error {
 		Error {

--- a/chain/src/linked_list.rs
+++ b/chain/src/linked_list.rs
@@ -390,12 +390,12 @@ impl<T: PosEntry> PruneableListIndex for MultiIndex<T> {
 		let mut list_count = 0;
 		let mut entry_count = 0;
 		let prefix = to_key(self.list_prefix, "");
-		for (key, _) in batch.db.iter::<ListWrapper<T>>(&prefix)? {
+		for key in batch.db.iter(&prefix, |k, _| Ok(k.to_vec()))? {
 			let _ = batch.delete(&key);
 			list_count += 1;
 		}
 		let prefix = to_key(self.entry_prefix, "");
-		for (key, _) in batch.db.iter::<ListEntry<T>>(&prefix)? {
+		for key in batch.db.iter(&prefix, |k, _| Ok(k.to_vec()))? {
 			let _ = batch.delete(&key);
 			entry_count += 1;
 		}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -23,8 +23,9 @@ use crate::linked_list::MultiIndex;
 use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
 use croaring::Bitmap;
+use grin_core::ser;
 use grin_store as store;
-use grin_store::{option_to_not_found, to_key, Error, SerIterator};
+use grin_store::{option_to_not_found, to_key, Error};
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -55,17 +56,6 @@ impl ChainStore {
 	pub fn new(db_root: &str) -> Result<ChainStore, Error> {
 		let db = store::Store::new(db_root, None, Some(STORE_SUBPATH), None)?;
 		Ok(ChainStore { db })
-	}
-
-	/// Create a new instance of the chain store based on this instance
-	/// but with the provided protocol version. This is used when migrating
-	/// data in the db to a different protocol version, reading using one version and
-	/// writing back to the db with a different version.
-	pub fn with_version(&self, version: ProtocolVersion) -> ChainStore {
-		let db_with_version = self.db.with_version(version);
-		ChainStore {
-			db: db_with_version,
-		}
 	}
 
 	/// The current chain head.
@@ -224,11 +214,20 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
-	/// Migrate a block stored in the db by serializing it using the provided protocol version.
-	/// Block may have been read using a previous protocol version but we do not actually care.
-	pub fn migrate_block(&self, b: &Block, version: ProtocolVersion) -> Result<(), Error> {
-		self.db
-			.put_ser_with_version(&to_key(BLOCK_PREFIX, b.hash())[..], b, version)?;
+	/// Migrate a block stored in the db reading from one protocol version and writing
+	/// with new protocol version.
+	pub fn migrate_block(
+		&self,
+		key: &[u8],
+		from_version: ProtocolVersion,
+		to_version: ProtocolVersion,
+	) -> Result<(), Error> {
+		let block: Option<Block> = self.db.get_with(key, move |_, mut v| {
+			ser::deserialize(&mut v, from_version).map_err(From::from)
+		})?;
+		if let Some(block) = block {
+			self.db.put_ser_with_version(key, &block, to_version)?;
+		}
 		Ok(())
 	}
 
@@ -283,9 +282,14 @@ impl<'a> Batch<'a> {
 	}
 
 	/// Iterator over the output_pos index.
-	pub fn output_pos_iter(&self) -> Result<SerIterator<(u64, u64)>, Error> {
+	pub fn output_pos_iter(&self) -> Result<impl Iterator<Item = (Vec<u8>, CommitPos)>, Error> {
 		let key = to_key(OUTPUT_POS_PREFIX, "");
-		self.db.iter(&key)
+		let protocol_version = self.db.protocol_version();
+		self.db.iter(&key, move |k, mut v| {
+			ser::deserialize(&mut v, protocol_version)
+				.map(|pos| (k.to_vec(), pos))
+				.map_err(From::from)
+		})
 	}
 
 	/// Get output_pos from index.
@@ -371,10 +375,26 @@ impl<'a> Batch<'a> {
 		})
 	}
 
-	/// An iterator to all block in db
-	pub fn blocks_iter(&self) -> Result<SerIterator<Block>, Error> {
+	/// Iterator over all full blocks in the db.
+	/// Uses default db serialization strategy via db protocol version.
+	pub fn blocks_iter(&self) -> Result<impl Iterator<Item = Block>, Error> {
 		let key = to_key(BLOCK_PREFIX, "");
-		self.db.iter(&key)
+		let protocol_version = self.db.protocol_version();
+		self.db.iter(&key, move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		})
+	}
+
+	/// Iterator over raw data for full blocks in the db.
+	/// Used during block migration (we need flexibility around deserialization).
+	pub fn blocks_raw_iter(&self) -> Result<impl Iterator<Item = (Vec<u8>, Vec<u8>)>, Error> {
+		let key = to_key(BLOCK_PREFIX, "");
+		self.db.iter(&key, |k, v| Ok((k.to_vec(), v.to_vec())))
+	}
+
+	/// Protocol version of our underlying db.
+	pub fn protocol_version(&self) -> ProtocolVersion {
+		self.db.protocol_version()
 	}
 }
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -513,12 +513,13 @@ impl TxHashSet {
 		// Iterate over the current output_pos index, removing any entries that
 		// do not point to to the expected output.
 		let mut removed_count = 0;
-		for (key, (pos, _)) in batch.output_pos_iter()? {
-			if let Some(out) = output_pmmr.get_data(pos) {
+		for (key, pos) in batch.output_pos_iter()? {
+			if let Some(out) = output_pmmr.get_data(pos.pos) {
 				if let Ok(pos_via_mmr) = batch.get_output_pos(&out.commitment()) {
 					// If the pos matches and the index key matches the commitment
 					// then keep the entry, other we want to clean it up.
-					if pos == pos_via_mmr && batch.is_match_output_pos_key(&key, &out.commitment())
+					if pos.pos == pos_via_mmr
+						&& batch.is_match_output_pos_key(&key, &out.commitment())
 					{
 						continue;
 					}

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -369,15 +369,16 @@ impl Peers {
 		}
 	}
 
-	/// All peer information we have in storage
+	/// Iterator over all peers we know about (stored in our db).
+	pub fn peers_iter(&self) -> Result<impl Iterator<Item = PeerData>, Error> {
+		self.store.peers_iter().map_err(From::from)
+	}
+
+	/// Convenience for reading all peers.
 	pub fn all_peers(&self) -> Vec<PeerData> {
-		match self.store.all_peers() {
-			Ok(peers) => peers,
-			Err(e) => {
-				error!("all_peers failed: {:?}", e);
-				vec![]
-			}
-		}
+		self.peers_iter()
+			.map(|peers| peers.collect())
+			.unwrap_or(vec![])
 	}
 
 	/// Find peers in store (not necessarily connected) and return their data

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -152,13 +152,15 @@ impl PeerStore {
 		cap: Capabilities,
 		count: usize,
 	) -> Result<Vec<PeerData>, Error> {
-		let peers = self.peers_iter()?
+		let peers = self
+			.peers_iter()?
 			.filter(|p| p.flags == state && p.capabilities.contains(cap))
 			.choose_multiple(&mut thread_rng(), count);
 		Ok(peers)
 	}
 
-	fn peers_iter(&self) -> Result<impl Iterator<Item = PeerData>, Error> {
+	/// Iterator over all known peers.
+	pub fn peers_iter(&self) -> Result<impl Iterator<Item = PeerData>, Error> {
 		let key = to_key(PEER_PREFIX, "");
 		let protocol_version = self.db.protocol_version();
 		self.db.iter(&key, move |_, mut v| {

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -169,9 +169,7 @@ impl PeerStore {
 	/// List all known peers
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
-		let peers: Vec<PeerData> = self
-			.peers_iter()?
-			.collect();
+		let peers: Vec<PeerData> = self.peers_iter()?.collect();
 		Ok(peers)
 	}
 

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -152,21 +152,27 @@ impl PeerStore {
 		cap: Capabilities,
 		count: usize,
 	) -> Result<Vec<PeerData>, Error> {
-		let key = to_key(PEER_PREFIX, "");
-		let peers = self
-			.db
-			.iter::<PeerData>(&key)?
-			.map(|(_, v)| v)
+		let peers = self.peers_iter()?
 			.filter(|p| p.flags == state && p.capabilities.contains(cap))
 			.choose_multiple(&mut thread_rng(), count);
 		Ok(peers)
 	}
 
+	fn peers_iter(&self) -> Result<impl Iterator<Item = PeerData>, Error> {
+		let key = to_key(PEER_PREFIX, "");
+		let protocol_version = self.db.protocol_version();
+		self.db.iter(&key, move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		})
+	}
+
 	/// List all known peers
 	/// Used for /v1/peers/all api endpoint
 	pub fn all_peers(&self) -> Result<Vec<PeerData>, Error> {
-		let key = to_key(PEER_PREFIX, "");
-		Ok(self.db.iter::<PeerData>(&key)?.map(|(_, v)| v).collect())
+		let peers: Vec<PeerData> = self
+			.peers_iter()?
+			.collect();
+		Ok(peers)
 	}
 
 	/// Convenience method to load a peer data, update its status and save it
@@ -194,7 +200,7 @@ impl PeerStore {
 	{
 		let mut to_remove = vec![];
 
-		for x in self.all_peers()? {
+		for x in self.peers_iter()? {
 			if predicate(&x) {
 				to_remove.push(x)
 			}

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -147,12 +147,12 @@ fn monitor_peers(
 ) {
 	// regularly check if we need to acquire more peers  and if so, gets
 	// them from db
-	let total_count = peers.all_peers().len();
+	let total_count = peers.peers_iter().count();
 	let mut healthy_count = 0;
 	let mut banned_count = 0;
 	let mut defuncts = vec![];
 
-	for x in peers.all_peers() {
+	for x in peers.peers_iter() {
 		match x.flags {
 			p2p::State::Banned => {
 				let interval = Utc::now().timestamp() - x.last_banned;

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -14,8 +14,8 @@
 
 //! Storage of core types using LMDB.
 
-use std::sync::Arc;
 use std::fs;
+use std::sync::Arc;
 
 use lmdb_zero as lmdb;
 use lmdb_zero::traits::CreateCursor;
@@ -284,20 +284,6 @@ impl Store {
 		})
 	}
 
-	// fn get_raw(
-	// 	&self,
-	// 	key: &[u8],
-	// 	access: &lmdb::ConstAccessor<'_>,
-	// 	db: Arc<lmdb::Database<'static>>,
-	// ) -> Result<Option<Cursor<Vec<u8>>>, Error> {
-	// 	let res: lmdb::error::Result<&[u8]> = access.get(&db, key);
-	// 	match res.to_opt() {
-	// 		Ok(Some(res)) => Ok(Some(Cursor::new(res.to_vec()))),
-	// 		Ok(None) => Ok(None),
-	// 		Err(e) => Err(From::from(e)),
-	// 	}
-	// }
-
 	/// Whether the provided key exists
 	pub fn exists(&self, key: &[u8]) -> Result<bool, Error> {
 		let lock = self.db.read();
@@ -426,18 +412,6 @@ impl<'a> Batch<'a> {
 		})
 	}
 
-	// /// Gets a db entry by provided key.
-	// pub fn get_raw(&self, key: &[u8]) -> Result<Option<Cursor<Vec<u8>>>, Error> {
-	// 	let access = self.tx.access();
-
-	// 	let lock = self.store.db.read();
-	// 	let db = lock
-	// 		.as_ref()
-	// 		.ok_or_else(|| Error::NotFoundErr("chain db is None".to_string()))?;
-
-	// 	self.store.get_raw(key, &access, db.clone())
-	// }
-
 	/// Deletes a key/value pair from the db
 	pub fn delete(&self, key: &[u8]) -> Result<(), Error> {
 		let lock = self.store.db.read();
@@ -494,11 +468,9 @@ where
 		};
 		kv.ok()
 			.filter(|(k, _)| k.starts_with(self.prefix.as_slice()))
-			.map(|(k, v)| {
-				match (self.deserialize)(k, v) {
-					Ok(v) => Some(v),
-					Err(_) => None,
-				}
+			.map(|(k, v)| match (self.deserialize)(k, v) {
+				Ok(v) => Some(v),
+				Err(_) => None,
 			})
 			.flatten()
 	}
@@ -514,7 +486,6 @@ where
 		cursor: Arc<lmdb::Cursor<'static, 'static>>,
 		prefix: &[u8],
 		deserialize: F,
-
 	) -> PrefixIterator<F, T> {
 		PrefixIterator {
 			tx,

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -15,7 +15,7 @@
 use grin_core as core;
 use grin_store as store;
 use grin_util as util;
-use store::SerIterator;
+use store::PrefixIterator;
 
 use crate::core::global;
 use crate::core::ser::{self, Readable, Reader, Writeable, Writer};
@@ -118,14 +118,14 @@ fn test_iter() -> Result<(), store::Error> {
 	// assert_eq!(iter.next(), None);
 
 	// Check we can not yet see the new entry via an iterator outside the uncommitted batch.
-	let mut iter: SerIterator<Vec<u8>> = store.iter(&[0])?;
+	let mut iter = store.iter(&[0], |_, v| Ok(v.to_vec()))?;
 	assert_eq!(iter.next(), None);
 
 	batch.commit()?;
 
 	// Check we can see the new entry via an iterator after committing the batch.
-	let mut iter: SerIterator<Vec<u8>> = store.iter(&[0])?;
-	assert_eq!(iter.next(), Some((key.to_vec(), value.to_vec())));
+	let mut iter = store.iter(&[0], |_, v| Ok(v.to_vec()))?;
+	assert_eq!(iter.next(), Some(value.to_vec()));
 	assert_eq!(iter.next(), None);
 
 	clean_output_dir(test_dir);


### PR DESCRIPTION
Resolves #3448
Resolves #3099
Related #3449  

* migrate blocks v2->v3 in batches of 100 blocks
  * identify blocks to migrate based on v2/v3 compatibility with multiple deserializaton attempts
  * small batches individually committed to db
  * this should support a "full archival" node migration
* rework our db iter impl for ~low level access~ more flexible deserialization strategies
  * replace `SerIterator` with new `PrefixIterator`
  * ~we now return raw `Vec<u8>` entries~
  * ~caller is responsible for deserialization~
  * `PrefixIterator` now takes a flexible `deserialize` fn
  * during block migration we use `PrefixIterator` to return raw data and attempt deserialization locally
* ~add a `db.get_raw()` to allow `Vec<u8>` to be retrieved for individual key~
* `blocks_raw_iter()` returns raw `(k, v)` data
* `block_iter()` returns deserialized blocks

