### PR TITLE
add rate limiting to outbound p2p msg sending

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -205,27 +205,13 @@ impl Peer {
 
 	/// Whether the peer is considered abusive, mostly for spammy nodes
 	pub fn is_abusive(&self) -> bool {
-		let rec = self.tracker.received_bytes.read();
-		let sent = self.tracker.sent_bytes.read();
-		rec.count_per_min() > MAX_PEER_MSG_PER_MIN || sent.count_per_min() > MAX_PEER_MSG_PER_MIN
+		let rec = self.tracker().received_bytes.read();
+		rec.count_per_min() > MAX_PEER_MSG_PER_MIN
 	}
 
-	/// Number of bytes sent to the peer
-	pub fn last_min_sent_bytes(&self) -> Option<u64> {
-		let sent_bytes = self.tracker.sent_bytes.read();
-		Some(sent_bytes.bytes_per_min())
-	}
-
-	/// Number of bytes received from the peer
-	pub fn last_min_received_bytes(&self) -> Option<u64> {
-		let received_bytes = self.tracker.received_bytes.read();
-		Some(received_bytes.bytes_per_min())
-	}
-
-	pub fn last_min_message_counts(&self) -> Option<(u64, u64)> {
-		let received_bytes = self.tracker.received_bytes.read();
-		let sent_bytes = self.tracker.sent_bytes.read();
-		Some((sent_bytes.count_per_min(), received_bytes.count_per_min()))
+	/// Tracker tracks sent/received bytes and message counts per minute.
+	pub fn tracker(&self) -> &conn::Tracker {
+		&self.tracker
 	}
 
 	/// Set this peer status to banned

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -324,12 +324,12 @@ impl Peers {
 					debug!("clean_peers {:?}, not connected", peer.info.addr);
 					rm.push(peer.info.addr.clone());
 				} else if peer.is_abusive() {
-					if let Some(counts) = peer.last_min_message_counts() {
-						debug!(
-							"clean_peers {:?}, abusive ({} sent, {} recv)",
-							peer.info.addr, counts.0, counts.1,
-						);
-					}
+					let received = peer.tracker().received_bytes.read().count_per_min();
+					let sent = peer.tracker().sent_bytes.read().count_per_min();
+					debug!(
+						"clean_peers {:?}, abusive ({} sent, {} recv)",
+						peer.info.addr, sent, received,
+					);
 					let _ = self.update_state(peer.info.addr, State::Banned);
 					rm.push(peer.info.addr.clone());
 				} else {

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -240,8 +240,8 @@ impl PeerStats {
 			height: peer.info.height(),
 			direction: direction.to_string(),
 			last_seen: peer.info.last_seen(),
-			sent_bytes_per_sec: peer.last_min_sent_bytes().unwrap_or(0) / 60,
-			received_bytes_per_sec: peer.last_min_received_bytes().unwrap_or(0) / 60,
+			sent_bytes_per_sec: peer.tracker().sent_bytes.read().bytes_per_min() / 60,
+			received_bytes_per_sec: peer.tracker().received_bytes.read().bytes_per_min() / 60,
 			capabilities: peer.info.capabilities,
 		}
 	}

--- a/util/src/rate_counter.rs
+++ b/util/src/rate_counter.rs
@@ -99,6 +99,14 @@ impl RateCounter {
 			.filter(|x| !x.is_quiet())
 			.count() as u64
 	}
+
+	/// Elapsed time in ms since the last entry.
+	/// We use this to rate limit when sending.
+	pub fn elapsed_since_last_msg(&self) -> Option<u64> {
+		self.last_min_entries
+			.last()
+			.map(|x| millis_since_epoch().saturating_sub(x.timestamp))
+	}
 }
 
 // turns out getting the millisecs since epoch in Rust isn't as easy as it


### PR DESCRIPTION
Resolves https://github.com/mimblewimble/grin/issues/3553

We treat peers as abusive if inbound or outbound msg rates exceed 500/min.

This PR modifies this to only consider inbound msg rate. 
We do not want to treat a peer as abusive if _we_ are responsible for sending lots of p2p messages.

Add basic "rate limiting" to `write_message()` by inspecting the previous timestamp tracked by the tracker.
We ensure 150ms has elapsed based on previous sent message before attempting to send another.
In normal operation this is rarely the case. We occasionally send a ping and a block header close together and these are now separated by 150ms.
The scenario where this _does_ come into play is during "fast sync" when requesting large numbers of full blocks from a small number of peers. Specifically "block archival sync" against archival nodes.
We no longer flood the peer connection with hundreds of block requests and these are now spaced out to avoid hitting the abusive peer limit on the receiving end.

----

As part of this PR cleaned up the readonly usage of `tracker`.
The following fns have been removed, replaced with exposing a simple `tracker()` accessor - 
* `last_min_sent_bytes`
* `last_min_received_bytes`
* `last_min_message_counts`

For example - 

```
    let received = peer.tracker().received_bytes.read().count_per_min();
```

This makes the read locks more explicit and removes a case where we take multiple read locks in one go.

----

Introduced `elapsed_since_last_msg()` to `RateCounter` for convenience. 
This simplifies the implementation of the rate limiting logic.

