### PR TITLE
[4.1.x] fix v2 conversion to ensure we provide blocks in correct format (#3465)

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -372,8 +372,8 @@ where
 		self.chain()
 			.get_block(&h)
 			.map(|b| match peer_info.version.value() {
-				0..=2 => Some(b),
-				3..=ProtocolVersion::MAX => self.chain().convert_block_v2(b).ok(),
+				0..=2 => self.chain().convert_block_v2(b).ok(),
+				3..=ProtocolVersion::MAX => Some(b),
 			})
 			.unwrap_or(None)
 	}


### PR DESCRIPTION
Porting #3465 across to `4.1.x` branch for a bugfix release.

`4.1.0` introduced a subtle issue that can cause problems if a `4.0.0` node attempts to sync full blocks from a `4.1.0` node.

