### PR TITLE
replace subtree with pruned root

### DIFF
--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -236,9 +236,10 @@ impl PruneList {
 		loop {
 			let (parent, sibling) = family(current);
 			if self.is_pruned_root(sibling) {
-				self.bitmap.remove(sibling as u32);
 				current = parent;
 			} else {
+				// replace the entire subtree with the single pruned root
+				self.bitmap.remove_range(pmmr::bintree_range(current));
 				self.bitmap.add(current as u32);
 				break;
 			}


### PR DESCRIPTION
We can make the prune_list.add() logic a little more robust by simply replacing the pruned subtree with the single pruned root. And with this we no longer need to explicitly remove the sibling pos each time we loop.

* Start at a given pos to be pruned
* Loop up through the MMR until we reach the root of the subtree to be pruned
* Remove the entire subtree
* Add the single root hash

This guarantees nothing will get "left behind" in the PMMR structure, regardless of insertion order, overlap between parent and child subtrees etc.
It also replaces multiple individual `remove()` calls with a single `remove_range()` at the end.