### PR TITLE
fix for missing block under certain startup conditions

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -236,8 +236,7 @@ impl Chain {
 		// In reality we will do this based on PIBD segment requests.
 		// Initialization (once per 12 hour period) will not be this slow once lmdb and PMMRs
 		// are warmed up.
-		{
-			let segmenter = chain.segmenter()?;
+		if let Ok(segmenter) = chain.segmenter() {
 			let _ = segmenter.kernel_segment(SegmentIdentifier { height: 9, idx: 0 });
 			let _ = segmenter.bitmap_segment(SegmentIdentifier { height: 9, idx: 0 });
 			let _ = segmenter.output_segment(SegmentIdentifier { height: 11, idx: 0 });


### PR DESCRIPTION
This PR fixes a "cannot find block" error that can occur during node startup.
We have some code that runs during node initialization that exercises the PIBD segmenter as we wanted to keep this code "in use".
There is an edge case during startup that we did not account for - if the node is shutdown while it is in the process of syncing then on next startup the chain can find itself in a state where traversing back to the "archive header" (our 720 block archival period) can fail as we do not have the full set of blocks for this time period yet.
This PR simply ensures the code that touches the segmenter does not fail in this situation (during startup).

This is related to a jump from one 720 block archive period to the next due to chain height, during sync. It is possible for the jump to result in "missing" blocks as we are still syncing. This is not a problem with data integrity or missing data - its just that we were making a bad assumption during node initialization without accounting for this scenario.

Resolves https://github.com/mimblewimble/grin/issues/3516

