### PR TITLE
add segmenter for generating segments from txhashset with consistent rewind

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -34,7 +34,8 @@ use crate::types::{
 	BlockStatus, ChainAdapter, CommitPos, NoStatus, Options, Tip, TxHashsetWriteStatus,
 };
 use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::{util::RwLock, ChainStore};
+use crate::util::RwLock;
+use crate::ChainStore;
 use grin_core::ser;
 use grin_store::Error::NotFoundErr;
 use std::fs::{self, File};
@@ -152,6 +153,7 @@ pub struct Chain {
 	header_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
 	sync_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
 	verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+	pibd_segmenter: Arc<RwLock<Option<Segmenter>>>,
 	// POW verification function
 	pow_verifier: fn(&BlockHeader) -> Result<(), pow::Error>,
 	archive_mode: bool,
@@ -217,6 +219,7 @@ impl Chain {
 			txhashset: Arc::new(RwLock::new(txhashset)),
 			header_pmmr: Arc::new(RwLock::new(header_pmmr)),
 			sync_pmmr: Arc::new(RwLock::new(sync_pmmr)),
+			pibd_segmenter: Arc::new(RwLock::new(None)),
 			pow_verifier,
 			verifier_cache,
 			archive_mode,
@@ -224,6 +227,15 @@ impl Chain {
 		};
 
 		chain.log_heads()?;
+
+		// Temporarily exercising the initialization process.
+		// Note: This is *really* slow because we are starting from cold.
+		//
+		// This is not required as we will lazily initialize our segmenter as required
+		// once we start receiving PIBD segment requests.
+		// In reality we will do this based on PIBD segment requests and initialization
+		// (once per 12 hour period) will not be this slow.
+		chain.segmenter()?;
 
 		Ok(chain)
 	}
@@ -815,39 +827,62 @@ impl Chain {
 		})
 	}
 
-	/// TODO - Pass header in here. Compare it to expected archive_header and previous archive_header.
+	/// The segmenter is responsible for generation PIBD segments.
+	/// We cache a segmenter instance based on the current archve period (new period every 12 hours).
+	/// This allows us to efficiently generate bitmap segments for the current archive period.
 	///
-	/// TODO - "Cache" two recent segmenters in our chain somewhere.
+	/// It is a relatively expensive operation to initializa and cache a new segmenter instance
+	/// as this involves rewinding the txhashet by approx 720 blocks (12 hours).
 	///
-	/// Handles consistent view of the data etc.
+	/// Caller is responsible for only doing this when required.
+	/// Caller should verify a peer segment request is valid before calling this for example.
 	///
 	pub fn segmenter(&self) -> Result<Segmenter, Error> {
-		let header = self.txhashset_archive_header()?;
+		// The archive header corresponds to the data we will segment.
+		let ref archive_header = self.txhashset_archive_header()?;
+
+		// Use our cached segmenter if we have one and the associated header matches.
+		if let Some(x) = self.pibd_segmenter.read().as_ref() {
+			if x.header() == archive_header {
+				return Ok(x.clone());
+			}
+		}
+
+		// We have no cached segmenter or the cached segmenter is no longer useful.
+		// Initialize a new segment, cache it and return it.
+		let segmenter = self.init_segmenter(archive_header)?;
+		let mut cache = self.pibd_segmenter.write();
+		*cache = Some(segmenter.clone());
+
+		return Ok(segmenter);
+	}
+
+	/// This is an expensive rewind to recreate bitmap state but we only need to do this once.
+	/// Caller is responsible for "caching" the segmenter (per archive period) for reuse.
+	fn init_segmenter(&self, header: &BlockHeader) -> Result<Segmenter, Error> {
+		let now = Instant::now();
+		debug!(
+			"init_segmenter: initializing new segmenter for {} at {}",
+			header.hash(),
+			header.height
+		);
 
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 
-		// This is an expensive rewind but we only need to do this once.
-		// We can then "cache" our segmenter for use later.
 		let bitmap_snapshot =
 			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
-				ext.extension.rewind(&header, batch)?;
+				ext.extension.rewind(header, batch)?;
 				Ok(ext.extension.bitmap_accumulator())
 			})?;
 
-		Ok(Segmenter::new(self.txhashset(), bitmap_snapshot, header))
-	}
+		debug!("init_segmenter: done, took {}ms", now.elapsed().as_millis());
 
