### PR TITLE
better naming of APIs file and variables

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -54,7 +54,7 @@ pub fn node_apis<B, P, V>(
 	tx_pool: Arc<RwLock<pool::TransactionPool<B, P, V>>>,
 	peers: Arc<p2p::Peers>,
 	sync_state: Arc<chain::SyncState>,
-	api_secret: Option<String>,
+	owner_api_secret: Option<String>,
 	foreign_api_secret: Option<String>,
 	tls_config: Option<TLSConfig>,
 ) -> Result<(), Error>
@@ -66,7 +66,7 @@ where
 	let mut router = Router::new();
 
 	// Add basic auth to v2 owner API
-	if let Some(api_secret) = api_secret {
+	if let Some(api_secret) = owner_api_secret {
 		let api_basic_auth =
 			"Basic ".to_string() + &to_base64(&("grin:".to_string() + &api_secret));
 		let basic_auth_middleware = Arc::new(BasicAuthMiddleware::new(

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -54,7 +54,7 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
-		"api_secret_path".to_string(),
+		"owner_api_secret_path".to_string(),
 		"
 #path of the secret token used by the Rest API and v2 Owner API to authenticate the calls
 #comment the it to disable basic auth

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -54,18 +54,18 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
-		"owner_api_secret_path".to_string(),
+		"node_owner_api_secret_path".to_string(),
 		"
-#path of the secret token used by the Rest API and v2 Owner API to authenticate the calls
+#path of the secret token used by the Node Owner API to authenticate the calls
 #comment the it to disable basic auth
 "
 		.to_string(),
 	);
 
 	retval.insert(
-		"foreign_api_secret_path".to_string(),
+		"node_foreign_api_secret_path".to_string(),
 		"
-#path of the secret token used by the Foreign API to authenticate the calls
+#path of the secret token used by the Node Foreign API to authenticate the calls
 #comment the it to disable basic auth
 "
 		.to_string(),

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -99,18 +99,7 @@ pub fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	Ok(())
 }
 
-/// Check that the default/custom api secret file exists and is valid when the config file exist
-fn check_api_file_existing_config(api_secret: String) -> Result<(), ConfigError> {
-	let mut api_secret_path = PathBuf::new();
-	api_secret_path.push(api_secret);
-	if !api_secret_path.exists() {
-		init_api_secret(&api_secret_path)
-	} else {
-		check_api_secret(&api_secret_path)
-	}
-}
-
-/// Check that the api secret file exists and is valid when the config file does not exist
+/// Check that the api secret file exists and is valid
 fn check_api_secret_files(
 	chain_type: &global::ChainTypes,
 	secret_file_name: &str,
@@ -132,6 +121,16 @@ fn check_api_secret_files(
 
 /// Handles setup and detection of paths for node
 pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalConfig, ConfigError> {
+	check_api_secret_files(
+		chain_type,
+		NODE_OWNER_API_SECRET_FILE_NAME,
+		OLD_NODE_OWNER_API_SECRET_FILE_NAME,
+	)?;
+	check_api_secret_files(
+		chain_type,
+		NODE_FOREIGN_API_SECRET_FILE_NAME,
+		OLD_NODE_FOREIGN_API_SECRET_FILE_NAME,
+	)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(SERVER_CONFIG_FILE_NAME) {
 		GlobalConfig::new(p.to_str().unwrap())
@@ -145,16 +144,6 @@ pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalCon
 
 		// Spit it out if it doesn't exist
 		if !config_path.exists() {
-			check_api_secret_files(
-				chain_type,
-				NODE_OWNER_API_SECRET_FILE_NAME,
-				OLD_NODE_OWNER_API_SECRET_FILE_NAME,
-			)?;
-			check_api_secret_files(
-				chain_type,
-				NODE_FOREIGN_API_SECRET_FILE_NAME,
-				OLD_NODE_FOREIGN_API_SECRET_FILE_NAME,
-			)?;
 			let mut default_config = GlobalConfig::for_chain(chain_type);
 			// update paths relative to current dir
 			default_config.update_paths(&grin_path);
@@ -258,26 +247,6 @@ impl GlobalConfig {
 		match decoded {
 			Ok(gc) => {
 				self.members = Some(gc);
-				if let Some(p) = self
-					.members
-					.as_mut()
-					.unwrap()
-					.server
-					.node_owner_api_secret_path
-					.clone()
-				{
-					check_api_file_existing_config(p)?;
-				}
-				if let Some(p) = self
-					.members
-					.as_mut()
-					.unwrap()
-					.server
-					.node_foreign_api_secret_path
-					.clone()
-				{
-					check_api_file_existing_config(p)?;
-				}
 				return Ok(self);
 			}
 			Err(e) => {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -36,10 +36,10 @@ pub const SERVER_CONFIG_FILE_NAME: &str = "grin-server.toml";
 const SERVER_LOG_FILE_NAME: &str = "grin-server.log";
 const GRIN_HOME: &str = ".grin";
 const GRIN_CHAIN_DIR: &str = "chain_data";
-/// Node Rest API and V2 Owner API secret
-pub const API_SECRET_FILE_NAME: &str = ".api_secret";
-/// Foreign API secret
-pub const FOREIGN_API_SECRET_FILE_NAME: &str = ".foreign_api_secret";
+/// Node Owner API secret
+pub const OWNER_API_SECRET_FILE_NAME: &str = ".node_owner_api_secret";
+/// Node Foreign API secret
+pub const FOREIGN_API_SECRET_FILE_NAME: &str = ".node_foreign_api_secret";
 
 fn get_grin_path(chain_type: &global::ChainTypes) -> Result<PathBuf, ConfigError> {
 	// Check if grin dir exists
@@ -112,7 +112,7 @@ fn check_api_secret_files(
 
 /// Handles setup and detection of paths for node
 pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalConfig, ConfigError> {
-	check_api_secret_files(chain_type, API_SECRET_FILE_NAME)?;
+	check_api_secret_files(chain_type, OWNER_API_SECRET_FILE_NAME)?;
 	check_api_secret_files(chain_type, FOREIGN_API_SECRET_FILE_NAME)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(SERVER_CONFIG_FILE_NAME) {
@@ -247,10 +247,10 @@ impl GlobalConfig {
 		let mut chain_path = grin_home.clone();
 		chain_path.push(GRIN_CHAIN_DIR);
 		self.members.as_mut().unwrap().server.db_root = chain_path.to_str().unwrap().to_owned();
-		let mut api_secret_path = grin_home.clone();
-		api_secret_path.push(API_SECRET_FILE_NAME);
-		self.members.as_mut().unwrap().server.api_secret_path =
-			Some(api_secret_path.to_str().unwrap().to_owned());
+		let mut owner_api_secret_path = grin_home.clone();
+		owner_api_secret_path.push(OWNER_API_SECRET_FILE_NAME);
+		self.members.as_mut().unwrap().server.owner_api_secret_path =
+			Some(owner_api_secret_path.to_str().unwrap().to_owned());
 		let mut foreign_api_secret_path = grin_home.clone();
 		foreign_api_secret_path.push(FOREIGN_API_SECRET_FILE_NAME);
 		self.members

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -99,7 +99,18 @@ pub fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	Ok(())
 }
 
-/// Check that the api secret files exist and are valid
+/// Check that the default/custom api secret file exists and is valid when the config file exist
+fn check_api_file_existing_config(api_secret: String) -> Result<(), ConfigError> {
+	let mut api_secret_path = PathBuf::new();
+	api_secret_path.push(api_secret);
+	if !api_secret_path.exists() {
+		init_api_secret(&api_secret_path)
+	} else {
+		check_api_secret(&api_secret_path)
+	}
+}
+
+/// Check that the api secret file exists and is valid when the config file does not exist
 fn check_api_secret_files(
 	chain_type: &global::ChainTypes,
 	secret_file_name: &str,
@@ -121,16 +132,6 @@ fn check_api_secret_files(
 
 /// Handles setup and detection of paths for node
 pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalConfig, ConfigError> {
-	check_api_secret_files(
-		chain_type,
-		NODE_OWNER_API_SECRET_FILE_NAME,
-		OLD_NODE_OWNER_API_SECRET_FILE_NAME,
-	)?;
-	check_api_secret_files(
-		chain_type,
-		NODE_FOREIGN_API_SECRET_FILE_NAME,
-		OLD_NODE_FOREIGN_API_SECRET_FILE_NAME,
-	)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(SERVER_CONFIG_FILE_NAME) {
 		GlobalConfig::new(p.to_str().unwrap())
@@ -144,6 +145,16 @@ pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalCon
 
 		// Spit it out if it doesn't exist
 		if !config_path.exists() {
+			check_api_secret_files(
+				chain_type,
+				NODE_OWNER_API_SECRET_FILE_NAME,
+				OLD_NODE_OWNER_API_SECRET_FILE_NAME,
+			)?;
+			check_api_secret_files(
+				chain_type,
+				NODE_FOREIGN_API_SECRET_FILE_NAME,
+				OLD_NODE_FOREIGN_API_SECRET_FILE_NAME,
+			)?;
 			let mut default_config = GlobalConfig::for_chain(chain_type);
 			// update paths relative to current dir
 			default_config.update_paths(&grin_path);
@@ -247,6 +258,26 @@ impl GlobalConfig {
 		match decoded {
 			Ok(gc) => {
 				self.members = Some(gc);
+				if let Some(p) = self
+					.members
+					.as_mut()
+					.unwrap()
+					.server
+					.node_owner_api_secret_path
+					.clone()
+				{
+					check_api_file_existing_config(p)?;
+				}
+				if let Some(p) = self
+					.members
+					.as_mut()
+					.unwrap()
+					.server
+					.node_foreign_api_secret_path
+					.clone()
+				{
+					check_api_file_existing_config(p)?;
+				}
 				return Ok(self);
 			}
 			Err(e) => {
@@ -265,14 +296,22 @@ impl GlobalConfig {
 		chain_path.push(GRIN_CHAIN_DIR);
 		self.members.as_mut().unwrap().server.db_root = chain_path.to_str().unwrap().to_owned();
 		let mut node_owner_api_secret_path = grin_home.clone();
-		node_owner_api_secret_path.push(NODE_OWNER_API_SECRET_FILE_NAME);
+		node_owner_api_secret_path.push(OLD_NODE_OWNER_API_SECRET_FILE_NAME);
+		if !node_owner_api_secret_path.exists() {
+			node_owner_api_secret_path.pop();
+			node_owner_api_secret_path.push(NODE_OWNER_API_SECRET_FILE_NAME);
+		}
 		self.members
 			.as_mut()
 			.unwrap()
 			.server
 			.node_owner_api_secret_path = Some(node_owner_api_secret_path.to_str().unwrap().to_owned());
 		let mut node_foreign_api_secret_path = grin_home.clone();
-		node_foreign_api_secret_path.push(NODE_FOREIGN_API_SECRET_FILE_NAME);
+		node_foreign_api_secret_path.push(OLD_NODE_FOREIGN_API_SECRET_FILE_NAME);
+		if !node_foreign_api_secret_path.exists() {
+			node_foreign_api_secret_path.pop();
+			node_foreign_api_secret_path.push(NODE_FOREIGN_API_SECRET_FILE_NAME);
+		}
 		self.members
 			.as_mut()
 			.unwrap()
@@ -357,10 +396,10 @@ fn test_fix_log_level() {
 
 #[test]
 fn test_forwards_compatibility() {
-	let config = "Warning | \nforeign_api_secret_path \napi_secret_path".to_string();
+	let config = "Warning \nforeign_api_secret_path \napi_secret_path".to_string();
 	let fixed_config = GlobalConfig::forwards_compatibility(config);
 	assert_eq!(
 		fixed_config,
-		"WARN | \nnode_foreign_api_secret_path \nnode_owner_api_secret_path"
+		"WARN \nnode_foreign_api_secret_path \nnode_owner_api_secret_path"
 	);
 }

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -3,18 +3,10 @@
 Used to query a node about various information on the blockchain, networks and peers. By default, the API will listen on `localhost:3413`. The API is started as the same time as the Grin node.
 This endpoint requires, by default, [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). The username is `grin`.
 
-## Node API v2
+## Node API
 
 This API version uses jsonrpc for its requests. It is split up in a foreign API and an owner API. The documentation for these endpoints is automatically generated:
 - [Owner API](https://docs.rs/grin_api/latest/grin_api/trait.OwnerRpc.html)
 - [Foreign API](https://docs.rs/grin_api/latest/grin_api/trait.ForeignRpc.html)
 
-Basic auth passwords can be found in `.node_owner_api_secret`/`.node_foreign_api_secret` files respectively.
-
-## Node API v1
-
-**Note:** version 1 of the API will be deprecated in v4.0.0 and subsequently removed in v5.0.0. Users of this API are encouraged to upgrade to API v2.
-
-This API uses REST for its requests. To learn about what specific calls can be made read the [node API v1 doc](node_api_v1.md).
-
-Basic auth password can be found in `.api_secret`
+Basic auth passwords can be found in `.node_owner_api_secret`/`.node_foreign_api_secret` files respectively. Note that as well it may be `.api_secret`/`.foreign_api_secret` if you are using an old version of grin

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -9,7 +9,7 @@ This API version uses jsonrpc for its requests. It is split up in a foreign API 
 - [Owner API](https://docs.rs/grin_api/latest/grin_api/trait.OwnerRpc.html)
 - [Foreign API](https://docs.rs/grin_api/latest/grin_api/trait.ForeignRpc.html)
 
-Basic auth passwords can be found in `.api_secret`/`.foreign_api_secret` files respectively.
+Basic auth passwords can be found in `.node_owner_api_secret`/`.node_foreign_api_secret` files respectively.
 
 ## Node API v1
 

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -145,10 +145,10 @@ pub struct ServerConfig {
 	/// Network address for the Rest API HTTP server.
 	pub api_http_addr: String,
 
-	/// Location of secret for basic auth on Rest API HTTP and V2 Owner API server.
-	pub api_secret_path: Option<String>,
+	/// Location of secret for basic auth on Owner API server.
+	pub owner_api_secret_path: Option<String>,
 
-	/// Location of secret for basic auth on v2 Foreign API server.
+	/// Location of secret for basic auth on Foreign API server.
 	pub foreign_api_secret_path: Option<String>,
 
 	/// TLS certificate file
@@ -214,8 +214,8 @@ impl Default for ServerConfig {
 		ServerConfig {
 			db_root: "grin_chain".to_string(),
 			api_http_addr: "127.0.0.1:3413".to_string(),
-			api_secret_path: Some(".api_secret".to_string()),
-			foreign_api_secret_path: Some(".foreign_api_secret".to_string()),
+			owner_api_secret_path: Some(".node_owner_api_secret".to_string()),
+			foreign_api_secret_path: Some(".node_foreign_api_secret".to_string()),
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			p2p_config: p2p::P2PConfig::default(),

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -146,10 +146,10 @@ pub struct ServerConfig {
 	pub api_http_addr: String,
 
 	/// Location of secret for basic auth on Owner API server.
-	pub owner_api_secret_path: Option<String>,
+	pub node_owner_api_secret_path: Option<String>,
 
 	/// Location of secret for basic auth on Foreign API server.
-	pub foreign_api_secret_path: Option<String>,
+	pub node_foreign_api_secret_path: Option<String>,
 
 	/// TLS certificate file
 	pub tls_certificate_file: Option<String>,
@@ -214,8 +214,8 @@ impl Default for ServerConfig {
 		ServerConfig {
 			db_root: "grin_chain".to_string(),
 			api_http_addr: "127.0.0.1:3413".to_string(),
-			owner_api_secret_path: Some(".node_owner_api_secret".to_string()),
-			foreign_api_secret_path: Some(".node_foreign_api_secret".to_string()),
+			node_owner_api_secret_path: Some(".node_owner_api_secret".to_string()),
+			node_foreign_api_secret_path: Some(".node_foreign_api_secret".to_string()),
 			tls_certificate_file: None,
 			tls_certificate_key: None,
 			p2p_config: p2p::P2PConfig::default(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -287,7 +287,7 @@ impl Server {
 			})?;
 
 		info!("Starting rest apis at: {}", &config.api_http_addr);
-		let api_secret = get_first_line(config.api_secret_path.clone());
+		let owner_api_secret = get_first_line(config.owner_api_secret_path.clone());
 		let foreign_api_secret = get_first_line(config.foreign_api_secret_path.clone());
 		let tls_conf = match config.tls_certificate_file.clone() {
 			None => None,
@@ -310,7 +310,7 @@ impl Server {
 			tx_pool.clone(),
 			p2p_server.peers.clone(),
 			sync_state.clone(),
-			api_secret,
+			owner_api_secret,
 			foreign_api_secret,
 			tls_conf,
 		)?;

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -287,8 +287,8 @@ impl Server {
 			})?;
 
 		info!("Starting rest apis at: {}", &config.api_http_addr);
-		let owner_api_secret = get_first_line(config.owner_api_secret_path.clone());
-		let foreign_api_secret = get_first_line(config.foreign_api_secret_path.clone());
+		let owner_api_secret = get_first_line(config.node_owner_api_secret_path.clone());
+		let foreign_api_secret = get_first_line(config.node_foreign_api_secret_path.clone());
 		let tls_conf = match config.tls_certificate_file.clone() {
 			None => None,
 			Some(file) => {

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -153,12 +153,8 @@ impl HTTPNodeClient {
 pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig) -> i32 {
 	// just get defaults from the global config
 	let server_config = global_config.members.unwrap().server;
-<<<<<<< HEAD
 	let api_secret = get_first_line(server_config.owner_api_secret_path.clone());
 	let node_client = HTTPNodeClient::new(&server_config.api_http_addr, api_secret);
-=======
-	let api_secret = get_first_line(server_config.owner_api_secret_path.clone());
->>>>>>> 5b902a0a... better naming of APIs file and variables
 
 	match client_args.subcommand() {
 		("status", Some(_)) => {

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -153,8 +153,8 @@ impl HTTPNodeClient {
 pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig) -> i32 {
 	// just get defaults from the global config
 	let server_config = global_config.members.unwrap().server;
-	let api_secret = get_first_line(server_config.owner_api_secret_path.clone());
-	let node_client = HTTPNodeClient::new(&server_config.api_http_addr, api_secret);
+	let node_owner_api_secret = get_first_line(server_config.node_owner_api_secret_path.clone());
+	let node_client = HTTPNodeClient::new(&server_config.api_http_addr, node_owner_api_secret);
 
 	match client_args.subcommand() {
 		("status", Some(_)) => {

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -153,8 +153,12 @@ impl HTTPNodeClient {
 pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig) -> i32 {
 	// just get defaults from the global config
 	let server_config = global_config.members.unwrap().server;
-	let api_secret = get_first_line(server_config.api_secret_path.clone());
+<<<<<<< HEAD
+	let api_secret = get_first_line(server_config.owner_api_secret_path.clone());
 	let node_client = HTTPNodeClient::new(&server_config.api_http_addr, api_secret);
+=======
+	let api_secret = get_first_line(server_config.owner_api_secret_path.clone());
+>>>>>>> 5b902a0a... better naming of APIs file and variables
 
 	match client_args.subcommand() {
 		("status", Some(_)) => {

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -102,7 +102,7 @@ fn real_main() -> i32 {
 		// When the subscommand is 'server' take into account the 'config_file' flag
 		("server", Some(server_args)) => {
 			if let Some(_path) = server_args.value_of("config_file") {
-				node_config = Some(config::GlobalConfig::new(_path).unwrap_or_else(|e| {
+				node_config = Some(config::GlobalConfig::new(_path, true).unwrap_or_else(|e| {
 					panic!("Error loading server configuration: {}", e);
 				}));
 			} else {


### PR DESCRIPTION
Related to PR https://github.com/mimblewimble/grin-wallet/pull/544
- Changed name of  `.foreign_api_secret` to `.node_foreign_api_secret` and `.api_secret` to `.node_owner_api_secret`
- Better naming of node `owner_api` variables
