### PR TITLE
Refactor prune file replace

### DIFF
--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -352,7 +352,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		// on the cutoff_pos provided.
 		let (leaves_removed, pos_to_rm) = self.pos_to_rm(cutoff_pos, rewind_rm_pos);
 
-		// 1. Save compact copy of the hash file, skipping removed data.
+		// Save compact copy of the hash file, skipping removed data.
 		{
 			let pos_to_rm = map_vec!(pos_to_rm, |pos| {
 				let shift = self.prune_list.get_shift(pos.into());
@@ -360,10 +360,9 @@ impl<T: PMMRable> PMMRBackend<T> {
 			});
 
 			self.hash_file.write_tmp_pruned(&pos_to_rm)?;
-			self.hash_file.replace_with_tmp()?;
 		}
 
-		// 2. Save compact copy of the data file, skipping removed leaves.
+		// Save compact copy of the data file, skipping removed leaves.
 		{
 			let leaf_pos_to_rm = pos_to_rm
 				.iter()
@@ -378,10 +377,18 @@ impl<T: PMMRable> PMMRBackend<T> {
 			});
 
 			self.data_file.write_tmp_pruned(&pos_to_rm)?;
-			self.data_file.replace_with_tmp()?;
 		}
 
-		// 3. Update the prune list and write to disk.
+		// Replace hash and data files with compact copies.
+		// Rebuild and intialize from the new files.
+		{
+			debug!("compact: about to replace hash and data files and rebuild...");
+			self.hash_file.replace_with_tmp()?;
+			self.data_file.replace_with_tmp()?;
+			debug!("compact: ...finished replacing and rebuilding");
+		}
+
+		// Update the prune list and write to disk.
 		{
 			for pos in leaves_removed.iter() {
 				self.prune_list.add(pos.into());
@@ -389,11 +396,10 @@ impl<T: PMMRable> PMMRBackend<T> {
 			self.prune_list.flush()?;
 		}
 
-		// 4. Write the leaf_set to disk.
+		// Write the leaf_set to disk.
 		// Optimize the bitmap storage in the process.
 		self.leaf_set.flush()?;
 
-		// 5. cleanup rewind files
 		self.clean_rewind_files()?;
 
 		Ok(true)

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -359,7 +359,8 @@ impl<T: PMMRable> PMMRBackend<T> {
 				pos as u64 - shift
 			});
 
-			self.hash_file.save_prune(&pos_to_rm)?;
+			self.hash_file.write_tmp_pruned(&pos_to_rm)?;
+			self.hash_file.replace_with_tmp()?;
 		}
 
 		// 2. Save compact copy of the data file, skipping removed leaves.
@@ -376,7 +377,8 @@ impl<T: PMMRable> PMMRBackend<T> {
 				flat_pos - shift
 			});
 
-			self.data_file.save_prune(&pos_to_rm)?;
+			self.data_file.write_tmp_pruned(&pos_to_rm)?;
+			self.data_file.replace_with_tmp()?;
 		}
 
 		// 3. Update the prune list and write to disk.


### PR DESCRIPTION
This is a smaller refactor based on #3568.
We now write the tmp hash file and the tmp data file during chain compaction and then replace both underlying files with the tmp files.
Writing the tmp files does not require `&mut self` and this mut reference is only necessary in the final replace step.
Writing the tmp files can now be done with a simple `&self` reference which makes the code more flexible.

Still testing these changes but as far as I can tell this does not reintroduce the issue in #3568 (reverted in #3569).