### PR TITLE
[5.0.x] inefficient locking on recv of peers lists can result in failure to get peers lock

### DIFF
--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -127,6 +127,15 @@ impl PeerStore {
 		batch.commit()
 	}
 
+	pub fn save_peers(&self, p: Vec<PeerData>) -> Result<(), Error> {
+		let batch = self.db.batch()?;
+		for pd in p {
+			debug!("save_peers: {:?} marked {:?}", pd.addr, pd.flags);
+			batch.put_ser(&peer_key(pd.addr)[..], &pd)?;
+		}
+		batch.commit()
+	}
+
 	pub fn get_peer(&self, peer_addr: PeerAddr) -> Result<PeerData, Error> {
 		option_to_not_found(self.db.get_ser(&peer_key(peer_addr)[..]), || {
 			format!("Peer at address: {}", peer_addr)


### PR DESCRIPTION
see: https://github.com/mimblewimble/grin/issues/3561

This change batches the write of PEER_LIST results into the peers lmdb to increase efficiency and reduce lock timeouts.

20210215 11:28:20.196 ERROR grin_p2p::peers - add_connected: failed to get peers lock
