### PR TITLE
Disable API v1

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -21,22 +21,6 @@ pub mod transactions_api;
 pub mod utils;
 pub mod version_api;
 
-use self::blocks_api::BlockHandler;
-use self::blocks_api::HeaderHandler;
-use self::chain_api::ChainCompactHandler;
-use self::chain_api::ChainHandler;
-use self::chain_api::ChainValidationHandler;
-use self::chain_api::KernelHandler;
-use self::chain_api::OutputHandler;
-use self::peers_api::PeerHandler;
-use self::peers_api::PeersAllHandler;
-use self::peers_api::PeersConnectedHandler;
-use self::pool_api::PoolInfoHandler;
-use self::pool_api::PoolPushHandler;
-use self::server_api::IndexHandler;
-use self::server_api::StatusHandler;
-use self::transactions_api::TxHashSetHandler;
-use self::version_api::VersionHandler;
 use crate::auth::{
 	BasicAuthMiddleware, BasicAuthURIMiddleware, GRIN_BASIC_REALM, GRIN_FOREIGN_BASIC_REALM,
 };
@@ -52,7 +36,7 @@ use crate::pool;
 use crate::pool::{BlockChain, PoolAdapter};
 use crate::rest::{ApiServer, Error, TLSConfig};
 use crate::router::ResponseFuture;
-use crate::router::{Router, RouterError};
+use crate::router::Router;
 use crate::util::to_base64;
 use crate::util::RwLock;
 use crate::web::*;
