### PR TITLE
[DNM] Revert "Removing verifier caches (#3597)"

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1246,23 +1246,42 @@ impl TransactionBody {
 	pub fn validate(
 		&self,
 		weighting: Weighting,
-		_verifier: Arc<RwLock<dyn VerifierCache>>,
+		verifier: Arc<RwLock<dyn VerifierCache>>,
 	) -> Result<(), Error> {
 		self.validate_read(weighting)?;
 
+		// Find all the outputs that have not had their rangeproofs verified.
+		let outputs = {
+			let mut verifier = verifier.write();
+			verifier.filter_rangeproof_unverified(&self.outputs)
+		};
+
 		// Now batch verify all those unverified rangeproofs
-		if !self.outputs.is_empty() {
+		if !outputs.is_empty() {
 			let mut commits = vec![];
 			let mut proofs = vec![];
-			for x in &self.outputs {
+			for x in &outputs {
 				commits.push(x.commitment());
 				proofs.push(x.proof);
 			}
 			Output::batch_verify_proofs(&commits, &proofs)?;
 		}
 
+		// Find all the kernels that have not yet been verified.
+		let kernels = {
+			let mut verifier = verifier.write();
+			verifier.filter_kernel_sig_unverified(&self.kernels)
+		};
+
 		// Verify the unverified tx kernels.
-		TxKernel::batch_sig_verify(&self.kernels)?;
+		TxKernel::batch_sig_verify(&kernels)?;
+
+		// Cache the successful verification results for the new outputs and kernels.
+		{
+			let mut verifier = verifier.write();
+			verifier.add_rangeproof_verified(outputs);
+			verifier.add_kernel_sig_verified(kernels);
+		}
 		Ok(())
 	}
 }


### PR DESCRIPTION
This reverts commit 87ff219d37b59c8e3cd8ab7f8629af4b9fd12dd1.

Per discussion with @antiochp. To be followed by a separate PR that fixes the cache keys.