### PR TITLE
refactor pmmr functions, improve efficiency; panic on 0 pos1

### DIFF
--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -91,7 +91,6 @@ fn first_100_mmr_heights() {
 
 #[test]
 fn test_bintree_range() {
-	assert_eq!(pmmr::bintree_range(0), 0..1);
 	assert_eq!(pmmr::bintree_range(1), 1..2);
 	assert_eq!(pmmr::bintree_range(2), 2..3);
 	assert_eq!(pmmr::bintree_range(3), 1..4);
@@ -104,7 +103,6 @@ fn test_bintree_range() {
 // The pos of the rightmost leaf for the provided MMR size (last leaf in subtree).
 #[test]
 fn test_bintree_rightmost() {
-	assert_eq!(pmmr::bintree_rightmost(0), 0);
 	assert_eq!(pmmr::bintree_rightmost(1), 1);
 	assert_eq!(pmmr::bintree_rightmost(2), 2);
 	assert_eq!(pmmr::bintree_rightmost(3), 2);
@@ -117,7 +115,6 @@ fn test_bintree_rightmost() {
 // The pos of the leftmost leaf for the provided MMR size (first leaf in subtree).
 #[test]
 fn test_bintree_leftmost() {
-	assert_eq!(pmmr::bintree_leftmost(0), 0);
 	assert_eq!(pmmr::bintree_leftmost(1), 1);
 	assert_eq!(pmmr::bintree_leftmost(2), 2);
 	assert_eq!(pmmr::bintree_leftmost(3), 1);
@@ -129,7 +126,6 @@ fn test_bintree_leftmost() {
 
 #[test]
 fn test_bintree_leaf_pos_iter() {
-	assert_eq!(pmmr::bintree_leaf_pos_iter(0).count(), 0);
 	assert_eq!(pmmr::bintree_leaf_pos_iter(1).collect::<Vec<_>>(), [1]);
 	assert_eq!(pmmr::bintree_leaf_pos_iter(2).collect::<Vec<_>>(), [2]);
 	assert_eq!(pmmr::bintree_leaf_pos_iter(3).collect::<Vec<_>>(), [1, 2]);
@@ -144,7 +140,6 @@ fn test_bintree_leaf_pos_iter() {
 
 #[test]
 fn test_bintree_pos_iter() {
-	assert_eq!(pmmr::bintree_pos_iter(0).count(), 0);
 	assert_eq!(pmmr::bintree_pos_iter(1).collect::<Vec<_>>(), [1]);
 	assert_eq!(pmmr::bintree_pos_iter(2).collect::<Vec<_>>(), [2]);
 	assert_eq!(pmmr::bintree_pos_iter(3).collect::<Vec<_>>(), [1, 2, 3]);
@@ -159,7 +154,6 @@ fn test_bintree_pos_iter() {
 
 #[test]
 fn test_is_leaf() {
-	assert_eq!(pmmr::is_leaf(0), false);
 	assert_eq!(pmmr::is_leaf(1), true);
 	assert_eq!(pmmr::is_leaf(2), true);
 	assert_eq!(pmmr::is_leaf(3), false);


### PR DESCRIPTION
---
name: fixmmr_part1
about: streamline MMR code
title: Fix MMR part 1
labels: 
assignees: Yeastplume

---
This PR refactors pmmr.rs, improving efficiency and clarifying use of 0-based vs 1-based positions, introducing panics when passing 0 as a 1-based position, which makes no sense in normal use. The latter did require removal of corresponding test-cases.
A followup PR is planned to make all methods use 0-based positions, which are preferable for two reasons:
1) they're baked into the consensus model through hash_with_index
2) they simplify some computations, such as converting leaf to node index:
     node_index = 2 * leaf_index - count_ones(leaf_index)
There appears to be no advantage to 1-based positions. The APIs use them though, so the API implementation is where all the conversion should take place.