### PR TITLE
retire support for v2 blocks

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -378,12 +378,14 @@ where
 	}
 
 	/// Gets a full block by its hash.
-	/// Will convert to v2 compatibility based on peer protocol version.
+	/// We only support v3 blocks since HF4.
+	/// If a peer is requesting a block and only appears to support v2
+	/// then ignore the request.
 	fn get_block(&self, h: Hash, peer_info: &PeerInfo) -> Option<core::Block> {
 		self.chain()
 			.get_block(&h)
 			.map(|b| match peer_info.version.value() {
-				0..=2 => self.chain().convert_block_v2(b).ok(),
+				0..=2 => None,
 				3..=ProtocolVersion::MAX => Some(b),
 			})
 			.unwrap_or(None)


### PR DESCRIPTION
We no longer need to support v2 peers when they request full blocks.
All nodes on the network support v3 blocks consistently since HF4.

v2 block support does not interact cleanly with full archival support as archival nodes cannot rewind beyond horizon to correctly convert to legacy v2 block regardless of having blocks in the local db.

Resolves #3586.
Related [tbd] (@bladedoyle has an issue somewhere related to rewind).