### PR TITLE
Rust 2021 Macro Warning Cleanup

### DIFF
--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -139,7 +139,7 @@ macro_rules! right_path_element(
 		match $req.uri().path().trim_end_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
-		};
+		}
 	));
 
 #[macro_export]

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -20,7 +20,7 @@
 #[macro_export]
 macro_rules! map_vec {
 	($thing:expr, $mapfn:expr) => {
-		$thing.iter().map($mapfn).collect::<Vec<_>>();
+		$thing.iter().map($mapfn).collect::<Vec<_>>()
 	};
 }
 

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -18,7 +18,6 @@ use self::core::core::hash::Hashed;
 use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::PoolError;
-use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -18,7 +18,6 @@ pub mod common;
 use self::core::core::hash::Hashed;
 use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
-use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -17,7 +17,6 @@ pub mod common;
 use self::core::core::hash::Hashed;
 use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
-use self::util::RwLock;
 use crate::common::ChainAdapter;
 use crate::common::*;
 use grin_core as core;

--- a/pool/tests/nrd_kernel_relative_height.rs
+++ b/pool/tests/nrd_kernel_relative_height.rs
@@ -21,7 +21,6 @@ use self::core::global;
 use self::core::libtx::aggsig;
 use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
 use self::pool::types::PoolError;
-use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/pool/tests/nrd_kernels_disabled.rs
+++ b/pool/tests/nrd_kernels_disabled.rs
@@ -19,7 +19,6 @@ use self::core::core::{HeaderVersion, KernelFeatures, NRDRelativeHeight};
 use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::types::PoolError;
-use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/pool/tests/nrd_kernels_enabled.rs
+++ b/pool/tests/nrd_kernels_enabled.rs
@@ -19,7 +19,6 @@ use self::core::core::{HeaderVersion, KernelFeatures, NRDRelativeHeight};
 use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::types::PoolError;
-use self::util::RwLock;
 use crate::common::*;
 use grin_core as core;
 use grin_keychain as keychain;

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -297,7 +297,7 @@ fn test_status_txhashset_kernels() {
 		kernels_total: 5000,
 	};
 	let basic_status = TUIStatusView::update_sync_status(status);
-	assert!(basic_status.contains("4%"), basic_status);
+	assert!(basic_status.contains("4%"), "{}", basic_status);
 }
 
 #[test]
@@ -307,5 +307,5 @@ fn test_status_txhashset_rproofs() {
 		rproofs_total: 1000,
 	};
 	let basic_status = TUIStatusView::update_sync_status(status);
-	assert!(basic_status.contains("64%"), basic_status);
+	assert!(basic_status.contains("64%"), "{}", basic_status);
 }


### PR DESCRIPTION
Small warning message cleanup of warnings related to upcoming changes in Rust. e.g:

```
warning: trailing semicolon in macro used in expression position
   --> api/src/web.rs:142:4
    |
142 |         };
    |          ^
    |
   ::: api/src/handlers/blocks_api.rs:203:18
    |
203 |         let el = right_path_element!(req);
    |                  ------------------------ in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `right_path_element` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Also cleans up unused import warnings from cargo tests.