### PR TITLE
fix for missing increment of stratum stats blocks_found

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -439,6 +439,7 @@ impl Handler {
 			share_is_block = true;
 			self.workers
 				.update_stats(worker_id, |worker_stats| worker_stats.num_blocks_found += 1);
+			self.workers.stratum_stats.write().blocks_found += 1;
 			// Log message to make it obvious we found a block
 			let stats = self.workers.get_stats(worker_id)?;
 			warn!(


### PR DESCRIPTION
Previous change is missing code to increment the stratum server stats when a worker finds a block.

I had originally planned to just add up all the worker blocks found in the tui code but then I thought that would break if somebody wanted to ever do cleanup on the worker list.  So instead I added a count to the StratumStats class...but then never added the code to increment it.