### PR TITLE
[DNM] Hash file simplification

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -990,9 +990,8 @@ impl Chain {
 		{
 			self.validate_kernel_history(&header, &txhashset)?;
 
-			let header_pmmr = self.header_pmmr.read();
 			let batch = self.store.batch()?;
-			txhashset.verify_kernel_pos_index(&genesis, &header_pmmr, &batch)?;
+			txhashset.verify_kernel_pos_index(&genesis, &batch)?;
 		}
 
 		// all good, prepare a new batch and update all the required records

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1475,6 +1475,9 @@ fn setup_head(
 	{
 		if batch.get_block_header(&genesis.hash()).is_err() {
 			batch.save_block_header(&genesis.header)?;
+
+			// We nned to bootstrap the existence of header_head for genesis here.
+			batch.save_header_head(&Tip::from_header(&genesis.header))?;
 		}
 
 		if header_pmmr.last_pos == 0 {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1099,7 +1099,7 @@ impl Chain {
 		}
 
 		let mut count = 0;
-		let tail_hash = header_pmmr.get_header_hash_by_height(head.height - horizon)?;
+		let tail_hash = batch.get_header_hash_by_height(head.height - horizon)?;
 		let tail = batch.get_block_header(&tail_hash)?;
 
 		// Remove old blocks (including short lived fork blocks) which height < tail.height
@@ -1309,15 +1309,17 @@ impl Chain {
 	/// Gets the block header at the provided height.
 	/// Note: Takes a read lock on the header_pmmr.
 	pub fn get_header_by_height(&self, height: u64) -> Result<BlockHeader, Error> {
+		let hash = self.store.get_header_hash_by_height(height)?;
+
 		let hash = self.get_header_hash_by_height(height)?;
 		self.get_block_header(&hash)
 	}
 
-	/// Gets the header hash at the provided height.
-	/// Note: Takes a read lock on the header_pmmr.
-	fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		self.header_pmmr.read().get_header_hash_by_height(height)
-	}
+	// /// Gets the header hash at the provided height.
+	// /// Note: Takes a read lock on the header_pmmr.
+	// fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
+	// 	self.header_pmmr.read().get_header_hash_by_height(height)
+	// }
 
 	/// Gets the block header in which a given output appears in the txhashset.
 	pub fn get_header_for_output(&self, commit: Commitment) -> Result<BlockHeader, Error> {
@@ -1374,7 +1376,7 @@ impl Chain {
 		let (kernel, mmr_index) = match self
 			.txhashset
 			.read()
-			.find_kernel(&excess, min_index, max_index)
+			.find_kernel(&excess, min_index, max_index)?
 		{
 			Some(k) => k,
 			None => return Ok(None),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -545,8 +545,8 @@ impl Chain {
 	pub fn get_unspent_output_at(&self, pos: u64) -> Result<Output, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, _| {
-			utxo.get_unspent_output_at(pos)
+		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, batch| {
+			utxo.get_unspent_output_at(pos, batch)
 		})
 	}
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1478,8 +1478,8 @@ fn setup_head(
 		}
 
 		if header_pmmr.last_pos == 0 {
-			txhashset::header_extending(header_pmmr, &mut batch, |ext, _| {
-				ext.apply_header(&genesis.header)
+			txhashset::header_extending(header_pmmr, &mut batch, |ext, batch| {
+				ext.apply_header(&genesis.header, batch)
 			})?;
 		}
 	}

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -90,6 +90,9 @@ pub enum ErrorKind {
 	/// Error validating a Merkle proof (coinbase output)
 	#[fail(display = "Error validating merkle proof")]
 	MerkleProof,
+	/// Header not found
+	#[fail(display = "Header not found")]
+	HeaderNotFound,
 	/// Output not found
 	#[fail(display = "Output not found")]
 	OutputNotFound,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -433,10 +433,8 @@ fn verify_coinbase_maturity(
 	ext: &txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
 ) -> Result<(), Error> {
-	let extension = &ext.extension;
-	let header_extension = &ext.header_extension;
-	extension
-		.utxo_view(header_extension)
+	ext.extension
+		.utxo_view()
 		.verify_coinbase_maturity(&block.inputs(), block.header.height, batch)
 }
 
@@ -631,9 +629,5 @@ fn validate_utxo(
 	ext: &mut txhashset::ExtensionPair<'_>,
 	batch: &store::Batch<'_>,
 ) -> Result<Vec<(OutputIdentifier, CommitPos)>, Error> {
-	let extension = &ext.extension;
-	let header_extension = &ext.header_extension;
-	extension
-		.utxo_view(header_extension)
-		.validate_block(block, batch)
+	ext.extension.utxo_view().validate_block(block, batch)
 }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -264,7 +264,7 @@ pub fn process_block_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) ->
 	txhashset::header_extending(&mut ctx.header_pmmr, &mut ctx.batch, |ext, batch| {
 		rewind_and_apply_header_fork(&prev_header, ext, batch)?;
 		ext.validate_root(header)?;
-		ext.apply_header(header)?;
+		ext.apply_header(header, batch)?;
 		if !has_more_work(&header, &header_head) {
 			ext.force_rollback();
 		}
@@ -561,7 +561,7 @@ pub fn rewind_and_apply_header_fork(
 			.get_block_header(&h)
 			.map_err(|e| ErrorKind::StoreErr(e, "getting forked headers".to_string()))?;
 		ext.validate_root(&header)?;
-		ext.apply_header(&header)?;
+		ext.apply_header(&header, batch)?;
 	}
 
 	Ok(())

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -193,11 +193,14 @@ pub fn process_block_headers(
 	// Check if we know about all these headers. If so we can accept them quickly.
 	// If they *do not* increase total work on the sync chain we are done.
 	// If they *do* increase total work then we should process them to update sync_head.
-	let head = {
-		let hash = ctx.header_pmmr.head_hash()?;
-		let header = ctx.batch.get_block_header(&hash)?;
-		Tip::from_header(&header)
-	};
+
+	let head = ctx.batch.header_head()?;
+
+	// let head = {
+	// 	let hash = ctx.header_pmmr.head_hash()?;
+	// 	let header = ctx.batch.get_block_header(&hash)?;
+	// 	Tip::from_header(&header)
+	// };
 
 	if let Ok(existing) = ctx.batch.get_block_header(&last_header.hash()) {
 		if !has_more_work(&existing, &head) {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -131,6 +131,10 @@ impl ChainStore {
 		self.db.get_ser(&u64_to_key(OUTPUT_MMR_PREFIX, pos))
 	}
 
+	pub fn get_rangeproof_by_pos(&self, pos: u64) -> Result<Option<RangeProof>, Error> {
+		self.db.get_ser(&u64_to_key(RANGEPROOF_MMR_PREFIX, pos))
+	}
+
 	/// Get kernel by MMR (leaf) pos.
 	pub fn get_kernel_by_pos(&self, pos: u64) -> Result<Option<TxKernel>, Error> {
 		self.db.get_ser(&u64_to_key(KERNEL_MMR_PREFIX, pos))

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -23,7 +23,10 @@ use crate::linked_list::MultiIndex;
 use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
 use croaring::Bitmap;
-use grin_core::{core::OutputIdentifier, ser};
+use grin_core::{
+	core::{OutputIdentifier, TxKernel},
+	ser,
+};
 use grin_store as store;
 use grin_store::{option_to_not_found, to_key, Error};
 use grin_util::secp::pedersen::RangeProof;
@@ -110,6 +113,10 @@ impl ChainStore {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_HEADER_PREFIX, h)), || {
 			format!("BLOCK HEADER: {}", h)
 		})
+	}
+
+	pub fn get_output_by_pos(&self, pos: u64) -> Result<Option<OutputIdentifier>, Error> {
+		unimplemented!();
 	}
 
 	/// Get PMMR pos for the given output commitment.
@@ -246,6 +253,18 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	pub fn save_output_by_pos(&self, out: &OutputIdentifier, pos: u64) -> Result<(), Error> {
+		unimplemented!();
+	}
+
+	pub fn save_rangeproof_by_pos(&self, rp: &RangeProof, pos: u64) -> Result<(), Error> {
+		unimplemented!();
+	}
+
+	pub fn save_kernel_by_pos(&self, kern: &TxKernel, pos: u64) -> Result<(), Error> {
+		unimplemented!();
+	}
+
 	/// Save output_pos and block height to index.
 	pub fn save_output_pos_height(&self, commit: &Commitment, pos: CommitPos) -> Result<(), Error> {
 		self.db
@@ -281,6 +300,10 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn get_rangeproof_by_pos(&self, pos: u64) -> Result<Option<RangeProof>, Error> {
+		unimplemented!();
+	}
+
+	pub fn get_kernel_by_pos(&self, pos: u64) -> Result<Option<TxKernel>, Error> {
 		unimplemented!();
 	}
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -24,7 +24,7 @@ use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
 use croaring::Bitmap;
 use grin_core::{
-	core::{OutputIdentifier, TxKernel},
+	core::{pmmr, OutputIdentifier, TxKernel},
 	ser,
 };
 use grin_store as store;
@@ -115,7 +115,17 @@ impl ChainStore {
 		})
 	}
 
+	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Option<Hash>, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+
+		unimplemented!();
+	}
+
 	pub fn get_output_by_pos(&self, pos: u64) -> Result<Option<OutputIdentifier>, Error> {
+		unimplemented!();
+	}
+
+	pub fn get_kernel_by_pos(&self, pos: u64) -> Result<Option<TxKernel>, Error> {
 		unimplemented!();
 	}
 
@@ -326,6 +336,12 @@ impl<'a> Batch<'a> {
 	/// Get the previous header.
 	pub fn get_previous_header(&self, header: &BlockHeader) -> Result<BlockHeader, Error> {
 		self.get_block_header(&header.prev_hash)
+	}
+
+	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Option<Hash>, Error> {
+		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+
+		unimplemented!();
 	}
 
 	/// Get block header.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -23,9 +23,10 @@ use crate::linked_list::MultiIndex;
 use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
 use croaring::Bitmap;
-use grin_core::ser;
+use grin_core::{core::OutputIdentifier, ser};
 use grin_store as store;
 use grin_store::{option_to_not_found, to_key, Error};
+use grin_util::secp::pedersen::RangeProof;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -273,6 +274,14 @@ impl<'a> Batch<'a> {
 				.map(|pos| (k.to_vec(), pos))
 				.map_err(From::from)
 		})
+	}
+
+	pub fn get_output_by_pos(&self, pos: u64) -> Result<Option<OutputIdentifier>, Error> {
+		unimplemented!();
+	}
+
+	pub fn get_rangeproof_by_pos(&self, pos: u64) -> Result<Option<RangeProof>, Error> {
+		unimplemented!();
 	}
 
 	/// Get output_pos from index.

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -339,8 +339,10 @@ impl<'a> Batch<'a> {
 	}
 
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Option<Hash>, Error> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		unimplemented!();
+	}
 
+	pub fn save_header_hash_by_height(&self, hash: Hash, height: u64) -> Result<(), Error> {
 		unimplemented!();
 	}
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -220,13 +220,13 @@ impl BitmapChunk {
 impl PMMRable for BitmapChunk {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		self.clone()
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	self.clone()
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		Some(Self::LEN_BYTES as u16)
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	Some(Self::LEN_BYTES as u16)
+	// }
 }
 
 impl DefaultHashable for BitmapChunk {}

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -16,6 +16,8 @@
 
 use std::{sync::Arc, time::Instant};
 
+use grin_core::core::pmmr;
+
 use crate::core::core::hash::Hash;
 use crate::core::core::pmmr::ReadablePMMR;
 use crate::core::core::{BlockHeader, OutputIdentifier, Segment, SegmentIdentifier, TxKernel};
@@ -96,7 +98,8 @@ impl Segmenter {
 		let now = Instant::now();
 		let bitmap_pmmr = self.bitmap_snapshot.readonly_pmmr();
 		let segment = Segment::from_pmmr(id, &bitmap_pmmr, false, |pos| {
-			unimplemented!("feed me");
+			let idx = pmmr::n_leaves(pos).saturating_sub(1);
+			self.bitmap_snapshot.get_chunk(idx).cloned()
 		})?;
 		let output_root = self.output_root()?;
 		debug!(

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -16,6 +16,8 @@
 
 use std::{sync::Arc, time::Instant};
 
+use grin_core::core::SegmentError;
+
 use crate::core::core::hash::Hash;
 use crate::core::core::pmmr::ReadablePMMR;
 use crate::core::core::{BlockHeader, OutputIdentifier, Segment, SegmentIdentifier, TxKernel};
@@ -57,7 +59,9 @@ impl Segmenter {
 		let now = Instant::now();
 		let txhashset = self.txhashset.read();
 		let kernel_pmmr = txhashset.kernel_pmmr_at(&self.header);
-		let segment = Segment::from_pmmr(id, &kernel_pmmr, false)?;
+		let segment = Segment::from_pmmr(id, &kernel_pmmr, false, |pos| {
+			txhashset.get_kernel_by_pos(pos).unwrap_or(None)
+		})?;
 		debug!(
 			"kernel_segment: id: ({}, {}), leaves: {}, hashes: {}, proof hashes: {}, took {}ms",
 			segment.id().height,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1098,6 +1098,8 @@ impl<'a> Extension<'a> {
 		pos: u64,
 		batch: &Batch<'_>,
 	) -> Result<Option<OutputIdentifier>, Error> {
+		// TODO - we should be leaf_set aware here for completeness.
+
 		if pos > self.output_pmmr.last_pos {
 			Ok(None)
 		} else {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -981,7 +981,7 @@ impl<'a> HeaderExtension<'a> {
 		self.pmmr.push(header).map_err(&ErrorKind::TxHashSetErr)?;
 
 		// Update the "header hash by height" index to reflect the new header.
-		batch.save_header_hash_by_height(header.hash(), header.height)?;
+		batch.save_header_hash_by_height(header.height, header.hash())?;
 
 		self.head = Tip::from_header(header);
 		Ok(())
@@ -1175,8 +1175,8 @@ impl<'a> Extension<'a> {
 
 			// Save output and associated rangeproof to the db.
 			// Update the output_pos_height index for the output commitment.
-			batch.save_output_by_pos(&out.identifier(), pos)?;
-			batch.save_rangeproof_by_pos(&out.proof(), pos)?;
+			batch.save_output_by_pos(pos, &out.identifier())?;
+			batch.save_rangeproof_by_pos(pos, &out.proof())?;
 			batch.save_output_pos_height(&out.commitment(), commit_pos)?;
 		}
 
@@ -1296,7 +1296,8 @@ impl<'a> Extension<'a> {
 		for kernel in kernels {
 			let pos = self.apply_kernel(kernel)?;
 
-			batch.save_kernel_by_pos(kernel, pos)?;
+			// Save the kernel to the db indexed by MMR pos.
+			batch.save_kernel_by_pos(pos, kernel)?;
 
 			let commit_pos = CommitPos { pos, height };
 			apply_kernel_rules(kernel, commit_pos, batch)?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1098,12 +1098,10 @@ impl<'a> Extension<'a> {
 		pos: u64,
 		batch: &Batch<'_>,
 	) -> Result<Option<OutputIdentifier>, Error> {
-		// TODO - we should be leaf_set aware here for completeness.
-
-		if pos > self.output_pmmr.last_pos {
-			Ok(None)
-		} else {
+		if self.output_pmmr.is_leaf(pos) {
 			Ok(batch.get_output_by_pos(pos)?)
+		} else {
+			Ok(None)
 		}
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -337,6 +337,18 @@ impl TxHashSet {
 		ReadonlyPMMR::at(&self.rproof_pmmr_h.backend, header.output_mmr_size)
 	}
 
+	pub fn get_output_by_pos(&self, pos: u64) -> Result<Option<OutputIdentifier>, Error> {
+		Ok(self.commit_index.get_output_by_pos(pos)?)
+	}
+
+	pub fn get_rangeproof_by_pos(&self, pos: u64) -> Result<Option<RangeProof>, Error> {
+		Ok(self.commit_index.get_rangeproof_by_pos(pos)?)
+	}
+
+	pub fn get_kernel_by_pos(&self, pos: u64) -> Result<Option<TxKernel>, Error> {
+		Ok(self.commit_index.get_kernel_by_pos(pos)?)
+	}
+
 	/// Convenience function to query the db for a header by its hash.
 	pub fn get_block_header(&self, hash: &Hash) -> Result<BlockHeader, Error> {
 		Ok(self.commit_index.get_block_header(&hash)?)

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -977,8 +977,12 @@ impl<'a> HeaderExtension<'a> {
 	/// Apply a new header to the header MMR extension.
 	/// This may be either the header MMR or the sync MMR depending on the
 	/// extension.
-	pub fn apply_header(&mut self, header: &BlockHeader) -> Result<(), Error> {
+	pub fn apply_header(&mut self, header: &BlockHeader, batch: &Batch<'_>) -> Result<(), Error> {
 		self.pmmr.push(header).map_err(&ErrorKind::TxHashSetErr)?;
+
+		// Update the "header hash by height" index to reflect the new header.
+		batch.save_header_hash_by_height(header.hash(), header.height)?;
+
 		self.head = Tip::from_header(header);
 		Ok(())
 	}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -20,28 +20,20 @@ use crate::core::global;
 use crate::error::{Error, ErrorKind};
 use crate::store::Batch;
 use crate::types::CommitPos;
-use crate::util::secp::pedersen::{Commitment, RangeProof};
+use crate::util::secp::pedersen::Commitment;
 use grin_store::pmmr::PMMRBackend;
 
 /// Readonly view of the UTXO set (based on output MMR).
 pub struct UTXOView<'a> {
-	header_pmmr: ReadonlyPMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
 	output_pmmr: ReadonlyPMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
-	rproof_pmmr: ReadonlyPMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 }
 
 impl<'a> UTXOView<'a> {
 	/// Build a new UTXO view.
 	pub fn new(
-		header_pmmr: ReadonlyPMMR<'a, BlockHeader, PMMRBackend<BlockHeader>>,
 		output_pmmr: ReadonlyPMMR<'a, OutputIdentifier, PMMRBackend<OutputIdentifier>>,
-		rproof_pmmr: ReadonlyPMMR<'a, RangeProof, PMMRBackend<RangeProof>>,
 	) -> UTXOView<'a> {
-		UTXOView {
-			header_pmmr,
-			output_pmmr,
-			rproof_pmmr,
-		}
+		UTXOView { output_pmmr }
 	}
 
 	/// Validate a block against the current UTXO set.

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -150,6 +150,8 @@ impl<'a> UTXOView<'a> {
 		pos: u64,
 		batch: &Batch<'_>,
 	) -> Result<Option<OutputIdentifier>, Error> {
+		// TODO - we should be leaf_set aware here for completeness.
+
 		if pos > self.output_pmmr.last_pos {
 			Ok(None)
 		} else {

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -14,7 +14,7 @@
 
 //! Lightweight readonly view into output MMR for convenience.
 
-use crate::core::core::pmmr::ReadonlyPMMR;
+use crate::core::core::pmmr::{ReadablePMMR, ReadonlyPMMR};
 use crate::core::core::{Block, BlockHeader, Inputs, Output, OutputIdentifier, Transaction};
 use crate::core::global;
 use crate::error::{Error, ErrorKind};
@@ -150,12 +150,10 @@ impl<'a> UTXOView<'a> {
 		pos: u64,
 		batch: &Batch<'_>,
 	) -> Result<Option<OutputIdentifier>, Error> {
-		// TODO - we should be leaf_set aware here for completeness.
-
-		if pos > self.output_pmmr.last_pos {
-			Ok(None)
-		} else {
+		if self.output_pmmr.is_leaf(pos) {
 			Ok(batch.get_output_by_pos(pos)?)
+		} else {
+			Ok(None)
 		}
 	}
 

--- a/chain/tests/chain_test_helper.rs
+++ b/chain/tests/chain_test_helper.rs
@@ -64,7 +64,7 @@ where
 	)
 	.unwrap();
 
-	genesis::genesis_dev().with_reward(reward.0, reward.1)
+	genesis::genesis_dev_with_reward(reward.0, reward.1)
 }
 
 /// Mine a chain of specified length to assist with automated tests.

--- a/chain/tests/mine_nrd_kernel.rs
+++ b/chain/tests/mine_nrd_kernel.rs
@@ -72,10 +72,13 @@ fn mine_block_with_nrd_kernel_and_nrd_feature_enabled() {
 	let genesis = genesis_block(&keychain);
 	let chain = init_chain(chain_dir, genesis.clone());
 
+	chain.validate(false).unwrap();
+
 	for n in 1..9 {
 		let key_id = ExtKeychainPath::new(1, n, 0, 0, 0).to_identifier();
 		let block = build_block(&chain, &keychain, &key_id, vec![]);
 		chain.process_block(block, Options::MINE).unwrap();
+		chain.validate(false).unwrap();
 	}
 
 	assert_eq!(chain.head().unwrap().height, 8);

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -252,21 +252,21 @@ impl Default for BlockHeader {
 impl PMMRable for BlockHeader {
 	type E = HeaderEntry;
 
-	fn as_elmt(&self) -> Self::E {
-		HeaderEntry {
-			hash: self.hash(),
-			timestamp: self.timestamp.timestamp() as u64,
-			total_difficulty: self.total_difficulty(),
-			secondary_scaling: self.pow.secondary_scaling,
-			is_secondary: self.pow.is_secondary(),
-		}
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	HeaderEntry {
+	// 		hash: self.hash(),
+	// 		timestamp: self.timestamp.timestamp() as u64,
+	// 		total_difficulty: self.total_difficulty(),
+	// 		secondary_scaling: self.pow.secondary_scaling,
+	// 		is_secondary: self.pow.is_secondary(),
+	// 	}
+	// }
 
-	// Size is hash + u64 + difficulty + u32 + u8.
-	fn elmt_size() -> Option<u16> {
-		const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
-		Some(LEN.try_into().unwrap())
-	}
+	// // Size is hash + u64 + difficulty + u32 + u8.
+	// fn elmt_size() -> Option<u16> {
+	// 	const LEN: usize = Hash::LEN + 8 + Difficulty::LEN + 4 + 1;
+	// 	Some(LEN.try_into().unwrap())
+	// }
 }
 
 /// Serialization of a block header

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -39,9 +39,6 @@ pub trait Backend<T: PMMRable> {
 	/// Get a Hash by insertion position.
 	fn get_hash(&self, position: u64) -> Option<Hash>;
 
-	// /// Get underlying data by insertion position.
-	// fn get_data(&self, position: u64) -> Option<T::E>;
-
 	/// Get a Hash  by original insertion position
 	/// (ignoring the remove log).
 	fn get_from_file(&self, position: u64) -> Option<Hash>;
@@ -50,10 +47,6 @@ pub trait Backend<T: PMMRable> {
 	/// Optimized for reading peak hashes rather than arbitrary pos hashes.
 	/// Peaks can be assumed to not be compacted.
 	fn get_peak_from_file(&self, position: u64) -> Option<Hash>;
-
-	// /// Get a Data Element by original insertion position
-	// /// (ignoring the remove log).
-	// fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_>;
@@ -64,6 +57,8 @@ pub trait Backend<T: PMMRable> {
 	/// Iterator over current (unpruned, unremoved) leaf insertion index.
 	/// Note: This differs from underlying MMR pos - [0, 1, 2, 3, 4] vs. [1, 2, 4, 5, 8].
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_>;
+
+	fn is_leaf(&self, pos: u64) -> bool;
 
 	/// Remove Hash by insertion position. An index is also provided so the
 	/// underlying backend can implement some rollback of positions up to a

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -27,7 +27,7 @@ pub trait Backend<T: PMMRable> {
 	/// associated data element to flatfile storage (for leaf nodes only). The
 	/// position of the first element of the Vec in the MMR is provided to
 	/// help the implementation.
-	fn append(&mut self, data: &T, hashes: &[Hash]) -> Result<(), String>;
+	fn append(&mut self, hashes: &[Hash]) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR
@@ -39,8 +39,8 @@ pub trait Backend<T: PMMRable> {
 	/// Get a Hash by insertion position.
 	fn get_hash(&self, position: u64) -> Option<Hash>;
 
-	/// Get underlying data by insertion position.
-	fn get_data(&self, position: u64) -> Option<T::E>;
+	// /// Get underlying data by insertion position.
+	// fn get_data(&self, position: u64) -> Option<T::E>;
 
 	/// Get a Hash  by original insertion position
 	/// (ignoring the remove log).
@@ -51,9 +51,9 @@ pub trait Backend<T: PMMRable> {
 	/// Peaks can be assumed to not be compacted.
 	fn get_peak_from_file(&self, position: u64) -> Option<Hash>;
 
-	/// Get a Data Element by original insertion position
-	/// (ignoring the remove log).
-	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
+	// /// Get a Data Element by original insertion position
+	// /// (ignoring the remove log).
+	// fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_>;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -236,7 +236,7 @@ where
 			hashes.push(current_hash);
 		}
 
-		// append all the new nodes and update the MMR index
+		// Append all the new hashes from leaf up to new peak and update the MMR index.
 		self.backend.append(&hashes)?;
 		self.last_pos = pos;
 		Ok(elmt_pos)

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -50,6 +50,10 @@ pub trait ReadablePMMR {
 	/// Iterator over current (unpruned, unremoved) leaf insertion indices.
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_>;
 
+	/// Is the pos a leaf?
+	/// Takes last_pos and the leaf_set (for prunable MMR) into consideration.
+	fn is_leaf(&self, pos: u64) -> bool;
+
 	/// Number of leaves in the MMR
 	fn n_unpruned_leaves(&self) -> u64;
 
@@ -414,6 +418,10 @@ where
 
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_> {
 		self.backend.leaf_idx_iter(from_idx)
+	}
+
+	fn is_leaf(&self, pos: u64) -> bool {
+		pos <= self.last_pos && is_leaf(pos) && self.backend.is_leaf(pos)
 	}
 
 	fn n_unpruned_leaves(&self) -> u64 {

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -33,9 +33,6 @@ pub trait ReadablePMMR {
 	/// Get the hash at provided position in the MMR.
 	fn get_hash(&self, pos: u64) -> Option<Hash>;
 
-	// /// Get the data element at provided position in the MMR.
-	// fn get_data(&self, pos: u64) -> Option<Self::Item>;
-
 	/// Get the hash from the underlying MMR file (ignores the remove log).
 	fn get_from_file(&self, pos: u64) -> Option<Hash>;
 
@@ -43,9 +40,6 @@ pub trait ReadablePMMR {
 	/// Optimized for reading peak hashes rather than arbitrary pos hashes.
 	/// Peaks can be assumed to not be compacted.
 	fn get_peak_from_file(&self, pos: u64) -> Option<Hash>;
-
-	// /// Get the data element at provided position in the MMR (ignores the remove log).
-	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item>;
 
 	/// Total size of the tree, including intermediary nodes and ignoring any pruning.
 	fn unpruned_size(&self) -> u64;
@@ -394,19 +388,6 @@ where
 		}
 	}
 
-	// fn get_data(&self, pos: u64) -> Option<Self::Item> {
-	// 	if pos > self.last_pos {
-	// 		// If we are beyond the rhs of the MMR return None.
-	// 		None
-	// 	} else if is_leaf(pos) {
-	// 		// If we are a leaf then get data from the backend.
-	// 		self.backend.get_data(pos)
-	// 	} else {
-	// 		// If we are not a leaf then return None as only leaves have data.
-	// 		None
-	// 	}
-	// }
-
 	fn get_from_file(&self, pos: u64) -> Option<Hash> {
 		if pos > self.last_pos {
 			None
@@ -422,14 +403,6 @@ where
 			self.backend.get_peak_from_file(pos)
 		}
 	}
-
-	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
-	// 	if pos > self.last_pos {
-	// 		None
-	// 	} else {
-	// 		self.backend.get_data_from_file(pos)
-	// 	}
-	// }
 
 	fn unpruned_size(&self) -> u64 {
 		self.last_pos

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -33,8 +33,8 @@ pub trait ReadablePMMR {
 	/// Get the hash at provided position in the MMR.
 	fn get_hash(&self, pos: u64) -> Option<Hash>;
 
-	/// Get the data element at provided position in the MMR.
-	fn get_data(&self, pos: u64) -> Option<Self::Item>;
+	// /// Get the data element at provided position in the MMR.
+	// fn get_data(&self, pos: u64) -> Option<Self::Item>;
 
 	/// Get the hash from the underlying MMR file (ignores the remove log).
 	fn get_from_file(&self, pos: u64) -> Option<Hash>;
@@ -44,8 +44,8 @@ pub trait ReadablePMMR {
 	/// Peaks can be assumed to not be compacted.
 	fn get_peak_from_file(&self, pos: u64) -> Option<Hash>;
 
-	/// Get the data element at provided position in the MMR (ignores the remove log).
-	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item>;
+	// /// Get the data element at provided position in the MMR (ignores the remove log).
+	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item>;
 
 	/// Total size of the tree, including intermediary nodes and ignoring any pruning.
 	fn unpruned_size(&self) -> u64;
@@ -237,7 +237,7 @@ where
 		}
 
 		// append all the new nodes and update the MMR index
-		self.backend.append(elmt, &hashes)?;
+		self.backend.append(&hashes)?;
 		self.last_pos = pos;
 		Ok(elmt_pos)
 	}
@@ -394,18 +394,18 @@ where
 		}
 	}
 
-	fn get_data(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
-			// If we are beyond the rhs of the MMR return None.
-			None
-		} else if is_leaf(pos) {
-			// If we are a leaf then get data from the backend.
-			self.backend.get_data(pos)
-		} else {
-			// If we are not a leaf then return None as only leaves have data.
-			None
-		}
-	}
+	// fn get_data(&self, pos: u64) -> Option<Self::Item> {
+	// 	if pos > self.last_pos {
+	// 		// If we are beyond the rhs of the MMR return None.
+	// 		None
+	// 	} else if is_leaf(pos) {
+	// 		// If we are a leaf then get data from the backend.
+	// 		self.backend.get_data(pos)
+	// 	} else {
+	// 		// If we are not a leaf then return None as only leaves have data.
+	// 		None
+	// 	}
+	// }
 
 	fn get_from_file(&self, pos: u64) -> Option<Hash> {
 		if pos > self.last_pos {
@@ -423,13 +423,13 @@ where
 		}
 	}
 
-	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
-			None
-		} else {
-			self.backend.get_data_from_file(pos)
-		}
-	}
+	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
+	// 	if pos > self.last_pos {
+	// 		None
+	// 	} else {
+	// 		self.backend.get_data_from_file(pos)
+	// 	}
+	// }
 
 	fn unpruned_size(&self) -> u64 {
 		self.last_pos

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -16,9 +16,9 @@
 
 use std::marker;
 
-use crate::core::hash::Hash;
-use crate::core::pmmr::pmmr::{bintree_rightmost, ReadablePMMR};
+use crate::core::pmmr::pmmr::ReadablePMMR;
 use crate::core::pmmr::{is_leaf, Backend};
+use crate::core::{hash::Hash, OutputIdentifier};
 use crate::ser::PMMRable;
 
 /// Readonly view of a PMMR.
@@ -28,7 +28,7 @@ where
 	B: Backend<T>,
 {
 	/// The last position in the PMMR
-	last_pos: u64,
+	pub last_pos: u64,
 	/// The backend for this readonly PMMR
 	backend: &'a B,
 	// only needed to parameterise Backend
@@ -68,7 +68,7 @@ where
 		max_count: u64,
 		max_pmmr_pos: Option<u64>,
 	) -> (u64, Vec<T::E>) {
-		panic!("no longer implemented");
+		panic!("implement me");
 	}
 	// 	let mut return_vec = vec![];
 	// 	let last_pos = match max_pmmr_pos {
@@ -91,7 +91,7 @@ where
 	/// n nodes along the bottom of the tree.
 	/// May return less than n items if the MMR has been pruned/compacted.
 	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(Hash, T::E)> {
-		panic!("no longer implemented");
+		panic!("implement me");
 	}
 	// 	let mut return_vec = vec![];
 	// 	let mut last_leaf = self.last_pos;

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -16,9 +16,9 @@
 
 use std::marker;
 
+use crate::core::hash::Hash;
 use crate::core::pmmr::pmmr::ReadablePMMR;
 use crate::core::pmmr::{is_leaf, Backend};
-use crate::core::{hash::Hash, OutputIdentifier};
 use crate::ser::PMMRable;
 
 /// Readonly view of a PMMR.
@@ -131,19 +131,6 @@ where
 		}
 	}
 
-	// fn get_data(&self, pos: u64) -> Option<Self::Item> {
-	// 	if pos > self.last_pos {
-	// 		// If we are beyond the rhs of the MMR return None.
-	// 		None
-	// 	} else if is_leaf(pos) {
-	// 		// If we are a leaf then get data from the backend.
-	// 		self.backend.get_data(pos)
-	// 	} else {
-	// 		// If we are not a leaf then return None as only leaves have data.
-	// 		None
-	// 	}
-	// }
-
 	fn get_from_file(&self, pos: u64) -> Option<Hash> {
 		if pos > self.last_pos {
 			None
@@ -159,14 +146,6 @@ where
 			self.backend.get_peak_from_file(pos)
 		}
 	}
-
-	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
-	// 	if pos > self.last_pos {
-	// 		None
-	// 	} else {
-	// 		self.backend.get_data_from_file(pos)
-	// 	}
-	// }
 
 	fn unpruned_size(&self) -> u64 {
 		self.last_pos

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -159,6 +159,10 @@ where
 		self.backend.leaf_idx_iter(from_idx)
 	}
 
+	fn is_leaf(&self, pos: u64) -> bool {
+		pos <= self.last_pos && is_leaf(pos) && self.backend.is_leaf(pos)
+	}
+
 	fn n_unpruned_leaves(&self) -> u64 {
 		self.backend.n_unpruned_leaves()
 	}

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -64,48 +64,52 @@ where
 	/// returns last pmmr index returned along with data
 	pub fn elements_from_pmmr_index(
 		&self,
-		mut pmmr_index: u64,
+		pmmr_index: u64,
 		max_count: u64,
 		max_pmmr_pos: Option<u64>,
 	) -> (u64, Vec<T::E>) {
-		let mut return_vec = vec![];
-		let last_pos = match max_pmmr_pos {
-			Some(p) => p,
-			None => self.last_pos,
-		};
-		if pmmr_index == 0 {
-			pmmr_index = 1;
-		}
-		while return_vec.len() < max_count as usize && pmmr_index <= last_pos {
-			if let Some(t) = self.get_data(pmmr_index) {
-				return_vec.push(t);
-			}
-			pmmr_index += 1;
-		}
-		(pmmr_index.saturating_sub(1), return_vec)
+		panic!("no longer implemented");
 	}
+	// 	let mut return_vec = vec![];
+	// 	let last_pos = match max_pmmr_pos {
+	// 		Some(p) => p,
+	// 		None => self.last_pos,
+	// 	};
+	// 	if pmmr_index == 0 {
+	// 		pmmr_index = 1;
+	// 	}
+	// 	while return_vec.len() < max_count as usize && pmmr_index <= last_pos {
+	// 		if let Some(t) = self.get_data(pmmr_index) {
+	// 			return_vec.push(t);
+	// 		}
+	// 		pmmr_index += 1;
+	// 	}
+	// 	(pmmr_index.saturating_sub(1), return_vec)
+	// }
 
 	/// Helper function to get the last N nodes inserted, i.e. the last
 	/// n nodes along the bottom of the tree.
 	/// May return less than n items if the MMR has been pruned/compacted.
 	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(Hash, T::E)> {
-		let mut return_vec = vec![];
-		let mut last_leaf = self.last_pos;
-		for _ in 0..n as u64 {
-			if last_leaf == 0 {
-				break;
-			}
-			last_leaf = bintree_rightmost(last_leaf);
-
-			if let Some(hash) = self.backend.get_hash(last_leaf) {
-				if let Some(data) = self.backend.get_data(last_leaf) {
-					return_vec.push((hash, data));
-				}
-			}
-			last_leaf -= 1;
-		}
-		return_vec
+		panic!("no longer implemented");
 	}
+	// 	let mut return_vec = vec![];
+	// 	let mut last_leaf = self.last_pos;
+	// 	for _ in 0..n as u64 {
+	// 		if last_leaf == 0 {
+	// 			break;
+	// 		}
+	// 		last_leaf = bintree_rightmost(last_leaf);
+
+	// 		if let Some(hash) = self.backend.get_hash(last_leaf) {
+	// 			if let Some(data) = self.backend.get_data(last_leaf) {
+	// 				return_vec.push((hash, data));
+	// 			}
+	// 		}
+	// 		last_leaf -= 1;
+	// 	}
+	// 	return_vec
+	// }
 }
 
 impl<'a, T, B> ReadablePMMR for ReadonlyPMMR<'a, T, B>
@@ -127,18 +131,18 @@ where
 		}
 	}
 
-	fn get_data(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
-			// If we are beyond the rhs of the MMR return None.
-			None
-		} else if is_leaf(pos) {
-			// If we are a leaf then get data from the backend.
-			self.backend.get_data(pos)
-		} else {
-			// If we are not a leaf then return None as only leaves have data.
-			None
-		}
-	}
+	// fn get_data(&self, pos: u64) -> Option<Self::Item> {
+	// 	if pos > self.last_pos {
+	// 		// If we are beyond the rhs of the MMR return None.
+	// 		None
+	// 	} else if is_leaf(pos) {
+	// 		// If we are a leaf then get data from the backend.
+	// 		self.backend.get_data(pos)
+	// 	} else {
+	// 		// If we are not a leaf then return None as only leaves have data.
+	// 		None
+	// 	}
+	// }
 
 	fn get_from_file(&self, pos: u64) -> Option<Hash> {
 		if pos > self.last_pos {
@@ -156,13 +160,13 @@ where
 		}
 	}
 
-	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
-			None
-		} else {
-			self.backend.get_data_from_file(pos)
-		}
-	}
+	// fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
+	// 	if pos > self.last_pos {
+	// 		None
+	// 	} else {
+	// 		self.backend.get_data_from_file(pos)
+	// 	}
+	// }
 
 	fn unpruned_size(&self) -> u64 {
 		self.last_pos

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -249,13 +249,15 @@ where
 		let (segment_first_pos, segment_last_pos) = segment.segment_pos_range(last_pos);
 		for pos in segment_first_pos..=segment_last_pos {
 			if pmmr::is_leaf(pos) {
-				if let Some(data) = pmmr.get_data_from_file(pos) {
-					segment.leaf_data.push(data);
-					segment.leaf_pos.push(pos);
-					continue;
-				} else if !prunable {
-					return Err(SegmentError::MissingLeaf(pos));
-				}
+				panic!("we need to read data from db here");
+
+				// if let Some(data) = pmmr.get_data_from_file(pos) {
+				// 	segment.leaf_data.push(data);
+				// 	segment.leaf_pos.push(pos);
+				// 	continue;
+				// } else if !prunable {
+				// 	return Err(SegmentError::MissingLeaf(pos));
+				// }
 			}
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -671,13 +671,13 @@ impl Readable for TxKernel {
 impl PMMRable for TxKernel {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		self.clone()
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	self.clone()
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		None
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	None
+	// }
 }
 
 impl KernelFeatures {
@@ -2282,17 +2282,17 @@ impl Readable for OutputIdentifier {
 impl PMMRable for OutputIdentifier {
 	type E = Self;
 
-	fn as_elmt(&self) -> OutputIdentifier {
-		*self
-	}
+	// fn as_elmt(&self) -> OutputIdentifier {
+	// 	*self
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		Some(
-			(1 + secp::constants::PEDERSEN_COMMITMENT_SIZE)
-				.try_into()
-				.unwrap(),
-		)
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	Some(
+	// 		(1 + secp::constants::PEDERSEN_COMMITMENT_SIZE)
+	// 			.try_into()
+	// 			.unwrap(),
+	// 	)
+	// }
 }
 
 impl From<&Input> for OutputIdentifier {

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -44,6 +44,21 @@ pub fn genesis_dev() -> core::Block {
 	})
 }
 
+pub fn genesis_dev_with_reward(out: core::Output, kern: core::TxKernel) -> core::Block {
+	let gen = core::Block::with_header(core::BlockHeader {
+		height: 0,
+		timestamp: Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
+		output_mmr_size: 1,
+		kernel_mmr_size: 1,
+		pow: ProofOfWork {
+			nonce: 0,
+			..Default::default()
+		},
+		..Default::default()
+	});
+	gen.with_reward(out, kern)
+}
+
 /// Testnet genesis block
 pub fn genesis_test() -> core::Block {
 	let gen = core::Block::with_header(core::BlockHeader {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -24,7 +24,6 @@ use crate::global::PROTOCOL_VERSION;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use bytes::Buf;
 use keychain::{BlindingFactor, Identifier, IDENTIFIER_SIZE};
-use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::io::{self, Read, Write};
 use std::{cmp, error, marker, string};

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -749,14 +749,14 @@ impl Readable for RangeProof {
 impl PMMRable for RangeProof {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		*self
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	*self
+	// }
 
-	// Size is length prefix (8 bytes for u64) + MAX_PROOF_SIZE.
-	fn elmt_size() -> Option<u16> {
-		Some((8 + MAX_PROOF_SIZE).try_into().unwrap())
-	}
+	// // Size is length prefix (8 bytes for u64) + MAX_PROOF_SIZE.
+	// fn elmt_size() -> Option<u16> {
+	// 	Some((8 + MAX_PROOF_SIZE).try_into().unwrap())
+	// }
 }
 
 impl Readable for Signature {
@@ -964,11 +964,11 @@ pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	/// This allows us to store Hash elements in the header MMR for variable size BlockHeaders.
 	type E: Readable + Writeable + Debug;
 
-	/// Convert the pmmrable into the element to be stored in the MMR data file.
-	fn as_elmt(&self) -> Self::E;
+	// /// Convert the pmmrable into the element to be stored in the MMR data file.
+	// fn as_elmt(&self) -> Self::E;
 
-	/// Size of each element if "fixed" size. Elements are "variable" size if None.
-	fn elmt_size() -> Option<u16>;
+	// /// Size of each element if "fixed" size. Elements are "variable" size if None.
+	// fn elmt_size() -> Option<u16>;
 }
 
 /// Generic trait to ensure PMMR elements can be hashed with an index

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -159,13 +159,13 @@ impl DefaultHashable for TestElem {}
 impl PMMRable for TestElem {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		*self
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	*self
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		Some(16)
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	Some(16)
+	// }
 }
 
 impl Writeable for TestElem {

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -42,26 +42,26 @@ fn leaf_pos_and_idx_iter_test() {
 	);
 }
 
-#[test]
-fn leaf_pos_and_idx_iter_hash_only_test() {
-	let elems = [
-		TestElem([0, 0, 0, 1]),
-		TestElem([0, 0, 0, 2]),
-		TestElem([0, 0, 0, 3]),
-		TestElem([0, 0, 0, 4]),
-		TestElem([0, 0, 0, 5]),
-	];
-	let mut backend = VecBackend::new_hash_only();
-	let mut pmmr = PMMR::new(&mut backend);
-	for x in &elems {
-		pmmr.push(x).unwrap();
-	}
-	assert_eq!(
-		vec![0, 1, 2, 3, 4],
-		pmmr.leaf_idx_iter(0).collect::<Vec<_>>()
-	);
-	assert_eq!(
-		vec![1, 2, 4, 5, 8],
-		pmmr.leaf_pos_iter().collect::<Vec<_>>()
-	);
-}
+// #[test]
+// fn leaf_pos_and_idx_iter_hash_only_test() {
+// 	let elems = [
+// 		TestElem([0, 0, 0, 1]),
+// 		TestElem([0, 0, 0, 2]),
+// 		TestElem([0, 0, 0, 3]),
+// 		TestElem([0, 0, 0, 4]),
+// 		TestElem([0, 0, 0, 5]),
+// 	];
+// 	let mut backend = VecBackend::new_hash_only();
+// 	let mut pmmr = PMMR::new(&mut backend);
+// 	for x in &elems {
+// 		pmmr.push(x).unwrap();
+// 	}
+// 	assert_eq!(
+// 		vec![0, 1, 2, 3, 4],
+// 		pmmr.leaf_idx_iter(0).collect::<Vec<_>>()
+// 	);
+// 	assert_eq!(
+// 		vec![1, 2, 4, 5, 8],
+// 		pmmr.leaf_pos_iter().collect::<Vec<_>>()
+// 	);
+// }

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -48,7 +48,7 @@ where
 	let key_id = keychain::ExtKeychain::derive_key_id(1, 0, 0, 0, 0);
 	let reward = reward::output(keychain, &ProofBuilder::new(keychain), &key_id, 0, false).unwrap();
 
-	genesis::genesis_dev().with_reward(reward.0, reward.1)
+	genesis::genesis_dev_with_reward(reward.0, reward.1)
 }
 
 pub fn init_chain(dir_name: &str, genesis: Block) -> Chain {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -352,8 +352,8 @@ where
 
 		let max_height = self.chain().header_head()?.height;
 
-		let header_pmmr = self.chain().header_pmmr();
-		let header_pmmr = header_pmmr.read();
+		// let header_pmmr = self.chain().header_pmmr();
+		// let header_pmmr = header_pmmr.read();
 
 		// looks like we know one, getting as many following headers as allowed
 		let hh = header.height;
@@ -363,7 +363,7 @@ where
 				break;
 			}
 
-			if let Ok(hash) = header_pmmr.get_header_hash_by_height(h) {
+			if let Ok(hash) = self.chain().get_header_hash_by_height(h) {
 				let header = self.chain().get_block_header(&hash)?;
 				headers.push(header);
 			} else {
@@ -599,12 +599,12 @@ where
 
 	// Find the first locator hash that refers to a known header on our main chain.
 	fn find_common_header(&self, locator: &[Hash]) -> Option<BlockHeader> {
-		let header_pmmr = self.chain().header_pmmr();
-		let header_pmmr = header_pmmr.read();
+		// let header_pmmr = self.chain().header_pmmr();
+		// let header_pmmr = header_pmmr.read();
 
 		for hash in locator {
 			if let Ok(header) = self.chain().get_block_header(&hash) {
-				if let Ok(hash_at_height) = header_pmmr.get_header_hash_by_height(header.height) {
+				if let Ok(hash_at_height) = self.chain().get_header_hash_by_height(header.height) {
 					if let Ok(header_at_height) = self.chain().get_block_header(&hash_at_height) {
 						if header.hash() == header_at_height.hash() {
 							return Some(header);

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -68,22 +68,15 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Add the new leaf pos to our leaf_set if this is a prunable MMR.
 	#[allow(unused_variables)]
 	fn append(&mut self, hashes: &[Hash]) -> Result<(), String> {
-		// let size = self
-		// 	.data_file
-		// 	.append(&data.as_elmt())
-		// 	.map_err(|e| format!("Failed to append data to file. {}", e))?;
-
-		self.hash_file
+		let root = self
+			.hash_file
 			.extend_from_slice(hashes)
 			.map_err(|e| format!("Failed to append hash to file. {}", e))?;
 
+		// Find the leaf pos based on the last subtree added.
+		let pos = pmmr::bintree_rightmost(root);
+
 		if self.prunable {
-			// // (Re)calculate the latest pos given updated size of data file
-			// // and the total leaf_shift, and add to our leaf_set.
-			// let pos = pmmr::insertion_to_pmmr_index(size + self.prune_list.get_total_leaf_shift());
-
-			let pos = self.unpruned_size() + 1;
-
 			self.leaf_set.add(pos);
 		}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -78,15 +78,11 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			.map_err(|e| format!("Failed to append hash to file. {}", e))?;
 
 		if self.prunable {
-			panic!(
-				"if we are appending a single elmt here then we can use last_pos to determine pos"
-			);
-
 			// // (Re)calculate the latest pos given updated size of data file
 			// // and the total leaf_shift, and add to our leaf_set.
 			// let pos = pmmr::insertion_to_pmmr_index(size + self.prune_list.get_total_leaf_shift());
 
-			let pos = 0;
+			let pos = self.unpruned_size() + 1;
 
 			self.leaf_set.add(pos);
 		}

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -73,8 +73,8 @@ fn pmmr_append() {
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 
 			assert_eq!(pmmr.n_unpruned_leaves(), 4);
-			assert_eq!(pmmr.get_data(1), Some(elems[0]));
-			assert_eq!(pmmr.get_data(2), Some(elems[1]));
+			// assert_eq!(pmmr.get_data(1), Some(elems[0]));
+			// assert_eq!(pmmr.get_data(2), Some(elems[1]));
 
 			assert_eq!(pmmr.get_hash(1), Some(pos_0));
 			assert_eq!(pmmr.get_hash(2), Some(pos_1));
@@ -967,13 +967,13 @@ impl DefaultHashable for TestElem {}
 impl PMMRable for TestElem {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		self.clone()
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	self.clone()
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		Some(4)
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	Some(4)
+	// }
 }
 
 impl Writeable for TestElem {

--- a/store/tests/segment.rs
+++ b/store/tests/segment.rs
@@ -392,13 +392,13 @@ impl DefaultHashable for TestElem {}
 impl PMMRable for TestElem {
 	type E = Self;
 
-	fn as_elmt(&self) -> Self::E {
-		*self
-	}
+	// fn as_elmt(&self) -> Self::E {
+	// 	*self
+	// }
 
-	fn elmt_size() -> Option<u16> {
-		Some(16)
-	}
+	// fn elmt_size() -> Option<u16> {
+	// 	Some(16)
+	// }
 }
 
 impl Writeable for TestElem {


### PR DESCRIPTION
Deprecate the (P)MMR data file (and size file) and store (leaf) data in the database.
This PR reworks the PMMR backend data strcutures to _only_ store the hash file on disk.
Everything else is pushed into the db (indexed by MMR pos).

Very much still an experimental WIP.

Outputs, rangeproofs and kernels -
* store entries in the db indexed by MMR pos (per leaf) `pos -> output`
* existing index still maps output commitment to output pos etc. `commitment -> pos`
* `commitment -> pos -> output`

Headers - 
* already store headers in the db indexed by hash `hash -> header`
* store new index mapping `height -> hash`
* `height -> hash -> header`

----

TODO

- [ ] get chain crate tests passing
- [ ] get other tests passing
- [ ] cleanup all the commented out code
- [ ] lots of missing docs on new fns etc.
- [ ] migration process for existing node 
  - [ ] populate the db on startup if missing if required
- [ ] handle receiving txhashset state sync
  - [ ] given a raw "data file" and a `prune_list` we can sequentially read leaf data for all unpruned leaf pos
- [ ] handle providing txhashset state sync (need to recreate data files from db etc.) 
  - [ ] iterate over unpruned leaf data in db and write bytes to "data file" when constructing `txhashset.zip`
  - [ ] `txhashset.zip` is cached every 720 blocks so we can take advantage of this to mitigate extra cost here 
  - [ ] consider not supporting state sync initially (no `TXHASHSET_HIST` capabilities)

