### PR TITLE
fix, no more FULL_NODE

### DIFF
--- a/src/bin/tui/table.rs
+++ b/src/bin/tui/table.rs
@@ -1061,7 +1061,7 @@ mod test {
 				last_seen: Utc::now(),
 				sent_bytes_per_sec: 0,
 				received_bytes_per_sec: 0,
-				capabilities: Capabilities::FULL_NODE,
+				capabilities: Capabilities::default(),
 			}
 		}
 	}


### PR DESCRIPTION
Not really sure how this happened but this PR cleans up a reference to `FULL_NODE` which no longer exists.

Edit: It was added in #3490 and should not have been as `FULL_NODE` no longer exists, we should be using `Capabilities::default()`.