### PR TITLE
add peer capabilities to tui peers screen

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -26,6 +26,7 @@ use chrono::prelude::*;
 
 use crate::chain::SyncStatus;
 use crate::p2p;
+use crate::p2p::Capabilities;
 use grin_core::pow::Difficulty;
 
 /// Server state info collection struct, to be passed around into internals
@@ -192,6 +193,8 @@ pub struct PeerStats {
 	pub sent_bytes_per_sec: u64,
 	/// Number of bytes we've received from the peer.
 	pub received_bytes_per_sec: u64,
+	/// Peer advertised capability flags.
+	pub capabilities: Capabilities,
 }
 
 impl PartialEq for PeerStats {
@@ -239,6 +242,7 @@ impl PeerStats {
 			last_seen: peer.info.last_seen(),
 			sent_bytes_per_sec: peer.last_min_sent_bytes().unwrap_or(0) / 60,
 			received_bytes_per_sec: peer.last_min_received_bytes().unwrap_or(0) / 60,
+			capabilities: peer.info.capabilities,
 		}
 	}
 }

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -41,6 +41,7 @@ pub enum PeerColumn {
 	Direction,
 	Version,
 	UserAgent,
+	Capabilities,
 }
 
 impl PeerColumn {
@@ -53,6 +54,7 @@ impl PeerColumn {
 			PeerColumn::TotalDifficulty => "Total Difficulty",
 			PeerColumn::Direction => "Direction",
 			PeerColumn::UserAgent => "User Agent",
+			PeerColumn::Capabilities => "Capabilities",
 		}
 	}
 }
@@ -82,6 +84,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::Direction => self.direction.clone(),
 			PeerColumn::Version => format!("{}", self.version),
 			PeerColumn::UserAgent => self.user_agent.clone(),
+			PeerColumn::Capabilities => format!("{}", self.capabilities.bits()),
 		}
 	}
 
@@ -115,6 +118,10 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::Direction => self.direction.cmp(&other.direction).then(sort_by_addr()),
 			PeerColumn::Version => self.version.cmp(&other.version).then(sort_by_addr()),
 			PeerColumn::UserAgent => self.user_agent.cmp(&other.user_agent).then(sort_by_addr()),
+			PeerColumn::Capabilities => self
+				.capabilities
+				.cmp(&other.capabilities)
+				.then(sort_by_addr()),
 		}
 	}
 }
@@ -133,7 +140,8 @@ impl TUIPeerView {
 			.column(PeerColumn::TotalDifficulty, "Total Difficulty", |c| {
 				c.width_percent(24)
 			})
-			.column(PeerColumn::Version, "Proto", |c| c.width_percent(6))
+			.column(PeerColumn::Version, "Proto", |c| c.width_percent(4))
+			.column(PeerColumn::Capabilities, "Capab", |c| c.width_percent(4))
 			.column(PeerColumn::UserAgent, "User Agent", |c| c.width_percent(18));
 		let peer_status_view = ResizedView::with_full_screen(
 			LinearLayout::new(Orientation::Vertical)

--- a/src/bin/tui/table.rs
+++ b/src/bin/tui/table.rs
@@ -995,6 +995,7 @@ impl<H: Copy + Clone + 'static> TableColumn<H> {
 
 #[cfg(test)]
 mod test {
+	use crate::p2p::Capabilities;
 	use crate::tui::peers::PeerColumn;
 	use crate::tui::table::TableView;
 	use chrono::Utc;
@@ -1060,6 +1061,7 @@ mod test {
 				last_seen: Utc::now(),
 				sent_bytes_per_sec: 0,
 				received_bytes_per_sec: 0,
+				capabilities: Capabilities::FULL_NODE,
 			}
 		}
 	}


### PR DESCRIPTION
Related #3484. 

Add a `Capab` column showig a simple u32 value for peer advertised capabilities.
`15` is the default (`FULL_NODE`) currently.
We plan to introduce a new value for PIBD support.

<img width="1036" alt="Screen Shot 2020-11-16 at 2 51 10 PM" src="https://user-images.githubusercontent.com/30642645/99266940-3eeed680-281b-11eb-9821-f25c9c3a9f21.png">
