### PR TITLE
Flexible peer filtering

### DIFF
--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -40,7 +40,9 @@ pub struct PeersConnectedHandler {
 impl PeersConnectedHandler {
 	pub fn get_connected_peers(&self) -> Result<Vec<PeerInfoDisplay>, Error> {
 		let peers = w(&self.peers)?
-			.connected_peers()
+			.peers_iter()
+			.connected()
+			.into_iter()
 			.map(|p| p.info.clone().into())
 			.collect::<Vec<PeerInfoDisplay>>();
 		Ok(peers)
@@ -50,7 +52,9 @@ impl PeersConnectedHandler {
 impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
 		let peers: Vec<PeerInfoDisplay> = w_fut!(&self.peers)
-			.connected_peers()
+			.peers_iter()
+			.connected()
+			.into_iter()
 			.map(|p| p.info.clone().into())
 			.collect();
 		json_response(&peers)

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -40,7 +40,7 @@ pub struct PeersConnectedHandler {
 impl PeersConnectedHandler {
 	pub fn get_connected_peers(&self) -> Result<Vec<PeerInfoDisplay>, Error> {
 		let peers = w(&self.peers)?
-			.peers_iter()
+			.iter()
 			.connected()
 			.into_iter()
 			.map(|p| p.info.clone().into())
@@ -52,7 +52,7 @@ impl PeersConnectedHandler {
 impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
 		let peers: Vec<PeerInfoDisplay> = w_fut!(&self.peers)
-			.peers_iter()
+			.iter()
 			.connected()
 			.into_iter()
 			.map(|p| p.info.clone().into())

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -41,7 +41,6 @@ impl PeersConnectedHandler {
 	pub fn get_connected_peers(&self) -> Result<Vec<PeerInfoDisplay>, Error> {
 		let peers = w(&self.peers)?
 			.connected_peers()
-			.iter()
 			.map(|p| p.info.clone().into())
 			.collect::<Vec<PeerInfoDisplay>>();
 		Ok(peers)
@@ -52,7 +51,6 @@ impl Handler for PeersConnectedHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
 		let peers: Vec<PeerInfoDisplay> = w_fut!(&self.peers)
 			.connected_peers()
-			.iter()
 			.map(|p| p.info.clone().into())
 			.collect();
 		json_response(&peers)

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -28,7 +28,7 @@ pub struct PeersAllHandler {
 
 impl Handler for PeersAllHandler {
 	fn get(&self, _req: Request<Body>) -> ResponseFuture {
-		let peers = &w_fut!(&self.peers).all_peers();
+		let peers = &w_fut!(&self.peers).all_peer_data();
 		json_response_pretty(&peers)
 	}
 }
@@ -79,7 +79,7 @@ impl PeerHandler {
 			})?;
 			return Ok(vec![peer_data]);
 		}
-		let peers = w(&self.peers)?.all_peers();
+		let peers = w(&self.peers)?.all_peer_data();
 		Ok(peers)
 	}
 

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -56,7 +56,7 @@ impl StatusHandler {
 		Ok(Status::from_tip_and_peers(
 			head,
 			w(&self.peers)?
-				.peers_iter()
+				.iter()
 				.connected()
 				.count()
 				.try_into()

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -56,7 +56,8 @@ impl StatusHandler {
 		Ok(Status::from_tip_and_peers(
 			head,
 			w(&self.peers)?
-				.connected_peers()
+				.peers_iter()
+				.connected()
 				.count()
 				.try_into()
 				.unwrap(),

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -21,6 +21,7 @@ use crate::types::*;
 use crate::web::*;
 use hyper::{Body, Request};
 use serde_json::json;
+use std::convert::TryInto;
 use std::sync::Weak;
 
 // RESTful index of available api endpoints
@@ -54,7 +55,11 @@ impl StatusHandler {
 		let (api_sync_status, api_sync_info) = sync_status_to_api(sync_status);
 		Ok(Status::from_tip_and_peers(
 			head,
-			w(&self.peers)?.peer_count(),
+			w(&self.peers)?
+				.connected_peers()
+				.count()
+				.try_into()
+				.unwrap(),
 			api_sync_status,
 			api_sync_info,
 		))

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -144,73 +144,11 @@ impl Peers {
 			.unwrap_or(Difficulty::zero())
 	}
 
-	// /// Number of peers currently connected to.
-	// pub fn peer_count(&self) -> u32 {
-	// 	self.connected_peers().count() as u32
-	// }
-
-	// /// Number of outbound peers currently connected to.
-	// pub fn peer_outbound_count(&self) -> u32 {
-	// 	self.outgoing_connected_peers().count() as u32
-	// }
-
-	// /// Number of inbound peers currently connected to.
-	// pub fn peer_inbound_count(&self) -> u32 {
-	// 	self.incoming_connected_peers().count() as u32
-	// }
-
-	// Return vec of connected peers that currently advertise more work
-	// (total_difficulty) than we do.
-	pub fn more_work_peers(&self) -> Result<Vec<Arc<Peer>>, chain::Error> {
-		let peers = self.connected_peers();
-
-		let total_difficulty = self.total_difficulty()?;
-
-		let mut max_peers = peers
-			.into_iter()
-			.filter(|x| x.info.total_difficulty() > total_difficulty)
-			.collect::<Vec<_>>();
-
-		max_peers.shuffle(&mut thread_rng());
-		Ok(max_peers)
-	}
-
-	// Return number of connected peers that currently advertise more/same work
-	// (total_difficulty) than/as we do.
-	pub fn more_or_same_work_peers(&self) -> Result<usize, chain::Error> {
-		let peers = self.connected_peers();
-
-		let total_difficulty = self.total_difficulty()?;
-
-		Ok(peers
-			.filter(|x| x.info.total_difficulty() >= total_difficulty)
-			.count())
-	}
-
-	// /// Returns single random peer with more work than us.
-	// pub fn more_work_peer(&self) -> Option<Arc<Peer>> {
-	// 	match self.more_work_peers() {
-	// 		Ok(mut peers) => peers.pop(),
-	// 		Err(e) => {
-	// 			error!("failed to get more work peers: {:?}", e);
-	// 			None
-	// 		}
-	// 	}
-	// }
-
-	// /// Iterator of connected peers known to have at least the provided difficulty.
-	// pub fn connected_peers_with_difficulty(&self, diff: Difficulty) -> impl Iterator<Item = Arc<Peer>> {
-	// 	self.connected_peers()
-	// 		.filter(|peer| peer.info.total_difficulty() >= diff)
-	// }
-
-	/// Returns single random peer with the most worked branch, showing the
-	/// highest total difficulty.
-	pub fn most_work_peer(&self) -> Option<Arc<Peer>> {
+	/// Choose a random connected peer >= provided difficulty.
+	pub fn peer_with_difficulty(&self, diff: Difficulty) -> Option<Arc<Peer>> {
 		let mut rng = rand::thread_rng();
-		let max_diff = self.max_peer_difficulty();
 		self.connected_peers()
-			.filter(|peer| peer.info.total_difficulty() >= max_diff)
+			.filter(|peer| peer.info.total_difficulty() >= diff)
 			.choose(&mut rng)
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -715,8 +715,13 @@ impl<I: Iterator<Item = Arc<Peer>>> PeersIter<I> {
 	}
 
 	/// Filter peers that support the provided capabilities.
-	pub fn with_capabilities(self, cap: Capabilities) -> Self {
-		unimplemented!("not yet implemented!")
+	pub fn with_capabilities(
+		self,
+		cap: Capabilities,
+	) -> PeersIter<impl Iterator<Item = Arc<Peer>>> {
+		PeersIter {
+			iter: self.iter.filter(move |p| p.info.capabilities.contains(cap)),
+		}
 	}
 
 	pub fn by_addr(&mut self, addr: PeerAddr) -> Option<Arc<Peer>> {

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -233,7 +233,7 @@ impl Server {
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
-		if self.peers.incoming_connected_peers().count() as u32
+		if self.peers.peers_iter().connected().inbound().count() as u32
 			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
 		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -233,7 +233,7 @@ impl Server {
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
-		if self.peers.peers_iter().inbound().connected().count() as u32
+		if self.peers.iter().inbound().connected().count() as u32
 			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
 		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -233,7 +233,7 @@ impl Server {
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
-		if self.peers.peer_inbound_count()
+		if self.peers.incoming_connected_peers().count() as u32
 			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
 		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -233,7 +233,7 @@ impl Server {
 	/// different sets of peers themselves. In addition, it prevent potential
 	/// duplicate connections, malicious or not.
 	fn check_undesirable(&self, stream: &TcpStream) -> bool {
-		if self.peers.peers_iter().connected().inbound().count() as u32
+		if self.peers.peers_iter().inbound().connected().count() as u32
 			>= self.config.peer_max_inbound_count() + self.config.peer_listener_buffer_count()
 		{
 			debug!("Accepting new connection will exceed peer limit, refusing connection.");

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -266,6 +266,7 @@ pub struct P2PConfig {
 	/// The list of seed nodes, if using Seeding as a seed type
 	pub seeds: Option<PeerAddrs>,
 
+	/// TODO: Rethink this. We need to separate what *we* advertise vs. who we connect to.
 	/// Capabilities expose by this node, also conditions which other peers this
 	/// node will have an affinity toward when connection.
 	pub capabilities: Capabilities,

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -97,5 +97,5 @@ fn peer_handshake() {
 
 	let server_peer = server.peers.get_connected_peer(my_addr).unwrap();
 	assert_eq!(server_peer.info.total_difficulty(), Difficulty::min());
-	assert!(server.peers.peers_iter().connected().count() > 0);
+	assert!(server.peers.iter().connected().count() > 0);
 }

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -97,5 +97,5 @@ fn peer_handshake() {
 
 	let server_peer = server.peers.get_connected_peer(my_addr).unwrap();
 	assert_eq!(server_peer.info.total_difficulty(), Difficulty::min());
-	assert!(server.peers.connected_peers().count() > 0);
+	assert!(server.peers.peers_iter().connected().count() > 0);
 }

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -97,5 +97,5 @@ fn peer_handshake() {
 
 	let server_peer = server.peers.get_connected_peer(my_addr).unwrap();
 	assert_eq!(server_peer.info.total_difficulty(), Difficulty::min());
-	assert!(server.peers.peer_count() > 0);
+	assert!(server.peers.connected_peers().count() > 0);
 }

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -344,12 +344,12 @@ impl DandelionEpoch {
 	/// Select stem/fluff based on configured stem_probability.
 	/// Choose a new outbound stem relay peer.
 	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
-		let mut rng = rand::thread_rng();
 		self.start_time = Some(Utc::now().timestamp());
-		self.relay_peer = peers.outgoing_connected_peers().choose(&mut rng);
+		self.relay_peer = peers.peers_iter().connected().outbound().choose_random();
 
 		// If stem_probability == 90 then we stem 90% of the time.
 		let stem_probability = self.config.stem_probability;
+		let mut rng = rand::thread_rng();
 		self.is_stem = rng.gen_range(0, 100) < stem_probability;
 
 		let addr = self.relay_peer.clone().map(|p| p.info.addr);
@@ -386,8 +386,7 @@ impl DandelionEpoch {
 		}
 
 		if update_relay {
-			let mut rng = rand::thread_rng();
-			self.relay_peer = peers.outgoing_connected_peers().choose(&mut rng);
+			self.relay_peer = peers.peers_iter().connected().outbound().choose_random();
 			info!(
 				"DandelionEpoch: relay_peer: new peer chosen: {:?}",
 				self.relay_peer.clone().map(|p| p.info.addr)

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -345,7 +345,7 @@ impl DandelionEpoch {
 	/// Choose a new outbound stem relay peer.
 	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
 		self.start_time = Some(Utc::now().timestamp());
-		self.relay_peer = peers.peers_iter().connected().outbound().choose_random();
+		self.relay_peer = peers.peers_iter().outbound().connected().choose_random();
 
 		// If stem_probability == 90 then we stem 90% of the time.
 		let stem_probability = self.config.stem_probability;
@@ -386,7 +386,7 @@ impl DandelionEpoch {
 		}
 
 		if update_relay {
-			self.relay_peer = peers.peers_iter().connected().outbound().choose_random();
+			self.relay_peer = peers.peers_iter().outbound().connected().choose_random();
 			info!(
 				"DandelionEpoch: relay_peer: new peer chosen: {:?}",
 				self.relay_peer.clone().map(|p| p.info.addr)

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -344,11 +344,11 @@ impl DandelionEpoch {
 	/// Select stem/fluff based on configured stem_probability.
 	/// Choose a new outbound stem relay peer.
 	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
+		let mut rng = rand::thread_rng();
 		self.start_time = Some(Utc::now().timestamp());
-		self.relay_peer = peers.outgoing_connected_peers().first().cloned();
+		self.relay_peer = peers.outgoing_connected_peers().choose(&mut rng);
 
 		// If stem_probability == 90 then we stem 90% of the time.
-		let mut rng = rand::thread_rng();
 		let stem_probability = self.config.stem_probability;
 		self.is_stem = rng.gen_range(0, 100) < stem_probability;
 
@@ -386,7 +386,8 @@ impl DandelionEpoch {
 		}
 
 		if update_relay {
-			self.relay_peer = peers.outgoing_connected_peers().first().cloned();
+			let mut rng = rand::thread_rng();
+			self.relay_peer = peers.outgoing_connected_peers().choose(&mut rng);
 			info!(
 				"DandelionEpoch: relay_peer: new peer chosen: {:?}",
 				self.relay_peer.clone().map(|p| p.info.addr)

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -345,7 +345,7 @@ impl DandelionEpoch {
 	/// Choose a new outbound stem relay peer.
 	pub fn next_epoch(&mut self, peers: &Arc<p2p::Peers>) {
 		self.start_time = Some(Utc::now().timestamp());
-		self.relay_peer = peers.peers_iter().outbound().connected().choose_random();
+		self.relay_peer = peers.iter().outbound().connected().choose_random();
 
 		// If stem_probability == 90 then we stem 90% of the time.
 		let stem_probability = self.config.stem_probability;
@@ -386,7 +386,7 @@ impl DandelionEpoch {
 		}
 
 		if update_relay {
-			self.relay_peer = peers.peers_iter().outbound().connected().choose_random();
+			self.relay_peer = peers.iter().outbound().connected().choose_random();
 			info!(
 				"DandelionEpoch: relay_peer: new peer chosen: {:?}",
 				self.relay_peer.clone().map(|p| p.info.addr)

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -180,7 +180,7 @@ fn monitor_peers(
 	let most_work_count = peers
 		.peers_iter()
 		.outbound()
-		.with_difficulty(max_diff)
+		.with_difficulty(|x| x >= max_diff)
 		.connected()
 		.count();
 

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -174,13 +174,19 @@ fn monitor_peers(
 		total_count += 1;
 	}
 
+	let max_diff = peers.max_peer_difficulty();
+	let most_work_count = peers
+		.connected_peers()
+		.filter(|peer| peer.info.total_difficulty() >= max_diff)
+		.count();
+
 	debug!(
 		"monitor_peers: on {}:{}, {} connected ({} most_work). \
 		 all {} = {} healthy + {} banned + {} defunct",
 		config.host,
 		config.port,
-		peers.peer_count(),
-		peers.most_work_peers().len(),
+		peers.connected_peers().count(),
+		most_work_count,
 		total_count,
 		healthy_count,
 		banned_count,

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -174,11 +174,11 @@ fn monitor_peers(
 		total_count += 1;
 	}
 
-	let peers_count = peers.peers_iter().connected().count();
+	let peers_count = peers.iter().connected().count();
 
 	let max_diff = peers.max_peer_difficulty();
 	let most_work_count = peers
-		.peers_iter()
+		.iter()
 		.outbound()
 		.with_difficulty(|x| x >= max_diff)
 		.connected()
@@ -212,7 +212,7 @@ fn monitor_peers(
 	// ask them for their list of peers
 	let mut connected_peers: Vec<PeerAddr> = vec![];
 	for p in peers
-		.peers_iter()
+		.iter()
 		.with_capabilities(p2p::Capabilities::PEER_LIST)
 		.connected()
 	{

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -151,7 +151,7 @@ fn monitor_peers(
 	let mut banned_count = 0;
 	let mut defuncts = vec![];
 
-	for x in peers.all_peers().into_iter() {
+	for x in peers.all_peer_data().into_iter() {
 		match x.flags {
 			p2p::State::Banned => {
 				let interval = Utc::now().timestamp() - x.last_banned;

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -179,8 +179,9 @@ fn monitor_peers(
 	let max_diff = peers.max_peer_difficulty();
 	let most_work_count = peers
 		.peers_iter()
-		.connected()
+		.outbound()
 		.with_difficulty(max_diff)
+		.connected()
 		.count();
 
 	debug!(

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -174,10 +174,13 @@ fn monitor_peers(
 		total_count += 1;
 	}
 
+	let peers_count = peers.peers_iter().connected().count();
+
 	let max_diff = peers.max_peer_difficulty();
 	let most_work_count = peers
-		.connected_peers()
-		.filter(|peer| peer.info.total_difficulty() >= max_diff)
+		.peers_iter()
+		.connected()
+		.with_difficulty(max_diff)
 		.count();
 
 	debug!(
@@ -185,7 +188,7 @@ fn monitor_peers(
 		 all {} = {} healthy + {} banned + {} defunct",
 		config.host,
 		config.port,
-		peers.connected_peers().count(),
+		peers_count,
 		most_work_count,
 		total_count,
 		healthy_count,
@@ -207,7 +210,7 @@ fn monitor_peers(
 	// loop over connected peers
 	// ask them for their list of peers
 	let mut connected_peers: Vec<PeerAddr> = vec![];
-	for p in peers.connected_peers() {
+	for p in peers.peers_iter().connected() {
 		trace!(
 			"monitor_peers: {}:{} ask {} for more peers",
 			config.host,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -356,7 +356,13 @@ impl Server {
 
 	/// Number of peers
 	pub fn peer_count(&self) -> u32 {
-		self.p2p.peers.connected_peers().count().try_into().unwrap()
+		self.p2p
+			.peers
+			.peers_iter()
+			.connected()
+			.count()
+			.try_into()
+			.unwrap()
 	}
 
 	/// Start a minimal "stratum" mining service on a separate thread
@@ -486,7 +492,8 @@ impl Server {
 		let peer_stats = self
 			.p2p
 			.peers
-			.connected_peers()
+			.peers_iter()
+			.connected()
 			.into_iter()
 			.map(|p| PeerStats::from_peer(&p))
 			.collect();

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -358,7 +358,7 @@ impl Server {
 	pub fn peer_count(&self) -> u32 {
 		self.p2p
 			.peers
-			.peers_iter()
+			.iter()
 			.connected()
 			.count()
 			.try_into()
@@ -492,7 +492,7 @@ impl Server {
 		let peer_stats = self
 			.p2p
 			.peers
-			.peers_iter()
+			.iter()
 			.connected()
 			.into_iter()
 			.map(|p| PeerStats::from_peer(&p))

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -16,11 +16,11 @@
 //! the peer-to-peer server, the blockchain and the transaction pool) and acts
 //! as a facade.
 
-use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 use std::sync::{mpsc, Arc};
+use std::{convert::TryInto, fs};
 use std::{
 	thread::{self, JoinHandle},
 	time::{self, Duration},
@@ -356,7 +356,7 @@ impl Server {
 
 	/// Number of peers
 	pub fn peer_count(&self) -> u32 {
-		self.p2p.peers.peer_count()
+		self.p2p.peers.connected_peers().count().try_into().unwrap()
 	}
 
 	/// Start a minimal "stratum" mining service on a separate thread

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -97,8 +97,9 @@ impl BodySync {
 		let peers: Vec<_> = self
 			.peers
 			.peers_iter()
-			.connected()
+			.outbound()
 			.with_difficulty(head.total_difficulty + Difficulty::from_num(1))
+			.connected()
 			.into_iter()
 			.collect();
 

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -95,7 +95,7 @@ impl BodySync {
 		// Find connected peers with strictly greater difficulty than us.
 		let peers: Vec<_> = self
 			.peers
-			.peers_iter()
+			.iter()
 			.outbound()
 			.with_difficulty(|x| x > head.total_difficulty)
 			.connected()

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -14,6 +14,7 @@
 
 use chrono::prelude::{DateTime, Utc};
 use chrono::Duration;
+use grin_core::pow::Difficulty;
 use rand::prelude::*;
 use std::cmp;
 use std::sync::Arc;
@@ -91,10 +92,14 @@ impl BodySync {
 		hashes.reverse();
 
 		let head = self.chain.head()?;
+
+		// Find connected peers with strictly greater difficulty than us.
 		let peers: Vec<_> = self
 			.peers
-			.connected_peers()
-			.filter(|peer| peer.info.total_difficulty() > head.total_difficulty)
+			.peers_iter()
+			.connected()
+			.with_difficulty(head.total_difficulty + Difficulty::from_num(1))
+			.into_iter()
 			.collect();
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -14,7 +14,6 @@
 
 use chrono::prelude::{DateTime, Utc};
 use chrono::Duration;
-use grin_core::pow::Difficulty;
 use rand::prelude::*;
 use std::cmp;
 use std::sync::Arc;
@@ -98,7 +97,7 @@ impl BodySync {
 			.peers
 			.peers_iter()
 			.outbound()
-			.with_difficulty(head.total_difficulty + Difficulty::from_num(1))
+			.with_difficulty(|x| x > head.total_difficulty)
 			.connected()
 			.into_iter()
 			.collect();

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -14,6 +14,7 @@
 
 use chrono::prelude::{DateTime, Utc};
 use chrono::Duration;
+use rand::prelude::*;
 use std::cmp;
 use std::sync::Arc;
 
@@ -89,7 +90,12 @@ impl BodySync {
 
 		hashes.reverse();
 
-		let peers = self.peers.more_work_peers()?;
+		let head = self.chain.head()?;
+		let peers: Vec<_> = self
+			.peers
+			.connected_peers()
+			.filter(|peer| peer.info.total_difficulty() > head.total_difficulty)
+			.collect();
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work
@@ -125,9 +131,9 @@ impl BodySync {
 			self.blocks_requested = 0;
 			self.receive_timeout = Utc::now() + Duration::seconds(6);
 
-			let mut peers_iter = peers.iter().cycle();
+			let mut rng = rand::thread_rng();
 			for hash in hashes_to_get.clone() {
-				if let Some(peer) = peers_iter.next() {
+				if let Some(peer) = peers.choose(&mut rng) {
 					if let Err(e) = peer.send_block_request(*hash, chain::Options::SYNC) {
 						debug!("Skipped request to {}: {:?}", peer.info.addr, e);
 						peer.stop();

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -173,7 +173,7 @@ impl HeaderSync {
 			let max_diff = self.peers.max_peer_difficulty();
 			let peer = self
 				.peers
-				.peers_iter()
+				.iter()
 				.outbound()
 				.with_capabilities(Capabilities::HEADER_HIST)
 				.with_difficulty(|x| x >= max_diff)

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -171,8 +171,8 @@ impl HeaderSync {
 	fn header_sync(&mut self) -> Option<Arc<Peer>> {
 		if let Ok(header_head) = self.chain.header_head() {
 			let difficulty = header_head.total_difficulty;
-			// TODO - We want to choose a random peer with more than our total difficulty.
-			if let Some(peer) = self.peers.most_work_peer() {
+			let max_diff = self.peers.max_peer_difficulty();
+			if let Some(peer) = self.peers.peer_with_difficulty(max_diff) {
 				if peer.info.total_difficulty() > difficulty {
 					return self.request_headers(peer);
 				}

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::chain::{self, SyncState, SyncStatus};
 use crate::common::types::Error;
 use crate::core::core::hash::{Hash, Hashed};
-use crate::p2p::{self, types::ReasonForBan, Peer};
+use crate::p2p::{self, types::ReasonForBan, Capabilities, Peer};
 
 pub struct HeaderSync {
 	sync_state: Arc<SyncState>,
@@ -175,6 +175,7 @@ impl HeaderSync {
 				.peers
 				.peers_iter()
 				.outbound()
+				.with_capabilities(Capabilities::HEADER_HIST)
 				.with_difficulty(max_diff)
 				.connected()
 				.choose_random();

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -174,8 +174,9 @@ impl HeaderSync {
 			let peer = self
 				.peers
 				.peers_iter()
-				.connected()
+				.outbound()
 				.with_difficulty(max_diff)
+				.connected()
 				.choose_random();
 			if let Some(peer) = peer {
 				if peer.info.total_difficulty() > header_head.total_difficulty {

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -176,7 +176,7 @@ impl HeaderSync {
 				.peers_iter()
 				.outbound()
 				.with_capabilities(Capabilities::HEADER_HIST)
-				.with_difficulty(max_diff)
+				.with_difficulty(|x| x >= max_diff)
 				.connected()
 				.choose_random();
 			if let Some(peer) = peer {

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -170,10 +170,15 @@ impl HeaderSync {
 
 	fn header_sync(&mut self) -> Option<Arc<Peer>> {
 		if let Ok(header_head) = self.chain.header_head() {
-			let difficulty = header_head.total_difficulty;
 			let max_diff = self.peers.max_peer_difficulty();
-			if let Some(peer) = self.peers.peer_with_difficulty(max_diff) {
-				if peer.info.total_difficulty() > difficulty {
+			let peer = self
+				.peers
+				.peers_iter()
+				.connected()
+				.with_difficulty(max_diff)
+				.choose_random();
+			if let Some(peer) = peer {
+				if peer.info.total_difficulty() > header_head.total_difficulty {
 					return self.request_headers(peer);
 				}
 			}

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -171,7 +171,7 @@ impl HeaderSync {
 	fn header_sync(&mut self) -> Option<Arc<Peer>> {
 		if let Ok(header_head) = self.chain.header_head() {
 			let difficulty = header_head.total_difficulty;
-
+			// TODO - We want to choose a random peer with more than our total difficulty.
 			if let Some(peer) = self.peers.most_work_peer() {
 				if peer.info.total_difficulty() > difficulty {
 					return self.request_headers(peer);

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -159,7 +159,13 @@ impl StateSync {
 		txhashset_height = txhashset_height.saturating_sub(txhashset_height % archive_interval);
 
 		let max_diff = self.peers.max_peer_difficulty();
-		if let Some(peer) = self.peers.peer_with_difficulty(max_diff) {
+		let peer = self
+			.peers
+			.peers_iter()
+			.connected()
+			.with_difficulty(max_diff)
+			.choose_random();
+		if let Some(peer) = peer {
 			// ask for txhashset at state_sync_threshold
 			let mut txhashset_head = self
 				.chain

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::chain::{self, SyncState, SyncStatus};
 use crate::core::core::hash::Hashed;
 use crate::core::global;
-use crate::p2p::{self, Peer};
+use crate::p2p::{self, Capabilities, Peer};
 
 /// Fast sync has 3 "states":
 /// * syncing headers
@@ -163,6 +163,7 @@ impl StateSync {
 			.peers
 			.peers_iter()
 			.outbound()
+			.with_capabilities(Capabilities::TXHASHSET_HIST)
 			.with_difficulty(max_diff)
 			.connected()
 			.choose_random();

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -164,7 +164,7 @@ impl StateSync {
 			.peers_iter()
 			.outbound()
 			.with_capabilities(Capabilities::TXHASHSET_HIST)
-			.with_difficulty(max_diff)
+			.with_difficulty(|x| x >= max_diff)
 			.connected()
 			.choose_random();
 		if let Some(peer) = peer {

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -162,8 +162,9 @@ impl StateSync {
 		let peer = self
 			.peers
 			.peers_iter()
-			.connected()
+			.outbound()
 			.with_difficulty(max_diff)
+			.connected()
 			.choose_random();
 		if let Some(peer) = peer {
 			// ask for txhashset at state_sync_threshold

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -158,7 +158,8 @@ impl StateSync {
 		let mut txhashset_height = header_head.height.saturating_sub(threshold);
 		txhashset_height = txhashset_height.saturating_sub(txhashset_height % archive_interval);
 
-		if let Some(peer) = self.peers.most_work_peer() {
+		let max_diff = self.peers.max_peer_difficulty();
+		if let Some(peer) = self.peers.peer_with_difficulty(max_diff) {
 			// ask for txhashset at state_sync_threshold
 			let mut txhashset_head = self
 				.chain

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -161,7 +161,7 @@ impl StateSync {
 		let max_diff = self.peers.max_peer_difficulty();
 		let peer = self
 			.peers
-			.peers_iter()
+			.iter()
 			.outbound()
 			.with_capabilities(Capabilities::TXHASHSET_HIST)
 			.with_difficulty(|x| x >= max_diff)

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -221,8 +221,8 @@ impl SyncRunner {
 	fn needs_syncing(&self) -> Result<(bool, u64), chain::Error> {
 		let local_diff = self.chain.head()?.total_difficulty;
 		let mut is_syncing = self.sync_state.is_syncing();
-		let peer = self.peers.most_work_peer();
 
+		let peer = self.peers.most_work_peer();
 		let peer_info = if let Some(p) = peer {
 			p.info.clone()
 		} else {

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -82,8 +82,9 @@ impl SyncRunner {
 			// Count peers with at least our difficulty.
 			let wp = self
 				.peers
-				.connected_peers()
-				.filter(|peer| peer.info.total_difficulty() >= head.total_difficulty)
+				.peers_iter()
+				.connected()
+				.with_difficulty(head.total_difficulty)
 				.count();
 
 			// exit loop when:
@@ -228,10 +229,14 @@ impl SyncRunner {
 		let local_diff = self.chain.head()?.total_difficulty;
 		let mut is_syncing = self.sync_state.is_syncing();
 
-		// Find max difficulty across all our peers.
-		// Then pick a random peer with this max difficulty.
+		// Find a random peer to sync from.
 		let max_diff = self.peers.max_peer_difficulty();
-		let peer = self.peers.peer_with_difficulty(max_diff);
+		let peer = self
+			.peers
+			.peers_iter()
+			.connected()
+			.with_difficulty(max_diff)
+			.choose_random();
 
 		let peer_info = if let Some(p) = peer {
 			p.info.clone()

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -230,7 +230,7 @@ impl SyncRunner {
 		let local_diff = self.chain.head()?.total_difficulty;
 		let mut is_syncing = self.sync_state.is_syncing();
 
-		// Find a random peer to sync from.
+		// Find a peer with greatest known difficulty.
 		let max_diff = self.peers.max_peer_difficulty();
 		let peer = self
 			.peers

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -83,8 +83,9 @@ impl SyncRunner {
 			let wp = self
 				.peers
 				.peers_iter()
-				.connected()
+				.outbound()
 				.with_difficulty(head.total_difficulty)
+				.connected()
 				.count();
 
 			// exit loop when:
@@ -234,8 +235,9 @@ impl SyncRunner {
 		let peer = self
 			.peers
 			.peers_iter()
-			.connected()
+			.outbound()
 			.with_difficulty(max_diff)
+			.connected()
 			.choose_random();
 
 		let peer_info = if let Some(p) = peer {

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -84,7 +84,7 @@ impl SyncRunner {
 				.peers
 				.peers_iter()
 				.outbound()
-				.with_difficulty(head.total_difficulty)
+				.with_difficulty(|x| x >= head.total_difficulty)
 				.connected()
 				.count();
 
@@ -236,7 +236,7 @@ impl SyncRunner {
 			.peers
 			.peers_iter()
 			.outbound()
-			.with_difficulty(max_diff)
+			.with_difficulty(|x| x >= max_diff)
 			.connected()
 			.choose_random();
 

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -82,7 +82,7 @@ impl SyncRunner {
 			// Count peers with at least our difficulty.
 			let wp = self
 				.peers
-				.peers_iter()
+				.iter()
 				.outbound()
 				.with_difficulty(|x| x >= head.total_difficulty)
 				.connected()
@@ -234,7 +234,7 @@ impl SyncRunner {
 		let max_diff = self.peers.max_peer_difficulty();
 		let peer = self
 			.peers
-			.peers_iter()
+			.iter()
 			.outbound()
 			.with_difficulty(|x| x >= max_diff)
 			.connected()


### PR DESCRIPTION
Takes inspiration from https://github.com/mimblewimble/grin/pull/3021 replacing custom cursor impl with `impl Iterator`.

As part of the PIBD work we will want to run nodes on the network that support various different sync strategies. some nodes may support PIBD while others only support "legacy" txhashset downloads.
So we need more flexible peer management and filtering of connected peers. This PR is a step toward this.

----

Introduce `PeersIter` so we can return iterator via "newtype iterator delegation".

```
pub fn peers_iter(&self) -> PeersIter<impl Iterator<Item = Arc<Peer>>> {
    ...
}
```

Then expose various filters and operators on `PeersIter` so we can chain them in various flexible ways -

```
self
    .peers_iter()
    .outbound()
    .connected()
    .count()
```

----

* moved the random sorting/shuffle out of the api and into a simpler `choose_random()` filter on `PeersIter`
* flexible `with_difficulty()` filtering to filter based on minimum difficulty
* flexible `with_capabilities()` filtering that can be combined with other chain-able filters

The following fns have all been replaced with the flexible `with_difficulty()` filter - 

* `more_work_peers()`
* `more_or_same_work_peers()`
* `more_work_peer()`
* `most_work_peers()`
* `most_work_peer()`

----

Note: As part of this PR the sync process has been modified slightly. 
During sync (both header_sync and state_sync) we now sync explicitly against _outbound_ peers. 
This makes the sync process more consistent across "public" and "private" nodes. We no longer attempt to sync against inbound nodes regardless of whether we accept incoming connections or not.
