### PR TITLE
enable PIBD_HIST capability by default

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -398,9 +398,7 @@ impl Default for Capabilities {
 			| Capabilities::TXHASHSET_HIST
 			| Capabilities::PEER_LIST
 			| Capabilities::TX_KERNEL_HASH
-
-		// To be enabled once we start supporting the various PIBD segment msgs.
-		// | Capabilities::PIBD_HIST
+			| Capabilities::PIBD_HIST
 	}
 }
 

--- a/p2p/tests/capabilities.rs
+++ b/p2p/tests/capabilities.rs
@@ -41,6 +41,7 @@ fn default_capabilities() {
 	assert!(x.contains(Capabilities::TXHASHSET_HIST));
 	assert!(x.contains(Capabilities::PEER_LIST));
 	assert!(x.contains(Capabilities::TX_KERNEL_HASH));
+	assert!(x.contains(Capabilities::PIBD_HIST));
 
 	assert_eq!(
 		x,
@@ -48,5 +49,6 @@ fn default_capabilities() {
 			| Capabilities::TXHASHSET_HIST
 			| Capabilities::PEER_LIST
 			| Capabilities::TX_KERNEL_HASH
+			| Capabilities::PIBD_HIST
 	);
 }

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -55,19 +55,19 @@ fn test_capabilities() {
 
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b1111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b11111 as u32),
 	);
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b00001111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b00011111 as u32),
 	);
 
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b01011111 as u32),
 	);
 
-	assert!(p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32).contains(expected));
+	assert!(p2p::types::Capabilities::from_bits_truncate(0b01011111 as u32).contains(expected));
 
 	assert!(
 		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32)


### PR DESCRIPTION
__Merge after #3496 is merged.__

----

This PR enables the new `PIBD_HIST` capabilities flag by default.

Related: https://github.com/mimblewimble/grin/pull/3496 (PIBD segment msg support).
Also related: #3490 (expose peer capabilities on tui peers screen).