### PR TITLE
Define get_data_from_file function on ReadablePMMR trait

### DIFF
--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -40,6 +40,9 @@ pub trait ReadablePMMR {
 	/// Get the hash from the underlying MMR file (ignores the remove log).
 	fn get_from_file(&self, pos: u64) -> Option<Hash>;
 
+	/// Get the data element at provided position in the MMR (ignores the remove log).
+	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item>;
+
 	/// Total size of the tree, including intermediary nodes and ignoring any pruning.
 	fn unpruned_size(&self) -> u64;
 
@@ -409,6 +412,14 @@ where
 			None
 		} else {
 			self.backend.get_from_file(pos)
+		}
+	}
+
+	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
+		if pos > self.last_pos {
+			None
+		} else {
+			self.backend.get_data_from_file(pos)
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -148,6 +148,14 @@ where
 		}
 	}
 
+	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
+		if pos > self.last_pos {
+			None
+		} else {
+			self.backend.get_data_from_file(pos)
+		}
+	}
+
 	fn unpruned_size(&self) -> u64 {
 		self.last_pos
 	}


### PR DESCRIPTION
This function is currently only defined on the backend but it would be very convenient to have it on the PMMR as well.