### PR TITLE
Defork croaring

### DIFF
--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -4,7 +4,7 @@ steps:
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |
       cargo clean
-      ROARING_ARCH=nehalem
+      ROARING_ARCH=x86-64-v2
       cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))

--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -2,7 +2,10 @@ steps:
   - script: 'cargo test --all'
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo build --release'
+  - script: |
+      cargo clean
+      ROARING_ARCH=nehalem
+      cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,6 +1,9 @@
 steps:
   - script: |
-      refreshenv && cargo test --all
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
   - script: 'cargo test --all'

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -3,12 +3,13 @@ steps:
       refreshenv
       LIBCLANG_PATH=C:\Program Files\LLVM\lib
       LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
       cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
-  - script: 'cargo test --all'
+  - script: 'ROARING_ARCH=x86-64-v2 cargo test --all'
     displayName: macOS Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Darwin' ), eq( variables['CI_JOB'], 'test-all' ))
-  - script: '.ci/general-jobs'
+  - script: 'ROARING_ARCH=x86-64-v2 .ci/general-jobs'
     displayName: Linux Cargo Test
     condition: eq( variables['Agent.OS'], 'Linux' )

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -3,13 +3,16 @@ steps:
       refreshenv
       LIBCLANG_PATH=C:\Program Files\LLVM\lib
       LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
       cargo test --all
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |
+      cargo clean
       refreshenv
       LIBCLANG_PATH=C:\Program Files\LLVM\lib
       LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
       cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,10 +1,16 @@
 steps:
   - script: |
-      refreshenv && cargo test --all
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      cargo test --all
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |
-      refreshenv && cargo build --release
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
 dependencies = [
  "getrandom 0.2.2",
  "once_cell",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -147,16 +147,15 @@ checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags 1.2.1",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.8.3",
  "lazy_static",
  "lazycell",
  "log",
@@ -275,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -308,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
  "libc",
@@ -374,21 +373,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "croaring-mw"
-version = "0.4.5"
+name = "croaring"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdee571ce4bf3e49c382de29c38bd33b9fa871e1358c7749b9dcc5dc2776221"
+checksum = "a00d14ad7d8cc067d7a5c93e8563791bfec3f7182361db955530db11d94ed63c"
 dependencies = [
  "byteorder",
- "croaring-sys-mw",
+ "croaring-sys",
  "libc",
 ]
 
 [[package]]
-name = "croaring-sys-mw"
-version = "0.4.5"
+name = "croaring-sys"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea52c177269fa54c526b054dac8e623721de18143ebfd2ea84ffc023d6c271ee"
+checksum = "c5d6a46501bb403a61e43bc7cd19977b4f9c54efd703949b00259cc61afb5a86"
 dependencies = [
  "bindgen",
  "cc",
@@ -658,7 +657,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -986,9 +998,9 @@ dependencies = [
  "bitflags 1.2.1",
  "byteorder",
  "chrono",
- "croaring-mw",
+ "croaring",
  "enum_primitive",
- "env_logger",
+ "env_logger 0.7.1",
  "failure",
  "failure_derive",
  "grin_core",
@@ -1027,7 +1039,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "croaring-mw",
+ "croaring",
  "enum_primitive",
  "failure",
  "failure_derive",
@@ -1158,8 +1170,8 @@ version = "5.1.0-alpha.1"
 dependencies = [
  "byteorder",
  "chrono",
- "croaring-mw",
- "env_logger",
+ "croaring",
+ "env_logger 0.7.1",
  "failure",
  "failure_derive",
  "filetime",
@@ -1289,6 +1301,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1468,11 +1486,11 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi 0.3.8",
 ]
 
@@ -1541,7 +1559,7 @@ dependencies = [
  "chrono",
  "flate2",
  "fnv",
- "humantime",
+ "humantime 1.3.0",
  "libc",
  "log",
  "log-mdc",
@@ -1709,12 +1727,12 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
- "version_check 0.1.5",
+ "version_check",
 ]
 
 [[package]]
@@ -2999,12 +3017,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = "1"
 byteorder = "1"
 failure = "0.1"
 failure_derive = "0.1"
-croaring = { version = "0.4.5", package = "croaring-mw", features = ["compat"] }
+croaring = "0.4.6"
 enum_primitive = "0.1"
 log = "0.4"
 serde = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 blake2 = { package = "blake2-rfc", version = "0.2"}
 byteorder = "1"
-croaring = { version = "0.4.5", package = "croaring-mw", features = ["compat"] }
+croaring = "0.4.6"
 enum_primitive = "0.1"
 failure = "0.1"
 failure_derive = "0.1"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1"
-croaring = { version = "0.4.5", package = "croaring-mw", features = ["compat"] }
+croaring = "0.4.6"
 libc = "0.2"
 failure = "0.1"
 failure_derive = "0.1"


### PR DESCRIPTION
Replace [mimblewimble/croaring-rs](https://github.com/mimblewimble/croaring-rs) / `croaring-mw` fork with upstream while ensuring no new AVX/AVX2 instructions are added in release builds.

Bumps the effective version of `croaring-rs` from 0.4.4 to 0.4.6. ([details](https://github.com/mimblewimble/grin/pull/3596#issuecomment-803197975))

Unblocks:
- https://github.com/mimblewimble/grin/issues/3545 - Support Apple Silicon
- https://github.com/mimblewimble/grin-wallet/issues/571 - Support Apple Silicon
- https://github.com/mimblewimble/grin-wallet/issues/479 - Build error when targeting Apple iOS for grin-wallet

Motivation: We want to update `croaring-rs` to unblock the above issues, and at the same time, the upstream merge of https://github.com/saulius/croaring-rs/pull/62 makes our fork unnecessary. See comments in #3545 for comments on why we originally forked.

## Verification

`cargo test --all` passes locally.

Verification of no new AVX/AVX2 instructions, using Intel XED from http://www.intel.com/software/xed:

```
git clone https://github.com/intelxed/xed.git
cd xed
./mfile.py examples install
cp kits/xed-install-base-2021-03-17-mac-x86-64/bin/xed /usr/local/bin/xed
```

```
$ cargo clean && cargo build --release
$ /usr/local/bin/xed -i target/release/grin > native-disasm
$ grep -c SSE2 native-disasm
22479
$ grep -c AVX native-disasm
4380
$ grep -c AVX2 native-disasm
1192

$ cargo clean && ROARING_ARCH=nehalem cargo build --release
$ /usr/local/bin/xed -i target/release/grin > nehalem-disasm
$ grep -c SSE2 nehalem-disasm 
22794
$ grep -c AVX nehalem-disasm
2505
$ grep -c AVX2 nehalem-disasm
570

$ cargo clean && ROARING_ARCH=x86-64-v2 cargo build --release
$ /usr/local/bin/xed -i target/release/grin > x86-64-v2-disasm
$ grep -c SSE2 x86-64-v2-disasm 
23235
$ grep -c AVX x86-64-v2-disasm
2505
$ grep -c AVX2 x86-64-v2-disasm
570

$ wget https://github.com/mimblewimble/grin/releases/download/v5.0.1/grin-v5.0.1-macos.tar.gz 
$ tar xzf grin-v5.0.1-macos.tar.gz
$ /usr/local/bin/xed -i grin/grin > release-disasm
$ grep -c SSE2 release-disasm
22908
$ grep -c AVX release-disasm 
2505
$ grep -c AVX2 release-disasm
570
```

I'm not sure where these other AVX instructions are coming from if the existing release is tested to function as we expect. It's possible they're behind runtime checks.