### PR TITLE
track sync_head on header_sync sync status

### DIFF
--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -79,11 +79,11 @@ fn sync_status_to_api(sync_status: SyncStatus) -> (String, Option<serde_json::Va
 		SyncStatus::NoSync => ("no_sync".to_string(), None),
 		SyncStatus::AwaitingPeers(_) => ("awaiting_peers".to_string(), None),
 		SyncStatus::HeaderSync {
-			current_height,
+			sync_head,
 			highest_height,
 		} => (
 			"header_sync".to_string(),
-			Some(json!({ "current_height": current_height, "highest_height": highest_height })),
+			Some(json!({ "current_height": sync_head.height, "highest_height": highest_height })),
 		),
 		SyncStatus::TxHashsetDownload(stats) => (
 			"txhashset_download".to_string(),

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -81,6 +81,7 @@ fn sync_status_to_api(sync_status: SyncStatus) -> (String, Option<serde_json::Va
 		SyncStatus::HeaderSync {
 			sync_head,
 			highest_height,
+			..
 		} => (
 			"header_sync".to_string(),
 			Some(json!({ "current_height": sync_head.height, "highest_height": highest_height })),

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -404,7 +404,7 @@ impl Chain {
 	/// Attempt to add new headers to the header chain (or fork).
 	/// This is only ever used during sync and is based on sync_head.
 	/// We update header_head here if our total work increases.
-	/// Returns the new sync_head (*not* not necessarily the header_head if on a fork).
+	/// Returns the new sync_head (may temporarily diverge from header_head when syncing a long fork).
 	pub fn sync_block_headers(
 		&self,
 		headers: &[BlockHeader],

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -404,19 +404,23 @@ impl Chain {
 	/// Attempt to add new headers to the header chain (or fork).
 	/// This is only ever used during sync and is based on sync_head.
 	/// We update header_head here if our total work increases.
-	pub fn sync_block_headers(&self, headers: &[BlockHeader], opts: Options) -> Result<(), Error> {
+	/// Returns the new sync_head (*not* not necessarily the header_head if on a fork).
+	pub fn sync_block_headers(
+		&self,
+		headers: &[BlockHeader],
+		sync_head: Tip,
+		opts: Options,
+	) -> Result<Option<Tip>, Error> {
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
+		let batch = self.store.batch()?;
 
 		// Sync the chunk of block headers, updating header_head if total work increases.
-		{
-			let batch = self.store.batch()?;
-			let mut ctx = self.new_ctx(opts, batch, &mut header_pmmr, &mut txhashset)?;
-			pipe::process_block_headers(headers, &mut ctx)?;
-			ctx.batch.commit()?;
-		}
+		let mut ctx = self.new_ctx(opts, batch, &mut header_pmmr, &mut txhashset)?;
+		let sync_head = pipe::process_block_headers(headers, sync_head, &mut ctx)?;
+		ctx.batch.commit()?;
 
-		Ok(())
+		Ok(sync_head)
 	}
 
 	/// Build a new block processing context.
@@ -1410,12 +1414,20 @@ impl Chain {
 	}
 
 	/// Gets multiple headers at the provided heights.
-	pub fn get_locator_hashes(&self, heights: &[u64]) -> Result<Vec<Hash>, Error> {
-		let pmmr = self.header_pmmr.read();
-		heights
-			.iter()
-			.map(|h| pmmr.get_header_hash_by_height(*h))
-			.collect()
+	/// Note: This is based on the provided sync_head to support syncing against a fork.
+	pub fn get_locator_hashes(&self, sync_head: Tip, heights: &[u64]) -> Result<Vec<Hash>, Error> {
+		let mut header_pmmr = self.header_pmmr.write();
+		txhashset::header_extending_readonly(&mut header_pmmr, &self.store(), |ext, batch| {
+			let header = batch.get_block_header(&sync_head.hash())?;
+			pipe::rewind_and_apply_header_fork(&header, ext, batch)?;
+
+			let hashes = heights
+				.iter()
+				.filter_map(|h| ext.get_header_hash_by_height(*h))
+				.collect();
+
+			Ok(hashes)
+		})
 	}
 
 	/// Builds an iterator on blocks starting from the current chain head and

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -915,6 +915,8 @@ impl<'a> HeaderExtension<'a> {
 		self.head.clone()
 	}
 
+	/// Get header hash by height.
+	/// Based on current header MMR.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Option<Hash> {
 		let pos = pmmr::insertion_to_pmmr_index(height + 1);
 		self.get_header_hash(pos)

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -52,8 +52,9 @@ pub enum SyncStatus {
 		/// current sync head
 		sync_head: Tip,
 		/// height of the most advanced peer
-		/// (would be useful if we could track the peer itself here)
 		highest_height: u64,
+		/// diff of the most advanced peer
+		highest_diff: Difficulty,
 	},
 	/// Downloading the various txhashsets
 	TxHashsetDownload(TxHashsetDownloadStats),

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -38,7 +38,7 @@ bitflags! {
 }
 
 /// Various status sync can be in, whether it's fast sync or archival.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
 pub enum SyncStatus {
 	/// Initial State (we do not yet know if we are/should be syncing)
 	Initial,
@@ -49,9 +49,10 @@ pub enum SyncStatus {
 	AwaitingPeers(bool),
 	/// Downloading block headers
 	HeaderSync {
-		/// current node height
-		current_height: u64,
+		/// current sync head
+		sync_head: Tip,
 		/// height of the most advanced peer
+		/// (would be useful if we could track the peer itself here)
 		highest_height: u64,
 	},
 	/// Downloading the various txhashsets
@@ -173,6 +174,17 @@ impl SyncState {
 			self.update_with_guard(new_status, status)
 		} else {
 			false
+		}
+	}
+
+	pub fn update_header_sync(&self, new_sync_head: Tip) {
+		let status: &mut SyncStatus = &mut self.current.write();
+		match status {
+			SyncStatus::HeaderSync { sync_head, .. } => {
+				debug!("update_header_sync: updating sync_head: {:?}", sync_head);
+				*sync_head = new_sync_head;
+			}
+			_ => (),
 		}
 	}
 
@@ -346,12 +358,7 @@ pub struct Tip {
 impl Tip {
 	/// Creates a new tip based on provided header.
 	pub fn from_header(header: &BlockHeader) -> Tip {
-		Tip {
-			height: header.height,
-			last_block_h: header.hash(),
-			prev_block_h: header.prev_hash,
-			total_difficulty: header.total_difficulty(),
-		}
+		header.into()
 	}
 }
 
@@ -369,6 +376,16 @@ impl Default for Tip {
 			last_block_h: ZERO_HASH,
 			prev_block_h: ZERO_HASH,
 			total_difficulty: Difficulty::min_dma(),
+		}
+	}
+}
+impl From<&BlockHeader> for Tip {
+	fn from(header: &BlockHeader) -> Tip {
+		Tip {
+			height: header.height,
+			last_block_h: header.hash(),
+			prev_block_h: header.prev_hash,
+			total_difficulty: header.total_difficulty(),
 		}
 	}
 }

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -178,11 +178,11 @@ impl SyncState {
 		}
 	}
 
+	/// Update sync_head if state is currently HeaderSync.
 	pub fn update_header_sync(&self, new_sync_head: Tip) {
 		let status: &mut SyncStatus = &mut self.current.write();
 		match status {
 			SyncStatus::HeaderSync { sync_head, .. } => {
-				debug!("update_header_sync: updating sync_head: {:?}", sync_head);
 				*sync_head = new_sync_head;
 			}
 			_ => (),

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -133,18 +133,21 @@ impl StateSync {
 						.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into()),
 				}
 
-				// to avoid the confusing log,
-				// update the final HeaderSync state mainly for 'current_height'
-				self.sync_state.update_if(
-					SyncStatus::HeaderSync {
-						current_height: header_head.height,
-						highest_height,
-					},
-					|s| match s {
-						SyncStatus::HeaderSync { .. } => true,
-						_ => false,
-					},
-				);
+				//
+				// TODO - is this still an issue?
+				//
+				// // to avoid the confusing log,
+				// // update the final HeaderSync state mainly for 'current_height'
+				// self.sync_state.update_if(
+				// 	SyncStatus::HeaderSync {
+				// 		sync_head: header_head.height,
+				// 		highest_height,
+				// 	},
+				// 	|s| match s {
+				// 		SyncStatus::HeaderSync { .. } => true,
+				// 		_ => false,
+				// 	},
+				// );
 
 				self.sync_state
 					.update(SyncStatus::TxHashsetDownload(Default::default()));

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -133,22 +133,6 @@ impl StateSync {
 						.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into()),
 				}
 
-				//
-				// TODO - is this still an issue?
-				//
-				// // to avoid the confusing log,
-				// // update the final HeaderSync state mainly for 'current_height'
-				// self.sync_state.update_if(
-				// 	SyncStatus::HeaderSync {
-				// 		sync_head: header_head.height,
-				// 		highest_height,
-				// 	},
-				// 	|s| match s {
-				// 		SyncStatus::HeaderSync { .. } => true,
-				// 		_ => false,
-				// 	},
-				// );
-
 				self.sync_state
 					.update(SyncStatus::TxHashsetDownload(Default::default()));
 			}

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -39,13 +39,13 @@ impl TUIStatusView {
 			SyncStatus::NoSync => Cow::Borrowed("Running"),
 			SyncStatus::AwaitingPeers(_) => Cow::Borrowed("Waiting for peers"),
 			SyncStatus::HeaderSync {
-				current_height,
+				sync_head,
 				highest_height,
 			} => {
 				let percent = if highest_height == 0 {
 					0
 				} else {
-					current_height * 100 / highest_height
+					sync_head.height * 100 / highest_height
 				};
 				Cow::Owned(format!("Sync step 1/7: Downloading headers: {}%", percent))
 			}

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -41,6 +41,7 @@ impl TUIStatusView {
 			SyncStatus::HeaderSync {
 				sync_head,
 				highest_height,
+				..
 			} => {
 				let percent = if highest_height == 0 {
 					0


### PR DESCRIPTION
The (somewhat) redundant sync_head MMR impl was removed and cleanup up in https://github.com/mimblewimble/grin/pull/3556.
This never worked as intended as it did not allow `header_head` and `sync_head` to diverge successfully beyond a single batch (512) of headers. We also did not require `sync_head` to be persisted in the db across node restarts (`sync_head` would be reset during header sync).

This PR moves the tracking of `sync_head` into the `HeaderSync` sync status that we already track.
This allows a `sync_head` to diverge from current `header_head` in a scenario where multiple batches of headers are required to successfully sync the fork.

We now track a `sync_head` on a header fork even if the cumulative difficulty on a given batch of headers is (temporarily) lower than the current `header_head`.

The issue that this fixes is as follows - 

* local node sees a new header fork based on a peer advertising greater cumulative difficulty (total work).
* we rewind from `header_head` (diff `X`) and process a batch of 512 headers on the fork
* this results in diff `Y` on the fork
  * `Y < X` so `header_head` is not updated
* we now fail to sync additional headers on the fork as "locator" is based on `header_head`
  * we keep syncing the _initial_ 512 headers on the fork and do not make further progress along the fork 

The changes in this PR ensure we now correctly track `sync_head` which in the scenario above would be the `last_header` of the initial batch of headers on the new fork.
This allows the "locator" to be constructed correctly and progress to be made along the fork.

Resolves #3615

----

We *could* have implemented this storing the `sync_head` in the db but this PR attempts to take advantage of the existing sync_status tracking. We only really need to track `sync_head` when we are in `HeaderSync` state for an extended period of time.

We can likely extend this in two ways in future work - 

1. rework the sync state to allow us to track the `sync_peer` and the various data for `stalling` etc. during `HeaderSync` so we can consolidate all the data being tracked during the sync process (currently spread all over header_sync.rs)
1. track `head` and associated data in a similar way during `BodySync` (mainly for consistency)

The work for (1) is a little convoluted as sync state is defined in `chain` crate currently and has no knowledge of peers etc. We need to spend a bit of time thinking through the best way of approaching this without making the code really awkward.

But it would open up a relatively clean way of tracking a _single_ peer during `header_sync`. i.e. We keep asking the same peer for subsequent headers until we either sync with that peer successfully or the peer disconnects.

----

This PR also adds an additional conditional check during `check_run` in `header_sync` - 

```
			// Quick check - nothing to sync if we are caught up with the peer.
			if peer_diff <= sync_head.total_difficulty {
				return Ok(false);
			}
```

This prevents our local node from flapping between `BodySync` and `HeaderSync` toward the end of IBD.

