### PR TITLE
refactor get_ser() to use get_with() internally

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -359,7 +359,9 @@ impl<'a> Batch<'a> {
 	fn get_legacy_input_bitmap(&self, bh: &Hash) -> Result<Bitmap, Error> {
 		option_to_not_found(
 			self.db
-				.get_with(&to_key(BLOCK_INPUT_BITMAP_PREFIX, bh), Bitmap::deserialize),
+				.get_with(&to_key(BLOCK_INPUT_BITMAP_PREFIX, bh), |data| {
+					Ok(Bitmap::deserialize(data))
+				}),
 			|| "legacy block input bitmap".to_string(),
 		)
 	}


### PR DESCRIPTION
This PR refactors some of the lmdb batch internals.

* `get_with()` deserialization function now fallible
* `get_ser()` uses `get_with()` internally and passes in default deserialization strategy
* removed the awkward `get_ser_access()`
* `batch.exists()` now aware of current write tx and not simply a wrapper to `db.exists()`

Related #3450 (which prompted this refactor).


We use `get_ser()` heavily as this uses the default deserialization strategy. But we also occasionally want more flexible access (see #3450). This PR consolidates `get_with()` and `get_ser()`.