### PR TITLE
Add migration to `config_file_version = 2`

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 fn comments() -> HashMap<String, String> {
 	let mut retval = HashMap::new();
 	retval.insert(
-		"[server]".to_string(),
+		"config_file_version".to_string(),
 		"
 # Generated Server Configuration File for Grin
 #
@@ -31,7 +31,13 @@ fn comments() -> HashMap<String, String> {
 # -[user home]/.grin
 #
 
-#########################################
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"[server]".to_string(),
+		"#########################################
 ### SERVER CONFIGURATION              ###
 #########################################
 
@@ -323,7 +329,6 @@ fn comments() -> HashMap<String, String> {
 		"accept_fee_base".to_string(),
 		"
 #base fee that's accepted into the pool
-#a setting to 1000000 will be overridden to 500000 to respect the fixfees RFC
 "
 		.to_string(),
 	);

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -140,7 +140,7 @@ pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalCon
 impl Default for ConfigMembers {
 	fn default() -> ConfigMembers {
 		ConfigMembers {
-			config_file_version: None,
+			config_file_version: Some(2),
 			server: ServerConfig::default(),
 			logging: Some(LoggingConfig::default()),
 		}

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -88,6 +88,8 @@ pub struct GlobalConfig {
 /// want serialised or deserialised
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ConfigMembers {
+	/// Config file version (None == version 1)
+	pub config_file_version: Option<u32>,
 	/// Server config
 	#[serde(default)]
 	pub server: ServerConfig,

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -167,11 +167,7 @@ fn real_main() -> i32 {
 		.server
 		.pool_config
 		.accept_fee_base;
-	let fix_afb = match afb {
-		1_000_000 => 500_000,
-		_ => afb,
-	};
-	global::init_global_accept_fee_base(fix_afb);
+	global::init_global_accept_fee_base(afb);
 	info!("Accept Fee Base: {:?}", global::get_accept_fee_base());
 	global::init_global_future_time_limit(config.members.unwrap().server.future_time_limit);
 	info!("Future Time Limit: {:?}", global::get_future_time_limit());


### PR DESCRIPTION
This adds an automatic migration of `grin-server.toml` to `config_file_version = 2`, performed as such:

- Add `config_file_version = 2` line after header comments
- If `server.pool_config.accept_fee_base` is 1000000, change it to 500000
- Remove the comment `#a setting to 1000000 will be overridden to 500000 to respect the fixfees RFC`, since it no longer will once `config_file_version` >= 2
- Verify that the updated toml parses to the expected result
- Write the updated `grin-server.toml` file to disk

This migration is only applied when the `config_file_version` key is not present in the existing `grin-server.toml` file.

For a fresh install, the migration is performed automatically when reading the initial default config.

Error handling can be improved upon request if this general approach is OK.

Closes #3540.