-	/// TODO - fn that returns height(s) and then lookup headers by height - make it testable
-	///
-	/// Our *previous* archive header (12 hours prior to current archive header).
-	/// PIBD requires multiple requests and we want to ensure we support PIBD
-	/// as we cross an archive interval boundary (so we support 2 recent header heights).
-	fn prev_archive_header(&self) -> Result<BlockHeader, Error> {
-		let archive_header = self.txhashset_archive_header()?;
-		let archive_interval = global::txhashset_archive_interval();
-		let prev_height = archive_header.height.saturating_sub(archive_interval);
-		self.get_header_by_height(prev_height)
+		Ok(Segmenter::new(
+			self.txhashset(),
+			bitmap_snapshot,
+			header.clone(),
+		))
 	}
 
 	/// To support the ability to download the txhashset from multiple peers in parallel,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -816,12 +816,12 @@ impl Chain {
 	}
 
 	/// TODO - Our segmenter is how we build segments for PIBD.
-	/// Handles consistent rewinding etc.
+	/// Handles consistent view of the data etc.
 	///
 	/// TODO - Use the txhashset_archive_header from below?
 	///
-	fn segmenter<'a>(txhashset: &'a TxHashSet, header: BlockHeader) -> Segmenter<'a> {
-		Segmenter::new(txhashset, header)
+	pub fn segmenter(&self, header: BlockHeader) -> Segmenter {
+		Segmenter::new(self.txhashset(), header)
 	}
 
 	/// To support the ability to download the txhashset from multiple peers in parallel,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -238,10 +238,10 @@ impl Chain {
 		// are warmed up.
 		{
 			let segmenter = chain.segmenter()?;
-			segmenter.kernel_segment(SegmentIdentifier { height: 9, idx: 0 })?;
-			segmenter.bitmap_segment(SegmentIdentifier { height: 9, idx: 0 })?;
-			segmenter.output_segment(SegmentIdentifier { height: 11, idx: 0 })?;
-			segmenter.rangeproof_segment(SegmentIdentifier { height: 7, idx: 0 })?;
+			let _ = segmenter.kernel_segment(SegmentIdentifier { height: 9, idx: 0 });
+			let _ = segmenter.bitmap_segment(SegmentIdentifier { height: 9, idx: 0 });
+			let _ = segmenter.output_segment(SegmentIdentifier { height: 11, idx: 0 });
+			let _ = segmenter.rangeproof_segment(SegmentIdentifier { height: 7, idx: 0 });
 		}
 
 		Ok(chain)

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -818,10 +818,9 @@ impl Chain {
 	/// TODO - Our segmenter is how we build segments for PIBD.
 	/// Handles consistent view of the data etc.
 	///
-	/// TODO - Use the txhashset_archive_header from below?
-	///
-	pub fn segmenter(&self, header: BlockHeader) -> Segmenter {
-		Segmenter::new(self.txhashset(), header)
+	pub fn segmenter(&self) -> Result<Segmenter, Error> {
+		let header = self.txhashset_archive_header()?;
+		Ok(Segmenter::new(self.header_pmmr(), self.txhashset(), header))
 	}
 
 	/// To support the ability to download the txhashset from multiple peers in parallel,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,7 +20,7 @@ use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{
 	Block, BlockHeader, BlockSums, Committed, Inputs, KernelFeatures, Output, OutputIdentifier,
-	Transaction, TxKernel,
+	SegmentIdentifier, Transaction, TxKernel,
 };
 use crate::core::global;
 use crate::core::pow;
@@ -233,9 +233,16 @@ impl Chain {
 		//
 		// This is not required as we will lazily initialize our segmenter as required
 		// once we start receiving PIBD segment requests.
-		// In reality we will do this based on PIBD segment requests and initialization
-		// (once per 12 hour period) will not be this slow.
-		chain.segmenter()?;
+		// In reality we will do this based on PIBD segment requests.
+		// Initialization (once per 12 hour period) will not be this slow once lmdb and PMMRs
+		// are warmed up.
+		{
+			let segmenter = chain.segmenter()?;
+			segmenter.kernel_segment(SegmentIdentifier { height: 9, idx: 0 })?;
+			segmenter.bitmap_segment(SegmentIdentifier { height: 9, idx: 0 })?;
+			segmenter.output_segment(SegmentIdentifier { height: 11, idx: 0 })?;
+			segmenter.rangeproof_segment(SegmentIdentifier { height: 7, idx: 0 })?;
+		}
 
 		Ok(chain)
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -29,7 +29,7 @@ use crate::error::{Error, ErrorKind};
 use crate::pipe;
 use crate::store;
 use crate::txhashset;
-use crate::txhashset::{PMMRHandle, TxHashSet};
+use crate::txhashset::{PMMRHandle, Segmenter, TxHashSet};
 use crate::types::{
 	BlockStatus, ChainAdapter, CommitPos, NoStatus, Options, Tip, TxHashsetWriteStatus,
 };
@@ -813,6 +813,15 @@ impl Chain {
 			txhashset::zip_read(self.db_root.clone(), &header)
 				.map(|file| (header.output_mmr_size, header.kernel_mmr_size, file))
 		})
+	}
+
+	/// TODO - Our segmenter is how we build segments for PIBD.
+	/// Handles consistent rewinding etc.
+	///
+	/// TODO - Use the txhashset_archive_header from below?
+	///
+	fn segmenter<'a>(txhashset: &'a TxHashSet, header: BlockHeader) -> Segmenter<'a> {
+		Segmenter::new(txhashset, header)
 	}
 
 	/// To support the ability to download the txhashset from multiple peers in parallel,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -887,7 +887,7 @@ impl Chain {
 
 		Ok(Segmenter::new(
 			self.txhashset(),
-			bitmap_snapshot,
+			Arc::new(bitmap_snapshot),
 			header.clone(),
 		))
 	}

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! Error types for chain
+use crate::core::core::pmmr::segment;
 use crate::core::core::{block, committed, transaction};
 use crate::core::ser;
 use crate::keychain;
