### PR TITLE
[5.0.x] override old accept_fee_base setting of 1000000 to new default 500000 (#3539)

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -323,6 +323,7 @@ fn comments() -> HashMap<String, String> {
 		"accept_fee_base".to_string(),
 		"
 #base fee that's accepted into the pool
+#a setting to 1000000 will be overridden to 500000 to respect the fixfees RFC
 "
 		.to_string(),
 	);

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -160,15 +160,18 @@ fn real_main() -> i32 {
 			global::init_global_nrd_enabled(true);
 		}
 	}
-	global::init_global_accept_fee_base(
-		config
-			.members
-			.as_ref()
-			.unwrap()
-			.server
-			.pool_config
-			.accept_fee_base,
-	);
+	let afb = config
+		.members
+		.as_ref()
+		.unwrap()
+		.server
+		.pool_config
+		.accept_fee_base;
+	let fix_afb = match afb {
+		1_000_000 => 500_000,
+		_ => afb,
+	};
+	global::init_global_accept_fee_base(fix_afb);
 	info!("Accept Fee Base: {:?}", global::get_accept_fee_base());
 	global::init_global_future_time_limit(config.members.unwrap().server.future_time_limit);
 	info!("Future Time Limit: {:?}", global::get_future_time_limit());


### PR DESCRIPTION
Override old accept_fee_base setting of 1000000 to new default 500000 (#3539)

* override old accept_fee_base setting of 1000000 to new default 500000

* document exceptional accept_fee_base behaviour in grin-server.toml

