### PR TITLE
on_block_accepted logging and webhooks all the time

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -737,11 +737,13 @@ where
 	V: VerifierCache + 'static,
 {
 	fn block_accepted(&self, b: &core::Block, status: BlockStatus, opts: Options) {
-		// not broadcasting blocks received through sync
+		// Trigger all registered "on_block_accepted" hooks (logging and webhooks).
+		for hook in &self.hooks {
+			hook.on_block_accepted(b, status);
+		}
+
+		// Suppress broadcast of new blocks received during sync.
 		if !opts.contains(chain::Options::SYNC) {
-			for hook in &self.hooks {
-				hook.on_block_accepted(b, status);
-			}
 			// If we mined the block then we want to broadcast the compact block.
 			// If we received the block from another node then broadcast "header first"
 			// to minimize network traffic.


### PR DESCRIPTION
Resolves #3485

We want to fire the registered `on_block_accepted` hooks regardless of `SYNC`.
We do still want to suppress block broadcast if `SYNC`.

Pretty sure this is fine to do even if we have webhooks registered. We use `futures` in the webhook code (hyper client) so these are not blocking and should be fine to run even during sync.

