### PR TITLE
we have no patch file and nothing to patch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,6 @@ jobs:
         PLATFORM: win-x64
   steps:
     - script: |
-        git apply .ci/win.patch
         choco install -y llvm
       displayName: Windows Install Dependencies
     - template: '.ci/test.yml'


### PR DESCRIPTION
Remove legacy code in the azure pipeline config that runs `git apply .ci/win.patch` as this file no longer exists.