### PR TITLE
Clarify how pow hash are created

### DIFF
--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -317,8 +317,9 @@ impl ProofOfWork {
 /// nonces a.k.a. edge indices range from 0 to (1 << edge_bits) - 1
 ///
 /// The hash of the `Proof` is the hash of its packed nonces when serializing
-/// them at their exact bit size. The resulting bit sequence is padded to be
-/// byte-aligned.
+/// them (each nonce) at their exact bit size.
+/// The resulting bit sequence (for each nonce) is padded to be byte-aligned.
+/// The final packed bit sequence of all padded nonces is interpreted as
 ///
 #[derive(Clone, PartialOrd, PartialEq, Serialize)]
 pub struct Proof {

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -320,6 +320,7 @@ impl ProofOfWork {
 /// them (each nonce) at their exact bit size.
 /// The resulting bit sequence (for each nonce) is padded to be byte-aligned.
 /// The final packed bit sequence of all padded nonces is interpreted as
+/// little-endian and hashed using blake2b with 32-byte hex digest.
 ///
 #[derive(Clone, PartialOrd, PartialEq, Serialize)]
 pub struct Proof {


### PR DESCRIPTION
Enhance comment to provide details on how a proof of work hash is created from the list pof pow nonces