### PR TITLE
Add test for duplicate rangeproof inflation bug

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -814,6 +814,89 @@ fn output_header_mappings() {
 	clean_output_dir(".grin_header_for_output");
 }
 
+/// Test the duplicate rangeproof bug
+#[test]
+fn test_duplicate_rangeproof() {
+	clean_output_dir(".grin_overflow");
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+	util::init_test_logger();
+	{
+		let chain = init_chain(".grin_overflow", pow::mine_genesis_block().unwrap());
+		let prev = chain.head_header().unwrap();
+		let kc = ExtKeychain::from_random_seed(false).unwrap();
+		let pb = ProofBuilder::new(&kc);
+
+		let mut head = prev;
+
+		// mine the first block and keep track of the block_hash
+		// so we can spend the coinbase later
+		let b = prepare_block(&kc, &head, &chain, 2);
+
+		assert!(b.outputs()[0].is_coinbase());
+		head = b.header.clone();
+		chain
+			.process_block(b.clone(), chain::Options::SKIP_POW)
+			.unwrap();
+
+		// now mine three further blocks
+		for n in 3..6 {
+			let b = prepare_block(&kc, &head, &chain, n);
+			head = b.header.clone();
+			chain.process_block(b, chain::Options::SKIP_POW).unwrap();
+		}
+
+		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
+		let key_id30 = ExtKeychainPath::new(1, 30, 0, 0, 0).to_identifier();
+		let key_id31 = ExtKeychainPath::new(1, 31, 0, 0, 0).to_identifier();
+		let key_id32 = ExtKeychainPath::new(1, 32, 0, 0, 0).to_identifier();
+
+		// build a regular transaction so we have a rangeproof to copy
+		let tx1 = build::transaction(
+			KernelFeatures::Plain { fee: 20000.into() },
+			&[
+				build::coinbase_input(consensus::REWARD, key_id2.clone()),
+				build::output(consensus::REWARD - 20000, key_id30.clone()),
+			],
+			&kc,
+			&pb,
+		)
+		.unwrap();
+
+		// mine block with tx1
+		let next = prepare_block_tx(&kc, &head, &chain, 7, &[tx1.clone()]);
+		let prev_main = next.header.clone();
+		chain
+			.process_block(next.clone(), chain::Options::SKIP_POW)
+			.unwrap();
+		chain.validate(false).unwrap();
+
+		// create a second tx
+		let mut tx2 = build::transaction(
+			KernelFeatures::Plain { fee: 0.into() },
+			&[
+				build::input(consensus::REWARD - 20000, key_id30.clone()), // 59999980000
+				build::output(consensus::REWARD - 20001, key_id31.clone()),
+				build::output(1, key_id32.clone()),
+			],
+			&kc,
+			&pb,
+		)
+		.unwrap();
+
+		// overwrite our rangeproof with a rangeproof from last block
+		tx2.body.outputs[1].proof = tx1.body.outputs[0].proof;
+
+		let next = prepare_block_tx(&kc, &prev_main, &chain, 8, &[tx2.clone()]);
+		// process_block fails with verifier_cache disabled or with correct verifier_cache
+		// implementations
+		assert_eq!(
+			chain.process_block(next, chain::Options::SKIP_POW).is_ok(),
+			false
+		);
+	}
+	clean_output_dir(".grin_overflow");
+}
+
 // Use diff as both diff *and* key_idx for convenience (deterministic private key for test blocks)
 fn prepare_block<K>(kc: &K, prev: &BlockHeader, chain: &Chain, diff: u64) -> Block
 where

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -816,9 +816,10 @@ fn output_header_mappings() {
 
 /// Test the duplicate rangeproof bug
 #[test]
-fn test_duplicate_rangeproof() {
+fn test_overflow_cached_rangeproof() {
 	clean_output_dir(".grin_overflow");
 	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+
 	util::init_test_logger();
 	{
 		let chain = init_chain(".grin_overflow", pow::mine_genesis_block().unwrap());
@@ -845,6 +846,7 @@ fn test_duplicate_rangeproof() {
 			chain.process_block(b, chain::Options::SKIP_POW).unwrap();
 		}
 
+		// create a few keys for use in txns
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id30 = ExtKeychainPath::new(1, 30, 0, 0, 0).to_identifier();
 		let key_id31 = ExtKeychainPath::new(1, 31, 0, 0, 0).to_identifier();
@@ -870,29 +872,49 @@ fn test_duplicate_rangeproof() {
 			.unwrap();
 		chain.validate(false).unwrap();
 
-		// create a second tx
+		// create a second tx that contains a negative output
+		// and a positive output for 1m grin
 		let mut tx2 = build::transaction(
 			KernelFeatures::Plain { fee: 0.into() },
 			&[
-				build::input(consensus::REWARD - 20000, key_id30.clone()), // 59999980000
-				build::output(consensus::REWARD - 20001, key_id31.clone()),
-				build::output(1, key_id32.clone()),
+				build::input(consensus::REWARD - 20000, key_id30.clone()),
+				build::output(
+					consensus::REWARD - 20000 + 1_000_000_000_000_000,
+					key_id31.clone(),
+				),
+				build::output_negative(1_000_000_000_000_000, key_id32.clone()),
 			],
 			&kc,
 			&pb,
 		)
 		.unwrap();
 
-		// overwrite our rangeproof with a rangeproof from last block
-		tx2.body.outputs[1].proof = tx1.body.outputs[0].proof;
+		// make sure tx1 only has one output as expected
+		assert_eq!(tx1.body.outputs.len(), 1);
+		let last_rp = tx1.body.outputs[0].proof;
+
+		// overwrite all our rangeproofs with the rangeproof from last block
+		for i in 0..tx2.body.outputs.len() {
+			tx2.body.outputs[i].proof = last_rp;
+		}
 
 		let next = prepare_block_tx(&kc, &prev_main, &chain, 8, &[tx2.clone()]);
 		// process_block fails with verifier_cache disabled or with correct verifier_cache
 		// implementations
-		assert_eq!(
-			chain.process_block(next, chain::Options::SKIP_POW).is_ok(),
-			false
-		);
+		let res = chain.process_block(next, chain::Options::SKIP_POW);
+
+		match res {
+			Err(e) => {
+				// error should contain "Invalid Block Proof"
+				// TODO: Better way to check error
+				let error_string = format!("{}", e.to_string());
+				assert_eq!(error_string.contains("Invalid Block Proof"), true);
+			}
+			Ok(_) => {
+				// the block was accepted. This is wrong.
+				panic!("Negative output accepted into block!");
+			}
+		}
 	}
 	clean_output_dir(".grin_overflow");
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -107,6 +107,49 @@ where
 	build_input(value, OutputFeatures::Coinbase, key_id)
 }
 
+/// Build a negative output. This function must not be used outside of tests.
+/// The commitment will be an inversion of the value passed in and the value is
+/// subtracted from the sum.
+pub fn output_negative<K, B>(value: u64, key_id: Identifier) -> Box<Append<K, B>>
+where
+	K: Keychain,
+	B: ProofBuild,
+{
+	Box::new(
+		move |build, acc| -> Result<(Transaction, BlindSum), Error> {
+			let (tx, sum) = acc?;
+
+			// TODO: proper support for different switch commitment schemes
+			let switch = SwitchCommitmentType::Regular;
+
+			let commit = build.keychain.commit(value, &key_id, switch)?;
+
+			// invert commitment
+			let commit = build.keychain.secp().commit_sum(vec![], vec![commit])?;
+
+			debug!("Building output: {}, {:?}", value, commit);
+
+			// build a proof with a rangeproof of 0 as a placeholder
+			// the test will replace this later
+			let proof = proof::create(
+				build.keychain,
+				build.builder,
+				0,
+				&key_id,
+				switch,
+				commit,
+				None,
+			)?;
+
+			// we return the output and the value is subtracted instead of added
+			Ok((
+				tx.with_output(Output::new(OutputFeatures::Plain, commit, proof)),
+				sum.sub_key_id(key_id.to_value_path(value)),
+			))
+		},
+	)
+}
+
 /// Adds an output with the provided value and key identifier from the
 /// keychain.
 pub fn output<K, B>(value: u64, key_id: Identifier) -> Box<Append<K, B>>


### PR DESCRIPTION
All credit to @snape479's work in https://github.com/mimblewimble/grin/pull/3621, cherry-picked on top of #3628.

First two commits are just cherry-picks of c4ab693 & 0354ed3:

```
git remote add snape479 https://github.com/snape479/grin.git
git fetch snape479
git cherry-pick c4ab693 0354ed3
```

Verify as failing on v5.0.1:

```
git remote add snape479 https://github.com/snape479/grin.git
git fetch snape479
git checkout v5.0.1
git cherry-pick c4ab693 0354ed3
cargo test --all -- test_overflow_cached_rangeproof
```


Completed:

- [x] Conditionally compile `output_negative` so it can only ever be called from tests
- [x] Verify that **antiochp**'s [review comments](https://github.com/mimblewimble/grin/pull/3621#pullrequestreview-623982316) are addressed from https://github.com/mimblewimble/grin/pull/3621
- [x] Improve validation of InvalidBlockProof type