### PR TITLE
Prune list iterators

### DIFF
--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -260,10 +260,6 @@ where
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {
 				if let Some(hash) = pmmr.get_from_file(pos) {
-					println!(
-						"***** pushing hash at {}, first: {}, last: {}",
-						pos, segment_first_pos, segment_last_pos
-					);
 					segment.hashes.push(hash);
 					segment.hash_pos.push(pos);
 				}

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -260,6 +260,10 @@ where
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {
 				if let Some(hash) = pmmr.get_from_file(pos) {
+					println!(
+						"***** pushing hash at {}, first: {}, last: {}",
+						pos, segment_first_pos, segment_last_pos
+					);
 					segment.hashes.push(hash);
 					segment.hash_pos.push(pos);
 				}

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -21,8 +21,11 @@
 //! must be shifted the appropriate amount when reading from the hash and data
 //! files.
 
-use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::{
+	io::{self, Write},
+	ops::Range,
+};
 
 use croaring::Bitmap;
 use grin_core::core::pmmr;
@@ -256,11 +259,6 @@ impl PruneList {
 		self.bitmap.is_empty()
 	}
 
-	/// Convert the prune_list to a vec of pos.
-	pub fn to_vec(&self) -> Vec<u64> {
-		self.bitmap.iter().map(|x| x as u64).collect()
-	}
-
 	/// A pos is pruned if it is a pruned root directly or if it is
 	/// beneath the "next" pruned subtree.
 	/// We only need to consider the "next" subtree due to the append-only MMR structure.
@@ -282,5 +280,60 @@ impl PruneList {
 	pub fn is_pruned_root(&self, pos: u64) -> bool {
 		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
 		self.bitmap.contains(pos as u32)
+	}
+
+	/// Iterator over the entries in the prune list (pruned roots).
+	pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
+		self.bitmap.iter().map(|x| x as u64)
+	}
+
+	/// Iterator over the pruned "bintree range" for each pruned root.
+	pub fn pruned_bintree_range_iter(&self) -> impl Iterator<Item = Range<u64>> + '_ {
+		self.iter().map(|x| pmmr::bintree_range(x))
+	}
+
+	/// Iterator over all pos that are *not* pruned based on current prune_list.
+	pub fn unpruned_iter(&self) -> impl Iterator<Item = u64> + '_ {
+		UnprunedIterator::new(self.pruned_bintree_range_iter())
+	}
+}
+
+struct UnprunedIterator<I> {
+	inner: I,
+	current_excl_range: Option<Range<u64>>,
+	current_pos: u64,
+}
+
+impl<I: Iterator<Item = Range<u64>>> UnprunedIterator<I> {
+	fn new(mut inner: I) -> UnprunedIterator<I> {
+		let current_excl_range = inner.next();
+		UnprunedIterator {
+			inner,
+			current_excl_range,
+			current_pos: 1,
+		}
+	}
+}
+
+impl<I: Iterator<Item = Range<u64>>> Iterator for UnprunedIterator<I> {
+	type Item = u64;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		if let Some(range) = &self.current_excl_range {
+			if self.current_pos < range.start {
+				let next = self.current_pos;
+				self.current_pos += 1;
+				Some(next)
+			} else {
+				// skip the entire excluded range, moving to next excluded range as necessary
+				self.current_pos = range.end;
+				self.current_excl_range = self.inner.next();
+				self.next()
+			}
+		} else {
+			let next = self.current_pos;
+			self.current_pos += 1;
+			Some(next)
+		}
 	}
 }

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -296,6 +296,13 @@ impl PruneList {
 	pub fn unpruned_iter(&self) -> impl Iterator<Item = u64> + '_ {
 		UnprunedIterator::new(self.pruned_bintree_range_iter())
 	}
+
+	/// Iterator over all leaf pos that are *not* pruned based on current prune_list.
+	/// Note this is not necessarily the same as the "leaf_set" as an output
+	/// can be spent but not yet pruned.
+	pub fn unpruned_leaf_iter(&self) -> impl Iterator<Item = u64> + '_ {
+		self.unpruned_iter().filter(|x| pmmr::is_leaf(*x))
+	}
 }
 
 struct UnprunedIterator<I> {

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -293,15 +293,16 @@ impl PruneList {
 	}
 
 	/// Iterator over all pos that are *not* pruned based on current prune_list.
-	pub fn unpruned_iter(&self) -> impl Iterator<Item = u64> + '_ {
+	pub fn unpruned_iter(&self, cutoff_pos: u64) -> impl Iterator<Item = u64> + '_ {
 		UnprunedIterator::new(self.pruned_bintree_range_iter())
+			.take_while(move |x| *x <= cutoff_pos)
 	}
 
 	/// Iterator over all leaf pos that are *not* pruned based on current prune_list.
 	/// Note this is not necessarily the same as the "leaf_set" as an output
 	/// can be spent but not yet pruned.