@@ -79,17 +63,9 @@ where
 	P: PoolAdapter + 'static,
 	V: VerifierCache + 'static,
 {
-	// Manually build router when getting rid of v1
-	//let mut router = Router::new();
-	let mut router = build_router(
-		chain.clone(),
-		tx_pool.clone(),
-		peers.clone(),
-		sync_state.clone(),
-	)
-	.expect("unable to build API router");
+	let mut router = Router::new();
 
-	// Add basic auth to v1 API and owner v2 API
+	// Add basic auth to v2 owner API
 	if let Some(api_secret) = api_secret {
 		let api_basic_auth =
 			"Basic ".to_string() + &to_base64(&("grin:".to_string() + &api_secret));
@@ -101,14 +77,14 @@ where
 		router.add_middleware(basic_auth_middleware);
 	}
 
-	let api_handler_v2 = OwnerAPIHandlerV2::new(
+	let api_handler = OwnerAPIHandlerV2::new(
 		Arc::downgrade(&chain),
 		Arc::downgrade(&peers),
 		Arc::downgrade(&sync_state),
 	);
-	router.add_route("/v2/owner", Arc::new(api_handler_v2))?;
+	router.add_route("/v2/owner", Arc::new(api_handler))?;
 
-	// Add basic auth to v2 foreign API only
+	// Add basic auth to v2 foreign API
 	if let Some(api_secret) = foreign_api_secret {
 		let api_basic_auth =
 			"Basic ".to_string() + &to_base64(&("grin:".to_string() + &api_secret));
@@ -120,12 +96,12 @@ where
 		router.add_middleware(basic_auth_middleware);
 	}
 
-	let api_handler_v2 = ForeignAPIHandlerV2::new(
+	let api_handler = ForeignAPIHandlerV2::new(
 		Arc::downgrade(&chain),
 		Arc::downgrade(&tx_pool),
 		Arc::downgrade(&sync_state),
 	);
-	router.add_route("/v2/foreign", Arc::new(api_handler_v2))?;
+	router.add_route("/v2/foreign", Arc::new(api_handler))?;
 
 	let mut apis = ApiServer::new();
 	warn!("Starting HTTP Node APIs server at {}.", addr);
@@ -324,116 +300,4 @@ fn response<T: Into<Body>>(status: StatusCode, text: T) -> Response<Body> {
 	}
 
 	builder.body(text.into()).unwrap()
-}
-
-// Legacy V1 router
-#[deprecated(
-	since = "4.0.0",
-	note = "The V1 Node API will be removed in grin 5.0.0. Please migrate to the V2 API as soon as possible."
-)]
-pub fn build_router<B, P, V>(
-	chain: Arc<chain::Chain>,
-	tx_pool: Arc<RwLock<pool::TransactionPool<B, P, V>>>,
-	peers: Arc<p2p::Peers>,
-	sync_state: Arc<chain::SyncState>,
-) -> Result<Router, RouterError>
-where
-	B: BlockChain + 'static,
-	P: PoolAdapter + 'static,
-	V: VerifierCache + 'static,
-{
-	let route_list = vec![
-		"get blocks".to_string(),
-		"get headers".to_string(),
-		"get chain".to_string(),
-		"post chain/compact".to_string(),
-		"get chain/validate".to_string(),
-		"get chain/kernels/xxx?min_height=yyy&max_height=zzz".to_string(),
-		"get chain/outputs/byids?id=xxx,yyy,zzz".to_string(),
-		"get chain/outputs/byheight?start_height=101&end_height=200".to_string(),
-		"get status".to_string(),
-		"get txhashset/roots".to_string(),
-		"get txhashset/lastoutputs?n=10".to_string(),
-		"get txhashset/lastrangeproofs".to_string(),
-		"get txhashset/lastkernels".to_string(),
-		"get txhashset/outputs?start_index=1&max=100".to_string(),
-		"get txhashset/merkleproof?n=1".to_string(),
-		"get pool".to_string(),
-		"post pool/push_tx".to_string(),
-		"post peers/a.b.c.d:p/ban".to_string(),
-		"post peers/a.b.c.d:p/unban".to_string(),
-		"get peers/all".to_string(),
-		"get peers/connected".to_string(),
-		"get peers/a.b.c.d".to_string(),
-		"get version".to_string(),
-	];
-	let index_handler = IndexHandler { list: route_list };
-
-	let output_handler = OutputHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let kernel_handler = KernelHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let block_handler = BlockHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let header_handler = HeaderHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let chain_tip_handler = ChainHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let chain_compact_handler = ChainCompactHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let chain_validation_handler = ChainValidationHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let status_handler = StatusHandler {
-		chain: Arc::downgrade(&chain),
-		peers: Arc::downgrade(&peers),
-		sync_state: Arc::downgrade(&sync_state),
-	};
-	let txhashset_handler = TxHashSetHandler {
-		chain: Arc::downgrade(&chain),
-	};
-	let pool_info_handler = PoolInfoHandler {
-		tx_pool: Arc::downgrade(&tx_pool),
-	};
-	let pool_push_handler = PoolPushHandler {
-		tx_pool: Arc::downgrade(&tx_pool),
-	};
-	let peers_all_handler = PeersAllHandler {
-		peers: Arc::downgrade(&peers),
-	};
-	let peers_connected_handler = PeersConnectedHandler {
-		peers: Arc::downgrade(&peers),
-	};
-	let peer_handler = PeerHandler {
-		peers: Arc::downgrade(&peers),
-	};
-	let version_handler = VersionHandler {
-		chain: Arc::downgrade(&chain),
-	};
-
-	let mut router = Router::new();
-
-	router.add_route("/v1/", Arc::new(index_handler))?;
-	router.add_route("/v1/blocks/*", Arc::new(block_handler))?;
-	router.add_route("/v1/headers/*", Arc::new(header_handler))?;
-	router.add_route("/v1/chain", Arc::new(chain_tip_handler))?;
-	router.add_route("/v1/chain/outputs/*", Arc::new(output_handler))?;
-	router.add_route("/v1/chain/kernels/*", Arc::new(kernel_handler))?;
-	router.add_route("/v1/chain/compact", Arc::new(chain_compact_handler))?;
-	router.add_route("/v1/chain/validate", Arc::new(chain_validation_handler))?;
-	router.add_route("/v1/txhashset/*", Arc::new(txhashset_handler))?;
-	router.add_route("/v1/status", Arc::new(status_handler))?;
-	router.add_route("/v1/pool", Arc::new(pool_info_handler))?;
-	router.add_route("/v1/pool/push_tx", Arc::new(pool_push_handler))?;
-	router.add_route("/v1/peers/all", Arc::new(peers_all_handler))?;
-	router.add_route("/v1/peers/connected", Arc::new(peers_connected_handler))?;
-	router.add_route("/v1/peers/**", Arc::new(peer_handler))?;
-	router.add_route("/v1/version", Arc::new(version_handler))?;
-	Ok(router)
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -249,10 +249,17 @@ impl GlobalConfig {
 		let mut chain_path = grin_home.clone();
 		chain_path.push(GRIN_CHAIN_DIR);
 		self.members.as_mut().unwrap().server.db_root = chain_path.to_str().unwrap().to_owned();
-		let mut secret_path = grin_home.clone();
-		secret_path.push(API_SECRET_FILE_NAME);
+		let mut api_secret_path = grin_home.clone();
+		api_secret_path.push(API_SECRET_FILE_NAME);
 		self.members.as_mut().unwrap().server.api_secret_path =
-			Some(secret_path.to_str().unwrap().to_owned());
+			Some(api_secret_path.to_str().unwrap().to_owned());
+		let mut foreign_api_secret_path = grin_home.clone();
+		foreign_api_secret_path.push(FOREIGN_API_SECRET_FILE_NAME);
+		self.members
+			.as_mut()
+			.unwrap()
+			.server
+			.foreign_api_secret_path = Some(foreign_api_secret_path.to_str().unwrap().to_owned());
 		let mut log_path = grin_home.clone();
 		log_path.push(SERVER_LOG_FILE_NAME);
 		self.members


### PR DESCRIPTION
As scheduled, the Node v1 API is now disabled.
A subsequent cleanup should be done but this is the minimal to do without causing too much disruption.