### PR TITLE
prefer outbound peers when syncing

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -128,13 +128,6 @@ impl Peers {
 		self.iter().connected().by_addr(addr)
 	}
 
-	pub fn max_peer_difficulty(&self) -> Difficulty {
-		self.iter()
-			.connected()
-			.max_difficulty()
-			.unwrap_or(Difficulty::zero())
-	}
-
 	pub fn is_banned(&self, peer_addr: PeerAddr) -> bool {
 		if let Ok(peer) = self.store.get_peer(peer_addr) {
 			return peer.flags == State::Banned;

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -26,6 +26,7 @@ use std::sync::{mpsc, Arc};
 use std::{cmp, str, thread, time};
 
 use crate::core::global;
+use crate::core::pow::Difficulty;
 use crate::p2p;
 use crate::p2p::types::PeerAddr;
 use crate::p2p::ChainAdapter;
@@ -172,15 +173,10 @@ fn monitor_peers(
 		total_count += 1;
 	}
 
-	let peers_count = peers.iter().connected().count();
-
-	let max_diff = peers.max_peer_difficulty();
-	let most_work_count = peers
-		.iter()
-		.outbound()
-		.with_difficulty(|x| x >= max_diff)
-		.connected()
-		.count();
+	let peers_iter = || peers.iter().connected();
+	let peers_count = peers_iter().count();
+	let max_diff = peers_iter().max_difficulty().unwrap_or(Difficulty::zero());
+	let most_work_count = peers_iter().with_difficulty(|x| x >= max_diff).count();
 
 	debug!(
 		"monitor_peers: on {}:{}, {} connected ({} most_work). \

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -93,14 +93,25 @@ impl BodySync {
 		let head = self.chain.head()?;
 
 		// Find connected peers with strictly greater difficulty than us.
-		let peers: Vec<_> = self
-			.peers
-			.iter()
-			.outbound()
-			.with_difficulty(|x| x > head.total_difficulty)
-			.connected()
-			.into_iter()
-			.collect();
+		let peers_iter = || {
+			self.peers
+				.iter()
+				.with_difficulty(|x| x > head.total_difficulty)
+				.connected()
+		};
+
+		// We prefer outbound peers with greater difficulty.
+		let mut peers: Vec<_> = peers_iter().outbound().into_iter().collect();
+		if peers.is_empty() {
+			debug!("no outbound peers with more work, considering inbound");
+			peers = peers_iter().inbound().into_iter().collect();
+		}
+
+		// If we have no peers (outbound or inbound) then we are done for now.
+		if peers.is_empty() {
+			debug!("no peers (inbound or outbound) with more work");
+			return Ok(false);
+		}
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -231,11 +231,18 @@ impl SyncRunner {
 		let mut is_syncing = self.sync_state.is_syncing();
 
 		// Find a peer with greatest known difficulty.
-		let max_diff = self.peers.max_peer_difficulty();
+		// Consider all peers, both inbound and outbound.
+		// We will prioritize syncing against outbound peers exclusively when possible.
+		// But we do support syncing against an inbound peer if greater work than any outbound peers.
+		let max_diff = self
+			.peers
+			.iter()
+			.connected()
+			.max_difficulty()
+			.unwrap_or(Difficulty::zero());
 		let peer = self
 			.peers
 			.iter()
-			.outbound()
 			.with_difficulty(|x| x >= max_diff)
 			.connected()
 			.choose_random();


### PR DESCRIPTION
Resolves #3518 

This PR fixes an edge case that we appear to be hitting on `testnet` due to low number of nodes and overall network health.

There was an inconsistency during sync where we would see a `max_diff` on an _inbound_ peer that would trigger sync but then we would attempt to sync against a randomly chosen _outbound_ peer. But it is possible that no outbound peers have sufficient difficulty to handle the sync request.

When checking for known `max_diff` we need to ensure we check against a set of peers that is consistent with those that we will actually sync from.

We want to prioritize syncing against _outbound_ peers whenever possible.
But we we also want to handle the case where an _inbound_ peer advertises more work than any other connected peers - in this case we will sync against that _inbound_ peer, but only if no outbound peers are known to have the same total work.

Outbound peers are considered more reliable as they are more likely to be long lived (and likely with faster connections and more bandwidth).
Related discussion - https://github.com/bitcoin/bitcoin/issues/5315#issuecomment-63675901

Rules are as follows - 
* find `max_diff` across _all_ connected peers (inbound and outbound)
* randomly choose an _outbound_ peer with `diff >= max_diff`
* if no _outbound_ peer then randomly choose _inbound_ peer with `diff >= max_diff`

This means we prefer outbound peers when syncing. And we sync against inbound peers only when necessary.

