### PR TITLE
Get the hash of a PMMR leaf ignoring the leafset

### DIFF
--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -39,6 +39,9 @@ pub trait Backend<T: PMMRable> {
 	/// Get a Hash by insertion position.
 	fn get_hash(&self, position: u64) -> Option<Hash>;
 
+	/// Get a leaf hash by insertion position, ignoring the leaf set
+	fn get_leaf_hash(&self, position: u64) -> Option<Hash>;
+
 	/// Get underlying data by insertion position.
 	fn get_data(&self, position: u64) -> Option<T::E>;
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -34,6 +34,9 @@ pub trait ReadablePMMR {
 	/// Get the hash at provided position in the MMR.
 	fn get_hash(&self, pos: u64) -> Option<Hash>;
 
+	/// Get the hash of a leaf, ignoring the leaf set
+	fn get_leaf_hash(&self, pos: u64) -> Option<Hash>;
+
 	/// Get the data element at provided position in the MMR.
 	fn get_data(&self, pos: u64) -> Option<Self::Item>;
 
@@ -388,6 +391,14 @@ where
 		} else {
 			// If we are not a leaf get hash ignoring the remove log.
 			self.backend.get_from_file(pos)
+		}
+	}
+
+	fn get_leaf_hash(&self, pos: u64) -> Option<Hash> {
+		if pos <= self.last_pos && is_leaf(pos) {
+			self.backend.get_leaf_hash(pos)
+		} else {
+			None
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -127,6 +127,14 @@ where
 		}
 	}
 
+	fn get_leaf_hash(&self, pos: u64) -> Option<Hash> {
+		if pos <= self.last_pos && is_leaf(pos) {
+			self.backend.get_leaf_hash(pos)
+		} else {
+			None
+		}
+	}
+
 	fn get_data(&self, pos: u64) -> Option<Self::Item> {
 		if pos > self.last_pos {
 			// If we are beyond the rhs of the MMR return None.

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -51,6 +51,15 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		}
 	}
 
+	fn get_leaf_hash(&self, position: u64) -> Option<Hash> {
+		// Vec backend doesn't have a leaf set
+		if pmmr::is_leaf(position) {
+			self.get_hash(position)
+		} else {
+			None
+		}
+	}
+
 	fn get_data(&self, position: u64) -> Option<T::E> {
 		if self.removed.contains(&position) {
 			None

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -118,6 +118,15 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.get_from_file(pos)
 	}
 
+	/// Get the hash of a leaf at pos, ignoring the leaf set.
+	fn get_leaf_hash(&self, pos: u64) -> Option<Hash> {
+		if pmmr::is_leaf(pos) {
+			self.get_from_file(pos)
+		} else {
+			None
+		}
+	}
+
 	/// Get the data at pos.
 	/// Return None if it has been removed or if pos is not a leaf node.
 	fn get_data(&self, pos: u64) -> Option<T::E> {


### PR DESCRIPTION
When a leaf is marked for removal (using the leafset), its hash is not actually removed from the backend until its sibling is also removed. The `get_hash` function on the PMMR will return a `None` for hashes that are marked for removal but not actually pruned yet. However in [this PR](https://github.com/mimblewimble/grin/pull/3453) we need access to this hash. So here we introduce a new function on the PMMR and Backend that will return a leaf hash, ignoring the leafset.