### PR TITLE
[DNM] hash_with_index() rework to support flexible hash entries

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -15,7 +15,7 @@
 use crate::chain;
 use crate::core::core::hash::Hashed;
 use crate::core::core::merkle_proof::MerkleProof;
-use crate::core::core::{KernelFeatures, TxKernel};
+use crate::core::core::{KernelFeatures, OutputIdentifier, TxKernel};
 use crate::core::{core, ser};
 use crate::p2p;
 use crate::util::secp::pedersen;
@@ -271,7 +271,7 @@ pub struct OutputPrintable {
 	/// Block height at which the output is found
 	pub block_height: Option<u64>,
 	/// Merkle Proof
-	pub merkle_proof: Option<MerkleProof>,
+	pub merkle_proof: Option<MerkleProof<OutputIdentifier>>,
 	/// MMR Position
 	pub mmr_index: u64,
 }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -24,7 +24,7 @@ use crate::core::core::{
 };
 use crate::core::global;
 use crate::core::pow;
-use crate::core::ser::ProtocolVersion;
+use crate::core::ser::{HashEntry, ProtocolVersion};
 use crate::error::{Error, ErrorKind};
 use crate::pipe;
 use crate::store;
@@ -719,7 +719,7 @@ impl Chain {
 			})?;
 
 		// Set the prev_root on the header.
-		header.prev_root = prev_root;
+		header.prev_root = prev_root.as_hash();
 
 		Ok(())
 	}
@@ -758,7 +758,7 @@ impl Chain {
 		}
 
 		// Set the prev_root on the header.
-		b.header.prev_root = prev_root;
+		b.header.prev_root = prev_root.as_hash();
 
 		// Set the output, rangeproof and kernel MMR roots.
 		b.header.output_root = roots.output_root(&b.header);
