### PR TITLE
try and call refreshenv before running tests on windows

### DIFF
--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,5 +1,7 @@
 steps:
-  - script: 'cargo test --all'
+  - script: |
+      refreshenv
+      cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
   - script: 'cargo test --all'

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,7 +1,6 @@
 steps:
   - script: |
-      refreshenv
-      cargo test --all
+      refreshenv && cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
   - script: 'cargo test --all'


### PR DESCRIPTION
Try and call `refreshenv` as part of the script when running tests on windows (env is not shared across tasks).