@@ -149,6 +150,9 @@ pub enum ErrorKind {
 	/// Error during chain sync
 	#[fail(display = "Sync error")]
 	SyncError(String),
+	/// PIBD segment related error
+	#[fail(display = "Segment error")]
+	SegmentError(segment::SegmentError),
 }
 
 impl Display for Error {
@@ -269,6 +273,14 @@ impl From<ser::Error> for Error {
 	fn from(error: ser::Error) -> Error {
 		Error {
 			inner: Context::new(ErrorKind::SerErr(error)),
+		}
+	}
+}
+
+impl From<segment::SegmentError> for Error {
+	fn from(error: segment::SegmentError) -> Error {
+		Error {
+			inner: Context::new(ErrorKind::SegmentError(error)),
 		}
 	}
 }

--- a/chain/src/txhashset.rs
+++ b/chain/src/txhashset.rs
@@ -17,10 +17,12 @@
 
 mod bitmap_accumulator;
 mod rewindable_kernel_view;
+mod segmenter;
 mod txhashset;
 mod utxo_view;
 
 pub use self::bitmap_accumulator::*;
 pub use self::rewindable_kernel_view::*;
+pub use self::segmenter::*;
 pub use self::txhashset::*;
 pub use self::utxo_view::*;

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -50,7 +50,7 @@ impl BitmapAccumulator {
 	/// Crate a new empty bitmap accumulator.
 	pub fn new() -> BitmapAccumulator {
 		BitmapAccumulator {
-			backend: VecBackend::new_hash_only(),
+			backend: VecBackend::new(),
 		}
 	}
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -176,9 +176,12 @@ impl BitmapAccumulator {
 
 	/// The root hash of the bitmap accumulator MMR.
 	pub fn root(&self) -> Hash {
+		self.readonly_pmmr().root().expect("no root, invalid tree")
+	}
+
+	/// Readonly access to our internal data.
+	pub fn readonly_pmmr(&self) -> ReadonlyPMMR<BitmapChunk, VecBackend<BitmapChunk>> {
 		ReadonlyPMMR::at(&self.backend, self.backend.size())
-			.root()
-			.expect("no root, invalid tree")
 	}
 }
 

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -1,0 +1,66 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generation of the various necessary segments requested during PIBD.
+
+use crate::core::core::BlockHeader;
+use crate::error::Error;
+use crate::txhashset::{self, TxHashSet};
+
+/// TODO - Replace this with SegmentIdentifier from segment PR.
+pub struct SegmentIdentifier {
+	height: u8,
+	idx: u64,
+}
+
+/// Segmenter for generating PIBS segments.
+pub struct Segmenter<'a> {
+	txhashset: &'a TxHashSet,
+	header: BlockHeader,
+}
+
+impl<'a> Segmenter<'a> {
+	/// Create a new segmenter based on the provided txhashset.
+	pub fn new(txhashset: &'a TxHashSet, header: BlockHeader) -> Segmenter<'a> {
+		Segmenter { txhashset, header }
+	}
+
+	/// Create a kernel segment.
+	pub fn kernel_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+		txhashset::rewindable_kernel_view(&self.txhashset, |view, batch| {
+			view.rewind(&self.header)?;
+
+			// now build a segment from the kernel MMR in our view.
+
+			Ok(())
+		})?;
+
+		Ok("this will return a segment")
+	}
+
+	/// Note: we need to rewind both the bitmap and the output MMR as we need both roots here.
+	pub fn bitmap_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+		unimplemented!()
+	}
+
+	/// Note: we need to rewind both the bitmap and the output MMR as we need both roots here.
+	pub fn output_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+		unimplemented!()
+	}
+
+	/// Create a rangeproof segment.
+	pub fn rangeproof_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+		unimplemented!()
+	}
+}

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -14,13 +14,15 @@
 
 //! Generation of the various necessary segments requested during PIBD.
 
