### PR TITLE
Spelling Improvements

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -25,7 +25,7 @@ The main goal and characteristics of the Grin project are:
 
 A detailed post on the step-by-step of how Grin transactions work (with graphics) can be found [in this Medium post](https://medium.com/@brandonarvanaghi/grin-transactions-explained-step-by-step-fdceb905a853).
 
-## Tongue Tying for Everyone
+## Tongue-Tying for Everyone
 
 This document is targeted at readers with a good
 understanding of blockchains and basic cryptography. With that in mind, we attempt

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -430,7 +430,7 @@ one input or output would change the sum of the transactions to be something oth
 
 ### Conclusion
 
-In this document we covered the basic principles that underlie a Mimblewimble
+In this document we covered the basic principles that underline a Mimblewimble
 blockchain. By using addition of elliptic curve points, we're
 able to build transactions that are completely opaque but can still be properly
 validated. And by generalizing those properties to blocks, we can eliminate a large

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -430,7 +430,7 @@ one input or output would change the sum of the transactions to be something oth
 
 ### Conclusion
 
-In this document we covered the basic principles that underline a Mimblewimble
+In this document we covered the basic principles that underlie a Mimblewimble
 blockchain. By using addition of elliptic curve points, we're
 able to build transactions that are completely opaque but can still be properly
 validated. And by generalizing those properties to blocks, we can eliminate a large

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -291,7 +291,7 @@ Recall that a transaction consists of the following:
   * kernel excess (the public key corresponding to the excess value)
   * transaction signature signed by the excess value (and verifies with the kernel excess)
 
-(the presentation above did not explicitly include the kernel excess in the transaction, because it can be computed from the inputs and outputs. This paragrpah shows the benefit in including it, for aggregation within block construction.)
+(The presentation above did not explicitly include the kernel excess in the transaction, because it can be computed from the inputs and outputs. This paragrpah shows the benefit in including it, for aggregation within block construction.)
 
 We can say the following is true for any valid transaction (ignoring fees for simplicity):
 


### PR DESCRIPTION
Line 28 says "Tongue Tying" but it's actually spelt "Tongue-Tying"

Also, line 294 requires a capital letter for proper grammar

Please excuse the last 2 commits, I realized my 3rd commit was unnecessary and supplied a 4th commit to retract the 3rd.