-	pub fn unpruned_leaf_iter(&self) -> impl Iterator<Item = u64> + '_ {
-		self.unpruned_iter().filter(|x| pmmr::is_leaf(*x))
+	pub fn unpruned_leaf_iter(&self, cutoff_pos: u64) -> impl Iterator<Item = u64> + '_ {
+		self.unpruned_iter(cutoff_pos).filter(|x| pmmr::is_leaf(*x))
 	}
 }
 

--- a/store/tests/prune_list.rs
+++ b/store/tests/prune_list.rs
@@ -44,7 +44,7 @@ fn test_is_pruned() {
 	pl.add(2);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), vec![2]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
 	assert_eq!(pl.is_pruned(1), false);
 	assert_eq!(pl.is_pruned(2), true);
 	assert_eq!(pl.is_pruned(3), false);
@@ -55,7 +55,7 @@ fn test_is_pruned() {
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 1);
-	assert_eq!(pl.to_vec(), [3]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3]);
 	assert_eq!(pl.is_pruned(1), true);
 	assert_eq!(pl.is_pruned(2), true);
 	assert_eq!(pl.is_pruned(3), true);
@@ -68,7 +68,7 @@ fn test_is_pruned() {
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 2);
-	assert_eq!(pl.to_vec(), [3, 4]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
 	assert_eq!(pl.is_pruned(1), true);
 	assert_eq!(pl.is_pruned(2), true);
 	assert_eq!(pl.is_pruned(3), true);
@@ -93,7 +93,7 @@ fn test_get_leaf_shift() {
 	pl.add(1);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), vec![1]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [1]);
 	assert_eq!(pl.get_leaf_shift(1), 0);
 	assert_eq!(pl.get_leaf_shift(2), 0);
 	assert_eq!(pl.get_leaf_shift(3), 0);
@@ -119,7 +119,7 @@ fn test_get_leaf_shift() {
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 2);
-	assert_eq!(pl.to_vec(), [3, 4]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
 	assert_eq!(pl.get_leaf_shift(1), 0);
 	assert_eq!(pl.get_leaf_shift(2), 0);
 	assert_eq!(pl.get_leaf_shift(3), 2);
@@ -138,7 +138,7 @@ fn test_get_leaf_shift() {
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 1);
-	assert_eq!(pl.to_vec(), [7]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [7]);
 	assert_eq!(pl.get_leaf_shift(1), 0);
 	assert_eq!(pl.get_leaf_shift(2), 0);
 	assert_eq!(pl.get_leaf_shift(3), 0);
@@ -159,7 +159,7 @@ fn test_get_leaf_shift() {
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 2);
-	assert_eq!(pl.to_vec(), [6, 13]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [6, 13]);
 	assert_eq!(pl.get_leaf_shift(2), 0);
 	assert_eq!(pl.get_leaf_shift(4), 0);
 	assert_eq!(pl.get_leaf_shift(8), 2);
@@ -182,7 +182,7 @@ fn test_get_shift() {
 	pl.add(1);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [1]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [1]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 0);
@@ -191,7 +191,7 @@ fn test_get_shift() {
 	pl.add(2);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [3]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 2);
@@ -204,7 +204,7 @@ fn test_get_shift() {
 	pl.add(3);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [3]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 2);
@@ -215,7 +215,7 @@ fn test_get_shift() {
 	pl.add(4);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [3, 4]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 2);
@@ -227,7 +227,7 @@ fn test_get_shift() {
 	pl.add(5);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [7]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [7]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 0);
@@ -254,7 +254,7 @@ fn test_get_shift() {
 	pl.add(4);
 	pl.flush().unwrap();
 
-	assert_eq!(pl.to_vec(), [6, 10]);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [6, 10]);
 	assert_eq!(pl.get_shift(1), 0);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 0);
@@ -267,4 +267,69 @@ fn test_get_shift() {
 	assert_eq!(pl.get_shift(10), 4);
 	assert_eq!(pl.get_shift(11), 4);
 	assert_eq!(pl.get_shift(12), 4);
+}
+
+#[test]
+pub fn test_iter() {
+	let mut pl = PruneList::empty();
+	pl.add(1);
+	pl.add(2);
+	pl.add(4);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
+
+	let mut pl = PruneList::empty();
+	pl.add(1);
+	pl.add(2);
+	pl.add(5);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 5]);
+}
+
+#[test]
+pub fn test_pruned_bintree_range_iter() {
+	let mut pl = PruneList::empty();
+	pl.add(1);
+	pl.add(2);
+	pl.add(4);
+	assert_eq!(
+		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
+		[1..4, 4..5]
+	);
+
+	let mut pl = PruneList::empty();
+	pl.add(1);
+	pl.add(2);
+	pl.add(5);
+	assert_eq!(
+		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
+		[1..4, 5..6]
+	);
+}
+
+#[test]
+pub fn test_unpruned_iter() {
+	let mut pl = PruneList::empty();
+	pl.add(2);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
+	assert_eq!(pl.pruned_bintree_range_iter().collect::<Vec<_>>(), [2..3]);
+	assert_eq!(pl.unpruned_iter().take(3).collect::<Vec<_>>(), [1, 3, 4]);
+
+	let mut pl = PruneList::empty();
+	pl.add(2);
+	pl.add(4);
+	pl.add(5);
+	assert_eq!(pl.iter().collect::<Vec<_>>(), [2, 6]);
+	assert_eq!(
+		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
+		[2..3, 4..7]
+	);
+	assert_eq!(
+		pl.unpruned_iter().take(5).collect::<Vec<_>>(),
+		[1, 3, 7, 8, 9]
+	);
+
+	let pl = PruneList::empty();
+	assert_eq!(
+		pl.unpruned_iter().take(5).collect::<Vec<_>>(),
+		[1, 2, 3, 4, 5]
+	);
 }

