### PR TITLE
[5.0.x] Fix PIBD segments

### DIFF
--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -340,7 +340,7 @@ impl From<BitmapSegment> for Segment<BitmapChunk> {
 		}
 
 		for (block_idx, block) in blocks.into_iter().enumerate() {
-			assert_eq!(block.inner.len(), BitmapBlock::NBITS as usize);
+			assert!(block.inner.len() <= BitmapBlock::NBITS as usize);
 			let offset = block_idx * BitmapBlock::NCHUNKS;
 			for (i, _) in block.inner.iter().enumerate().filter(|&(_, v)| v) {
 				chunks
@@ -412,7 +412,7 @@ impl Writeable for BitmapBlock {
 			// Write raw bytes
 			Writeable::write(&BitmapBlockSerialization::Raw, writer)?;
 			let bytes = self.inner.to_bytes();
-			assert_eq!(bytes.len(), Self::NBITS as usize / 8);
+			assert!(bytes.len() <= Self::NBITS as usize / 8);
 			writer.write_fixed_bytes(&bytes)?;
 		}
 

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -464,6 +464,7 @@ where
 		last_pos: u64,
 		bitmap: Option<&Bitmap>,
 		mmr_root: Hash,
+		hash_last_pos: u64,
 		other_root: Hash,
 		other_is_left: bool,
 	) -> Result<(), SegmentError> {
@@ -476,6 +477,7 @@ where
 			last,
 			segment_root,
 			segment_unpruned_pos,
+			hash_last_pos,
 			other_root,
 			other_is_left,
 		)
@@ -708,6 +710,7 @@ impl SegmentProof {
 		segment_last_pos: u64,
 		segment_root: Hash,
 		segment_unpruned_pos: u64,
+		hash_last_pos: u64,
 		other_root: Hash,
 		other_is_left: bool,
 	) -> Result<(), SegmentError> {
@@ -719,9 +722,9 @@ impl SegmentProof {
 			segment_unpruned_pos,
 		)?;
 		let root = if other_is_left {
-			(other_root, root).hash_with_index(last_pos)
+			(other_root, root).hash_with_index(hash_last_pos)
 		} else {
-			(root, other_root).hash_with_index(last_pos)
+			(root, other_root).hash_with_index(hash_last_pos)
 		};
 		if root == mmr_root {
 			Ok(())

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -539,7 +539,7 @@ where
 		hash: Hash,
 		id: SegmentIdentifier,
 	) -> Result<Segment<RangeProof>, chain::Error> {
-		if RANGEPROOF_SEGMENT_HEIGHT_RANGE.contains(&id.height) {
+		if !RANGEPROOF_SEGMENT_HEIGHT_RANGE.contains(&id.height) {
 			return Err(chain::ErrorKind::InvalidSegmentHeight.into());
 		}
 		let segmenter = self.chain().segmenter()?;


### PR DESCRIPTION
I performed a bunch of tests on testnet using other 5.0.x nodes and found a couple of bugs in the code that generates/validates PIBD segments
- When generating the bitmap segments, we incorrectly assumed that the segments were always full, resulting in a panic
- We forgot a negation in the range proof segment height check
- During validation of bitmap segments, we need to hash the `output|bitmap` root with the output MMR size, not the bitmap MMR size, so we need to add an argument to the `validate_with` functions. This does not affect current nodes since they don't do any validation but we might as well fix it now.