### PR TITLE
rewind bad headers, ban on explicit bad headers

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -230,6 +230,9 @@ impl Chain {
 		// Suppress any errors here in case we cannot find
 		chain.rewind_bad_block()?;
 
+		let header_head = chain.header_head()?;
+		chain.rebuild_sync_mmr(&header_head)?;
+
 		chain.log_heads()?;
 
 		// Temporarily exercising the initialization process.
@@ -349,9 +352,6 @@ impl Chain {
 					}
 
 					batch.commit()?;
-
-					// Make sure teh "sync mmr" reflects the updated header_head.
-					self.rebuild_sync_mmr(&new_head)?;
 				}
 			}
 		}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -277,6 +277,11 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Delete a block header.
+	pub fn delete_block_header(&self, h: &Hash) -> Result<(), Error> {
+		self.db.delete(&to_key(BLOCK_HEADER_PREFIX, h)[..])
+	}
+
 	/// Save block header to db.
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
 		let hash = header.hash();

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -850,8 +850,11 @@ where
 	// Use underlying MMR to determine the "head".
 	let head = match handle.head_hash() {
 		Ok(hash) => {
-			let header = child_batch.get_block_header(&hash)?;
-			Tip::from_header(&header)
+			if let Ok(header) = child_batch.get_block_header(&hash) {
+				Tip::from_header(&header)
+			} else {
+				Tip::default()
+			}
 		}
 		Err(_) => Tip::default(),
 	};


### PR DESCRIPTION
* validate against explicit list of bad headers
* rewind both `header_head` and `head` if bad block on current chain

