### PR TITLE
make the job_id of every task in stratum server unique to reduce iPollo G1 rejected shares.

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -343,9 +343,10 @@ impl Handler {
 		}
 		let pre_pow = header_buf.to_hex();
 		let current_state = self.current_state.read();
+		let job_id = (current_state.current_block_versions.len() as u64) * bh.height;
 		let job_template = JobTemplate {
 			height: bh.height,
-			job_id: (current_state.current_block_versions.len() - 1) as u64,
+			job_id: job_id,
 			difficulty: current_state.minimum_share_difficulty,
 			pre_pow,
 		};
@@ -366,7 +367,8 @@ impl Handler {
 
 		let state = self.current_state.read();
 		// Find the correct version of the block to match this header
-		let b: Option<&Block> = state.current_block_versions.get(params.job_id as usize);
+		let block_index = (params.job_id / params.height - 1) as usize;
+		let b: Option<&Block> = state.current_block_versions.get(block_index);
 		if params.height != state.current_block_versions.last().unwrap().header.height
 			|| b.is_none()
 		{


### PR DESCRIPTION
Problem to fix

https://forum.grin.mw/t/ipollo-g1-rejected-shares/8432

I work with iPollo G1 miner's developer and found that the reason of ipollo miner rejected shares is 
grin stratum server sometimes send job with same job_id but is not same pre_work, which make miner failed to work on the new job then submit the wrong share, which to be rejected.

In this pr, we use (current_state.current_block_versions.len() as u64) * bh.height as unique job_id. 

we have tested it in goblinpool.com, and reduce iPollo G1 rejected shares from ~5% -> ~0.2%