### PR TITLE
refreshenv as part of windows release script

### DIFF
--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,8 +1,10 @@
 steps:
-  - script: 'cargo test --all'
+  - script: |
+      refreshenv && cargo test --all
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo build --release'
+  - script: |
+      refreshenv && cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |


### PR DESCRIPTION
We need to run `refreshenv` after installing `llvm` as part of the windows release script.
Related #3498.