### PR TITLE
optimization for reading peak hashes from backend file

### DIFF
--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -46,6 +46,11 @@ pub trait Backend<T: PMMRable> {
 	/// (ignoring the remove log).
 	fn get_from_file(&self, position: u64) -> Option<Hash>;
 
+	/// Get hash for peak pos.
+	/// Optimized for reading peak hashes rather than arbitrary pos hashes.
+	/// Peaks can be assumed to not be compacted.
+	fn get_peak_from_file(&self, position: u64) -> Option<Hash>;
+
 	/// Get a Data Element by original insertion position
 	/// (ignoring the remove log).
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -148,6 +148,14 @@ where
 		}
 	}
 
+	fn get_peak_from_file(&self, pos: u64) -> Option<Hash> {
+		if pos > self.last_pos {
+			None
+		} else {
+			self.backend.get_peak_from_file(pos)
+		}
+	}
+
 	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
 		if pos > self.last_pos {
 			None

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -64,6 +64,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		self.hashes.get(idx).cloned()
 	}
 
+	fn get_peak_from_file(&self, position: u64) -> Option<Hash> {
+		self.get_from_file(position)
+	}
+
 	fn get_data_from_file(&self, position: u64) -> Option<T::E> {
 		if let Some(data) = &self.data {
 			let idx = usize::try_from(pmmr::n_leaves(position).saturating_sub(1))


### PR DESCRIPTION
We do a lot of reading _peak_ hashes from the backend PMMR file.
When we compute the new root hash we hash all the peaks together.

Peaks are _never_ compacted away while they exist as peaks in the PMMR.
So we can introduce a small optimization as we do not need to check for `is_compacted` for these.