@@ -773,7 +773,7 @@ impl Chain {
 		&self,
 		out_id: T,
 		header: &BlockHeader,
-	) -> Result<MerkleProof, Error> {
+	) -> Result<MerkleProof<OutputIdentifier>, Error> {
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		let merkle_proof =
@@ -787,7 +787,10 @@ impl Chain {
 
 	/// Return a merkle proof valid for the current output pmmr state at the
 	/// given pos
-	pub fn get_merkle_proof_for_pos(&self, commit: Commitment) -> Result<MerkleProof, Error> {
+	pub fn get_merkle_proof_for_pos(
+		&self,
+		commit: Commitment,
+	) -> Result<MerkleProof<OutputIdentifier>, Error> {
 		let mut txhashset = self.txhashset.write();
 		txhashset.merkle_proof(commit)
 	}

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -214,7 +214,6 @@ impl BitmapChunk {
 
 impl PMMRable for BitmapChunk {
 	type E = Self;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -229,7 +228,7 @@ impl PMMRIndexHashable for BitmapChunk {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -17,8 +17,9 @@ use std::time::Instant;
 
 use bit_vec::BitVec;
 use croaring::Bitmap;
+use grin_core::ser::PMMRIndexHashable;
 
-use crate::core::core::hash::{DefaultHashable, Hash};
+use crate::core::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::core::core::pmmr::{self, ReadablePMMR, ReadonlyPMMR, VecBackend, PMMR};
 use crate::core::ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
 use crate::error::{Error, ErrorKind};
@@ -213,7 +214,7 @@ impl BitmapChunk {
 
 impl PMMRable for BitmapChunk {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -221,6 +222,14 @@ impl PMMRable for BitmapChunk {
 
 	fn elmt_size() -> Option<u16> {
 		Some(Self::LEN_BYTES as u16)
+	}
+}
+
+impl PMMRIndexHashable for BitmapChunk {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -230,6 +230,10 @@ impl PMMRIndexHashable for BitmapChunk {
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
 	}
+
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
+		Self::index_hash(index, (lc, rc))
+	}
 }
 
 impl DefaultHashable for BitmapChunk {}

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -213,6 +213,7 @@ impl BitmapChunk {
 
 impl PMMRable for BitmapChunk {
 	type E = Self;
+	type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -298,7 +298,7 @@ impl OutputRoots {
 	/// together with the size of the output PMMR (for consistency with existing PMMR impl).
 	/// H(pmmr_size | pmmr_root | bitmap_root)
 	fn merged_root(&self, header: &BlockHeader) -> Hash {
-		(self.pmmr_root, self.bitmap_root).hash_with_index(header.output_mmr_size)
+		(header.output_mmr_size, self.pmmr_root, self.bitmap_root).hash()
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -14,7 +14,6 @@
 
 //! Blocks and blockheaders
 
-use crate::consensus::{self, reward, REWARD};
 use crate::core::committed::{self, Committed};
 use crate::core::compact_block::CompactBlock;
 use crate::core::hash::{DefaultHashable, Hash, Hashed, ZERO_HASH};
@@ -27,6 +26,10 @@ use crate::global;
 use crate::pow::{verify_size, Difficulty, Proof, ProofOfWork};
 use crate::ser::{
 	self, deserialize_default, serialize_default, PMMRable, Readable, Reader, Writeable, Writer,
+};
+use crate::{
+	consensus::{self, reward, REWARD},
+	ser::PMMRIndexHashable,
 };
 use chrono::naive::{MAX_DATE, MIN_DATE};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
@@ -251,7 +254,7 @@ impl Default for BlockHeader {
 
 impl PMMRable for BlockHeader {
 	type E = HeaderEntry;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		HeaderEntry {
@@ -267,6 +270,14 @@ impl PMMRable for BlockHeader {
 	fn elmt_size() -> Option<u16> {
 		const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
 		Some(LEN.try_into().unwrap())
+	}
+}
+
+impl PMMRIndexHashable for BlockHeader {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -14,7 +14,6 @@
 
 //! Blocks and blockheaders
 
-use crate::core::committed::{self, Committed};
 use crate::core::compact_block::CompactBlock;
 use crate::core::hash::{DefaultHashable, Hash, Hashed, ZERO_HASH};
 use crate::core::verifier_cache::VerifierCache;
@@ -30,6 +29,10 @@ use crate::ser::{
 use crate::{
 	consensus::{self, reward, REWARD},
 	ser::PMMRIndexHashable,
+};
+use crate::{
+	core::committed::{self, Committed},
+	ser::HashEntry,
 };
 use chrono::naive::{MAX_DATE, MIN_DATE};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
@@ -274,10 +277,21 @@ impl PMMRable for BlockHeader {
 }
 
 impl PMMRIndexHashable for BlockHeader {
-	type H = Hash;
+	type H = HeaderHashEntry;
 
-	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
+		let hash = (index, self).hash();
+		HeaderHashEntry { hash }
+	}
+}
+
+pub struct HeaderHashEntry {
+	hash: Hash,
+}
+
+impl HashEntry for HeaderHashEntry {
+	fn as_hash(&self) -> Hash {
+		self.hash
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -290,7 +290,7 @@ impl PMMRIndexHashable for BlockHeader {
 }
 
 /// Hash entry for the header MMR.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HeaderHashEntry {
 	hash: Hash,
 }
@@ -311,25 +311,32 @@ impl HashEntry for HeaderHashEntry {
 
 impl DefaultHashable for HeaderHashEntry {}
 
-/// TODO - What do we need this for?
-impl PMMRIndexHashable for (HeaderHashEntry, HeaderHashEntry) {
-	type H = HeaderHashEntry;
+// /// TODO - What do we need this for?
+// impl PMMRIndexHashable for (HeaderHashEntry, HeaderHashEntry) {
+// 	type H = HeaderHashEntry;
 
-	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
-		let hash = Self::index_hash(index, self);
-		HeaderHashEntry { hash }
-	}
+// 	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
+// 		let hash = Self::index_hash(index, self);
+// 		HeaderHashEntry { hash }
+// 	}
 
-	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
-		let hash = Self::index_hash(index, (lc, rc));
-		HeaderHashEntry { hash }
-	}
-}
+// 	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+// 		let hash = Self::index_hash(index, (lc, rc));
+// 		HeaderHashEntry { hash }
+// 	}
+// }
 
 impl Writeable for HeaderHashEntry {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		self.hash.write(writer)?;
 		Ok(())
+	}
+}
+
+impl Readable for HeaderHashEntry {
+	fn read<R: Reader>(reader: &mut R) -> Result<HeaderHashEntry, ser::Error> {
+		let hash = Hash::read(reader)?;
+		Ok(HeaderHashEntry { hash })
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -257,7 +257,6 @@ impl Default for BlockHeader {
 
 impl PMMRable for BlockHeader {
 	type E = HeaderEntry;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		HeaderEntry {
@@ -280,11 +279,13 @@ impl PMMRIndexHashable for BlockHeader {
 	type H = HeaderHashEntry;
 
 	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
-		let hash = (index, self).hash();
+		let hash = Self::index_hash(index, self);
 		HeaderHashEntry { hash }
 	}
 }
 
+/// Hash entry for the header MMR.
+#[derive(Clone, Debug)]
 pub struct HeaderHashEntry {
 	hash: Hash,
 }
@@ -292,6 +293,24 @@ pub struct HeaderHashEntry {
 impl HashEntry for HeaderHashEntry {
 	fn as_hash(&self) -> Hash {
 		self.hash
+	}
+}
+
+impl DefaultHashable for HeaderHashEntry {}
+
+impl PMMRIndexHashable for (HeaderHashEntry, HeaderHashEntry) {
+	type H = HeaderHashEntry;
+
+	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
+		let hash = Self::index_hash(index, self);
+		HeaderHashEntry { hash }
+	}
+}
+
+impl Writeable for HeaderHashEntry {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		self.hash.write(writer)?;
+		Ok(())
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -251,6 +251,7 @@ impl Default for BlockHeader {
 
 impl PMMRable for BlockHeader {
 	type E = HeaderEntry;
+	type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		HeaderEntry {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -283,7 +283,7 @@ impl PMMRIndexHashable for BlockHeader {
 		HeaderHashEntry { hash }
 	}
 
-	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+	fn hash_children(index: u64, lc: HeaderHashEntry, rc: HeaderHashEntry) -> HeaderHashEntry {
 		let hash = Self::index_hash(index, (lc, rc));
 		HeaderHashEntry { hash }
 	}
@@ -310,21 +310,6 @@ impl HashEntry for HeaderHashEntry {
 }
 
 impl DefaultHashable for HeaderHashEntry {}
-
-// /// TODO - What do we need this for?
-// impl PMMRIndexHashable for (HeaderHashEntry, HeaderHashEntry) {
-// 	type H = HeaderHashEntry;
-
-// 	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
-// 		let hash = Self::index_hash(index, self);
-// 		HeaderHashEntry { hash }
-// 	}
-
-// 	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
-// 		let hash = Self::index_hash(index, (lc, rc));
-// 		HeaderHashEntry { hash }
-// 	}
-// }
 
 impl Writeable for HeaderHashEntry {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -282,12 +282,25 @@ impl PMMRIndexHashable for BlockHeader {
 		let hash = Self::index_hash(index, self);
 		HeaderHashEntry { hash }
 	}
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		let hash = Self::index_hash(index, (lc, rc));
+		HeaderHashEntry { hash }
+	}
 }
 
 /// Hash entry for the header MMR.
 #[derive(Clone, Debug)]
 pub struct HeaderHashEntry {
 	hash: Hash,
+}
+
+impl Default for HeaderHashEntry {
+	fn default() -> Self {
+		HeaderHashEntry {
+			hash: Default::default(),
+		}
+	}
 }
 
 impl HashEntry for HeaderHashEntry {
@@ -298,11 +311,17 @@ impl HashEntry for HeaderHashEntry {
 
 impl DefaultHashable for HeaderHashEntry {}
 
+/// TODO - What do we need this for?
 impl PMMRIndexHashable for (HeaderHashEntry, HeaderHashEntry) {
 	type H = HeaderHashEntry;
 
 	fn hash_with_index(&self, index: u64) -> HeaderHashEntry {
 		let hash = Self::index_hash(index, self);
+		HeaderHashEntry { hash }
+	}
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		let hash = Self::index_hash(index, (lc, rc));
 		HeaderHashEntry { hash }
 	}
 }

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -290,7 +290,7 @@ impl PMMRIndexHashable for BlockHeader {
 }
 
 /// Hash entry for the header MMR.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HeaderHashEntry {
 	hash: Hash,
 }

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -17,7 +17,7 @@
 use crate::core::hash::Hash;
 use crate::core::pmmr;
 use crate::ser;
-use crate::ser::{PMMRIndexHashable, Readable, Reader, Writeable, Writer};
+use crate::ser::{HashEntry, PMMRIndexHashable, Readable, Reader, Writeable, Writer};
 use util::ToHex;
 
 /// Merkle proof errors.
@@ -92,10 +92,10 @@ impl MerkleProof {
 
 	/// Verifies the Merkle proof against the provided
 	/// root hash, element and position in the MMR.
-	pub fn verify(
+	pub fn verify<P: PMMRIndexHashable>(
 		&self,
 		root: Hash,
-		element: &dyn PMMRIndexHashable,
+		element: &P,
 		node_pos: u64,
 	) -> Result<(), MerkleProofError> {
 		let mut proof = self.clone();
@@ -108,10 +108,10 @@ impl MerkleProof {
 	/// Consumes the Merkle proof while verifying it.
 	/// The proof can no longer be used by the caller after dong this.
 	/// Caller must clone() the proof first.
-	fn verify_consume(
+	fn verify_consume<P: PMMRIndexHashable>(
 		&mut self,
 		root: Hash,
-		element: &dyn PMMRIndexHashable,
+		element: &P,
 		node_pos: u64,
 		peaks_pos: &[u64],
 	) -> Result<(), MerkleProofError> {
@@ -119,7 +119,8 @@ impl MerkleProof {
 			element.hash_with_index(self.mmr_size)
 		} else {
 			element.hash_with_index(node_pos - 1)
-		};
+		}
+		.as_hash();
 
 		// handle special case of only a single entry in the MMR
 		// (no siblings to hash together)

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -27,7 +27,7 @@ pub trait Backend<T: PMMRable + PMMRIndexHashable> {
 	/// associated data element to flatfile storage (for leaf nodes only). The
 	/// position of the first element of the Vec in the MMR is provided to
 	/// help the implementation.
-	fn append(&mut self, data: &T, hashes: Vec<Hash>) -> Result<(), String>;
+	fn append(&mut self, data: &T, hashes: Vec<T::H>) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR
@@ -37,14 +37,14 @@ pub trait Backend<T: PMMRable + PMMRIndexHashable> {
 	fn rewind(&mut self, position: u64, rewind_rm_pos: &Bitmap) -> Result<(), String>;
 
 	/// Get a Hash by insertion position.
-	fn get_hash(&self, position: u64) -> Option<Hash>; // TODO ******** T::H
+	fn get_hash(&self, position: u64) -> Option<T::H>;
 
 	/// Get underlying data by insertion position.
 	fn get_data(&self, position: u64) -> Option<T::E>;
 
 	/// Get a Hash  by original insertion position
 	/// (ignoring the remove log).
-	fn get_from_file(&self, position: u64) -> Option<Hash>;
+	fn get_from_file(&self, position: u64) -> Option<T::H>;
 
 	/// Get a Data Element by original insertion position
 	/// (ignoring the remove log).

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -16,13 +16,13 @@ use croaring::Bitmap;
 
 use crate::core::hash::Hash;
 use crate::core::BlockHeader;
-use crate::ser::PMMRable;
+use crate::ser::{PMMRIndexHashable, PMMRable};
 
 /// Storage backend for the MMR, just needs to be indexed by order of insertion.
 /// The PMMR itself does not need the Backend to be accurate on the existence
 /// of an element (i.e. remove could be a no-op) but layers above can
 /// depend on an accurate Backend to check existence.
-pub trait Backend<T: PMMRable> {
+pub trait Backend<T: PMMRable + PMMRIndexHashable> {
 	/// Append the provided Hashes to the backend storage, and optionally an
 	/// associated data element to flatfile storage (for leaf nodes only). The
 	/// position of the first element of the Vec in the MMR is provided to

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -37,7 +37,7 @@ pub trait Backend<T: PMMRable + PMMRIndexHashable> {
 	fn rewind(&mut self, position: u64, rewind_rm_pos: &Bitmap) -> Result<(), String>;
 
 	/// Get a Hash by insertion position.
-	fn get_hash(&self, position: u64) -> Option<Hash>;
+	fn get_hash(&self, position: u64) -> Option<Hash>; // TODO ******** T::H
 
 	/// Get underlying data by insertion position.
 	fn get_data(&self, position: u64) -> Option<T::E>;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -21,7 +21,7 @@ use crate::core::hash::{Hash, ZERO_HASH};
 use crate::core::merkle_proof::MerkleProof;
 use crate::core::pmmr::{Backend, ReadonlyPMMR};
 use crate::core::BlockHeader;
-use crate::ser::{PMMRIndexHashable, PMMRable};
+use crate::ser::{HashEntry, PMMRIndexHashable, PMMRable};
 
 /// 64 bits all ones: 0b11111111...1
 const ALL_ONES: u64 = u64::MAX;
@@ -182,7 +182,7 @@ where
 
 impl<'a, T, B> PMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	/// Build a new prunable Merkle Mountain Range using the provided backend.
@@ -213,7 +213,7 @@ where
 	/// the same time if applicable.
 	pub fn push(&mut self, elmt: &T) -> Result<u64, String> {
 		let elmt_pos = self.last_pos + 1;
-		let mut current_hash = elmt.hash_with_index(elmt_pos - 1);
+		let mut current_hash = elmt.hash_with_index(elmt_pos - 1).as_hash();
 
 		let mut hashes = vec![current_hash];
 		let mut pos = elmt_pos;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -170,7 +170,7 @@ pub trait ReadablePMMR {
 /// we are in the sequence of nodes making up the MMR.
 pub struct PMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: Backend<T>,
 {
 	/// The last position in the PMMR
@@ -377,7 +377,7 @@ where
 
 impl<'a, T, B> ReadablePMMR for PMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	type Item = T::E;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -345,9 +345,7 @@ where
 	}
 
 	/// Build a Merkle proof for the element at the given position.
-	///
-	///
-	fn merkle_proof(&self, pos: u64) -> Result<MerkleProof<T>, String> {
+	pub fn merkle_proof(&self, pos: u64) -> Result<MerkleProof<T>, String> {
 		let last_pos = self.unpruned_size();
 		debug!("merkle_proof  {}, last_pos {}", pos, last_pos);
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -88,7 +88,7 @@ where
 	/// Helper function to get the last N nodes inserted, i.e. the last
 	/// n nodes along the bottom of the tree.
 	/// May return less than n items if the MMR has been pruned/compacted.
-	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(Hash, T::E)> {
+	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(T::H, T::E)> {
 		let mut return_vec = vec![];
 		let mut last_leaf = self.last_pos;
 		for _ in 0..n as u64 {
@@ -114,8 +114,9 @@ where
 	B: 'a + Backend<T>,
 {
 	type Item = T::E;
+	type H = T::H;
 
-	fn get_hash(&self, pos: u64) -> Option<Hash> {
+	fn get_hash(&self, pos: u64) -> Option<Self::H> {
 		if pos > self.last_pos {
 			None
 		} else if is_leaf(pos) {
@@ -140,7 +141,7 @@ where
 		}
 	}
 
-	fn get_from_file(&self, pos: u64) -> Option<Hash> {
+	fn get_from_file(&self, pos: u64) -> Option<Self::H> {
 		if pos > self.last_pos {
 			None
 		} else {
@@ -170,5 +171,10 @@ where
 
 	fn n_unpruned_leaves(&self) -> u64 {
 		self.backend.n_unpruned_leaves()
+	}
+
+	/// Delegate our child hashing logic.
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		T::hash_children(index, lc, rc)
 	}
 }

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -19,12 +19,12 @@ use std::marker;
 use crate::core::hash::Hash;
 use crate::core::pmmr::pmmr::{bintree_rightmost, ReadablePMMR};
 use crate::core::pmmr::{is_leaf, Backend};
-use crate::ser::PMMRable;
+use crate::ser::{PMMRIndexHashable, PMMRable};
 
 /// Readonly view of a PMMR.
 pub struct ReadonlyPMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: Backend<T>,
 {
 	/// The last position in the PMMR
@@ -37,7 +37,7 @@ where
 
 impl<'a, T, B> ReadonlyPMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	/// Build a new readonly PMMR.
@@ -110,7 +110,7 @@ where
 
 impl<'a, T, B> ReadablePMMR for ReadonlyPMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	type Item = T::E;

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -24,7 +24,7 @@ use crate::ser::{PMMRIndexHashable, PMMRable};
 /// Rewindable (but still readonly) view of a PMMR.
 pub struct RewindablePMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: Backend<T>,
 {
 	/// The last position in the PMMR
@@ -37,7 +37,7 @@ where
 
 impl<'a, T, B> RewindablePMMR<'a, T, B>
 where
-	T: PMMRable,
+	T: PMMRable + PMMRIndexHashable,
 	B: 'a + Backend<T>,
 {
 	/// Build a new readonly PMMR.

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -100,22 +100,22 @@ where
 
 	/// Computes the root of the MMR. Find all the peaks in the current
 	/// tree and "bags" them to get a single peak.
-	pub fn root(&self) -> Result<Hash, String> {
+	pub fn root(&self) -> Result<T::H, String> {
 		if self.is_empty() {
-			return Ok(ZERO_HASH);
+			return Ok(Default::default());
 		}
 		let mut res = None;
 		for peak in self.peaks().iter().rev() {
 			res = match res {
 				None => Some(*peak),
-				Some(rhash) => Some((*peak, rhash).hash_with_index(self.unpruned_size())),
+				Some(rhash) => Some(T::hash_children(self.unpruned_size(), *peak, rhash)),
 			}
 		}
 		res.ok_or_else(|| "no root, invalid tree".to_owned())
 	}
 
 	/// Returns a vec of the peaks of this MMR.
-	pub fn peaks(&self) -> Vec<Hash> {
+	pub fn peaks(&self) -> Vec<T::H> {
 		let peaks_pos = peaks(self.last_pos);
 		peaks_pos
 			.into_iter()

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -20,7 +20,7 @@ use croaring::Bitmap;
 use crate::core::hash::Hash;
 use crate::core::pmmr::{self, Backend};
 use crate::core::BlockHeader;
-use crate::ser::PMMRable;
+use crate::ser::{PMMRIndexHashable, PMMRable};
 
 /// Simple/minimal/naive MMR backend implementation backed by Vec<T> and Vec<Hash>.
 /// Removed pos are maintained in a HashSet<u64>.
@@ -34,7 +34,7 @@ pub struct VecBackend<T: PMMRable> {
 	pub removed: HashSet<u64>,
 }
 
-impl<T: PMMRable> Backend<T> for VecBackend<T> {
+impl<T: PMMRable + PMMRIndexHashable> Backend<T> for VecBackend<T> {
 	fn append(&mut self, elmt: &T, hashes: Vec<Hash>) -> Result<(), String> {
 		if let Some(data) = &mut self.data {
 			data.push(elmt.clone());

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -14,7 +14,7 @@
 
 //! Transactions
 
-use crate::core::hash::{DefaultHashable, Hashed};
+use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{committed, Committed};
 use crate::libtx::{aggsig, secp_ser};
@@ -491,6 +491,7 @@ impl Readable for TxKernel {
 /// Note: These are "variable size" to support different kernel feature variants.
 impl PMMRable for TxKernel {
 	type E = Self;
+	type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -2065,6 +2066,7 @@ impl Readable for OutputIdentifier {
 
 impl PMMRable for OutputIdentifier {
 	type E = Self;
+	type H = Hash;
 
 	fn as_elmt(&self) -> OutputIdentifier {
 		*self

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -14,7 +14,6 @@
 
 //! Transactions
 
-use crate::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{committed, Committed};
 use crate::libtx::{aggsig, secp_ser};
@@ -23,6 +22,10 @@ use crate::ser::{
 	Writeable, Writer,
 };
 use crate::{consensus, global};
+use crate::{
+	core::hash::{DefaultHashable, Hash, Hashed},
+	ser::PMMRIndexHashable,
+};
 use enum_primitive::FromPrimitive;
 use keychain::{self, BlindingFactor};
 use std::cmp::Ordering;
@@ -491,7 +494,7 @@ impl Readable for TxKernel {
 /// Note: These are "variable size" to support different kernel feature variants.
 impl PMMRable for TxKernel {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -499,6 +502,14 @@ impl PMMRable for TxKernel {
 
 	fn elmt_size() -> Option<u16> {
 		None
+	}
+}
+
+impl PMMRIndexHashable for TxKernel {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 
@@ -2066,7 +2077,7 @@ impl Readable for OutputIdentifier {
 
 impl PMMRable for OutputIdentifier {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> OutputIdentifier {
 		*self
@@ -2078,6 +2089,14 @@ impl PMMRable for OutputIdentifier {
 				.try_into()
 				.unwrap(),
 		)
+	}
+}
+
+impl PMMRIndexHashable for OutputIdentifier {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -511,7 +511,7 @@ impl PMMRIndexHashable for TxKernel {
 		Self::index_hash(index, self)
 	}
 
-	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
 		Self::index_hash(index, (lc, rc))
 	}
 }
@@ -2101,7 +2101,7 @@ impl PMMRIndexHashable for OutputIdentifier {
 		Self::index_hash(index, self)
 	}
 
-	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
 		Self::index_hash(index, (lc, rc))
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -494,7 +494,6 @@ impl Readable for TxKernel {
 /// Note: These are "variable size" to support different kernel feature variants.
 impl PMMRable for TxKernel {
 	type E = Self;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -509,7 +508,7 @@ impl PMMRIndexHashable for TxKernel {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 
@@ -2077,7 +2076,6 @@ impl Readable for OutputIdentifier {
 
 impl PMMRable for OutputIdentifier {
 	type E = Self;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> OutputIdentifier {
 		*self
@@ -2096,7 +2094,7 @@ impl PMMRIndexHashable for OutputIdentifier {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -510,6 +510,10 @@ impl PMMRIndexHashable for TxKernel {
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
 	}
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		Self::index_hash(index, (lc, rc))
+	}
 }
 
 impl KernelFeatures {
@@ -2095,6 +2099,10 @@ impl PMMRIndexHashable for OutputIdentifier {
 
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
+	}
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		Self::index_hash(index, (lc, rc))
 	}
 }
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -764,7 +764,7 @@ impl PMMRIndexHashable for RangeProof {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 
@@ -984,26 +984,23 @@ pub trait PMMRable: Clone + Debug + DefaultHashable {
 
 /// Generic trait to ensure PMMR elements can be hashed with an index
 pub trait PMMRIndexHashable: DefaultHashable {
+	/// Type of hash entry for intermediate nodes.
 	type H: HashEntry;
 
 	/// Hash with a given index
 	fn hash_with_index(&self, index: u64) -> Self::H;
+
+	/// Hash given index and data.
+	fn index_hash<T: DefaultHashable>(index: u64, data: T) -> Hash {
+		(index, data).hash()
+	}
 }
-
-// Concrete impls of these for all our PMMRable structs.
-// impl<P: PMMRable<H = Hash>> PMMRIndexHashable for P {
-// 	type H = P::H;
-
-// 	fn hash_with_index(&self, index: u64) -> Self::H {
-// 		(index, self).hash()
-// 	}
-// }
 
 impl PMMRIndexHashable for (Hash, Hash) {
 	type H = Hash;
 
-	fn hash_with_index(&self, index: u64) -> Self::H {
-		(index, self).hash()
+	fn hash_with_index(&self, index: u64) -> Hash {
+		Self::index_hash(index, self)
 	}
 }
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -748,7 +748,7 @@ impl Readable for RangeProof {
 
 impl PMMRable for RangeProof {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		*self
@@ -757,6 +757,14 @@ impl PMMRable for RangeProof {
 	// Size is length prefix (8 bytes for u64) + MAX_PROOF_SIZE.
 	fn elmt_size() -> Option<u16> {
 		Some((8 + MAX_PROOF_SIZE).try_into().unwrap())
+	}
+}
+
+impl PMMRIndexHashable for RangeProof {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 
@@ -965,7 +973,7 @@ pub trait PMMRable: Clone + Debug + DefaultHashable {
 	/// This allows us to store Hash elements in the header MMR for variable size BlockHeaders.
 	type E: Readable + Writeable + Debug;
 
-	type H: HashEntry;
+	// type H: HashEntry;
 
 	/// Convert the pmmrable into the element to be stored in the MMR data file.
 	fn as_elmt(&self) -> Self::E;
@@ -982,13 +990,14 @@ pub trait PMMRIndexHashable: DefaultHashable {
 	fn hash_with_index(&self, index: u64) -> Self::H;
 }
 
-impl<P: PMMRable<H = Hash>> PMMRIndexHashable for P {
-	type H = P::H;
+// Concrete impls of these for all our PMMRable structs.
+// impl<P: PMMRable<H = Hash>> PMMRIndexHashable for P {
+// 	type H = P::H;
 
-	fn hash_with_index(&self, index: u64) -> Self::H {
-		(index, self).hash()
-	}
-}
+// 	fn hash_with_index(&self, index: u64) -> Self::H {
+// 		(index, self).hash()
+// 	}
+// }
 
 impl PMMRIndexHashable for (Hash, Hash) {
 	type H = Hash;
@@ -997,6 +1006,7 @@ impl PMMRIndexHashable for (Hash, Hash) {
 		(index, self).hash()
 	}
 }
+
 pub trait HashEntry {
 	fn as_hash(&self) -> Hash;
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -1002,24 +1002,13 @@ pub trait PMMRIndexHashable: DefaultHashable {
 	}
 }
 
-// /// TODO - What do we need this for?
-// impl PMMRIndexHashable for (Hash, Hash) {
-// 	type H = Hash;
-
-// 	fn hash_with_index(&self, index: u64) -> Hash {
-// 		Self::index_hash(index, self)
-// 	}
-
-// 	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
-// 		Self::index_hash(index, (lc, rc))
-// 	}
-// }
-
 pub trait HashEntry:
 	DefaultHashable
 	+ Readable
 	+ Default
 	+ Clone
+	+ Copy
+	+ Debug
 	+ PartialEq
 	+ serde::ser::Serialize
 	+ serde::de::DeserializeOwned

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -989,7 +989,7 @@ pub trait PMMRable: Clone + Debug + DefaultHashable {
 /// Generic trait to ensure PMMR elements can be hashed with an index
 pub trait PMMRIndexHashable: DefaultHashable {
 	/// Type of hash entry for intermediate nodes.
-	type H: HashEntry + Clone + Default;
+	type H: HashEntry;
 
 	/// Hash with a given index
 	fn hash_with_index(&self, index: u64) -> Self::H;
@@ -1002,20 +1002,28 @@ pub trait PMMRIndexHashable: DefaultHashable {
 	}
 }
 
-/// TODO - What do we need this for?
-impl PMMRIndexHashable for (Hash, Hash) {
-	type H = Hash;
+// /// TODO - What do we need this for?
+// impl PMMRIndexHashable for (Hash, Hash) {
+// 	type H = Hash;
 
-	fn hash_with_index(&self, index: u64) -> Hash {
-		Self::index_hash(index, self)
-	}
+// 	fn hash_with_index(&self, index: u64) -> Hash {
+// 		Self::index_hash(index, self)
+// 	}
 
-	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
-		Self::index_hash(index, (lc, rc))
-	}
-}
+// 	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
+// 		Self::index_hash(index, (lc, rc))
+// 	}
+// }
 
-pub trait HashEntry: DefaultHashable {
+pub trait HashEntry:
+	DefaultHashable
+	+ Readable
+	+ Default
+	+ Clone
+	+ PartialEq
+	+ serde::ser::Serialize
+	+ serde::de::DeserializeOwned
+{
 	fn as_hash(&self) -> Hash;
 }
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -767,7 +767,7 @@ impl PMMRIndexHashable for RangeProof {
 		Self::index_hash(index, self)
 	}
 
-	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
 		Self::index_hash(index, (lc, rc))
 	}
 }
@@ -994,9 +994,11 @@ pub trait PMMRIndexHashable: DefaultHashable {
 	/// Hash with a given index
 	fn hash_with_index(&self, index: u64) -> Self::H;
 
+	/// Hash a pair of child hash entries together.
 	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H;
 
 	/// Hash given index and data.
+	/// Note: This returns a raw hash and not a hash entry.
 	fn index_hash<T: DefaultHashable>(index: u64, data: T) -> Hash {
 		(index, data).hash()
 	}

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -766,6 +766,10 @@ impl PMMRIndexHashable for RangeProof {
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
 	}
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H {
+		Self::index_hash(index, (lc, rc))
+	}
 }
 
 impl Readable for Signature {
@@ -985,10 +989,12 @@ pub trait PMMRable: Clone + Debug + DefaultHashable {
 /// Generic trait to ensure PMMR elements can be hashed with an index
 pub trait PMMRIndexHashable: DefaultHashable {
 	/// Type of hash entry for intermediate nodes.
-	type H: HashEntry;
+	type H: HashEntry + Clone + Default;
 
 	/// Hash with a given index
 	fn hash_with_index(&self, index: u64) -> Self::H;
+
+	fn hash_children(index: u64, lc: Self::H, rc: Self::H) -> Self::H;
 
 	/// Hash given index and data.
 	fn index_hash<T: DefaultHashable>(index: u64, data: T) -> Hash {
@@ -996,15 +1002,20 @@ pub trait PMMRIndexHashable: DefaultHashable {
 	}
 }
 
+/// TODO - What do we need this for?
 impl PMMRIndexHashable for (Hash, Hash) {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
 	}
+
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
+		Self::index_hash(index, (lc, rc))
+	}
 }
 
-pub trait HashEntry {
+pub trait HashEntry: DefaultHashable {
 	fn as_hash(&self) -> Hash;
 }
 

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -14,7 +14,7 @@
 
 //! Common test functions
 
-use grin_core::core::hash::DefaultHashable;
+use grin_core::core::hash::{DefaultHashable, Hash};
 use grin_core::core::{
 	Block, BlockHeader, KernelFeatures, OutputFeatures, OutputIdentifier, Transaction,
 };
@@ -155,6 +155,7 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
+	type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		*self

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -158,7 +158,6 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		*self
@@ -173,7 +172,7 @@ impl PMMRIndexHashable for TestElem {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -174,6 +174,10 @@ impl PMMRIndexHashable for TestElem {
 	fn hash_with_index(&self, index: u64) -> Hash {
 		Self::index_hash(index, self)
 	}
+
+	fn hash_children(index: u64, lc: Hash, rc: Hash) -> Hash {
+		Self::index_hash(index, (lc, rc))
+	}
 }
 
 impl Writeable for TestElem {

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -14,7 +14,6 @@
 
 //! Common test functions
 
-use grin_core::core::hash::{DefaultHashable, Hash};
 use grin_core::core::{
 	Block, BlockHeader, KernelFeatures, OutputFeatures, OutputIdentifier, Transaction,
 };
@@ -25,6 +24,10 @@ use grin_core::libtx::{
 };
 use grin_core::pow::Difficulty;
 use grin_core::ser::{self, PMMRable, Readable, Reader, Writeable, Writer};
+use grin_core::{
+	core::hash::{DefaultHashable, Hash, Hashed},
+	ser::PMMRIndexHashable,
+};
 use keychain::{Identifier, Keychain};
 
 // utility producing a transaction with 2 inputs and a single outputs
@@ -155,7 +158,7 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		*self
@@ -163,6 +166,14 @@ impl PMMRable for TestElem {
 
 	fn elmt_size() -> Option<u16> {
 		Some(16)
+	}
+}
+
+impl PMMRIndexHashable for TestElem {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -966,7 +966,6 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
-	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -981,7 +980,7 @@ impl PMMRIndexHashable for TestElem {
 	type H = Hash;
 
 	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
+		Self::index_hash(index, self)
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -21,7 +21,7 @@ use std::fs;
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 
-use crate::core::core::hash::{DefaultHashable, Hash};
+use crate::core::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::core::core::pmmr::{Backend, ReadablePMMR, PMMR};
 use crate::core::ser::{
 	Error, PMMRIndexHashable, PMMRable, ProtocolVersion, Readable, Reader, Writeable, Writer,
@@ -966,7 +966,7 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
-	type H = Hash;
+	// type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
@@ -974,6 +974,14 @@ impl PMMRable for TestElem {
 
 	fn elmt_size() -> Option<u16> {
 		Some(4)
+	}
+}
+
+impl PMMRIndexHashable for TestElem {
+	type H = Hash;
+
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -21,7 +21,7 @@ use std::fs;
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 
-use crate::core::core::hash::DefaultHashable;
+use crate::core::core::hash::{DefaultHashable, Hash};
 use crate::core::core::pmmr::{Backend, ReadablePMMR, PMMR};
 use crate::core::ser::{
 	Error, PMMRIndexHashable, PMMRable, ProtocolVersion, Readable, Reader, Writeable, Writer,
@@ -966,6 +966,7 @@ impl DefaultHashable for TestElem {}
 
 impl PMMRable for TestElem {
 	type E = Self;
+	type H = Hash;
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()


### PR DESCRIPTION
[WIP]

Something along these lines would allow us to support additional data at parent nodes in the MMR.
This is similar in concept to our early "sumtree" idea.

This could be used to support the "variable difficulty MMR" for FlyClient if this indeed turns out to be necessary.

Related: #3479 

Most MMR structures simply use `Hash` as the `HashEntry`.
The header MMR would use a `HeaderHashEntry` which could be extended to include various additional pieces of aggregate data, summarizing the header leaf nodes contained in the subtree.

The way this is implemented in this PR we can include additional data in each `HashEntry` and _exclude_ it when hashing or _include_ it when hashing. So this would allow us to maintain additional arbitrary data in an MMR without affecting the MMR root _or_ do something along the lines of the "variable difficulty MMR" and commit to this additional data when hashing and producing the root.
I'm pretty sure our early "sumtree" concept excluded the commitment sum from the hash (and did not commit to it directly).