-use std::sync::Arc;
+use std::{marker, sync::Arc};
 
 use crate::core::core::hash::Hash;
-use crate::core::core::pmmr::ReadablePMMR;
-use crate::core::core::BlockHeader;
+use crate::core::core::pmmr::{Backend, ReadablePMMR, ReadonlyPMMR};
+use crate::core::core::{BlockHeader, OutputIdentifier, TxKernel};
+use crate::core::ser::{PMMRable, Readable, Writeable};
 use crate::error::{Error, ErrorKind};
-use crate::txhashset::{self, PMMRHandle, TxHashSet};
+use crate::txhashset::{self, BitmapChunk, PMMRHandle, TxHashSet};
+use crate::util::secp::pedersen::RangeProof;
 use crate::util::RwLock;
 
 /// TODO - Replace this with SegmentIdentifier from segment PR.
@@ -29,7 +31,35 @@ pub struct SegmentIdentifier {
 	idx: u64,
 }
 
-/// Segmenter for generating PIBS segments.
+/// TODO - Replace this the real Segment
+pub struct Segment<T> {
+	id: SegmentIdentifier,
+	_marker: marker::PhantomData<T>,
+}
+
+/// TODO - Replace this the real Segment
+impl<T> Segment<T>
+where
+	T: std::fmt::Debug + Readable + Writeable,
+{
+	/// Generate a segment from a PMMR
+	pub fn from_pmmr<U, B>(
+		segment_id: SegmentIdentifier,
+		pmmr: &ReadonlyPMMR<'_, U, B>,
+		prunable: bool,
+	) -> Result<Self, Error>
+	where
+		U: PMMRable<E = T>,
+		B: Backend<U>,
+	{
+		Ok(Segment {
+			id: segment_id,
+			_marker: marker::PhantomData,
+		})
+	}
+}
+
+/// Segmenter for generating PIBD segments.
 pub struct Segmenter {
 	header_pmmr: Arc<RwLock<PMMRHandle<BlockHeader>>>,
 	txhashset: Arc<RwLock<TxHashSet>>,
@@ -52,25 +82,23 @@ impl Segmenter {
 
 	/// Create a kernel segment.
 	/// We use a lightweight "rewindable kernel view" here as we do not need to worry about pruning.
-	pub fn kernel_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+	pub fn kernel_segment(&self, id: SegmentIdentifier) -> Result<Segment<TxKernel>, Error> {
 		let txhashset = self.txhashset.read();
 		txhashset::rewindable_kernel_view(&txhashset, |view, _| {
 			// This rewind is fast as we take advantage of our "rewindable kernel view".
 			view.rewind(&self.header)?;
-
-			// TODO - Generate segment from our rewound kernel view.
 			let pmmr = view.readonly_pmmr();
-			// let segment = Segment::from_pmmr(id, &pmmr, false)?;
-
-			Ok(())
-		})?;
-
-		Ok("this will return a segment")
+			let segment = Segment::from_pmmr(id, &pmmr, false)?;
+			Ok(segment)
+		})
 	}
 
+	/// Create a utxo bitmap segment.
 	/// Note: we need to rewind both the bitmap and the output MMR as we need both roots here.
