### PR TITLE
Fix Windows CI `cargo test` silently passing

### DIFF
--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,11 +1,9 @@
 steps:
-  - script: |
-      refreshenv
-      set LIBCLANG_PATH="C:\Program Files\LLVM\lib"
-      set LLVM_CONFIG_PATH="C:\Program Files\LLVM\bin\llvm-config"
-      set ROARING_ARCH=x86-64-v2
-      set
-      cargo test --all
+  - script: 'refreshenv && cargo test --all'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
   - script: 'ROARING_ARCH=x86-64-v2 cargo test --all'

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,9 +1,10 @@
 steps:
   - script: |
       refreshenv
-      LIBCLANG_PATH="C:\Program Files\LLVM\lib"
-      LLVM_CONFIG_PATH="C:\Program Files\LLVM\bin\llvm-config"
-      ROARING_ARCH=x86-64-v2
+      set LIBCLANG_PATH="C:\Program Files\LLVM\lib"
+      set LLVM_CONFIG_PATH="C:\Program Files\LLVM\bin\llvm-config"
+      set ROARING_ARCH=x86-64-v2
+      set
       cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,8 +1,8 @@
 steps:
   - script: |
       refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      LIBCLANG_PATH="C:\Program Files\LLVM\lib"
+      LLVM_CONFIG_PATH="C:\Program Files\LLVM\bin\llvm-config"
       ROARING_ARCH=x86-64-v2
       cargo test --all
     displayName: Windows Cargo Test

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,19 +1,16 @@
 steps:
-  - script: |
-      refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
-      ROARING_ARCH=x86-64-v2
-      cargo test --all
+  - script: 'refreshenv && cargo test --all'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: |
-      cargo clean
-      refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
-      ROARING_ARCH=x86-64-v2
-      cargo build --release
+  - script: 'refreshenv && cargo build --release'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -6,7 +6,7 @@ steps:
       ROARING_ARCH: x86-64-v2
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'refreshenv && cargo build --release'
+  - script: 'refreshenv && cargo clean && cargo build --release'
     env:
       LIBCLANG_PATH: C:\Program Files\LLVM\lib
       LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config


### PR DESCRIPTION
I don't really know why, but the changes I made in the CI scripts for #3596 were causing the Windows CI tests to silently pass without doing anything. Changing the way the env variables are set seems to fix this, the full tests now run. `grin-wallet` counterpart in a moment.

```
Starting: Windows Cargo Test
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.182.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
========================== Starting Command Output ===========================
"C:\Windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "D:\a\_temp\a4073cdf-5e02-40b8-8632-2b6fd7d6a3c8.cmd""
Refreshing environment variables from registry for cmd.exe. Please wait...Finished..
Finishing: Windows Cargo Test
```