### PR TITLE
client invalidateheader and resetchainhead

### DIFF
--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -87,6 +87,12 @@ impl ChainResetHandler {
 		w(&self.sync_state)?.reset();
 		Ok(())
 	}
+
+	pub fn invalidate_header(&self, hash: Hash) -> Result<(), Error> {
+		let chain = w(&self.chain)?;
+		chain.invalidate_header(hash)?;
+		Ok(())
+	}
 }
 
 /// Chain compaction handler. Trigger a compaction of the chain state to regain

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -14,7 +14,7 @@
 
 use super::utils::{get_output, get_output_v2, w};
 use crate::chain;
-use crate::core::core::hash::Hashed;
+use crate::core::core::hash::{Hash, Hashed};
 use crate::rest::*;
 use crate::router::{Handler, ResponseFuture};
 use crate::types::*;
@@ -69,6 +69,16 @@ impl Handler for ChainValidationHandler {
 				format!("validate failed: {}", e),
 			),
 		}
+	}
+}
+
+pub struct ChainResetHandler {
+	pub chain: Weak<chain::Chain>,
+}
+
+impl ChainResetHandler {
+	pub fn reset_chain_head(&self, hash: Hash) -> Result<(), Error> {
+		unimplemented!()
 	}
 }
 

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -78,7 +78,10 @@ pub struct ChainResetHandler {
 
 impl ChainResetHandler {
 	pub fn reset_chain_head(&self, hash: Hash) -> Result<(), Error> {
-		unimplemented!()
+		let chain = w(&self.chain)?;
+		let header = chain.get_block_header(&hash)?;
+		chain.reset_chain_head(&header)?;
+		Ok(())
 	}
 }
 
@@ -91,9 +94,9 @@ pub struct ChainCompactHandler {
 
 impl ChainCompactHandler {
 	pub fn compact_chain(&self) -> Result<(), Error> {
-		w(&self.chain)?
-			.compact()
-			.map_err(|_| ErrorKind::Internal("chain error".to_owned()).into())
+		let chain = w(&self.chain)?;
+		chain.compact()?;
+		Ok(())
 	}
 }
 

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -74,6 +74,7 @@ impl Handler for ChainValidationHandler {
 
 pub struct ChainResetHandler {
 	pub chain: Weak<chain::Chain>,
+	pub sync_state: Weak<chain::SyncState>,
 }
 
 impl ChainResetHandler {
@@ -81,6 +82,9 @@ impl ChainResetHandler {
 		let chain = w(&self.chain)?;
 		let header = chain.get_block_header(&hash)?;
 		chain.reset_chain_head(&header)?;
+
+		// Reset the sync status and clear out any sync error.
+		w(&self.sync_state)?.reset();
 		Ok(())
 	}
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -179,7 +179,8 @@ impl Owner {
 	}
 
 	pub fn reset_chain_head(&self, hash: String) -> Result<(), Error> {
-		let hash = Hash::from_hex(&hash).map_err(|_| ErrorKind::RequestError("wat".into()))?;
+		let hash = Hash::from_hex(&hash)
+			.map_err(|_| ErrorKind::RequestError("invalid header hash".into()))?;
 		let handler = ChainResetHandler {
 			chain: self.chain.clone(),
 		};

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -178,7 +178,8 @@ impl Owner {
 		peer_handler.unban_peer(addr)
 	}
 
-	pub fn reset_chain_head(&self, hash: Hash) -> Result<(), Error> {
+	pub fn reset_chain_head(&self, hash: String) -> Result<(), Error> {
+		let hash = Hash::from_hex(&hash).map_err(|_| ErrorKind::RequestError("wat".into()))?;
 		let handler = ChainResetHandler {
 			chain: self.chain.clone(),
 		};

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -118,6 +118,16 @@ impl Owner {
 		handler.reset_chain_head(hash)
 	}
 
+	pub fn invalidate_header(&self, hash: String) -> Result<(), Error> {
+		let hash = Hash::from_hex(&hash)
+			.map_err(|_| ErrorKind::RequestError("invalid header hash".into()))?;
+		let handler = ChainResetHandler {
+			chain: self.chain.clone(),
+			sync_state: self.sync_state.clone(),
+		};
+		handler.invalidate_header(hash)
+	}
+
 	/// Retrieves information about stored peers.
 	/// If `None` is provided, will list all stored peers.
 	///

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -15,7 +15,8 @@
 //! Owner API External Definition
 
 use crate::chain::{Chain, SyncState};
-use crate::handlers::chain_api::{ChainCompactHandler, ChainValidationHandler};
+use crate::core::core::hash::Hash;
+use crate::handlers::chain_api::{ChainCompactHandler, ChainResetHandler, ChainValidationHandler};
 use crate::handlers::peers_api::{PeerHandler, PeersConnectedHandler};
 use crate::handlers::server_api::StatusHandler;
 use crate::p2p::types::PeerInfoDisplay;
@@ -175,5 +176,12 @@ impl Owner {
 			peers: self.peers.clone(),
 		};
 		peer_handler.unban_peer(addr)
+	}
+
+	pub fn reset_chain_head(&self, hash: Hash) -> Result<(), Error> {
+		let handler = ChainResetHandler {
+			chain: self.chain.clone(),
+		};
+		handler.reset_chain_head(hash)
 	}
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -108,6 +108,16 @@ impl Owner {
 		chain_compact_handler.compact_chain()
 	}
 
+	pub fn reset_chain_head(&self, hash: String) -> Result<(), Error> {
+		let hash = Hash::from_hex(&hash)
+			.map_err(|_| ErrorKind::RequestError("invalid header hash".into()))?;
+		let handler = ChainResetHandler {
+			chain: self.chain.clone(),
+			sync_state: self.sync_state.clone(),
+		};
+		handler.reset_chain_head(hash)
+	}
+
 	/// Retrieves information about stored peers.
 	/// If `None` is provided, will list all stored peers.
 	///
@@ -176,14 +186,5 @@ impl Owner {
 			peers: self.peers.clone(),
 		};
 		peer_handler.unban_peer(addr)
-	}
-
-	pub fn reset_chain_head(&self, hash: String) -> Result<(), Error> {
-		let hash = Hash::from_hex(&hash)
-			.map_err(|_| ErrorKind::RequestError("invalid header hash".into()))?;
-		let handler = ChainResetHandler {
-			chain: self.chain.clone(),
-		};
-		handler.reset_chain_head(hash)
 	}
 }

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -133,7 +133,7 @@ pub trait OwnerRpc: Sync + Send {
 	 */
 	fn compact_chain(&self) -> Result<(), ErrorKind>;
 
-	fn reset_chain_head(&self, hash: Hash) -> Result<(), ErrorKind>;
+	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::get_peers](struct.Owner.html#method.get_peers).
@@ -366,6 +366,10 @@ impl OwnerRpc for Owner {
 		Owner::validate_chain(self).map_err(|e| e.kind().clone())
 	}
 
+	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind> {
+		Owner::reset_chain_head(self, hash).map_err(|e| e.kind().clone())
+	}
+
 	fn compact_chain(&self) -> Result<(), ErrorKind> {
 		Owner::compact_chain(self).map_err(|e| e.kind().clone())
 	}
@@ -384,10 +388,6 @@ impl OwnerRpc for Owner {
 
 	fn unban_peer(&self, addr: SocketAddr) -> Result<(), ErrorKind> {
 		Owner::unban_peer(self, addr).map_err(|e| e.kind().clone())
-	}
-
-	fn reset_chain_head(&self, hash: Hash) -> Result<(), ErrorKind> {
-		Owner::reset_chain_head(self, hash).map_err(|e| e.kind().clone())
 	}
 }
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -14,7 +14,6 @@
 
 //! JSON-RPC Stub generation for the Owner API
 
-use crate::core::core::hash::Hash;
 use crate::owner::Owner;
 use crate::p2p::types::PeerInfoDisplay;
 use crate::p2p::PeerData;

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -14,6 +14,7 @@
 
 //! JSON-RPC Stub generation for the Owner API
 
+use crate::core::core::hash::Hash;
 use crate::owner::Owner;
 use crate::p2p::types::PeerInfoDisplay;
 use crate::p2p::PeerData;
@@ -131,6 +132,8 @@ pub trait OwnerRpc: Sync + Send {
 	```
 	 */
 	fn compact_chain(&self) -> Result<(), ErrorKind>;
+
+	fn reset_chain_head(&self, hash: Hash) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::get_peers](struct.Owner.html#method.get_peers).
@@ -382,6 +385,10 @@ impl OwnerRpc for Owner {
 	fn unban_peer(&self, addr: SocketAddr) -> Result<(), ErrorKind> {
 		Owner::unban_peer(self, addr).map_err(|e| e.kind().clone())
 	}
+
+	fn reset_chain_head(&self, hash: Hash) -> Result<(), ErrorKind> {
+		Owner::reset_chain_head(self, hash).map_err(|e| e.kind().clone())
+	}
 }
 
 #[doc(hidden)]
@@ -391,7 +398,7 @@ macro_rules! doctest_helper_json_rpc_owner_assert_response {
 		// create temporary grin server, run jsonrpc request on node api, delete server, return
 		// json response.
 
-		{
+			{
 			/*use grin_servers::test_framework::framework::run_doctest;
 			use grin_util as util;
 			use serde_json;
@@ -425,6 +432,6 @@ macro_rules! doctest_helper_json_rpc_owner_assert_response {
 					serde_json::to_string_pretty(&expected_response).unwrap()
 				);
 				}*/
-		}
+			}
 	};
 }

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -134,6 +134,8 @@ pub trait OwnerRpc: Sync + Send {
 
 	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind>;
 
+	fn invalidate_header(&self, hash: String) -> Result<(), ErrorKind>;
+
 	/**
 	Networked version of [Owner::get_peers](struct.Owner.html#method.get_peers).
 
@@ -367,6 +369,10 @@ impl OwnerRpc for Owner {
 
 	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind> {
 		Owner::reset_chain_head(self, hash).map_err(|e| e.kind().clone())
+	}
+
+	fn invalidate_header(&self, hash: String) -> Result<(), ErrorKind> {
+		Owner::invalidate_header(self, hash).map_err(|e| e.kind().clone())
 	}
 
 	fn compact_chain(&self) -> Result<(), ErrorKind> {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -225,12 +225,14 @@ impl Chain {
 	/// Reset both head and header_head to the provided header.
 	/// Handles simple rewind and more complex fork scenarios.
 	/// Used by the reset_chain_head owner api endpoint.
-	pub fn reset_chain_head(&self, header: &BlockHeader) -> Result<(), Error> {
-		let head = Tip::from_header(header);
+	pub fn reset_chain_head<T: Into<Tip>>(&self, head: T) -> Result<(), Error> {
+		let head = head.into();
 
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		let mut batch = self.store.batch()?;
+
+		let header = batch.get_block_header(&head.hash())?;
 
 		// Rewind and reapply headers to reset the header MMR
 		txhashset::header_extending(&mut header_pmmr, &mut batch, |ext, batch| {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -304,8 +304,8 @@ impl Chain {
 	) -> BlockStatus {
 		// If head is updated then we are either "next" block or we just experienced a "reorg" to new head.
 		// Otherwise this is a "fork" off the main chain.
-		if let Some(head) = head {
-			if head.prev_block_h == prev_head.last_block_h {
+		if head.is_some() {
+			if self.is_on_current_chain(prev_head).is_ok() {
 				BlockStatus::Next { prev }
 			} else {
 				BlockStatus::Reorg {
@@ -1432,9 +1432,10 @@ impl Chain {
 	/// Verifies the given block header is actually on the current chain.
 	/// Checks the header_by_height index to verify the header is where we say
 	/// it is
-	pub fn is_on_current_chain(&self, header: &BlockHeader) -> Result<(), Error> {
-		let chain_header = self.get_header_by_height(header.height)?;
-		if chain_header.hash() == header.hash() {
+	pub fn is_on_current_chain<T: Into<Tip>>(&self, t: T) -> Result<(), Error> {
+		let tip: Tip = t.into();
+		let chain_header = self.get_header_by_height(tip.height)?;
+		if chain_header.hash() == tip.hash() {
 			Ok(())
 		} else {
 			Err(ErrorKind::Other("not on current chain".to_string()).into())

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -468,9 +468,15 @@ impl Chain {
 		header_pmmr: &'a mut txhashset::PMMRHandle<BlockHeader>,
 		txhashset: &'a mut txhashset::TxHashSet,
 	) -> Result<pipe::BlockContext<'a>, Error> {
+		// TODO - track "denylist" in current chain instance (interact via api)
+		let denylist = vec![];
+
 		Ok(pipe::BlockContext {
 			opts,
 			pow_verifier: self.pow_verifier,
+			header_invalidated: Box::new(move |header| {
+				pipe::validate_header_denylist(header, &denylist)
+			}),
 			header_pmmr,
 			txhashset,
 			batch,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -807,8 +807,6 @@ where
 {
 	let batch = store.batch()?;
 
-	// Note: Extending either the sync_head or header_head MMR here.
-	// Use underlying MMR to determine the "head".
 	let head = match handle.head_hash() {
 		Ok(hash) => {
 			let header = batch.get_block_header(&hash)?;
@@ -845,8 +843,6 @@ where
 	// index saving can be undone
 	let child_batch = batch.child()?;
 
-	// Note: Extending either the sync_head or header_head MMR here.
-	// Use underlying MMR to determine the "head".
 	let head = match handle.head_hash() {
 		Ok(hash) => {
 			let header = child_batch.get_block_header(&hash)?;

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -363,6 +363,23 @@ impl Tip {
 	}
 }
 
+impl From<BlockHeader> for Tip {
+	fn from(header: BlockHeader) -> Self {
+		Self::from(&header)
+	}
+}
+
+impl From<&BlockHeader> for Tip {
+	fn from(header: &BlockHeader) -> Self {
+		Tip {
+			height: header.height,
+			last_block_h: header.hash(),
+			prev_block_h: header.prev_hash,
+			total_difficulty: header.total_difficulty(),
+		}
+	}
+}
+
 impl Hashed for Tip {
 	/// The hash of the underlying block.
 	fn hash(&self) -> Hash {
@@ -377,16 +394,6 @@ impl Default for Tip {
 			last_block_h: ZERO_HASH,
 			prev_block_h: ZERO_HASH,
 			total_difficulty: Difficulty::min_dma(),
-		}
-	}
-}
-impl From<&BlockHeader> for Tip {
-	fn from(header: &BlockHeader) -> Tip {
-		Tip {
-			height: header.height,
-			last_block_h: header.hash(),
-			prev_block_h: header.prev_hash,
-			total_difficulty: header.total_difficulty(),
 		}
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -134,6 +134,12 @@ impl SyncState {
 		}
 	}
 
+	/// Reset sync status to NoSync.
+	pub fn reset(&self) {
+		self.clear_sync_error();
+		self.update(SyncStatus::NoSync);
+	}
+
 	/// Whether the current state matches any active syncing operation.
 	/// Note: This includes our "initial" state.
 	pub fn is_syncing(&self) -> bool {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -139,9 +139,10 @@ where
 		peer_info: &PeerInfo,
 		opts: chain::Options,
 	) -> Result<bool, chain::Error> {
-		if self.chain().block_exists(b.hash())? {
+		if self.chain().is_known(&b.header).is_err() {
 			return Ok(true);
 		}
+
 		debug!(
 			"Received block {} at {} from {} [in/out/kern: {}/{}/{}] going to process.",
 			b.hash(),
@@ -160,9 +161,10 @@ where
 		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		// No need to process this compact block if we have previously accepted the _full block_.
-		if self.chain().block_exists(cb.hash())? {
+		if self.chain().is_known(&cb.header).is_err() {
 			return Ok(true);
 		}
+
 		let bhash = cb.hash();
 		debug!(
 			"Received compact_block {} at {} from {} [out/kern/kern_ids: {}/{}/{}] going to process.",

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -140,7 +140,13 @@ impl HTTPNodeClient {
 	}
 
 	pub fn invalidate_header(&self, hash: String) {
-		unimplemented!()
+		let mut e = term::stdout().unwrap();
+		let params = json!([hash]);
+		match self.send_json_request::<()>("invalidate_header", &params) {
+			Ok(_) => writeln!(e, "Successfully invalidated header: {}", hash).unwrap(),
+			Err(_) => writeln!(e, "Failed to invalidate header: {}", hash).unwrap(),
+		}
+		e.reset().unwrap();
 	}
 
 	pub fn ban_peer(&self, peer_addr: &SocketAddr) {
@@ -180,6 +186,10 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 		("resetchainhead", Some(args)) => {
 			let hash = args.value_of("hash").unwrap();
 			node_client.reset_chain_head(hash.to_string());
+		}
+		("invalidateheader", Some(args)) => {
+			let hash = args.value_of("hash").unwrap();
+			node_client.invalidate_header(hash.to_string());
 		}
 		("ban", Some(peer_args)) => {
 			let peer = peer_args.value_of("peer").unwrap();

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -129,6 +129,16 @@ impl HTTPNodeClient {
 		e.reset().unwrap();
 	}
 
+	pub fn reset_chain_head(&self, hash: String) {
+		let mut e = term::stdout().unwrap();
+		let params = json!([hash]);
+		match self.send_json_request::<()>("reset_chain_head", &params) {
+			Ok(_) => writeln!(e, "Successfully reset chain head {}", hash).unwrap(),
+			Err(_) => writeln!(e, "Failed to reset chain head {}", hash).unwrap(),
+		}
+		e.reset().unwrap();
+	}
+
 	pub fn ban_peer(&self, peer_addr: &SocketAddr) {
 		let mut e = term::stdout().unwrap();
 		let params = json!([peer_addr]);
@@ -162,6 +172,10 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 		}
 		("listconnectedpeers", Some(_)) => {
 			node_client.list_connected_peers();
+		}
+		("resetchainhead", Some(args)) => {
+			let hash = args.value_of("hash").unwrap();
+			node_client.reset_chain_head(hash.to_string());
 		}
 		("ban", Some(peer_args)) => {
 			let peer = peer_args.value_of("peer").unwrap();

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -139,6 +139,10 @@ impl HTTPNodeClient {
 		e.reset().unwrap();
 	}
 
+	pub fn invalidate_header(&self, hash: String) {
+		unimplemented!()
+	}
+
 	pub fn ban_peer(&self, peer_addr: &SocketAddr) {
 		let mut e = term::stdout().unwrap();
 		let params = json!([peer_addr]);

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -72,3 +72,9 @@ subcommands:
                   long: peer
                   required: true
                   takes_value: true
+        - resetchainhead:
+            about: Resets the local chain head
+            args:
+                - hash:
+                    help: The header hash to reset to
+                    required: true

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -78,3 +78,9 @@ subcommands:
                 - hash:
                     help: The header hash to reset to
                     required: true
+        - invalidateheader:
+            about: Adds header hash to denylist
+            args:
+                - hash:
+                    help: The header hash to invalidate
+                    required: true


### PR DESCRIPTION
Resolves #3607

----

Experimenting with a different approach here to resolving the various issues around sync and how it interacts with a chain fork.

This PR adds an endpoint and handler for `resetchainhead` via the owner api.

This will take a block hash and will do something roughly along the following lines -

* check the header being reset to is indeed present in the local db
* reset `header_head` to the existing `head` via "rewind and reapply" on the header extension
* then reset `head` (and `header_head` consistently) via "rewind and reapply" on txhashset extension (full blocks)

The _should_ result in the ability to arbitrarily "rewind" or "reset" to an alternative block header.

Rather than trying to resolve all edge cases related to sync I'm proposing it makes more sense to have additional flexibility and allow a node operator to "manually" work around a fork via this api endpoint.

If we can get this working robustly then there is an additional api endpoint that could be added - 
* `invalidateheader`

These could be used together to invalidate one chain fork and then reset the local chain to a header on an alternative fork.
I believe these would allow most fork scenarios to be recovered from reasonably gracefully albeit manually.

If this approach works _then_ we may consider extending this and doing the "reset" in a more automated fashion without api involvement.

----

Non-archival node should be able to "reset" to prior to the horizon by -
* remove recent full blocks from db (effectively all blocks, horizon onwards)
* reset `head` (and `tail`)
* truncate the MMR structures
* force a state sync

This would potentially be a convenient way of retaining headers (up to reset point) locally while still resyncing state.

----

TODO

- [x] error checking and basic validation (make sure its actually a hash)
- [x] user feedback - success/failure messages (jsonrpc issues?)
- [x] "can we rewind beyond horizon"
  - [x] For a full archival node - need to confirm but technically possible?
  - [x] For non-archival node see above (for now this is prevented and full resync is required)
- [x] cleanup

