### PR TITLE
Revert "rework prune rewrite with iterators (#3568)"

### DIFF
--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -25,6 +25,7 @@ extern crate log;
 use failure;
 #[macro_use]
 extern crate failure_derive;
+#[macro_use]
 extern crate grin_core as core;
 extern crate grin_util as util;
 


### PR DESCRIPTION
#3568 passes all tests and runs successfully in _most_ scenarios but I suspect it has introduced a subtle edge case (still not tracked down). I'm going to revert for now once tests pass on this.

It appears to be possible to leave the output MMR in a bad state after chain compaction, not yet reliably reproducible.
Going to revert on master and continue investigating on a branch.
