### PR TITLE
more consistent handling of peers_preferred and peer_allow during startup

### DIFF
--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -529,6 +529,40 @@ impl Readable for PeerAddrs {
 	}
 }
 
+impl IntoIterator for PeerAddrs {
+	type Item = PeerAddr;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.peers.into_iter()
+	}
+}
+
+impl Default for PeerAddrs {
+	fn default() -> Self {
+		PeerAddrs { peers: vec![] }
+	}
+}
+
+impl PeerAddrs {
+	pub fn as_slice(&self) -> &[PeerAddr] {
+		self.peers.as_slice()
+	}
+
+	pub fn contains(&self, addr: &PeerAddr) -> bool {
+		self.peers.contains(addr)
+	}
+
+	pub fn difference(&self, other: &[PeerAddr]) -> PeerAddrs {
+		let peers = self
+			.peers
+			.iter()
+			.filter(|x| !other.contains(x))
+			.cloned()
+			.collect();
+		PeerAddrs { peers }
+	}
+}
+
 /// We found some issue in the communication, sending an error back, usually
 /// followed by closing the connection.
 pub struct PeerError {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -27,6 +27,7 @@ use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::{OutputIdentifier, Segment, SegmentIdentifier, TxKernel};
 use crate::core::global;
 use crate::core::pow::Difficulty;
+use crate::msg::PeerAddrs;
 use crate::peer::Peer;
 use crate::store::{PeerData, PeerStore, State};
 use crate::types::{
@@ -322,8 +323,10 @@ impl Peers {
 		&self,
 		max_inbound_count: usize,
 		max_outbound_count: usize,
-		preferred_peers: &[PeerAddr],
+		config: P2PConfig,
 	) {
+		let preferred_peers = config.peers_preferred.unwrap_or(PeerAddrs::default());
+
 		let mut rm = vec![];
 
 		// build a list of peers to be cleaned up

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -240,7 +240,7 @@ impl Server {
 		let mut connect_thread = None;
 
 		if config.p2p_config.seeding_type != p2p::Seeding::Programmatic {
-			let seeder = match config.p2p_config.seeding_type {
+			let seed_list = match config.p2p_config.seeding_type {
 				p2p::Seeding::None => {
 					warn!("No seed configured, will stay solo until connected to");
 					seed::predefined_seeds(vec![])
@@ -257,15 +257,10 @@ impl Server {
 				_ => unreachable!(),
 			};
 
-			let preferred_peers = match &config.p2p_config.peers_preferred {
-				Some(addrs) => addrs.peers.clone(),
-				None => vec![],
-			};
-
 			connect_thread = Some(seed::connect_and_monitor(
 				p2p_server.clone(),
-				seeder,
-				&preferred_peers,
+				seed_list,
+				config.p2p_config.clone(),
 				stop_state.clone(),
 			)?);
 		}


### PR DESCRIPTION
The following config options can be configured in `grin-server.toml` - 

* `peers_allow`
* `peers_deny`
* `peers_preferred`

This PR reworks the initial connection handling process during startup to make `peers_preferred` and `peers_allow` more consistent.

We can now restart the node and have it reconnect to our configured list of preferred (or allowed) peers more reliably.
This has been useful during local testing of "archival sync" with `peers_allow` and `peers_preferred` configured, connecting to known archival nodes.

