### PR TITLE
fix v2 conversion to ensure we provide blocks in correct format

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -372,8 +372,8 @@ where
 		self.chain()
 			.get_block(&h)
 			.map(|b| match peer_info.version.value() {
-				0..=2 => Some(b),
-				3..=ProtocolVersion::MAX => self.chain().convert_block_v2(b).ok(),
+				0..=2 => self.chain().convert_block_v2(b).ok(),
+				3..=ProtocolVersion::MAX => Some(b),
 			})
 			.unwrap_or(None)
 	}


### PR DESCRIPTION
Testing on `testnet` (was `floonet`) uncovered an issue in our protocol version handling when providing blocks to v2 peers.

I think we see this on `testnet` because there are relatively few nodes in sync.
This does not appear to be happening on `mainnet` but I suspect this is simply masked by the fact we have better connectivity and more peers available.

The following error occurs when attempting to provide a full block to a v2 peer - 
```
20201007 14:54:15.459 DEBUG grin_p2p::conn - try_break: exit the loop: Serialization(UnsupportedProtocolVersion)
```

This is because we store v3 `CommitOnly` blocks in the local db and the bug resulted in us not converting the block into v2 compatible format prior to the serialization attempt. We do not have "input features" and cannot serialize successfully.

* We need to do the conversion _if_ the peer is `v2`. 
* For `v3` peers and above we do _not_ need to convert.

The bug had this logic flipped.

----

This would most obviously manifest itself if a `4.0.0` node attempted to sync against a number of `4.1.0` nodes.
Given `4.1.0` is the latest binary this is unlikely to occur. I think this is why we did not see this on `mainnet` and we are only seeing it on `testnet`.