--- a/store/tests/prune_list.rs
+++ b/store/tests/prune_list.rs
@@ -313,16 +313,13 @@ pub fn test_pruned_bintree_range_iter() {
 #[test]
 pub fn test_unpruned_iter() {
 	let pl = PruneList::empty();
-	assert_eq!(
-		pl.unpruned_iter().take(5).collect::<Vec<_>>(),
-		[1, 2, 3, 4, 5]
-	);
+	assert_eq!(pl.unpruned_iter(5).collect::<Vec<_>>(), [1, 2, 3, 4, 5]);
 
 	let mut pl = PruneList::empty();
 	pl.add(2);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
 	assert_eq!(pl.pruned_bintree_range_iter().collect::<Vec<_>>(), [2..3]);
-	assert_eq!(pl.unpruned_iter().take(3).collect::<Vec<_>>(), [1, 3, 4]);
+	assert_eq!(pl.unpruned_iter(4).collect::<Vec<_>>(), [1, 3, 4]);
 
 	let mut pl = PruneList::empty();
 	pl.add(2);
@@ -333,17 +330,14 @@ pub fn test_unpruned_iter() {
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
 		[2..3, 4..7]
 	);
-	assert_eq!(
-		pl.unpruned_iter().take(5).collect::<Vec<_>>(),
-		[1, 3, 7, 8, 9]
-	);
+	assert_eq!(pl.unpruned_iter(9).collect::<Vec<_>>(), [1, 3, 7, 8, 9]);
 }
 
 #[test]
 fn test_unpruned_leaf_iter() {
 	let pl = PruneList::empty();
 	assert_eq!(
-		pl.unpruned_leaf_iter().take(5).collect::<Vec<_>>(),
+		pl.unpruned_leaf_iter(8).collect::<Vec<_>>(),
 		[1, 2, 4, 5, 8]
 	);
 
@@ -351,10 +345,7 @@ fn test_unpruned_leaf_iter() {
 	pl.add(2);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
 	assert_eq!(pl.pruned_bintree_range_iter().collect::<Vec<_>>(), [2..3]);
-	assert_eq!(
-		pl.unpruned_leaf_iter().take(3).collect::<Vec<_>>(),
-		[1, 4, 5]
-	);
+	assert_eq!(pl.unpruned_leaf_iter(5).collect::<Vec<_>>(), [1, 4, 5]);
 
 	let mut pl = PruneList::empty();
 	pl.add(2);
@@ -365,8 +356,5 @@ fn test_unpruned_leaf_iter() {
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
 		[2..3, 4..7]
 	);
-	assert_eq!(
-		pl.unpruned_leaf_iter().take(3).collect::<Vec<_>>(),
-		[1, 8, 9]
-	);
+	assert_eq!(pl.unpruned_leaf_iter(9).collect::<Vec<_>>(), [1, 8, 9]);
 }


### PR DESCRIPTION
~We want to merge #3576 and #3575 before we merge this.~
~Likely to be some conflicts as I pulled those changes out as separate PRs.~

----

Lets us do the following - 

```
  let bitmap: Bitmap = prune_list
    .unpruned_leaf_iter(cutoff_pos)
    .collect();
```

Which is a really convenient way of producing a bitmap representing _unpruned_ leaf positions based on a prune_list.
This in effect "inverts" the prune_list giving the leaves that remain after pruning.

We can take advantage of this for more efficient pruning/compaction.

It is possible to efficiently compute the difference between what was pruned last time and what needs to be pruned this time -

```
20210224 09:17:13.613 DEBUG grin_store::pmmr - ***** prev_leaf_bitmap: 209732
20210224 09:17:13.616 DEBUG grin_store::pmmr - ***** next_leaf_bitmap: 196498
20210224 09:17:13.616 DEBUG grin_store::pmmr - ***** diff between bitmaps: 15467
```
