### PR TITLE
Enable block archival sync

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -889,6 +889,11 @@ impl Chain {
 	/// If beyond the horizon then we cannot sync via recent full blocks
 	/// and we need a state (txhashset) sync.
 	pub fn check_txhashset_needed(&self, fork_point: &BlockHeader) -> Result<bool, Error> {
+		if self.archive_mode {
+			debug!("check_txhashset_needed: we are running with archive_mode=true, not needed");
+			return Ok(false);
+		}
+
 		let header_head = self.header_head()?;
 		let horizon = global::cut_through_horizon() as u64;
 		Ok(fork_point.height < header_head.height.saturating_sub(horizon))

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -226,6 +226,11 @@ impl Chain {
 		Ok(chain)
 	}
 
+	/// Are we running with archive_mode enabled?
+	pub fn archive_mode(&self) -> bool {
+		self.archive_mode
+	}
+
 	/// Return our shared header MMR handle.
 	pub fn header_pmmr(&self) -> Arc<RwLock<PMMRHandle<BlockHeader>>> {
 		self.header_pmmr.clone()
@@ -889,7 +894,7 @@ impl Chain {
 	/// If beyond the horizon then we cannot sync via recent full blocks
 	/// and we need a state (txhashset) sync.
 	pub fn check_txhashset_needed(&self, fork_point: &BlockHeader) -> Result<bool, Error> {
-		if self.archive_mode {
+		if self.archive_mode() {
 			debug!("check_txhashset_needed: we are running with archive_mode=true, not needed");
 			return Ok(false);
 		}
@@ -1080,7 +1085,7 @@ impl Chain {
 		header_pmmr: &txhashset::PMMRHandle<BlockHeader>,
 		batch: &store::Batch<'_>,
 	) -> Result<(), Error> {
-		if self.archive_mode {
+		if self.archive_mode() {
 			return Ok(());
 		}
 
@@ -1166,7 +1171,7 @@ impl Chain {
 		}
 
 		// If we are not in archival mode remove historical blocks from the db.
-		if !self.archive_mode {
+		if !self.archive_mode() {
 			self.remove_historical_blocks(&header_pmmr, &batch)?;
 		}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1173,6 +1173,7 @@ impl Chain {
 		// Make sure our output_pos index is consistent with the UTXO set.
 		txhashset.init_output_pos_index(&header_pmmr, &batch)?;
 
+		// TODO - Why is this part of chain compaction?
 		// Rebuild our NRD kernel_pos index based on recent kernel history.
 		txhashset.init_recent_kernel_pos_index(&header_pmmr, &batch)?;
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -704,11 +704,6 @@ where
 	}
 
 	fn check_compact(&self) {
-		// Skip compaction if we are syncing.
-		if self.sync_state.is_syncing() {
-			return;
-		}
-
 		// Roll the dice to trigger compaction at 1/COMPACTION_CHECK chance per block,
 		// uses a different thread to avoid blocking the caller thread (likely a peer)
 		let mut rng = thread_rng();

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -100,6 +100,8 @@ impl BodySync {
 			peers = peers_iter().inbound().into_iter().collect();
 		}
 
+		debug!("*** body_sync: peers: {}", peers.len());
+
 		// If we have no peers (outbound or inbound) then we are done for now.
 		if peers.is_empty() {
 			debug!("no peers (inbound or outbound) with more work");

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -116,6 +116,7 @@ impl BodySync {
 				peers = peers_iter().inbound().into_iter().collect();
 			}
 
+<<<<<<< HEAD
 			// If we have no peers (outbound or inbound) then we are done for now.
 			if peers.is_empty() {
 				debug!("no peers (inbound or outbound) with more work");
@@ -124,6 +125,13 @@ impl BodySync {
 
 			peers
 		};
+=======
+		// If we have no peers (outbound or inbound) then we are done for now.
+		if peers.is_empty() {
+			debug!("no peers (inbound or outbound) with more work");
+			return Ok(false);
+		}
+>>>>>>> 667624c0 (allow chain compaction during sync)
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -116,7 +116,6 @@ impl BodySync {
 				peers = peers_iter().inbound().into_iter().collect();
 			}
 
-<<<<<<< HEAD
 			// If we have no peers (outbound or inbound) then we are done for now.
 			if peers.is_empty() {
 				debug!("no peers (inbound or outbound) with more work");
@@ -125,13 +124,6 @@ impl BodySync {
 
 			peers
 		};
-=======
-		// If we have no peers (outbound or inbound) then we are done for now.
-		if peers.is_empty() {
-			debug!("no peers (inbound or outbound) with more work");
-			return Ok(false);
-		}
->>>>>>> 667624c0 (allow chain compaction during sync)
 
 		// if we have 5 peers to sync from then ask for 50 blocks total (peer_count *
 		// 10) max will be 80 if all 8 peers are advertising more work

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -100,8 +100,6 @@ impl BodySync {
 			peers = peers_iter().inbound().into_iter().collect();
 		}
 
-		debug!("*** body_sync: peers: {}", peers.len());
-
 		// If we have no peers (outbound or inbound) then we are done for now.
 		if peers.is_empty() {
 			debug!("no peers (inbound or outbound) with more work");


### PR DESCRIPTION
Archival Peers (as of 20210315) - 

* `78.47.168.92:3414`
* `46.101.247.184:3414`
* `3.81.230.109:3414`
* `23.124.76.209:3414`

```
# configure the above as peers_preferred to help archive node connectivity
peers_preferred = ["78.47.168.92:3414", "46.101.247.184:3414", "3.81.230.109:3414", "23.124.76.209:3414"]
```

----

Two relatively minor changes that allow a node to run in "block archival mode" and sync fully from other archival peers.
This works in conjunction with various related PRs recently merged.

1. Simply return false for `check_txhashset_needed()` if running with `archive_mode` enabled
2. No longer skip compaction during sync (compact periodically during full archival sync).

----

The local `chain_data` dir should be cleared out prior to a full archival sync - the node will sync from scratch.

A node will only be able to sync historical blocks from other archival nodes.
The best way of configuring the local node to peer with archival nodes is via the following config.

```
#
# with [server] section -
#

archive_mode = true


#
# within [server.p2p_config] section -
# 

# These are known archival nodes. Sync works best if these are both "preferred" and "allow".
peers_preferred = ["85.10.201.143:3414", "49.12.108.173:3414", "176.9.86.219:3414", "116.203.154.223:3414", "213.239.217.14:3414", "46.101.247.184:3414"]
peers_allow = ["85.10.201.143:3414", "49.12.108.173:3414", "176.9.86.219:3414", "116.203.154.223:3414", "213.239.217.14:3414", "46.101.247.184:3414"]
```

----

Once the node has completed an archival sync we can update the config to allow other nodes to connect.

```
# No explicit peers_allow list, so all peers implicitly allowed.
# peers_allow = ["85.10.201.143:3414", "49.12.108.173:3414", "176.9.86.219:3414", "116.203.154.223:3414", "213.239.217.14:3414", "46.101.247.184:3414"]
```

----

Full archival sync takes several hours to complete, probably close to 24 hours.
On completion the local node will have full block history from height 1 onwards.

Disk usage is approx 9.5GB for a full archival node.

----

It is anticipated that `peers_preferred` will be a required config for archival nodes, to ensure we good good connectivity.

The additional `peers_allow` config is a **temporary solution** while we test this out prior to having nodes correctly advertising archival capabilities.

----

### TODO

- [x] uncomment the BLOCK_HIST capability filtering (we only sync from other archival nodes)
- [x] collect a list of known good ip addresses for existing archival nodes so we can publish a list of `preferred` peers for bootstrapping
- [ ] release this as part of `5.1.0`
