### PR TITLE
Retire pruned cache

### DIFF
--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::u64;
-use std::{marker, ops::RangeInclusive};
+use std::{marker, ops::Range, u64};
 
 use croaring::Bitmap;
 
@@ -667,9 +666,9 @@ pub fn bintree_leftmost(num: u64) -> u64 {
 	num + 2 - (2 << height)
 }
 
-pub fn bintree_range(num: u64) -> RangeInclusive<u64> {
+/// All pos in the subtree beneath the provided root, including root itself.
+pub fn bintree_range(num: u64) -> Range<u64> {
 	let height = bintree_postorder_height(num);
 	let leftmost = num + 2 - (2 << height);
-	let rightmost = num - height;
-	RangeInclusive::new(leftmost, rightmost)
+	leftmost..(num + 1)
 }

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker;
 use std::u64;
+use std::{marker, ops::RangeInclusive};
 
 use croaring::Bitmap;
 
@@ -541,10 +541,18 @@ pub fn peak_map_height(mut pos: u64) -> (u64, u64) {
 /// index. This function is the base on which all others, as well as the MMR,
 /// are built.
 pub fn bintree_postorder_height(num: u64) -> u64 {
-	if num == 0 {
+	let mut pos = num.saturating_sub(1);
+	if pos == 0 {
 		return 0;
 	}
-	peak_map_height(num - 1).1
+	let mut peak_size = ALL_ONES >> pos.leading_zeros();
+	while peak_size != 0 {
+		if pos >= peak_size {
+			pos -= peak_size;
+		}
+		peak_size >>= 1;
+	}
+	pos
 }
 
 /// Is this position a leaf in the MMR?
@@ -657,4 +665,11 @@ pub fn bintree_rightmost(num: u64) -> u64 {
 pub fn bintree_leftmost(num: u64) -> u64 {
 	let height = bintree_postorder_height(num);
 	num + 2 - (2 << height)
+}
+
+pub fn bintree_range(num: u64) -> RangeInclusive<u64> {
+	let height = bintree_postorder_height(num);
+	let leftmost = num + 2 - (2 << height);
+	let rightmost = num - height;
+	RangeInclusive::new(leftmost, rightmost)
 }

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -260,10 +260,6 @@ where
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {
 				if let Some(hash) = pmmr.get_from_file(pos) {
-					println!(
-						"***** pushing hash at {}, first: {}, last: {}",
-						pos, segment_first_pos, segment_last_pos
-					);
 					segment.hashes.push(hash);
 					segment.hash_pos.push(pos);
 				}

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -260,6 +260,10 @@ where
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {
 				if let Some(hash) = pmmr.get_from_file(pos) {
+					println!(
+						"***** pushing hash at {}, first: {}, last: {}",
+						pos, segment_first_pos, segment_last_pos
+					);
 					segment.hashes.push(hash);
 					segment.hash_pos.push(pos);
 				}

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -92,14 +92,14 @@ fn first_100_mmr_heights() {
 
 #[test]
 fn test_bintree_range() {
-	assert_eq!(pmmr::bintree_range(0), 0..=0);
-	assert_eq!(pmmr::bintree_range(1), 1..=1);
-	assert_eq!(pmmr::bintree_range(2), 2..=2);
-	assert_eq!(pmmr::bintree_range(3), 1..=2);
-	assert_eq!(pmmr::bintree_range(4), 4..=4);
-	assert_eq!(pmmr::bintree_range(5), 5..=5);
-	assert_eq!(pmmr::bintree_range(6), 4..=5);
-	assert_eq!(pmmr::bintree_range(7), 1..=5);
+	assert_eq!(pmmr::bintree_range(0), 0..1);
+	assert_eq!(pmmr::bintree_range(1), 1..2);
+	assert_eq!(pmmr::bintree_range(2), 2..3);
+	assert_eq!(pmmr::bintree_range(3), 1..4);
+	assert_eq!(pmmr::bintree_range(4), 4..5);
+	assert_eq!(pmmr::bintree_range(5), 5..6);
+	assert_eq!(pmmr::bintree_range(6), 4..7);
+	assert_eq!(pmmr::bintree_range(7), 1..8);
 }
 
 // The pos of the rightmost leaf for the provided MMR size (last leaf in subtree).

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -90,6 +90,18 @@ fn first_100_mmr_heights() {
 	}
 }
 
+#[test]
+fn test_bintree_range() {
+	assert_eq!(pmmr::bintree_range(0), 0..=0);
+	assert_eq!(pmmr::bintree_range(1), 1..=1);
+	assert_eq!(pmmr::bintree_range(2), 2..=2);
+	assert_eq!(pmmr::bintree_range(3), 1..=2);
+	assert_eq!(pmmr::bintree_range(4), 4..=4);
+	assert_eq!(pmmr::bintree_range(5), 5..=5);
+	assert_eq!(pmmr::bintree_range(6), 4..=5);
+	assert_eq!(pmmr::bintree_range(7), 1..=5);
+}
+
 // The pos of the rightmost leaf for the provided MMR size (last leaf in subtree).
 #[test]
 fn test_bintree_rightmost() {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -285,6 +285,9 @@ impl<T: PMMRable> PMMRBackend<T> {
 	}
 
 	fn is_compacted(&self, pos: u64) -> bool {
+		if self.leaf_set.includes(pos) {
+			return false;
+		}
 		self.is_pruned(pos) && !self.is_pruned_root(pos)
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use croaring::Bitmap;
 use grin_core::core::pmmr;
 
-use crate::core::core::pmmr::{bintree_postorder_height, family, path};
+use crate::core::core::pmmr::{bintree_postorder_height, family};
 use crate::{read_bitmap, save_via_temp_file};
 
 /// Maintains a list of previously pruned nodes in PMMR, compacting the list as
@@ -45,8 +45,6 @@ pub struct PruneList {
 	path: Option<PathBuf>,
 	/// Bitmap representing pruned root node positions.
 	bitmap: Bitmap,
-	// Bitmap representing all pruned node positions (everything under the pruned roots).
-	// pruned_cache: Bitmap,
 	shift_cache: Vec<u64>,
 	leaf_shift_cache: Vec<u64>,
 }
@@ -60,7 +58,6 @@ impl PruneList {
 		PruneList {
 			path,
 			bitmap,
-			// pruned_cache: Bitmap::create(),
 			shift_cache: vec![],
 			leaf_shift_cache: vec![],
 		}
@@ -90,8 +87,6 @@ impl PruneList {
 				"bitmap {} pos ({} bytes), shift_cache {}, leaf_shift_cache {}",
 				prune_list.bitmap.cardinality(),
 				prune_list.bitmap.get_serialized_size_in_bytes(),
-				// prune_list.pruned_cache.cardinality(),
-				// prune_list.pruned_cache.get_serialized_size_in_bytes(),
 				prune_list.shift_cache.len(),
 				prune_list.leaf_shift_cache.len(),
 			);
@@ -104,7 +99,6 @@ impl PruneList {
 	pub fn init_caches(&mut self) {
 		self.build_shift_cache();
 		self.build_leaf_shift_cache();
-		// self.build_pruned_cache();
 	}
 
 	/// Save the prune_list to disk.
@@ -234,17 +228,17 @@ impl PruneList {
 	pub fn add(&mut self, pos: u64) {
 		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
 
+		if self.is_pruned(pos) {
+			return;
+		}
+
 		let mut current = pos;
 		loop {
 			let (parent, sibling) = family(current);
-
-			// if self.bitmap.contains(sibling as u32) || self.pruned_cache.contains(sibling as u32) {
-			if self.is_pruned(sibling) {
-				// self.pruned_cache.add(current as u32);
+			if self.is_pruned_root(sibling) {
 				self.bitmap.remove(sibling as u32);
 				current = parent;
 			} else {
-				// self.pruned_cache.add(current as u32);
 				self.bitmap.add(current as u32);
 				break;
 			}
@@ -266,53 +260,22 @@ impl PruneList {
 		self.bitmap.iter().map(|x| x as u64).collect()
 	}
 
-	/// TODO -
-	/// 1) find "next" entry (root) in prune_list
-	/// 2) find leftmost and rightmost leaf pos beneath it
-	/// 3) is this pos within this range?
-	/// use bitmap.rank() to find the rank based on our pos.
-	/// "Rank returns the number of values smaller or equal to x."
-	///
-	/// then bitmap.select(next_rank) to find the next one
-	///
-	/// Is the pos pruned?
-	/// Assumes the pruned_cache is fully built and up to date.
+	/// A pos is pruned if it is a pruned root directly or if it is
+	/// beneath the "next" pruned subtree.
+	/// We only need to consider the "next" subtree due to the append-only MMR structure.
 	pub fn is_pruned(&self, pos: u64) -> bool {
 		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
-
 		if self.is_pruned_root(pos) {
 			return true;
 		}
-
 		let rank = self.bitmap.rank(pos as u32);
 		if let Some(root) = self.bitmap.select(rank as u32) {
 			let range = pmmr::bintree_range(root as u64);
-			error!(
-				"********** pos: {}, rank: {}, root: {}, range: {:?}",
-				pos, rank, root, range
-			);
 			range.contains(&pos)
 		} else {
 			false
 		}
-
-		// self.pruned_cache.contains(pos as u32)
 	}
-
-	// fn build_pruned_cache(&mut self) {
-	// 	if self.bitmap.is_empty() {
-	// 		return;
-	// 	}
-	// 	let maximum = self.bitmap.maximum().unwrap_or(0);
-	// 	self.pruned_cache = Bitmap::create_with_capacity(maximum);
-	// 	for pos in 1..(maximum + 1) {
-	// 		let pruned = path(pos as u64, maximum as u64).any(|x| self.bitmap.contains(x as u32));
-	// 		if pruned {
-	// 			self.pruned_cache.add(pos as u32)
-	// 		}
-	// 	}
-	// 	self.pruned_cache.run_optimize();
-	// }
 
 	/// Is the specified position a root of a pruned subtree?
 	pub fn is_pruned_root(&self, pos: u64) -> bool {


### PR DESCRIPTION
Our "prune list" implementation maintains an internal "prune cache".
* The prune list consists of roots of fully pruned subtrees.
* The cache contains all pos beneath these roots.
* We check if a pos was pruned by looking in the cache.

We can improve this without needing to maintain an internal cache.

To check if a pos is pruned we can look for the "next" pruned subtree and check if pos is beneath it.
We only need to consider the "next" subtree due to the append-only PMMR semantics.
If the next subtree does not include pos then we know that no other subtree will either.