-	/// TODO - Return a segment and the corresponding output root.
-	pub fn bitmap_segment(&self, _id: SegmentIdentifier) -> Result<(&str, Hash), Error> {
+	pub fn bitmap_segment(
+		&self,
+		id: SegmentIdentifier,
+	) -> Result<(Segment<BitmapChunk>, Hash), Error> {
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
@@ -82,25 +110,24 @@ impl Segmenter {
 			// to allow for fast subsequent reads?
 			extension.rewind(&self.header, batch)?;
 
-			// TODO - Generate segment from our rewound extension.
 			let bitmap_pmmr = extension.bitmap_readonly_pmmr();
-			// let segment = Segment::from_pmmr(id, &bitmap_pmmr, true)?;
+			let segment = Segment::from_pmmr(id, &bitmap_pmmr, true)?;
 
 			let output_pmmr = extension.output_readonly_pmmr();
 			let output_root = output_pmmr
 				.root()
 				.map_err(|_| ErrorKind::TxHashSetErr("failed to get output root".into()))?;
 
-			Ok((
-				"this will return a bitmap segment and corresponding output root",
-				output_root,
-			))
+			Ok((segment, output_root))
 		})
 	}
 
+	/// Create an output segment.
 	/// Note: we need to rewind both the bitmap and the output MMR as we need both roots here.
-	/// TODO - Return a segment and the corresponding bitmap root.
-	pub fn output_segment(&self, _id: SegmentIdentifier) -> Result<(&str, Hash), Error> {
+	pub fn output_segment(
+		&self,
+		id: SegmentIdentifier,
+	) -> Result<(Segment<OutputIdentifier>, Hash), Error> {
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
@@ -112,24 +139,20 @@ impl Segmenter {
 			// Then we can directly init a ReadonlyPMMR with the correct sizes for subsequent reads.
 			extension.rewind(&self.header, batch)?;
 
-			// TODO - Generate segment from our rewound extension.
 			let output_pmmr = extension.output_readonly_pmmr();
-			// let segment = Segment::from_pmmr(id, &output_pmmr, true)?;
+			let segment = Segment::from_pmmr(id, &output_pmmr, true)?;
 
 			let bitmap_pmmr = extension.bitmap_readonly_pmmr();
 			let bitmap_root = bitmap_pmmr
 				.root()
 				.map_err(|_| ErrorKind::TxHashSetErr("failed to get bitmap root".into()))?;
 
-			Ok((
-				"this will return an output segment and corresponding bitmap root",
-				bitmap_root,
-			))
+			Ok((segment, bitmap_root))
 		})
 	}
 
 	/// Create a rangeproof segment.
-	pub fn rangeproof_segment(&self, _id: SegmentIdentifier) -> Result<&str, Error> {
+	pub fn rangeproof_segment(&self, id: SegmentIdentifier) -> Result<Segment<RangeProof>, Error> {
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
@@ -141,11 +164,9 @@ impl Segmenter {
 			// Then we can directly init a ReadonlyPMMR with the correct sizes for subsequent reads.
 			extension.rewind(&self.header, batch)?;
 
-			// TODO - Generate segment from our rewound extension.
 			let pmmr = extension.rproof_readonly_pmmr();
-			// let segment = Segment::from_pmmr(id, &pmmr, false)?;
-
-			Ok("this will return a segment")
+			let segment = Segment::from_pmmr(id, &pmmr, false)?;
+			Ok(segment)
 		})
 	}
 }

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -28,7 +28,7 @@ use crate::util::RwLock;
 #[derive(Clone)]
 pub struct Segmenter {
 	txhashset: Arc<RwLock<TxHashSet>>,
-	bitmap_snapshot: BitmapAccumulator,
+	bitmap_snapshot: Arc<BitmapAccumulator>,
 	header: BlockHeader,
 }
 
