### PR TITLE
reorg cache fix

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -318,7 +318,7 @@ fn comments() -> HashMap<String, String> {
 		"reorg_cache_period".to_string(),
 		"
 #reorg cache retention period in minute.
-#the reorg cache repopulates nodes mempool in a reorg scenario.
+#the reorg cache repopulates local mempool in a reorg scenario.
 "
 		.to_string(),
 	);

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -315,6 +315,15 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"reorg_cache_period".to_string(),
+		"
+#reorg cache retention period in minute.
+#the reorg cache repopulates nodes mempool in a reorg scenario.
+"
+		.to_string(),
+	);
+
+	retval.insert(
 		"max_pool_size".to_string(),
 		"
 #maximum number of transactions allowed in the pool

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -107,6 +107,11 @@ pub struct PoolConfig {
 	#[serde(default = "default_accept_fee_base")]
 	pub accept_fee_base: u64,
 
+	// Reorg cache retention period in minute.
+	// The reorg cache repopulates nodes mempool in a reorg scenario.
+	#[serde(default = "default_reorg_cache_period")]
+	pub reorg_cache_period: i64,
+
 	/// Maximum capacity of the pool in number of transactions
 	#[serde(default = "default_max_pool_size")]
 	pub max_pool_size: usize,
@@ -126,6 +131,7 @@ impl Default for PoolConfig {
 	fn default() -> PoolConfig {
 		PoolConfig {
 			accept_fee_base: default_accept_fee_base(),
+			reorg_cache_period: default_reorg_cache_period(),
 			max_pool_size: default_max_pool_size(),
 			max_stempool_size: default_max_stempool_size(),
 			mineable_max_weight: default_mineable_max_weight(),
@@ -135,6 +141,9 @@ impl Default for PoolConfig {
 
 fn default_accept_fee_base() -> u64 {
 	consensus::MILLI_GRIN
+}
+fn default_reorg_cache_period() -> i64 {
+	30
 }
 fn default_max_pool_size() -> usize {
 	50_000

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -110,7 +110,7 @@ pub struct PoolConfig {
 	// Reorg cache retention period in minute.
 	// The reorg cache repopulates local mempool in a reorg scenario.
 	#[serde(default = "default_reorg_cache_period")]
-	pub reorg_cache_period: i64,
+	pub reorg_cache_period: u32,
 
 	/// Maximum capacity of the pool in number of transactions
 	#[serde(default = "default_max_pool_size")]
@@ -142,7 +142,7 @@ impl Default for PoolConfig {
 fn default_accept_fee_base() -> u64 {
 	consensus::MILLI_GRIN
 }
-fn default_reorg_cache_period() -> i64 {
+fn default_reorg_cache_period() -> u32 {
 	30
 }
 fn default_max_pool_size() -> usize {

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -108,7 +108,7 @@ pub struct PoolConfig {
 	pub accept_fee_base: u64,
 
 	// Reorg cache retention period in minute.
-	// The reorg cache repopulates nodes mempool in a reorg scenario.
+	// The reorg cache repopulates local mempool in a reorg scenario.
 	#[serde(default = "default_reorg_cache_period")]
 	pub reorg_cache_period: i64,
 

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -167,6 +167,7 @@ where
 	TransactionPool::new(
 		PoolConfig {
 			accept_fee_base: 0,
+			reorg_cache_period: 30,
 			max_pool_size: 50,
 			max_stempool_size: 50,
 			mineable_max_weight: 10_000,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -767,7 +767,7 @@ where
 			let _ = tx_pool.reconcile_block(b);
 
 			// First "age out" any old txs in the reorg_cache.
-			let cutoff = Utc::now() - Duration::minutes(tx_pool.config.reorg_cache_period);
+			let cutoff = Utc::now() - Duration::minutes(tx_pool.config.reorg_cache_period as i64);
 			tx_pool.truncate_reorg_cache(cutoff);
 		}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -767,7 +767,7 @@ where
 			let _ = tx_pool.reconcile_block(b);
 
 			// First "age out" any old txs in the reorg_cache.
-			let cutoff = Utc::now() - Duration::minutes(30);
+			let cutoff = Utc::now() - Duration::minutes(tx_pool.config.reorg_cache_period);
 			tx_pool.truncate_reorg_cache(cutoff);
 		}
 


### PR DESCRIPTION
Related to #3489 

- **reorg cache period configurable** :  Allow everyone to configure themselves the reorg cache period, so they could increase it easily in function of their constraint. To repopulate their local mempool.


- ~~**treat cached txs as "new" during reconciliation** :  Allow our nodes to broadcast txs to their peers.~~
>  ~~_For every tx in the reorg cache that is successfully added back to the mempool during reconciliation should also be (re)broadcast out to our peers. We should treat these txs as "new" in this scenario._~~


- ~~**increase max pool size to 300K txs** : To prevent for the future, in case of large reorg with empty blocks, against stale full blocks, nodes mempool should be able to handle 6 hours of transactions of full blocks.~~

- ~~**Evict duplicate txs in reorg cache** : Given we add transactions back transaction to the pool, and in the pool we add them back in the reorg cache, we remove them from the reorg cache before they are sent in the pool.~~

- ~~**Evict only txs accepted to pool and sourced from reorg cache when rec…** : Fix of commit [3d8df3a](https://github.com/mimblewimble/grin/pull/3495/commits/3d8df3a7c82ecd8c0f05c25c87b05a7013957ee4), It will evict _only_ from reorg cache, transactions sourced from reorg cache, accepted by the pool to be broadcasted and added to the reorg_cache again. As we want to keep every transactions that were not accepted by the pool in the reorg_cache in the case where a reorg with larger depth happen again.~~

**test**: 
- ~~reorg on testnet made, node rebroadcasted successfully the transactions to other peers~~

- ~~I plan also to make a stress test on testnet with 50k transactions - not done yet.~~
