### PR TITLE
Block migration db flag (only migrate once)

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -18,7 +18,7 @@ use crate::core::consensus::HeaderInfo;
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::{Block, BlockHeader, BlockSums};
 use crate::core::pow::Difficulty;
-use crate::core::ser::ProtocolVersion;
+use crate::core::ser::{ProtocolVersion, Readable, Writeable};
 use crate::linked_list::MultiIndex;
 use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
@@ -45,6 +45,11 @@ pub const NRD_KERNEL_ENTRY_PREFIX: u8 = b'k';
 
 const BLOCK_SUMS_PREFIX: u8 = b'M';
 const BLOCK_SPENT_PREFIX: u8 = b'S';
+
+/// Prefix for various boolean flags stored in the db.
+const BOOL_FLAG_PREFIX: u8 = b'B';
+/// Boolean flag for v3 migration.
+const BLOCKS_V3_MIGRATED: &str = "blocks_v3_migrated";
 
 /// All chain-related database operations
 pub struct ChainStore {
@@ -211,6 +216,27 @@ impl<'a> Batch<'a> {
 	pub fn save_spent_index(&self, h: &Hash, spent: &[CommitPos]) -> Result<(), Error> {
 		self.db
 			.put_ser(&to_key(BLOCK_SPENT_PREFIX, h)[..], &spent.to_vec())?;
+		Ok(())
+	}
+
+	/// DB flag representing full migration of blocks to v3 version.
+	/// Default to false if flag not present.
+	pub fn is_blocks_v3_migrated(&self) -> Result<bool, Error> {
+		let migrated: Option<BoolFlag> = self
+			.db
+			.get_ser(&to_key(BOOL_FLAG_PREFIX, BLOCKS_V3_MIGRATED))?;
+		match migrated {
+			None => Ok(false),
+			Some(x) => Ok(x.into()),
+		}
+	}
+
+	/// Set DB flag representing full migration of blocks to v3 version.
+	pub fn set_blocks_v3_migrated(&self, migrated: bool) -> Result<(), Error> {
+		self.db.put_ser(
+			&to_key(BOOL_FLAG_PREFIX, BLOCKS_V3_MIGRATED)[..],
+			&BoolFlag(migrated),
+		)?;
 		Ok(())
 	}
 
@@ -495,4 +521,26 @@ impl<'a> Iterator for DifficultyIter<'a> {
 /// Allows for fast lookup of the most recent entry per excess commitment.
 pub fn nrd_recent_kernel_index() -> MultiIndex<CommitPos> {
 	MultiIndex::init(NRD_KERNEL_LIST_PREFIX, NRD_KERNEL_ENTRY_PREFIX)
+}
+
+struct BoolFlag(bool);
+
+impl From<BoolFlag> for bool {
+	fn from(b: BoolFlag) -> Self {
+		b.0
+	}
+}
+
+impl Readable for BoolFlag {
+	fn read<R: ser::Reader>(reader: &mut R) -> Result<Self, ser::Error> {
+		let x = reader.read_u8()?;
+		Ok(BoolFlag(1 & x == 1))
+	}
+}
+
+impl Writeable for BoolFlag {
+	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_u8(self.0.into())?;
+		Ok(())
+	}
 }


### PR DESCRIPTION
Resolves #3511

We only need to run the block migration process to completion once, to migrate existing blocks from v2 -> v3.

This PR introduces - 
* `batch.is_blocks_v3_migrated()`
* `batch.set_blocks_v3_migrated(true)`
* `BoolFlag` (de/ser of simple bool value in lmdb)
* `BOOL_FLAG_PREFIX` prefix for arbitrary bool flags in the db
* `BLOCKS_V3_MIGRATED` lmdb key for this specific bool flag

`BoolFlag` and the associated db code should be reusable if we decide to store additional flags in the db.

This PR also reworks the actual migration process to reduce the amount of deserialization attempts required to determine which blocks do need migrating. This will reduce the time required for the initial migration process.
We were attempting reads of both `v2` and `v3` format and looking for errors during `v3`.
We now do a single `v3` read and only on failure do we perform the additional `v2` read.
Empty blocks do not need to be migrated (no inputs to migrate) which is why we can skip successful `v3` reads.
And for these we do not need the additional redundant `v2` read.

After a successful migration, subsequent node restarts will result in -

```
20201207 20:56:44.437 DEBUG grin_chain::chain - migrate_db_v2_v3: previously migrated, skipping
```