@@ -36,7 +36,7 @@ impl Segmenter {
 	/// Create a new segmenter based on the provided txhashset.
 	pub fn new(
 		txhashset: Arc<RwLock<TxHashSet>>,
-		bitmap_snapshot: BitmapAccumulator,
+		bitmap_snapshot: Arc<BitmapAccumulator>,
 		header: BlockHeader,
 	) -> Segmenter {
 		Segmenter {

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -60,6 +60,7 @@ where
 }
 
 /// Segmenter for generating PIBD segments.
+#[derive(Clone)]
 pub struct Segmenter {
 	txhashset: Arc<RwLock<TxHashSet>>,
 	bitmap_snapshot: BitmapAccumulator,
@@ -78,6 +79,12 @@ impl Segmenter {
 			bitmap_snapshot,
 			header,
 		}
+	}
+
+	/// Header associated with this segmenter instance.
+	/// The bitmap "snapshot" corresponds to rewound state at this header.
+	pub fn header(&self) -> &BlockHeader {
+		&self.header
 	}
 
 	/// Create a kernel segment.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -303,6 +303,30 @@ impl TxHashSet {
 			.get_last_n_insertions(distance)
 	}
 
+	/// Efficient view into the kernel PMMR based on size in header.
+	pub fn kernel_pmmr_at(
+		&self,
+		header: &BlockHeader,
+	) -> ReadonlyPMMR<TxKernel, PMMRBackend<TxKernel>> {
+		ReadonlyPMMR::at(&self.kernel_pmmr_h.backend, header.kernel_mmr_size)
+	}
+
+	/// Efficient view into the output PMMR based on size in header.
+	pub fn output_pmmr_at(
+		&self,
+		header: &BlockHeader,
+	) -> ReadonlyPMMR<OutputIdentifier, PMMRBackend<OutputIdentifier>> {
+		ReadonlyPMMR::at(&self.output_pmmr_h.backend, header.output_mmr_size)
+	}
+
+	/// Efficient view into the rangeproof PMMR based on size in header.
+	pub fn rangeproof_pmmr_at(
+		&self,
+		header: &BlockHeader,
+	) -> ReadonlyPMMR<RangeProof, PMMRBackend<RangeProof>> {
+		ReadonlyPMMR::at(&self.rproof_pmmr_h.backend, header.output_mmr_size)
+	}
+
 	/// Convenience function to query the db for a header by its hash.
 	pub fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, Error> {
 		Ok(self.commit_index.get_block_header(&hash)?)
@@ -1083,6 +1107,12 @@ impl<'a> Extension<'a> {
 		self.output_pmmr.readonly_pmmr()
 	}
 
+	/// Take a snapshot of our bitmap accumulator
+	pub fn bitmap_accumulator(&self) -> BitmapAccumulator {
+		self.bitmap_accumulator.clone()
+	}
+
+	/// Readonly view of our bitmap accumulator data.
 	pub fn bitmap_readonly_pmmr(&self) -> ReadonlyPMMR<BitmapChunk, VecBackend<BitmapChunk>> {
 		self.bitmap_accumulator.readonly_pmmr()
 	}

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -132,6 +132,7 @@ impl<T> Segment<T> {
 		(first, last)
 	}
 
+	/// TODO - binary_search_by_key() here (can we assume these are sorted by pos?)
 	fn get_hash(&self, pos: u64) -> Result<Hash, SegmentError> {
 		self.hash_pos
 			.iter()
@@ -152,6 +153,16 @@ impl<T> Segment<T> {
 			.iter()
 			.zip(&self.hashes)
 			.map(|(&p, &h)| (p, h))
+	}
+
+	/// Segment proof
+	pub fn proof(&self) -> &SegmentProof {
+		&self.proof
+	}
+
+	/// Segment identifier
+	pub fn id(&self) -> SegmentIdentifier {
+		self.identifier
 	}
 }
 
@@ -537,6 +548,11 @@ impl SegmentProof {
 		proof.hashes.extend(peaks?);
 
 		Ok(proof)
+	}
+
+	/// Size of the proof in hashes.
+	pub fn size(&self) -> usize {
+		self.hashes.len()
 	}
 
 	/// Reconstruct PMMR root using this proof

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -15,7 +15,6 @@
 use grin_core as core;
 use grin_store as store;
 use grin_util as util;
-use store::PrefixIterator;
 
 use crate::core::global;
 use crate::core::ser::{self, Readable, Reader, Writeable, Writer};

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -28,8 +28,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
 // Re-export so only has to be included once
-pub use parking_lot::Mutex;
-pub use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 // Re-export so only has to be included once
 pub use secp256k1zkp as secp;


### PR DESCRIPTION
Related #3453.

* Cache a `segmenter` instance based on current archive header (every 12 hours)
* The cached `segmenter` contains a "snapshot" of the bitmap accumulator
  * This can be read directly without needing to rewind (based on archive header)
* Fast reads of output, rangeproof and kernel MMR data via `ReadonlyPMMR::at()` (no rewind required).

The caller (p2p handling peer PIBD segment requests) is responsible for verifying the provided header is valid with respect to the current archive header. 

We only support generation of PIBD segments at the current local archive header (single cached `segmenter`).
Note: As discussed below, PMMR data is apppend-only (bitmap is an exception) so this is not as limiting as it appears.

This PR is going to have a bunch of placeholder code in it until #3453 is merged. 
This is the bridge between actual segment creation and current chain state.

