### PR TITLE
Fixmmr part2

### DIFF
--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -71,7 +71,7 @@ pub fn get_output_v2(
 		None => return Ok(None),
 	};
 
-	let output = chain.get_unspent_output_at(pos.pos)?;
+	let output = chain.get_unspent_output_at(pos.pos - 1)?;
 	let header = if include_merkle_proof && output.is_coinbase() {
 		chain.get_header_by_height(pos.height).ok()
 	} else {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1550,7 +1550,7 @@ fn setup_head(
 			batch.save_block_header(&genesis.header)?;
 		}
 
-		if header_pmmr.last_pos == 0 {
+		if header_pmmr.size == 0 {
 			txhashset::header_extending(header_pmmr, &mut batch, |ext, _| {
 				ext.apply_header(&genesis.header)
 			})?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1272,7 +1272,7 @@ impl Chain {
 		let txhashset = self.txhashset.read();
 		let last_index = match max_pmmr_index {
 			Some(i) => i,
-			None => txhashset.highest_output_insertion_index(),
+			None => txhashset.output_mmr_size(),
 		};
 		let outputs = txhashset.outputs_by_pmmr_index(start_index, max_count, max_pmmr_index);
 		let rangeproofs =
@@ -1301,13 +1301,14 @@ impl Chain {
 			None => self.head_header()?.height,
 		};
 		// Return headers at the given heights
-		let prev_to_start_header =
-			self.get_header_by_height(start_block_height.saturating_sub(1))?;
-		let end_header = self.get_header_by_height(end_block_height)?;
-		Ok((
-			prev_to_start_header.output_mmr_size + 1,
-			end_header.output_mmr_size,
-		))
+		let start_mmr_size = if start_block_height == 0 {
+			0
+		} else {
+			self.get_header_by_height(start_block_height - 1)?
+				.output_mmr_size + 1
+		};
+		let end_mmr_size = self.get_header_by_height(end_block_height)?.output_mmr_size;
+		Ok((start_mmr_size, end_mmr_size))
 	}
 
 	/// Orphans pool size

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -572,11 +572,11 @@ impl Chain {
 	}
 
 	/// Retrieves an unspent output using its PMMR position
-	pub fn get_unspent_output_at(&self, pos: u64) -> Result<Output, Error> {
+	pub fn get_unspent_output_at(&self, pos0: u64) -> Result<Output, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		txhashset::utxo_view(&header_pmmr, &txhashset, |utxo, _| {
-			utxo.get_unspent_output_at(pos)
+			utxo.get_unspent_output_at(pos0)
 		})
 	}
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -114,7 +114,7 @@ impl ChainStore {
 	/// Get PMMR pos for the given output commitment.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		match self.get_output_pos_height(commit)? {
-			Some(pos) => Ok(pos.pos),
+			Some(pos) => Ok(pos.pos - 1),
 			None => Err(Error::NotFoundErr(format!(
 				"Output position for: {:?}",
 				commit
@@ -278,7 +278,7 @@ impl<'a> Batch<'a> {
 	/// Get output_pos from index.
 	pub fn get_output_pos(&self, commit: &Commitment) -> Result<u64, Error> {
 		match self.get_output_pos_height(commit)? {
-			Some(pos) => Ok(pos.pos),
+			Some(pos) => Ok(pos.pos - 1),
 			None => Err(Error::NotFoundErr(format!(
 				"Output position for: {:?}",
 				commit

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -149,7 +149,7 @@ impl BitmapAccumulator {
 		let chunk_idx = BitmapAccumulator::chunk_idx(from_idx);
 		let last_pos = self.backend.size();
 		let mut pmmr = PMMR::at(&mut self.backend, last_pos);
-		let chunk_pos = pmmr::insertion_to_pmmr_index(chunk_idx + 1);
+		let chunk_pos = 1 + pmmr::insertion_to_pmmr_index(chunk_idx);
 		let rewind_pos = chunk_pos.saturating_sub(1);
 		pmmr.rewind(rewind_pos, &Bitmap::create())
 			.map_err(ErrorKind::Other)?;
@@ -333,9 +333,9 @@ impl From<BitmapSegment> for Segment<BitmapChunk> {
 			+ blocks.last().map(|b| b.n_chunks()).unwrap_or(0);
 		let mut leaf_pos = Vec::with_capacity(n_chunks);
 		let mut chunks = Vec::with_capacity(n_chunks);
-		let offset = (1 << identifier.height) * identifier.idx + 1;
+		let offset = (1 << identifier.height) * identifier.idx;
 		for i in 0..(n_chunks as u64) {
-			leaf_pos.push(pmmr::insertion_to_pmmr_index(offset + i));
+			leaf_pos.push(1 + pmmr::insertion_to_pmmr_index(offset + i));
 			chunks.push(BitmapChunk::new());
 		}
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -335,7 +335,7 @@ impl From<BitmapSegment> for Segment<BitmapChunk> {
 		let mut chunks = Vec::with_capacity(n_chunks);
 		let offset = (1 << identifier.height) * identifier.idx;
 		for i in 0..(n_chunks as u64) {
-			leaf_pos.push(1 + pmmr::insertion_to_pmmr_index(offset + i));
+			leaf_pos.push(pmmr::insertion_to_pmmr_index(offset + i));
 			chunks.push(BitmapChunk::new());
 		}
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -125,6 +125,8 @@ impl BitmapAccumulator {
 	/// If size is 1 then we will have a single chunk.
 	/// If size is 1023 then we will have a single chunk (bits 0 to 1023 inclusive).
 	/// If the size is 1024 then we will have two chunks.
+	/// TODO: first argument is an iterator for no good reason;
+	/// might as well pass from_idx as first argument
 	pub fn apply<T, U>(&mut self, invalidated_idx: T, idx: U, size: u64) -> Result<(), Error>
 	where
 		T: IntoIterator<Item = u64>,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -406,9 +406,9 @@ impl TxHashSet {
 
 	/// build a new merkle proof for the given position.
 	pub fn merkle_proof(&mut self, commit: Commitment) -> Result<MerkleProof, Error> {
-		let pos = self.commit_index.get_output_pos(&commit)?;
+		let pos1 = self.commit_index.get_output_pos(&commit)?;
 		PMMR::at(&mut self.output_pmmr_h.backend, self.output_pmmr_h.size)
-			.merkle_proof(pos)
+			.merkle_proof(pos1 - 1)
 			.map_err(|_| ErrorKind::MerkleProof.into())
 	}
 
@@ -1272,10 +1272,10 @@ impl<'a> Extension<'a> {
 		let out_id = out_id.as_ref();
 		debug!("txhashset: merkle_proof: output: {:?}", out_id.commit);
 		// then calculate the Merkle Proof based on the known pos
-		let pos = batch.get_output_pos(&out_id.commit)?;
+		let pos1 = batch.get_output_pos(&out_id.commit)?;
 		let merkle_proof = self
 			.output_pmmr
-			.merkle_proof(pos)
+			.merkle_proof(pos1 - 1)
 			.map_err(&ErrorKind::TxHashSetErr)?;
 
 		Ok(merkle_proof)

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -896,8 +896,8 @@ impl<'a> HeaderExtension<'a> {
 	}
 
 	/// Get the header hash for the specified pos from the underlying MMR backend.
-	fn get_header_hash(&self, pos1: u64) -> Option<Hash> {
-		self.pmmr.get_data(pos1 - 1).map(|x| x.hash())
+	fn get_header_hash(&self, pos0: u64) -> Option<Hash> {
+		self.pmmr.get_data(pos0).map(|x| x.hash())
 	}
 
 	/// The head representing the furthest extent of the current extension.
@@ -908,7 +908,7 @@ impl<'a> HeaderExtension<'a> {
 	/// Get header hash by height.
 	/// Based on current header MMR.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Option<Hash> {
-		let pos = 1 + pmmr::insertion_to_pmmr_index(height);
+		let pos = pmmr::insertion_to_pmmr_index(height);
 		self.get_header_hash(pos)
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -126,7 +126,7 @@ impl PMMRHandle<BlockHeader> {
 			return Err(ErrorKind::Other("MMR empty, no head".to_string()).into());
 		}
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.last_pos);
-		let leaf_pos = pmmr::bintree_rightmost(self.last_pos);
+		let leaf_pos = 1 + pmmr::bintree_rightmost(self.last_pos - 1);
 		if let Some(entry) = header_pmmr.get_data(leaf_pos) {
 			Ok(entry.hash())
 		} else {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1228,7 +1228,7 @@ impl<'a> Extension<'a> {
 				);
 			}
 		}
-		Ok(output_pos)
+		Ok(1 + output_pos)
 	}
 
 	/// Apply kernels to the kernel MMR.
@@ -1256,7 +1256,7 @@ impl<'a> Extension<'a> {
 			.kernel_pmmr
 			.push(kernel)
 			.map_err(&ErrorKind::TxHashSetErr)?;
-		Ok(pos)
+		Ok(1 + pos)
 	}
 
 	/// Build a Merkle proof for the given output and the block

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -587,15 +587,14 @@ impl TxHashSet {
 			let hash = header_pmmr.get_header_hash_by_height(search_height + 1)?;
 			let h = batch.get_block_header(&hash)?;
 			while i < total_outputs {
-				let (commit, pos) = outputs_pos[i];
-				if pos > h.output_mmr_size {
-					// NOTE: output position is 1-based and not 0-based, so here must be '>' instead of '>='
+				let (commit, pos1) = outputs_pos[i];
+				if pos1 > h.output_mmr_size {
 					break;
 				}
 				batch.save_output_pos_height(
 					&commit,
 					CommitPos {
-						pos,
+						pos: pos1,
 						height: h.height,
 					},
 				)?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -90,7 +90,7 @@ impl PMMRHandle<BlockHeader> {
 		// 1-indexed pos and we want to account for subsequent parent hash pos.
 		// so use next header pos to find our last_pos.
 		let next_height = head.height + 1;
-		let next_pos = pmmr::insertion_to_pmmr_index(next_height + 1);
+		let next_pos = 1 + pmmr::insertion_to_pmmr_index(next_height);
 		let pos = next_pos.saturating_sub(1);
 
 		debug!(
@@ -110,7 +110,7 @@ impl PMMRHandle<BlockHeader> {
 
 	/// Get the header hash at the specified height based on the current header MMR state.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		let pos = 1 + pmmr::insertion_to_pmmr_index(height);
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.last_pos);
 		if let Some(entry) = header_pmmr.get_data(pos) {
 			Ok(entry.hash())
@@ -914,7 +914,7 @@ impl<'a> HeaderExtension<'a> {
 	/// Get header hash by height.
 	/// Based on current header MMR.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Option<Hash> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
+		let pos = 1 + pmmr::insertion_to_pmmr_index(height);
 		self.get_header_hash(pos)
 	}
 
@@ -973,7 +973,7 @@ impl<'a> HeaderExtension<'a> {
 			self.head.height,
 		);
 
-		let header_pos = pmmr::insertion_to_pmmr_index(header.height + 1);
+		let header_pos = 1 + pmmr::insertion_to_pmmr_index(header.height);
 		self.pmmr
 			.rewind(header_pos, &Bitmap::create())
 			.map_err(&ErrorKind::TxHashSetErr)?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1179,10 +1179,10 @@ impl<'a> Extension<'a> {
 	// Prune output and rangeproof PMMRs based on provided pos.
 	// Input is not valid if we cannot prune successfully.
 	fn apply_input(&mut self, commit: Commitment, pos: CommitPos) -> Result<(), Error> {
-		match self.output_pmmr.prune(pos.pos) {
+		match self.output_pmmr.prune(pos.pos - 1) {
 			Ok(true) => {
 				self.rproof_pmmr
-					.prune(pos.pos)
+					.prune(pos.pos - 1)
 					.map_err(ErrorKind::TxHashSetErr)?;
 				Ok(())
 			}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -554,9 +554,9 @@ impl TxHashSet {
 		);
 
 		let mut outputs_pos: Vec<(Commitment, u64)> = vec![];
-		for pos1 in output_pmmr.leaf_pos_iter() {
-			if let Some(out) = output_pmmr.get_data(pos1 - 1) {
-				outputs_pos.push((out.commit, pos1));
+		for pos0 in output_pmmr.leaf_pos_iter() {
+			if let Some(out) = output_pmmr.get_data(pos0) {
+				outputs_pos.push((out.commit, 1 + pos0));
 			}
 		}
 
@@ -588,7 +588,7 @@ impl TxHashSet {
 			while i < total_outputs {
 				let (commit, pos) = outputs_pos[i];
 				if pos > h.output_mmr_size {
-					// Note: MMR position is 1-based and not 0-based, so here must be '>' instead of '>='
+					// NOTE: output position is 1-based and not 0-based, so here must be '>' instead of '>='
 					break;
 				}
 				batch.save_output_pos_height(
@@ -1034,8 +1034,8 @@ impl<'a> Committed for Extension<'a> {
 
 	fn outputs_committed(&self) -> Vec<Commitment> {
 		let mut commitments = vec![];
-		for pos1 in self.output_pmmr.leaf_pos_iter() {
-			if let Some(out) = self.output_pmmr.get_data(pos1 - 1) {
+		for pos0 in self.output_pmmr.leaf_pos_iter() {
+			if let Some(out) = self.output_pmmr.get_data(pos0) {
 				commitments.push(out.commit);
 			}
 		}
@@ -1651,9 +1651,9 @@ impl<'a> Extension<'a> {
 		let mut proof_count = 0;
 		let total_rproofs = self.output_pmmr.n_unpruned_leaves();
 
-		for pos1 in self.output_pmmr.leaf_pos_iter() {
-			let output = self.output_pmmr.get_data(pos1 - 1);
-			let proof = self.rproof_pmmr.get_data(pos1 - 1);
+		for pos0 in self.output_pmmr.leaf_pos_iter() {
+			let output = self.output_pmmr.get_data(pos0);
+			let proof = self.rproof_pmmr.get_data(pos0);
 
 			// Output and corresponding rangeproof *must* exist.
 			// It is invalid for either to be missing and we fail immediately in this case.

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -123,12 +123,12 @@ impl<'a> UTXOView<'a> {
 		batch: &Batch<'_>,
 	) -> Result<(OutputIdentifier, CommitPos), Error> {
 		let pos = batch.get_output_pos_height(&input)?;
-		if let Some(pos) = pos {
-			if let Some(out) = self.output_pmmr.get_data(pos.pos) {
+		if let Some(pos1) = pos {
+			if let Some(out) = self.output_pmmr.get_data(pos1.pos - 1) {
 				if out.commitment() == input {
-					return Ok((out, pos));
+					return Ok((out, pos1));
 				} else {
-					error!("input mismatch: {:?}, {:?}, {:?}", out, pos, input);
+					error!("input mismatch: {:?}, {:?}, {:?}", out, pos1, input);
 					return Err(ErrorKind::Other(
 						"input mismatch (output_pos index mismatch?)".into(),
 					)
@@ -141,8 +141,8 @@ impl<'a> UTXOView<'a> {
 
 	// Output is valid if it would not result in a duplicate commitment in the output MMR.
 	fn validate_output(&self, output: &Output, batch: &Batch<'_>) -> Result<(), Error> {
-		if let Ok(pos) = batch.get_output_pos(&output.commitment()) {
-			if let Some(out_mmr) = self.output_pmmr.get_data(pos) {
+		if let Ok(pos1) = batch.get_output_pos(&output.commitment()) {
+			if let Some(out_mmr) = self.output_pmmr.get_data(pos1 - 1) {
 				if out_mmr.commitment() == output.commitment() {
 					return Err(ErrorKind::DuplicateCommitment(output.commitment()).into());
 				}
@@ -152,9 +152,9 @@ impl<'a> UTXOView<'a> {
 	}
 
 	/// Retrieves an unspent output using its PMMR position
-	pub fn get_unspent_output_at(&self, pos: u64) -> Result<Output, Error> {
-		match self.output_pmmr.get_data(pos) {
-			Some(output_id) => match self.rproof_pmmr.get_data(pos) {
+	pub fn get_unspent_output_at(&self, pos1: u64) -> Result<Output, Error> {
+		match self.output_pmmr.get_data(pos1 - 1) {
+			Some(output_id) => match self.rproof_pmmr.get_data(pos1 - 1) {
 				Some(rproof) => Ok(output_id.into_output(rproof)),
 				None => Err(ErrorKind::RangeproofNotFound.into()),
 			},
@@ -214,8 +214,8 @@ impl<'a> UTXOView<'a> {
 	}
 
 	/// Get the header hash for the specified pos from the underlying MMR backend.
-	fn get_header_hash(&self, pos: u64) -> Option<Hash> {
-		self.header_pmmr.get_data(pos).map(|x| x.hash())
+	fn get_header_hash(&self, pos1: u64) -> Option<Hash> {
+		self.header_pmmr.get_data(pos1 - 1).map(|x| x.hash())
 	}
 
 	/// Get the header at the specified height based on the current state of the extension.

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -226,8 +226,8 @@ impl<'a> UTXOView<'a> {
 		height: u64,
 		batch: &Batch<'_>,
 	) -> Result<BlockHeader, Error> {
-		let pos = pmmr::insertion_to_pmmr_index(height + 1);
-		if let Some(hash) = self.get_header_hash(pos) {
+		let pos1 = 1 + pmmr::insertion_to_pmmr_index(height);
+		if let Some(hash) = self.get_header_hash(pos1) {
 			let header = batch.get_block_header(&hash)?;
 			Ok(header)
 		} else {

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -141,8 +141,8 @@ impl<'a> UTXOView<'a> {
 
 	// Output is valid if it would not result in a duplicate commitment in the output MMR.
 	fn validate_output(&self, output: &Output, batch: &Batch<'_>) -> Result<(), Error> {
-		if let Ok(pos1) = batch.get_output_pos(&output.commitment()) {
-			if let Some(out_mmr) = self.output_pmmr.get_data(pos1 - 1) {
+		if let Ok(pos0) = batch.get_output_pos(&output.commitment()) {
+			if let Some(out_mmr) = self.output_pmmr.get_data(pos0) {
 				if out_mmr.commitment() == output.commitment() {
 					return Err(ErrorKind::DuplicateCommitment(output.commitment()).into());
 				}

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -152,9 +152,9 @@ impl<'a> UTXOView<'a> {
 	}
 
 	/// Retrieves an unspent output using its PMMR position
-	pub fn get_unspent_output_at(&self, pos1: u64) -> Result<Output, Error> {
-		match self.output_pmmr.get_data(pos1 - 1) {
-			Some(output_id) => match self.rproof_pmmr.get_data(pos1 - 1) {
+	pub fn get_unspent_output_at(&self, pos0: u64) -> Result<Output, Error> {
+		match self.output_pmmr.get_data(pos0) {
+			Some(output_id) => match self.rproof_pmmr.get_data(pos0) {
 				Some(rproof) => Ok(output_id.into_output(rproof)),
 				None => Err(ErrorKind::RangeproofNotFound.into()),
 			},

--- a/chain/tests/process_block_cut_through.rs
+++ b/chain/tests/process_block_cut_through.rs
@@ -56,10 +56,11 @@ where
 		chain.set_prev_root_only(&mut block.header)?;
 
 		// Manually set the mmr sizes for a "valid" block (increment prev output and kernel counts).
-		// I don't see how 1 + 0-based index corresponds to a completed size
-		// E.g. output_mmr_count==3 gives size 5
-		block.header.output_mmr_size = 1 + pmmr::insertion_to_pmmr_index(prev.output_mmr_count());
-		block.header.kernel_mmr_size = 1 + pmmr::insertion_to_pmmr_index(prev.kernel_mmr_count());
+		// The 2 lines below were bogus before when using 1-based positions.
+		// They worked only for even output_mmr_count()s
+		// But it was actually correct for 0-based position!
+		block.header.output_mmr_size = pmmr::insertion_to_pmmr_index(prev.output_mmr_count() + 1);
+		block.header.kernel_mmr_size = pmmr::insertion_to_pmmr_index(prev.kernel_mmr_count() + 1);
 	} else {
 		chain.set_txhashset_roots(&mut block)?;
 	}

--- a/chain/tests/process_block_cut_through.rs
+++ b/chain/tests/process_block_cut_through.rs
@@ -56,8 +56,10 @@ where
 		chain.set_prev_root_only(&mut block.header)?;
 
 		// Manually set the mmr sizes for a "valid" block (increment prev output and kernel counts).
-		block.header.output_mmr_size = pmmr::insertion_to_pmmr_index(prev.output_mmr_count() + 1);
-		block.header.kernel_mmr_size = pmmr::insertion_to_pmmr_index(prev.kernel_mmr_count() + 1);
+		// I don't see how 1 + 0-based index corresponds to a completed size
+		// E.g. output_mmr_count==3 gives size 5
+		block.header.output_mmr_size = 1 + pmmr::insertion_to_pmmr_index(prev.output_mmr_count());
+		block.header.kernel_mmr_size = 1 + pmmr::insertion_to_pmmr_index(prev.kernel_mmr_count());
 	} else {
 		chain.set_txhashset_roots(&mut block)?;
 	}

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -102,23 +102,23 @@ impl MerkleProof {
 		// calculate the peaks once as these are based on overall MMR size
 		// (and will not change)
 		let peaks_pos = pmmr::peaks(self.mmr_size);
-		proof.verify_consume(root, element, node_pos, &peaks_pos)
+		proof.verify_consume0(root, element, node_pos, &peaks_pos)
 	}
 
 	/// Consumes the Merkle proof while verifying it.
 	/// The proof can no longer be used by the caller after dong this.
 	/// Caller must clone() the proof first.
-	fn verify_consume(
+	fn verify_consume0(
 		&mut self,
 		root: Hash,
 		element: &dyn PMMRIndexHashable,
-		node_pos: u64,
-		peaks_pos: &[u64],
+		node_pos1: u64,
+		peaks_pos0: &[u64],
 	) -> Result<(), MerkleProofError> {
-		let node_hash = if node_pos > self.mmr_size {
+		let node_hash = if node_pos1 > self.mmr_size {
 			element.hash_with_index(self.mmr_size)
 		} else {
-			element.hash_with_index(node_pos - 1)
+			element.hash_with_index(node_pos1 - 1)
 		};
 
 		// handle special case of only a single entry in the MMR
@@ -132,10 +132,10 @@ impl MerkleProof {
 		}
 
 		let sibling = self.path.remove(0);
-		let (parent_pos0, sibling_pos0) = pmmr::family(node_pos - 1);
+		let (parent_pos0, sibling_pos0) = pmmr::family(node_pos1 - 1);
 
-		if let Ok(x) = peaks_pos.binary_search(&node_pos) {
-			let parent = if x == peaks_pos.len() - 1 {
+		if let Ok(x) = peaks_pos0.binary_search(&(node_pos1 - 1)) {
+			let parent = if x == peaks_pos0.len() - 1 {
 				(sibling, node_hash)
 			} else {
 				(node_hash, sibling)

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -102,23 +102,23 @@ impl MerkleProof {
 		// calculate the peaks once as these are based on overall MMR size
 		// (and will not change)
 		let peaks_pos = pmmr::peaks(self.mmr_size);
-		proof.verify_consume0(root, element, node_pos, &peaks_pos)
+		proof.verify_consume(root, element, node_pos, &peaks_pos)
 	}
 
 	/// Consumes the Merkle proof while verifying it.
 	/// The proof can no longer be used by the caller after dong this.
 	/// Caller must clone() the proof first.
-	fn verify_consume0(
+	fn verify_consume(
 		&mut self,
 		root: Hash,
 		element: &dyn PMMRIndexHashable,
-		node_pos1: u64,
+		node_pos0: u64,
 		peaks_pos0: &[u64],
 	) -> Result<(), MerkleProofError> {
-		let node_hash = if node_pos1 > self.mmr_size {
+		let node_hash = if node_pos0 >= self.mmr_size {
 			element.hash_with_index(self.mmr_size)
 		} else {
-			element.hash_with_index(node_pos1 - 1)
+			element.hash_with_index(node_pos0)
 		};
 
 		// handle special case of only a single entry in the MMR
@@ -132,25 +132,25 @@ impl MerkleProof {
 		}
 
 		let sibling = self.path.remove(0);
-		let (parent_pos0, sibling_pos0) = pmmr::family(node_pos1 - 1);
+		let (parent_pos0, sibling_pos0) = pmmr::family(node_pos0);
 
-		if let Ok(x) = peaks_pos0.binary_search(&(node_pos1 - 1)) {
+		if let Ok(x) = peaks_pos0.binary_search(&(node_pos0)) {
 			let parent = if x == peaks_pos0.len() - 1 {
 				(sibling, node_hash)
 			} else {
 				(node_hash, sibling)
 			};
-			self.verify(root, &parent, parent_pos0 + 1)
+			self.verify(root, &parent, parent_pos0)
 		} else if parent_pos0 >= self.mmr_size {
 			let parent = (sibling, node_hash);
-			self.verify(root, &parent, parent_pos0 + 1)
+			self.verify(root, &parent, parent_pos0)
 		} else {
 			let parent = if pmmr::is_left_sibling(sibling_pos0) {
 				(sibling, node_hash)
 			} else {
 				(node_hash, sibling)
 			};
-			self.verify(root, &parent, parent_pos0 + 1)
+			self.verify(root, &parent, parent_pos0)
 		}
 	}
 }

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -145,7 +145,7 @@ impl MerkleProof {
 			let parent = (sibling, node_hash);
 			self.verify(root, &parent, parent_pos0 + 1)
 		} else {
-			let parent = if pmmr::is_left_sibling(sibling_pos0 + 1) {
+			let parent = if pmmr::is_left_sibling(sibling_pos0) {
 				(sibling, node_hash)
 			} else {
 				(node_hash, sibling)

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -132,7 +132,7 @@ impl MerkleProof {
 		}
 
 		let sibling = self.path.remove(0);
-		let (parent_pos, sibling_pos) = pmmr::family(node_pos);
+		let (parent_pos0, sibling_pos0) = pmmr::family(node_pos - 1);
 
 		if let Ok(x) = peaks_pos.binary_search(&node_pos) {
 			let parent = if x == peaks_pos.len() - 1 {
@@ -140,17 +140,17 @@ impl MerkleProof {
 			} else {
 				(node_hash, sibling)
 			};
-			self.verify(root, &parent, parent_pos)
-		} else if parent_pos > self.mmr_size {
+			self.verify(root, &parent, parent_pos0 + 1)
+		} else if parent_pos0 >= self.mmr_size {
 			let parent = (sibling, node_hash);
-			self.verify(root, &parent, parent_pos)
+			self.verify(root, &parent, parent_pos0 + 1)
 		} else {
-			let parent = if pmmr::is_left_sibling(sibling_pos) {
+			let parent = if pmmr::is_left_sibling(sibling_pos0 + 1) {
 				(sibling, node_hash)
 			} else {
 				(node_hash, sibling)
 			};
-			self.verify(root, &parent, parent_pos)
+			self.verify(root, &parent, parent_pos0 + 1)
 		}
 	}
 }

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -31,7 +31,7 @@ pub trait Backend<T: PMMRable> {
 
 	/// Rebuilding a PMMR locally from PIBD segments requires pruned subtree support.
 	/// This allows us to append an existing pruned subtree directly without the underlying leaf nodes.
-	fn append_pruned_subtree(&mut self, hash: Hash, pos1: u64) -> Result<(), String>;
+	fn append_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -48,7 +48,7 @@ pub trait Backend<T: PMMRable> {
 
 	/// Get a Hash  by original insertion position
 	/// (ignoring the remove log).
-	fn get_from_file(&self, position: u64) -> Option<Hash>;
+	fn get_from_file(&self, pos0: u64) -> Option<Hash>;
 
 	/// Get hash for peak pos.
 	/// Optimized for reading peak hashes rather than arbitrary pos hashes.

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -31,17 +31,17 @@ pub trait Backend<T: PMMRable> {
 
 	/// Rebuilding a PMMR locally from PIBD segments requires pruned subtree support.
 	/// This allows us to append an existing pruned subtree directly without the underlying leaf nodes.
-	fn append_pruned_subtree(&mut self, hash: Hash, pos: u64) -> Result<(), String>;
+	fn append_pruned_subtree(&mut self, hash: Hash, pos1: u64) -> Result<(), String>;
 
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR
 	/// to rewind to as well as bitmaps representing the positions added and
 	/// removed since the rewind position. These are what we will "undo"
 	/// during the rewind.
-	fn rewind(&mut self, position: u64, rewind_rm_pos: &Bitmap) -> Result<(), String>;
+	fn rewind(&mut self, pos1: u64, rewind_rm_pos: &Bitmap) -> Result<(), String>;
 
 	/// Get a Hash by insertion position.
-	fn get_hash(&self, position: u64) -> Option<Hash>;
+	fn get_hash(&self, pos0: u64) -> Option<Hash>;
 
 	/// Get underlying data by insertion position.
 	fn get_data(&self, pos0: u64) -> Option<T::E>;

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -57,7 +57,7 @@ pub trait Backend<T: PMMRable> {
 
 	/// Get a Data Element by original insertion position
 	/// (ignoring the remove log).
-	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
+	fn get_data_from_file(&self, pos0: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_>;

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -53,7 +53,7 @@ pub trait Backend<T: PMMRable> {
 	/// Get hash for peak pos.
 	/// Optimized for reading peak hashes rather than arbitrary pos hashes.
 	/// Peaks can be assumed to not be compacted.
-	fn get_peak_from_file(&self, position: u64) -> Option<Hash>;
+	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash>;
 
 	/// Get a Data Element by original insertion position
 	/// (ignoring the remove log).

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -44,7 +44,7 @@ pub trait Backend<T: PMMRable> {
 	fn get_hash(&self, position: u64) -> Option<Hash>;
 
 	/// Get underlying data by insertion position.
-	fn get_data(&self, position: u64) -> Option<T::E>;
+	fn get_data(&self, pos0: u64) -> Option<T::E>;
 
 	/// Get a Hash  by original insertion position
 	/// (ignoring the remove log).

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -387,13 +387,13 @@ where
 		}
 	}
 
-	fn get_data(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.size {
+	fn get_data(&self, pos0: u64) -> Option<Self::Item> {
+		if pos0 >= self.size {
 			// If we are beyond the rhs of the MMR return None.
 			None
-		} else if is_leaf(pos1 - 1) {
+		} else if is_leaf(pos0) {
 			// If we are a leaf then get data from the backend.
-			self.backend.get_data(pos1)
+			self.backend.get_data(pos0)
 		} else {
 			// If we are not a leaf then return None as only leaves have data.
 			None

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -672,9 +672,9 @@ pub fn bintree_leftmost(pos0: u64) -> u64 {
 }
 
 /// Iterator over all leaf pos beneath the provided subtree root (including the root itself).
-pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
-	let leaf_start = pmmr_leaf_to_insertion_index(bintree_leftmost(pos1 - 1));
-	let leaf_end = pmmr_leaf_to_insertion_index(bintree_rightmost(pos1 - 1));
+pub fn bintree_leaf_pos_iter(pos0: u64) -> Box<dyn Iterator<Item = u64>> {
+	let leaf_start = pmmr_leaf_to_insertion_index(bintree_leftmost(pos0));
+	let leaf_end = pmmr_leaf_to_insertion_index(bintree_rightmost(pos0));
 	let leaf_start = match leaf_start {
 		Some(l) => l,
 		None => return Box::new(iter::empty::<u64>()),
@@ -683,7 +683,7 @@ pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
 		Some(l) => l,
 		None => return Box::new(iter::empty::<u64>()),
 	};
-	Box::new((leaf_start..=leaf_end).map(|n| 1 + insertion_to_pmmr_index(n)))
+	Box::new((leaf_start..=leaf_end).map(|n| insertion_to_pmmr_index(n)))
 }
 
 /// Iterator over all pos beneath the provided subtree root (including the root itself).

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -276,7 +276,7 @@ where
 			return Ok(false);
 		}
 
-		self.backend.remove(1 + pos0)?;
+		self.backend.remove(pos0)?;
 		Ok(true)
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -687,9 +687,9 @@ pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
 }
 
 /// Iterator over all pos beneath the provided subtree root (including the root itself).
-pub fn bintree_pos_iter(pos1: u64) -> impl Iterator<Item = u64> {
-	let leaf_start = 1 + bintree_leftmost(pos1 as u64 - 1);
-	(leaf_start..=pos1).into_iter()
+pub fn bintree_pos_iter(pos0: u64) -> impl Iterator<Item = u64> {
+	let leaf_start = bintree_leftmost(pos0);
+	(leaf_start..=pos0).into_iter()
 }
 
 /// All pos in the subtree beneath the provided root, including root itself.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -578,11 +578,8 @@ pub fn family(pos0: u64) -> (u64, u64) {
 }
 
 /// Is the node at this pos the "left" sibling of its parent?
-pub fn is_left_sibling(pos1: u64) -> bool {
-	if pos1 == 0 {
-		panic!("is_left_sibling called with pos1 == 0");
-	}
-	let (peak_map, height) = peak_map_height(pos1 - 1);
+pub fn is_left_sibling(pos0: u64) -> bool {
+	let (peak_map, height) = peak_map_height(pos0);
 	let peak = 1 << height;
 	(peak_map & peak) == 0
 }

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -587,54 +587,6 @@ pub fn is_left_sibling(pos0: u64) -> bool {
 	(peak_map & peak) == 0
 }
 
-/// Returns the path from the specified position up to its
-/// corresponding peak in the MMR.
-/// The size (and therefore the set of peaks) of the MMR
-/// is defined by size.
-/// NOTE this function and the Path struct is UNUSED and
-/// mostly redundant as family_branch has similar functionality
-pub fn path(pos0: u64, size: u64) -> impl Iterator<Item = u64> {
-	Path::new(pos0, size)
-}
-
-struct Path {
-	current: u64,
-	size: u64,
-	peak: u64,
-	peak_map: u64,
-}
-
-impl Path {
-	fn new(pos0: u64, size: u64) -> Self {
-		let (peak_map, height) = peak_map_height(pos0);
-		Path {
-			current: pos0,
-			peak: 1 << height,
-			peak_map,
-			size,
-		}
-	}
-}
-
-impl Iterator for Path {
-	type Item = u64;
-
-	fn next(&mut self) -> Option<Self::Item> {
-		if self.current >= self.size {
-			return None;
-		}
-
-		let next = Some(self.current);
-		self.current += if (self.peak_map & self.peak) != 0 {
-			1
-		} else {
-			2 * self.peak
-		};
-		self.peak <<= 1;
-		next
-	}
-}
-
 /// For a given starting position calculate the parent and sibling positions
 /// for the branch/path from that position to the peak of the tree.
 /// We will use the sibling positions to generate the "path" of a Merkle proof.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -265,16 +265,16 @@ where
 	/// Returns an error if prune is called on a non-leaf position.
 	/// Returns false if the leaf node has already been pruned.
 	/// Returns true if pruning is successful.
-	pub fn prune(&mut self, pos1: u64) -> Result<bool, String> {
-		if !is_leaf(pos1 - 1) {
-			return Err(format!("Node at {} is not a leaf, can't prune.", pos1 - 1));
+	pub fn prune(&mut self, pos0: u64) -> Result<bool, String> {
+		if !is_leaf(pos0) {
+			return Err(format!("Node at {} is not a leaf, can't prune.", pos0));
 		}
 
-		if self.backend.get_hash(pos1).is_none() {
+		if self.backend.get_hash(1 + pos0).is_none() {
 			return Ok(false);
 		}
 
-		self.backend.remove(pos1)?;
+		self.backend.remove(1 + pos0)?;
 		Ok(true)
 	}
 
@@ -313,7 +313,7 @@ where
 		if sz > 2000 && !short {
 			return;
 		}
-		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
+		let start = if short { sz / 8 } else { 0 };
 		for n in start..(sz / 8 + 1) {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();
@@ -347,7 +347,7 @@ where
 		if sz > 2000 && !short {
 			return;
 		}
-		let start = if short && sz > 7 { sz / 8 - 1 } else { 0 };
+		let start = if short { sz / 8 } else { 0 };
 		for n in start..(sz / 8 + 1) {
 			let mut idx = "".to_owned();
 			let mut hashes = "".to_owned();

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -693,8 +693,8 @@ pub fn bintree_pos_iter(pos0: u64) -> impl Iterator<Item = u64> {
 }
 
 /// All pos in the subtree beneath the provided root, including root itself.
-pub fn bintree_range(pos1: u64) -> Range<u64> {
-	let height = bintree_postorder_height(pos1 - 1);
-	let leftmost = pos1 + 2 - (2 << height);
-	leftmost..(pos1 + 1)
+pub fn bintree_range(pos0: u64) -> Range<u64> {
+	let height = bintree_postorder_height(pos0);
+	let leftmost = pos0 + 2 - (2 << height);
+	leftmost..(pos0 + 1)
 }

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -533,15 +533,12 @@ pub fn round_up_to_leaf_pos(pos0: u64) -> u64 {
 	} else {
 		insert_idx + 1
 	};
-	return insertion_to_pmmr_index(leaf_idx + 1) - 1;
+	return insertion_to_pmmr_index(leaf_idx);
 }
 
-/// Returns the 1-based pmmr index of 1-based leaf n
-pub fn insertion_to_pmmr_index(nleaf1: u64) -> u64 {
-	if nleaf1 == 0 {
-		panic!("insertion_to_pmmr_index called with nleaf1 == 0");
-	}
-	2 * (nleaf1 - 1) + 1 - (nleaf1 - 1).count_ones() as u64
+/// Returns the 0-based pmmr index of 0-based leaf index n
+pub fn insertion_to_pmmr_index(nleaf0: u64) -> u64 {
+	2 * nleaf0 - nleaf0.count_ones() as u64
 }
 
 /// Returns the insertion index of the given leaf index
@@ -699,7 +696,7 @@ pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
 		Some(l) => l,
 		None => return Box::new(iter::empty::<u64>()),
 	};
-	Box::new((leaf_start..=leaf_end).map(|n| insertion_to_pmmr_index(n + 1)))
+	Box::new((leaf_start..=leaf_end).map(|n| 1 + insertion_to_pmmr_index(n)))
 }
 
 /// Iterator over all pos beneath the provided subtree root (including the root itself).

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -70,7 +70,7 @@ pub trait ReadablePMMR {
 		let rhs = peaks(size)
 			.into_iter()
 			.filter(|&x| x >= peak_pos1)
-			.filter_map(|x| self.get_from_file(1 + x));
+			.filter_map(|x| self.get_from_file(x));
 
 		let mut res = None;
 		for peak in rhs.rev() {
@@ -141,7 +141,7 @@ pub trait ReadablePMMR {
 
 		let mut path = family_branch
 			.iter()
-			.filter_map(|x| self.get_from_file(1 + x.1))
+			.filter_map(|x| self.get_from_file(x.1))
 			.collect::<Vec<_>>();
 
 		let peak_pos = match family_branch.last() {
@@ -285,8 +285,8 @@ where
 			let height = bintree_postorder_height(n);
 			if height > 0 {
 				if let Some(hash) = self.get_hash(n + 1) {
-					let left_pos = n + 1 - (1 << height);
-					let right_pos = n;
+					let left_pos = n - (1 << height);
+					let right_pos = n - 1;
 					// using get_from_file here for the children (they may have been "removed")
 					if let Some(left_child_hs) = self.get_from_file(left_pos) {
 						if let Some(right_child_hs) = self.get_from_file(right_pos) {
@@ -356,7 +356,7 @@ where
 					break;
 				}
 				idx.push_str(&format!("{:>8} ", m + 1));
-				let ohs = self.get_from_file(m + 1);
+				let ohs = self.get_from_file(m);
 				match ohs {
 					Some(hs) => hashes.push_str(&format!("{} ", hs)),
 					None => hashes.push_str(&format!("{:>8} ", " .")),
@@ -383,7 +383,7 @@ where
 			self.backend.get_hash(pos1)
 		} else {
 			// If we are not a leaf get hash ignoring the remove log.
-			self.backend.get_from_file(pos1)
+			self.backend.get_from_file(pos1 - 1)
 		}
 	}
 
@@ -400,11 +400,11 @@ where
 		}
 	}
 
-	fn get_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.size {
+	fn get_from_file(&self, pos0: u64) -> Option<Hash> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_from_file(pos1)
+			self.backend.get_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -661,20 +661,20 @@ pub fn family_branch(pos0: u64, size: u64) -> Vec<(u64, u64)> {
 }
 
 /// Gets the position of the rightmost node (i.e. leaf) beneath the provided subtree root.
-pub fn bintree_rightmost(pos1: u64) -> u64 {
-	pos1 - bintree_postorder_height(pos1 - 1)
+pub fn bintree_rightmost(pos0: u64) -> u64 {
+	pos0 - bintree_postorder_height(pos0)
 }
 
 /// Gets the position of the leftmost node (i.e. leaf) beneath the provided subtree root.
-pub fn bintree_leftmost(pos1: u64) -> u64 {
-	let height = bintree_postorder_height(pos1 - 1);
-	pos1 + 2 - (2 << height)
+pub fn bintree_leftmost(pos0: u64) -> u64 {
+	let height = bintree_postorder_height(pos0);
+	pos0 + 2 - (2 << height)
 }
 
 /// Iterator over all leaf pos beneath the provided subtree root (including the root itself).
 pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
-	let leaf_start = pmmr_leaf_to_insertion_index(bintree_leftmost(pos1) - 1);
-	let leaf_end = pmmr_leaf_to_insertion_index(bintree_rightmost(pos1) - 1);
+	let leaf_start = pmmr_leaf_to_insertion_index(bintree_leftmost(pos1 - 1));
+	let leaf_end = pmmr_leaf_to_insertion_index(bintree_rightmost(pos1 - 1));
 	let leaf_start = match leaf_start {
 		Some(l) => l,
 		None => return Box::new(iter::empty::<u64>()),
@@ -688,7 +688,7 @@ pub fn bintree_leaf_pos_iter(pos1: u64) -> Box<dyn Iterator<Item = u64>> {
 
 /// Iterator over all pos beneath the provided subtree root (including the root itself).
 pub fn bintree_pos_iter(pos1: u64) -> impl Iterator<Item = u64> {
-	let leaf_start = bintree_leftmost(pos1 as u64);
+	let leaf_start = 1 + bintree_leftmost(pos1 as u64 - 1);
 	(leaf_start..=pos1).into_iter()
 }
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -567,16 +567,13 @@ pub fn is_leaf(pos0: u64) -> bool {
 
 /// Calculates the positions of the parent and sibling of the node at the
 /// provided position.
-pub fn family(pos1: u64) -> (u64, u64) {
-	if pos1 == 0 {
-		panic!("family called with pos1 == 0");
-	}
-	let (peak_map, height) = peak_map_height(pos1 - 1);
+pub fn family(pos0: u64) -> (u64, u64) {
+	let (peak_map, height) = peak_map_height(pos0);
 	let peak = 1 << height;
 	if (peak_map & peak) != 0 {
-		(pos1 + 1, pos1 + 1 - 2 * peak)
+		(pos0 + 1, pos0 + 1 - 2 * peak)
 	} else {
-		(pos1 + 2 * peak, pos1 + 2 * peak - 1)
+		(pos0 + 2 * peak, pos0 + 2 * peak - 1)
 	}
 }
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -416,11 +416,11 @@ where
 		}
 	}
 
-	fn get_data_from_file(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.size {
+	fn get_data_from_file(&self, pos0: u64) -> Option<Self::Item> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_data_from_file(pos1)
+			self.backend.get_data_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -510,7 +510,7 @@ pub fn peaks(size: u64) -> Vec<u64> {
 				*acc += &x;
 				Some(*acc)
 			})
-			.map(|x| { x - 1 }) -- rust doesn't allow starting scan with -1 as u64
+			.map(|x| x - 1) // rust doesn't allow starting scan with -1 as u64
 			.collect()
 	} else {
 		vec![]

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -86,7 +86,7 @@ pub trait ReadablePMMR {
 	fn peaks(&self) -> Vec<Hash> {
 		peaks(self.unpruned_size())
 			.into_iter()
-			.filter_map(move |pi0| self.get_peak_from_file(1 + pi0))
+			.filter_map(move |pi0| self.get_peak_from_file(pi0))
 			.collect()
 	}
 
@@ -96,7 +96,7 @@ pub trait ReadablePMMR {
 		let mut res = peaks(self.unpruned_size())
 			.into_iter()
 			.filter(|&x| 1 + x < peak_pos1)
-			.filter_map(|x| self.get_peak_from_file(1 + x))
+			.filter_map(|x| self.get_peak_from_file(x))
 			.collect::<Vec<_>>();
 		if let Some(rhs) = rhs {
 			res.push(rhs);
@@ -225,7 +225,7 @@ where
 			let left_sibling = pos + 1 - 2 * peak;
 			let left_hash = self
 				.backend
-				.get_peak_from_file(1 + left_sibling)
+				.get_peak_from_file(left_sibling)
 				.ok_or("missing left sibling in tree, should not have been pruned")?;
 			peak *= 2;
 			pos += 1;
@@ -408,11 +408,11 @@ where
 		}
 	}
 
-	fn get_peak_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.size {
+	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_peak_from_file(pos1)
+			self.backend.get_peak_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -134,8 +134,8 @@ pub trait ReadablePMMR {
 		}
 
 		// check we actually have a hash in the MMR at this pos
-		self.get_hash(1 + pos0)
-			.ok_or_else(|| format!("no element at pos {}", 1 + pos0))?;
+		self.get_hash(pos0)
+			.ok_or_else(|| format!("no element at pos {}", pos0))?;
 
 		let family_branch = family_branch(pos0, size);
 
@@ -270,7 +270,7 @@ where
 			return Err(format!("Node at {} is not a leaf, can't prune.", pos0));
 		}
 
-		if self.backend.get_hash(1 + pos0).is_none() {
+		if self.backend.get_hash(pos0).is_none() {
 			return Ok(false);
 		}
 
@@ -284,7 +284,7 @@ where
 		for n in 0..self.size {
 			let height = bintree_postorder_height(n);
 			if height > 0 {
-				if let Some(hash) = self.get_hash(n + 1) {
+				if let Some(hash) = self.get_hash(n) {
 					let left_pos = n - (1 << height);
 					let right_pos = n - 1;
 					// using get_from_file here for the children (they may have been "removed")
@@ -322,7 +322,7 @@ where
 					break;
 				}
 				idx.push_str(&format!("{:>8} ", m + 1));
-				let ohs = self.get_hash(m + 1);
+				let ohs = self.get_hash(m);
 				match ohs {
 					Some(hs) => hashes.push_str(&format!("{} ", hs)),
 					None => hashes.push_str(&format!("{:>8} ", "??")),
@@ -375,15 +375,15 @@ where
 {
 	type Item = T::E;
 
-	fn get_hash(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.size {
+	fn get_hash(&self, pos0: u64) -> Option<Hash> {
+		if pos0 >= self.size {
 			None
-		} else if is_leaf(pos1 - 1) {
+		} else if is_leaf(pos0) {
 			// If we are a leaf then get hash from the backend.
-			self.backend.get_hash(pos1)
+			self.backend.get_hash(pos0)
 		} else {
 			// If we are not a leaf get hash ignoring the remove log.
-			self.backend.get_from_file(pos1 - 1)
+			self.backend.get_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -124,20 +124,20 @@ pub trait ReadablePMMR {
 	}
 
 	/// Build a Merkle proof for the element at the given position.
-	fn merkle_proof(&self, pos1: u64) -> Result<MerkleProof, String> {
+	fn merkle_proof(&self, pos0: u64) -> Result<MerkleProof, String> {
 		let size = self.unpruned_size();
-		debug!("merkle_proof  {}, size {}", pos1, size);
+		debug!("merkle_proof  {}, size {}", pos0, size);
 
 		// check this pos is actually a leaf in the MMR
-		if !is_leaf(pos1 - 1) {
-			return Err(format!("not a leaf at pos {}", pos1));
+		if !is_leaf(pos0) {
+			return Err(format!("not a leaf at pos {}", pos0));
 		}
 
 		// check we actually have a hash in the MMR at this pos
-		self.get_hash(pos1)
-			.ok_or_else(|| format!("no element at pos {}", pos1))?;
+		self.get_hash(1 + pos0)
+			.ok_or_else(|| format!("no element at pos {}", 1 + pos0))?;
 
-		let family_branch = family_branch(pos1 - 1, size);
+		let family_branch = family_branch(pos0, size);
 
 		let mut path = family_branch
 			.iter()
@@ -145,11 +145,11 @@ pub trait ReadablePMMR {
 			.collect::<Vec<_>>();
 
 		let peak_pos = match family_branch.last() {
-			Some(&(x, _)) => 1 + x,
-			None => pos1,
+			Some(&(x, _)) => x,
+			None => pos0,
 		};
 
-		path.append(&mut self.peak_path(peak_pos));
+		path.append(&mut self.peak_path(1 + peak_pos));
 
 		Ok(MerkleProof {
 			mmr_size: size,

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -496,7 +496,7 @@ pub fn peak_sizes_height(mut size: u64) -> (Vec<u64>, u64) {
 	(peak_sizes, size)
 }
 
-/// Gets the postorder traversal 1-based index of all peaks in a MMR given its size.
+/// Gets the postorder traversal 0-based index of all peaks in a MMR given its size.
 /// Starts with the top peak, which is always on the left
 /// side of the range, and navigates toward lower siblings toward the right
 /// of the range.
@@ -510,7 +510,7 @@ pub fn peaks(size: u64) -> Vec<u64> {
 				*acc += &x;
 				Some(*acc)
 			})
-			.map(|x| x - 1)
+			.map(|x| { x - 1 }) -- rust doesn't allow starting scan with -1 as u64
 			.collect()
 	} else {
 		vec![]

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -28,6 +28,8 @@ pub trait ReadablePMMR {
 	type Item;
 
 	/// Get the hash at provided position in the MMR.
+	/// NOTE all positions are 0-based, so a size n MMR has nodes in positions 0 through n-1
+	/// just like a Rust Range 0..n
 	fn get_hash(&self, pos: u64) -> Option<Hash>;
 
 	/// Get the data element at provided position in the MMR.
@@ -91,11 +93,11 @@ pub trait ReadablePMMR {
 	}
 
 	/// Hashes of the peaks excluding `peak_pos`, where the rhs is bagged together
-	fn peak_path(&self, peak_pos1: u64) -> Vec<Hash> {
-		let rhs = self.bag_the_rhs(peak_pos1);
+	fn peak_path(&self, peak_pos0: u64) -> Vec<Hash> {
+		let rhs = self.bag_the_rhs(1 + peak_pos0);
 		let mut res = peaks(self.unpruned_size())
 			.into_iter()
-			.filter(|&x| 1 + x < peak_pos1)
+			.filter(|&x| x < peak_pos0)
 			.filter_map(|x| self.get_peak_from_file(x))
 			.collect::<Vec<_>>();
 		if let Some(rhs) = rhs {
@@ -149,7 +151,7 @@ pub trait ReadablePMMR {
 			None => pos0,
 		};
 
-		path.append(&mut self.peak_path(1 + peak_pos));
+		path.append(&mut self.peak_path(peak_pos));
 
 		Ok(MerkleProof {
 			mmr_size: size,

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -64,25 +64,23 @@ where
 	/// returns last pmmr index returned along with data
 	pub fn elements_from_pmmr_index(
 		&self,
-		mut pmmr_index: u64,
+		pmmr_index1: u64,
 		max_count: u64,
-		max_pmmr_pos: Option<u64>,
+		max_pmmr_pos1: Option<u64>,
 	) -> (u64, Vec<T::E>) {
 		let mut return_vec = vec![];
-		let size = match max_pmmr_pos {
+		let size = match max_pmmr_pos1 {
 			Some(p) => p,
 			None => self.size,
 		};
-		if pmmr_index == 0 {
-			pmmr_index = 1;
-		}
-		while return_vec.len() < max_count as usize && pmmr_index <= size {
+		let mut pmmr_index = pmmr_index1 - 1;
+		while return_vec.len() < max_count as usize && pmmr_index < size {
 			if let Some(t) = self.get_data(pmmr_index) {
 				return_vec.push(t);
 			}
 			pmmr_index += 1;
 		}
-		(pmmr_index.saturating_sub(1), return_vec)
+		(pmmr_index, return_vec)
 	}
 
 	/// Helper function to get the last N nodes inserted, i.e. the last
@@ -98,7 +96,7 @@ where
 			last_leaf = 1 + bintree_rightmost(last_leaf - 1);
 
 			if let Some(hash) = self.backend.get_hash(last_leaf) {
-				if let Some(data) = self.backend.get_data(last_leaf) {
+				if let Some(data) = self.backend.get_data(last_leaf - 1) {
 					return_vec.push((hash, data));
 				}
 			}
@@ -127,13 +125,13 @@ where
 		}
 	}
 
-	fn get_data(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.size {
+	fn get_data(&self, pos0: u64) -> Option<Self::Item> {
+		if pos0 >= self.size {
 			// If we are beyond the rhs of the MMR return None.
 			None
-		} else if is_leaf(pos1 - 1) {
+		} else if is_leaf(pos0) {
 			// If we are a leaf then get data from the backend.
-			self.backend.get_data(pos1)
+			self.backend.get_data(pos0)
 		} else {
 			// If we are not a leaf then return None as only leaves have data.
 			None

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -156,11 +156,11 @@ where
 		}
 	}
 
-	fn get_data_from_file(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.size {
+	fn get_data_from_file(&self, pos0: u64) -> Option<Self::Item> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_data_from_file(pos1)
+			self.backend.get_data_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -115,52 +115,52 @@ where
 {
 	type Item = T::E;
 
-	fn get_hash(&self, pos: u64) -> Option<Hash> {
-		if pos > self.last_pos {
+	fn get_hash(&self, pos1: u64) -> Option<Hash> {
+		if pos1 > self.last_pos {
 			None
-		} else if is_leaf(pos) {
+		} else if is_leaf(pos1 - 1) {
 			// If we are a leaf then get hash from the backend.
-			self.backend.get_hash(pos)
+			self.backend.get_hash(pos1)
 		} else {
 			// If we are not a leaf get hash ignoring the remove log.
-			self.backend.get_from_file(pos)
+			self.backend.get_from_file(pos1)
 		}
 	}
 
-	fn get_data(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
+	fn get_data(&self, pos1: u64) -> Option<Self::Item> {
+		if pos1 > self.last_pos {
 			// If we are beyond the rhs of the MMR return None.
 			None
-		} else if is_leaf(pos) {
+		} else if is_leaf(pos1 - 1) {
 			// If we are a leaf then get data from the backend.
-			self.backend.get_data(pos)
+			self.backend.get_data(pos1)
 		} else {
 			// If we are not a leaf then return None as only leaves have data.
 			None
 		}
 	}
 
-	fn get_from_file(&self, pos: u64) -> Option<Hash> {
-		if pos > self.last_pos {
+	fn get_from_file(&self, pos1: u64) -> Option<Hash> {
+		if pos1 > self.last_pos {
 			None
 		} else {
-			self.backend.get_from_file(pos)
+			self.backend.get_from_file(pos1)
 		}
 	}
 
-	fn get_peak_from_file(&self, pos: u64) -> Option<Hash> {
-		if pos > self.last_pos {
+	fn get_peak_from_file(&self, pos1: u64) -> Option<Hash> {
+		if pos1 > self.last_pos {
 			None
 		} else {
-			self.backend.get_peak_from_file(pos)
+			self.backend.get_peak_from_file(pos1)
 		}
 	}
 
-	fn get_data_from_file(&self, pos: u64) -> Option<Self::Item> {
-		if pos > self.last_pos {
+	fn get_data_from_file(&self, pos1: u64) -> Option<Self::Item> {
+		if pos1 > self.last_pos {
 			None
 		} else {
-			self.backend.get_data_from_file(pos)
+			self.backend.get_data_from_file(pos1)
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -148,11 +148,11 @@ where
 		}
 	}
 
-	fn get_peak_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.size {
+	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_peak_from_file(pos1)
+			self.backend.get_peak_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -123,7 +123,7 @@ where
 			self.backend.get_hash(pos1)
 		} else {
 			// If we are not a leaf get hash ignoring the remove log.
-			self.backend.get_from_file(pos1)
+			self.backend.get_from_file(pos1 - 1)
 		}
 	}
 
@@ -140,11 +140,11 @@ where
 		}
 	}
 
-	fn get_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.size {
+	fn get_from_file(&self, pos0: u64) -> Option<Hash> {
+		if pos0 >= self.size {
 			None
 		} else {
-			self.backend.get_from_file(pos1)
+			self.backend.get_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -95,7 +95,7 @@ where
 			if last_leaf == 0 {
 				break;
 			}
-			last_leaf = bintree_rightmost(last_leaf);
+			last_leaf = 1 + bintree_rightmost(last_leaf - 1);
 
 			if let Some(hash) = self.backend.get_hash(last_leaf) {
 				if let Some(data) = self.backend.get_data(last_leaf) {

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -28,7 +28,7 @@ where
 	B: Backend<T>,
 {
 	/// The last position in the PMMR
-	last_pos: u64,
+	size: u64,
 	/// The backend for this readonly PMMR
 	backend: &'a B,
 	// only needed to parameterise Backend
@@ -44,17 +44,17 @@ where
 	pub fn new(backend: &'a B) -> ReadonlyPMMR<'_, T, B> {
 		ReadonlyPMMR {
 			backend,
-			last_pos: 0,
+			size: 0,
 			_marker: marker::PhantomData,
 		}
 	}
 
 	/// Build a new readonly PMMR pre-initialized to
-	/// last_pos with the provided backend.
-	pub fn at(backend: &'a B, last_pos: u64) -> ReadonlyPMMR<'_, T, B> {
+	/// size with the provided backend.
+	pub fn at(backend: &'a B, size: u64) -> ReadonlyPMMR<'_, T, B> {
 		ReadonlyPMMR {
 			backend,
-			last_pos,
+			size,
 			_marker: marker::PhantomData,
 		}
 	}
@@ -69,14 +69,14 @@ where
 		max_pmmr_pos: Option<u64>,
 	) -> (u64, Vec<T::E>) {
 		let mut return_vec = vec![];
-		let last_pos = match max_pmmr_pos {
+		let size = match max_pmmr_pos {
 			Some(p) => p,
-			None => self.last_pos,
+			None => self.size,
 		};
 		if pmmr_index == 0 {
 			pmmr_index = 1;
 		}
-		while return_vec.len() < max_count as usize && pmmr_index <= last_pos {
+		while return_vec.len() < max_count as usize && pmmr_index <= size {
 			if let Some(t) = self.get_data(pmmr_index) {
 				return_vec.push(t);
 			}
@@ -90,7 +90,7 @@ where
 	/// May return less than n items if the MMR has been pruned/compacted.
 	pub fn get_last_n_insertions(&self, n: u64) -> Vec<(Hash, T::E)> {
 		let mut return_vec = vec![];
-		let mut last_leaf = self.last_pos;
+		let mut last_leaf = self.size;
 		for _ in 0..n as u64 {
 			if last_leaf == 0 {
 				break;
@@ -116,7 +116,7 @@ where
 	type Item = T::E;
 
 	fn get_hash(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.last_pos {
+		if pos1 > self.size {
 			None
 		} else if is_leaf(pos1 - 1) {
 			// If we are a leaf then get hash from the backend.
@@ -128,7 +128,7 @@ where
 	}
 
 	fn get_data(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.last_pos {
+		if pos1 > self.size {
 			// If we are beyond the rhs of the MMR return None.
 			None
 		} else if is_leaf(pos1 - 1) {
@@ -141,7 +141,7 @@ where
 	}
 
 	fn get_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.last_pos {
+		if pos1 > self.size {
 			None
 		} else {
 			self.backend.get_from_file(pos1)
@@ -149,7 +149,7 @@ where
 	}
 
 	fn get_peak_from_file(&self, pos1: u64) -> Option<Hash> {
-		if pos1 > self.last_pos {
+		if pos1 > self.size {
 			None
 		} else {
 			self.backend.get_peak_from_file(pos1)
@@ -157,7 +157,7 @@ where
 	}
 
 	fn get_data_from_file(&self, pos1: u64) -> Option<Self::Item> {
-		if pos1 > self.last_pos {
+		if pos1 > self.size {
 			None
 		} else {
 			self.backend.get_data_from_file(pos1)
@@ -165,7 +165,7 @@ where
 	}
 
 	fn unpruned_size(&self) -> u64 {
-		self.last_pos
+		self.size
 	}
 
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -17,7 +17,7 @@
 
 use std::marker;
 
-use crate::core::pmmr::{bintree_postorder_height, Backend, ReadonlyPMMR};
+use crate::core::pmmr::{round_up_to_leaf_pos, Backend, ReadonlyPMMR};
 use crate::ser::PMMRable;
 
 /// Rewindable (but still readonly) view of a PMMR.
@@ -64,11 +64,7 @@ where
 		// Identify which actual position we should rewind to as the provided
 		// position is a leaf. We traverse the MMR to include any parent(s) that
 		// need to be included for the MMR to be valid.
-		let mut pos = position;
-		while bintree_postorder_height(pos + 1) > 0 {
-			pos += 1;
-		}
-		self.last_pos = pos;
+		self.last_pos = round_up_to_leaf_pos(position);
 		Ok(())
 	}
 

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -447,8 +447,8 @@ where
 		self.proof.validate(
 			size,
 			mmr_root,
-			1 + first,
-			1 + last,
+			first,
+			last,
 			segment_root,
 			segment_unpruned_pos,
 		)
@@ -692,8 +692,8 @@ impl SegmentProof {
 	) -> Result<(), SegmentError> {
 		let root = self.reconstruct_root(
 			last_pos,
-			segment_first_pos - 1,
-			segment_last_pos - 1,
+			segment_first_pos,
+			segment_last_pos,
 			segment_root,
 			segment_unpruned_pos,
 		)?;

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -259,7 +259,7 @@ where
 			}
 			// TODO: optimize, no need to send every intermediary hash
 			if prunable {
-				if let Some(hash) = pmmr.get_from_file(pos) {
+				if let Some(hash) = pmmr.get_from_file(pos - 1) {
 					segment.hashes.push(hash);
 					segment.hash_pos.push(pos);
 				}
@@ -271,7 +271,7 @@ where
 		if segment.leaf_data.is_empty() && segment.hashes.is_empty() {
 			let family_branch = pmmr::family_branch(segment_last_pos - 1, last_pos);
 			for (pos0, _) in family_branch {
-				if let Some(hash) = pmmr.get_from_file(1 + pos0) {
+				if let Some(hash) = pmmr.get_from_file(pos0) {
 					segment.hashes.push(hash);
 					segment.hash_pos.push(1 + pos0);
 					start_pos = Some(1 + pos0);

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -597,8 +597,8 @@ impl SegmentProof {
 		// 2. bagged peaks to the right
 		let peak_pos = family_branch
 			.last()
-			.map(|&(p0, _)| 1 + p0)
-			.unwrap_or(segment_last_pos);
+			.map(|&(p0, _)| p0)
+			.unwrap_or(segment_last_pos - 1);
 		if let Some(h) = pmmr.bag_the_rhs(peak_pos) {
 			proof.hashes.push(h);
 		}

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -248,7 +248,7 @@ where
 		// Fill leaf data and hashes
 		let (segment_first_pos, segment_last_pos) = segment.segment_pos_range(last_pos);
 		for pos in segment_first_pos..=segment_last_pos {
-			if pmmr::is_leaf(pos) {
+			if pmmr::is_leaf(pos - 1) {
 				if let Some(data) = pmmr.get_data_from_file(pos) {
 					segment.leaf_data.push(data);
 					segment.leaf_pos.push(pos);

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -249,7 +249,7 @@ where
 		let (segment_first_pos, segment_last_pos) = segment.segment_pos_range(last_pos);
 		for pos in segment_first_pos..=segment_last_pos {
 			if pmmr::is_leaf(pos - 1) {
-				if let Some(data) = pmmr.get_data_from_file(pos) {
+				if let Some(data) = pmmr.get_data_from_file(pos - 1) {
 					segment.leaf_data.push(data);
 					segment.leaf_pos.push(pos);
 					continue;

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -121,9 +121,9 @@ impl<T> Segment<T> {
 	pub fn segment_pos_range(&self, last_pos: u64) -> (u64, u64) {
 		let segment_size = self.segment_unpruned_size(last_pos);
 		let leaf_offset = self.leaf_offset();
-		let first = pmmr::insertion_to_pmmr_index(leaf_offset + 1);
+		let first = 1 + pmmr::insertion_to_pmmr_index(leaf_offset);
 		let last = if self.full_segment(last_pos) {
-			pmmr::insertion_to_pmmr_index(leaf_offset + segment_size)
+			1 + pmmr::insertion_to_pmmr_index(leaf_offset + segment_size - 1)
 				+ (self.identifier.height as u64)
 		} else {
 			last_pos

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -470,8 +470,8 @@ where
 		self.proof.validate_with(
 			size,
 			mmr_root,
-			1 + first,
-			1 + last,
+			first,
+			last,
 			segment_root,
 			segment_unpruned_pos,
 			hash_last_pos,
@@ -720,8 +720,8 @@ impl SegmentProof {
 	) -> Result<(), SegmentError> {
 		let root = self.reconstruct_root(
 			last_pos,
-			segment_first_pos - 1,
-			segment_last_pos - 1,
+			segment_first_pos,
+			segment_last_pos,
 			segment_root,
 			segment_unpruned_pos,
 		)?;

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -314,7 +314,7 @@ where
 				if bitmap
 					.map(|b| {
 						let idx_1 = pmmr::n_leaves(pos1) - 1;
-						let idx_2 = if pmmr::is_left_sibling(pos1) {
+						let idx_2 = if pmmr::is_left_sibling(pos1 - 1) {
 							idx_1 + 1
 						} else {
 							idx_1 - 1
@@ -634,7 +634,7 @@ impl SegmentProof {
 			.filter(|&&(p, _)| p > segment_unpruned_pos)
 		{
 			let sibling_hash = iter.next().ok_or_else(|| SegmentError::MissingHash(s))?;
-			root = if pmmr::is_left_sibling(s) {
+			root = if pmmr::is_left_sibling(s - 1) {
 				(sibling_hash, root).hash_with_index(p - 1)
 			} else {
 				(root, sibling_hash).hash_with_index(p - 1)

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -428,8 +428,8 @@ where
 
 			if let Some((p0, _)) = family_branch.next() {
 				pos = 1 + p0;
-				let range = (pmmr::n_leaves(pmmr::bintree_leftmost(1 + p0)) - 1)
-					..min(pmmr::n_leaves(pmmr::bintree_rightmost(1 + p0)), n_leaves);
+				let range = (pmmr::n_leaves(1 + pmmr::bintree_leftmost(p0)) - 1)
+					..min(pmmr::n_leaves(1 + pmmr::bintree_rightmost(p0)), n_leaves);
 				cardinality = bitmap.range_cardinality(range);
 			} else {
 				break;

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -48,7 +48,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 	}
 
 	fn get_hash(&self, pos0: u64) -> Option<Hash> {
-		if self.removed.contains(&(1 + pos0)) {
+		if self.removed.contains(&pos0) {
 			None
 		} else {
 			self.get_from_file(pos0)
@@ -56,8 +56,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 	}
 
 	fn get_data(&self, pos0: u64) -> Option<T::E> {
-		if self.removed.contains(&(1 + pos0)) {
-			// sucks that removed is 1-based:-(
+		if self.removed.contains(&pos0) {
 			None
 		} else {
 			self.get_data_from_file(pos0)
@@ -93,7 +92,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 				.iter()
 				.enumerate()
 				.map(|(x, _)| (x + 1) as u64)
-				.filter(move |x| pmmr::is_leaf(*x - 1) && !self.removed.contains(x)),
+				.filter(move |x| pmmr::is_leaf(*x - 1) && !self.removed.contains(&(x - 1))),
 		)
 	}
 
@@ -106,8 +105,8 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		)
 	}
 
-	fn remove(&mut self, position: u64) -> Result<(), String> {
-		self.removed.insert(position);
+	fn remove(&mut self, pos0: u64) -> Result<(), String> {
+		self.removed.insert(pos0);
 		Ok(())
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -68,8 +68,8 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		self.hashes.get(idx).cloned()
 	}
 
-	fn get_peak_from_file(&self, position: u64) -> Option<Hash> {
-		self.get_from_file(position)
+	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
+		self.get_from_file(1 + pos0)
 	}
 
 	fn get_data_from_file(&self, position: u64) -> Option<T::E> {

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -55,11 +55,11 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		}
 	}
 
-	fn get_data(&self, pos1: u64) -> Option<T::E> {
-		if self.removed.contains(&pos1) {
+	fn get_data(&self, pos0: u64) -> Option<T::E> {
+		if self.removed.contains(&(1 + pos0)) {
 			None
 		} else {
-			self.get_data_from_file(pos1 - 1)
+			self.get_data_from_file(pos0)
 		}
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -47,16 +47,17 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
-	fn get_hash(&self, pos1: u64) -> Option<Hash> {
-		if self.removed.contains(&pos1) {
+	fn get_hash(&self, pos0: u64) -> Option<Hash> {
+		if self.removed.contains(&(1 + pos0)) {
 			None
 		} else {
-			self.get_from_file(pos1 - 1)
+			self.get_from_file(pos0)
 		}
 	}
 
 	fn get_data(&self, pos0: u64) -> Option<T::E> {
 		if self.removed.contains(&(1 + pos0)) {
+			// sucks that removed is 1-based:-(
 			None
 		} else {
 			self.get_data_from_file(pos0)

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -47,11 +47,11 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
-	fn get_hash(&self, position: u64) -> Option<Hash> {
-		if self.removed.contains(&position) {
+	fn get_hash(&self, pos1: u64) -> Option<Hash> {
+		if self.removed.contains(&pos1) {
 			None
 		} else {
-			self.get_from_file(position)
+			self.get_from_file(pos1 - 1)
 		}
 	}
 
@@ -63,13 +63,13 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		}
 	}
 
-	fn get_from_file(&self, position: u64) -> Option<Hash> {
-		let idx = usize::try_from(position.saturating_sub(1)).expect("usize from u64");
+	fn get_from_file(&self, pos0: u64) -> Option<Hash> {
+		let idx = usize::try_from(pos0).expect("usize from u64");
 		self.hashes.get(idx).cloned()
 	}
 
 	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
-		self.get_from_file(1 + pos0)
+		self.get_from_file(pos0)
 	}
 
 	fn get_data_from_file(&self, pos0: u64) -> Option<T::E> {

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -43,7 +43,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		Ok(())
 	}
 
-	fn append_pruned_subtree(&mut self, _hash: Hash, _pos: u64) -> Result<(), String> {
+	fn append_pruned_subtree(&mut self, _hash: Hash, _pos0: u64) -> Result<(), String> {
 		unimplemented!()
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -93,7 +93,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 				.iter()
 				.enumerate()
 				.map(|(x, _)| (x + 1) as u64)
-				.filter(move |x| pmmr::is_leaf(*x) && !self.removed.contains(x)),
+				.filter(move |x| pmmr::is_leaf(*x - 1) && !self.removed.contains(x)),
 		)
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -91,17 +91,18 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 			self.hashes
 				.iter()
 				.enumerate()
-				.map(|(x, _)| (x + 1) as u64)
-				.filter(move |x| pmmr::is_leaf(*x - 1) && !self.removed.contains(&(x - 1))),
+				.map(|(x, _)| x as u64)
+				.filter(move |x| pmmr::is_leaf(*x) && !self.removed.contains(x)),
 		)
 	}
 
+	/// NOTE this function is needlessly inefficient with repeated calls to n_leaves()
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_> {
-		let from_pos = 1 + pmmr::insertion_to_pmmr_index(from_idx);
+		let from_pos = pmmr::insertion_to_pmmr_index(from_idx);
 		Box::new(
 			self.leaf_pos_iter()
 				.skip_while(move |x| *x < from_pos)
-				.map(|x| pmmr::n_leaves(x).saturating_sub(1)),
+				.map(|x| pmmr::n_leaves(x + 1) - 1),
 		)
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -98,7 +98,7 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 	}
 
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_> {
-		let from_pos = pmmr::insertion_to_pmmr_index(from_idx + 1);
+		let from_pos = 1 + pmmr::insertion_to_pmmr_index(from_idx);
 		Box::new(
 			self.leaf_pos_iter()
 				.skip_while(move |x| *x < from_pos)

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -55,11 +55,11 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		}
 	}
 
-	fn get_data(&self, position: u64) -> Option<T::E> {
-		if self.removed.contains(&position) {
+	fn get_data(&self, pos1: u64) -> Option<T::E> {
+		if self.removed.contains(&pos1) {
 			None
 		} else {
-			self.get_data_from_file(position)
+			self.get_data_from_file(pos1 - 1)
 		}
 	}
 
@@ -72,10 +72,9 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		self.get_from_file(1 + pos0)
 	}
 
-	fn get_data_from_file(&self, position: u64) -> Option<T::E> {
+	fn get_data_from_file(&self, pos0: u64) -> Option<T::E> {
 		if let Some(data) = &self.data {
-			let idx = usize::try_from(pmmr::n_leaves(position).saturating_sub(1))
-				.expect("usize from u64");
+			let idx = usize::try_from(pmmr::n_leaves(1 + pos0) - 1).expect("usize from u64");
 			data.get(idx).map(|x| x.as_elmt())
 		} else {
 			None

--- a/core/tests/merkle_proof.rs
+++ b/core/tests/merkle_proof.rs
@@ -34,7 +34,7 @@ fn merkle_proof_ser_deser() {
 	for x in 0..15 {
 		pmmr.push(&TestElem([0, 0, 0, x])).unwrap();
 	}
-	let proof = pmmr.merkle_proof(9).unwrap();
+	let proof = pmmr.merkle_proof(8).unwrap();
 
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &proof).expect("serialization failed");
@@ -49,12 +49,12 @@ fn pmmr_merkle_proof_prune_and_rewind() {
 	let mut pmmr = PMMR::new(&mut ba);
 	pmmr.push(&TestElem([0, 0, 0, 1])).unwrap();
 	pmmr.push(&TestElem([0, 0, 0, 2])).unwrap();
-	let proof = pmmr.merkle_proof(2).unwrap();
+	let proof = pmmr.merkle_proof(1).unwrap();
 
 	// now prune an element and check we can still generate
 	// the correct Merkle proof for the other element (after sibling pruned)
 	pmmr.prune(0).unwrap();
-	let proof_2 = pmmr.merkle_proof(2).unwrap();
+	let proof_2 = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(proof, proof_2);
 }
 
@@ -79,7 +79,7 @@ fn pmmr_merkle_proof() {
 	let pos_0 = elems[0].hash_with_index(0);
 	assert_eq!(pmmr.get_hash(1).unwrap(), pos_0);
 
-	let proof = pmmr.merkle_proof(1).unwrap();
+	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
 
@@ -93,11 +93,11 @@ fn pmmr_merkle_proof() {
 	assert_eq!(pmmr.peaks(), vec![pos_2]);
 
 	// single peak, path with single sibling
-	let proof = pmmr.merkle_proof(1).unwrap();
+	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![pos_1]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
 
-	let proof = pmmr.merkle_proof(2).unwrap();
+	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(proof.path, vec![pos_0]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
 
@@ -109,15 +109,15 @@ fn pmmr_merkle_proof() {
 	assert_eq!(pmmr.root().unwrap(), (pos_2, pos_3).hash_with_index(4));
 	assert_eq!(pmmr.peaks(), vec![pos_2, pos_3]);
 
-	let proof = pmmr.merkle_proof(1).unwrap();
+	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![pos_1, pos_3]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
 
-	let proof = pmmr.merkle_proof(2).unwrap();
+	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(proof.path, vec![pos_0, pos_3]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
 
-	let proof = pmmr.merkle_proof(4).unwrap();
+	let proof = pmmr.merkle_proof(3).unwrap();
 	assert_eq!(proof.path, vec![pos_2]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 4).is_ok());
 
@@ -147,43 +147,43 @@ fn pmmr_merkle_proof() {
 
 	assert_eq!(pmmr.unpruned_size(), 11);
 
-	let proof = pmmr.merkle_proof(1).unwrap();
+	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_1, pos_5, (pos_9, pos_10).hash_with_index(11)]
 	);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
 
-	let proof = pmmr.merkle_proof(2).unwrap();
+	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_0, pos_5, (pos_9, pos_10).hash_with_index(11)]
 	);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
 
-	let proof = pmmr.merkle_proof(4).unwrap();
+	let proof = pmmr.merkle_proof(3).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_4, pos_2, (pos_9, pos_10).hash_with_index(11)]
 	);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 4).is_ok());
 
-	let proof = pmmr.merkle_proof(5).unwrap();
+	let proof = pmmr.merkle_proof(4).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_3, pos_2, (pos_9, pos_10).hash_with_index(11)]
 	);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[3], 5).is_ok());
 
-	let proof = pmmr.merkle_proof(8).unwrap();
+	let proof = pmmr.merkle_proof(7).unwrap();
 	assert_eq!(proof.path, vec![pos_8, pos_10, pos_6]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[4], 8).is_ok());
 
-	let proof = pmmr.merkle_proof(9).unwrap();
+	let proof = pmmr.merkle_proof(8).unwrap();
 	assert_eq!(proof.path, vec![pos_7, pos_10, pos_6]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[5], 9).is_ok());
 
-	let proof = pmmr.merkle_proof(11).unwrap();
+	let proof = pmmr.merkle_proof(10).unwrap();
 	assert_eq!(proof.path, vec![pos_9, pos_6]);
 	assert!(proof.verify(pmmr.root().unwrap(), &elems[6], 11).is_ok());
 }

--- a/core/tests/merkle_proof.rs
+++ b/core/tests/merkle_proof.rs
@@ -77,7 +77,7 @@ fn pmmr_merkle_proof() {
 
 	pmmr.push(&elems[0]).unwrap();
 	let pos_0 = elems[0].hash_with_index(0);
-	assert_eq!(pmmr.get_hash(1).unwrap(), pos_0);
+	assert_eq!(pmmr.get_hash(0).unwrap(), pos_0);
 
 	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![]);
@@ -85,9 +85,9 @@ fn pmmr_merkle_proof() {
 
 	pmmr.push(&elems[1]).unwrap();
 	let pos_1 = elems[1].hash_with_index(1);
-	assert_eq!(pmmr.get_hash(2).unwrap(), pos_1);
+	assert_eq!(pmmr.get_hash(1).unwrap(), pos_1);
 	let pos_2 = (pos_0, pos_1).hash_with_index(2);
-	assert_eq!(pmmr.get_hash(3).unwrap(), pos_2);
+	assert_eq!(pmmr.get_hash(2).unwrap(), pos_2);
 
 	assert_eq!(pmmr.root().unwrap(), pos_2);
 	assert_eq!(pmmr.peaks(), vec![pos_2]);
@@ -104,7 +104,7 @@ fn pmmr_merkle_proof() {
 	// three leaves, two peaks (one also the right-most leaf)
 	pmmr.push(&elems[2]).unwrap();
 	let pos_3 = elems[2].hash_with_index(3);
-	assert_eq!(pmmr.get_hash(4).unwrap(), pos_3);
+	assert_eq!(pmmr.get_hash(3).unwrap(), pos_3);
 
 	assert_eq!(pmmr.root().unwrap(), (pos_2, pos_3).hash_with_index(4));
 	assert_eq!(pmmr.peaks(), vec![pos_2, pos_3]);
@@ -124,26 +124,26 @@ fn pmmr_merkle_proof() {
 	// 7 leaves, 3 peaks, 11 pos in total
 	pmmr.push(&elems[3]).unwrap();
 	let pos_4 = elems[3].hash_with_index(4);
-	assert_eq!(pmmr.get_hash(5).unwrap(), pos_4);
+	assert_eq!(pmmr.get_hash(4).unwrap(), pos_4);
 	let pos_5 = (pos_3, pos_4).hash_with_index(5);
-	assert_eq!(pmmr.get_hash(6).unwrap(), pos_5);
+	assert_eq!(pmmr.get_hash(5).unwrap(), pos_5);
 	let pos_6 = (pos_2, pos_5).hash_with_index(6);
-	assert_eq!(pmmr.get_hash(7).unwrap(), pos_6);
+	assert_eq!(pmmr.get_hash(6).unwrap(), pos_6);
 
 	pmmr.push(&elems[4]).unwrap();
 	let pos_7 = elems[4].hash_with_index(7);
-	assert_eq!(pmmr.get_hash(8).unwrap(), pos_7);
+	assert_eq!(pmmr.get_hash(7).unwrap(), pos_7);
 
 	pmmr.push(&elems[5]).unwrap();
 	let pos_8 = elems[5].hash_with_index(8);
-	assert_eq!(pmmr.get_hash(9).unwrap(), pos_8);
+	assert_eq!(pmmr.get_hash(8).unwrap(), pos_8);
 
 	let pos_9 = (pos_7, pos_8).hash_with_index(9);
-	assert_eq!(pmmr.get_hash(10).unwrap(), pos_9);
+	assert_eq!(pmmr.get_hash(9).unwrap(), pos_9);
 
 	pmmr.push(&elems[6]).unwrap();
 	let pos_10 = elems[6].hash_with_index(10);
-	assert_eq!(pmmr.get_hash(11).unwrap(), pos_10);
+	assert_eq!(pmmr.get_hash(10).unwrap(), pos_10);
 
 	assert_eq!(pmmr.unpruned_size(), 11);
 

--- a/core/tests/merkle_proof.rs
+++ b/core/tests/merkle_proof.rs
@@ -81,7 +81,7 @@ fn pmmr_merkle_proof() {
 
 	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 0).is_ok());
 
 	pmmr.push(&elems[1]).unwrap();
 	let pos_1 = elems[1].hash_with_index(1);
@@ -95,11 +95,11 @@ fn pmmr_merkle_proof() {
 	// single peak, path with single sibling
 	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![pos_1]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 0).is_ok());
 
 	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(proof.path, vec![pos_0]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 1).is_ok());
 
 	// three leaves, two peaks (one also the right-most leaf)
 	pmmr.push(&elems[2]).unwrap();
@@ -111,15 +111,15 @@ fn pmmr_merkle_proof() {
 
 	let proof = pmmr.merkle_proof(0).unwrap();
 	assert_eq!(proof.path, vec![pos_1, pos_3]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 0).is_ok());
 
 	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(proof.path, vec![pos_0, pos_3]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 1).is_ok());
 
 	let proof = pmmr.merkle_proof(3).unwrap();
 	assert_eq!(proof.path, vec![pos_2]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 4).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 3).is_ok());
 
 	// 7 leaves, 3 peaks, 11 pos in total
 	pmmr.push(&elems[3]).unwrap();
@@ -152,38 +152,38 @@ fn pmmr_merkle_proof() {
 		proof.path,
 		vec![pos_1, pos_5, (pos_9, pos_10).hash_with_index(11)]
 	);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 1).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[0], 0).is_ok());
 
 	let proof = pmmr.merkle_proof(1).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_0, pos_5, (pos_9, pos_10).hash_with_index(11)]
 	);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 2).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[1], 1).is_ok());
 
 	let proof = pmmr.merkle_proof(3).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_4, pos_2, (pos_9, pos_10).hash_with_index(11)]
 	);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 4).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[2], 3).is_ok());
 
 	let proof = pmmr.merkle_proof(4).unwrap();
 	assert_eq!(
 		proof.path,
 		vec![pos_3, pos_2, (pos_9, pos_10).hash_with_index(11)]
 	);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[3], 5).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[3], 4).is_ok());
 
 	let proof = pmmr.merkle_proof(7).unwrap();
 	assert_eq!(proof.path, vec![pos_8, pos_10, pos_6]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[4], 8).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[4], 7).is_ok());
 
 	let proof = pmmr.merkle_proof(8).unwrap();
 	assert_eq!(proof.path, vec![pos_7, pos_10, pos_6]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[5], 9).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[5], 8).is_ok());
 
 	let proof = pmmr.merkle_proof(10).unwrap();
 	assert_eq!(proof.path, vec![pos_9, pos_6]);
-	assert!(proof.verify(pmmr.root().unwrap(), &elems[6], 11).is_ok());
+	assert!(proof.verify(pmmr.root().unwrap(), &elems[6], 10).is_ok());
 }

--- a/core/tests/merkle_proof.rs
+++ b/core/tests/merkle_proof.rs
@@ -53,7 +53,7 @@ fn pmmr_merkle_proof_prune_and_rewind() {
 
 	// now prune an element and check we can still generate
 	// the correct Merkle proof for the other element (after sibling pruned)
-	pmmr.prune(1).unwrap();
+	pmmr.prune(0).unwrap();
 	let proof_2 = pmmr.merkle_proof(2).unwrap();
 	assert_eq!(proof, proof_2);
 }

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -91,13 +91,13 @@ fn first_100_mmr_heights() {
 
 #[test]
 fn test_bintree_range() {
+	assert_eq!(pmmr::bintree_range(0), 0..1);
 	assert_eq!(pmmr::bintree_range(1), 1..2);
-	assert_eq!(pmmr::bintree_range(2), 2..3);
-	assert_eq!(pmmr::bintree_range(3), 1..4);
+	assert_eq!(pmmr::bintree_range(2), 0..3);
+	assert_eq!(pmmr::bintree_range(3), 3..4);
 	assert_eq!(pmmr::bintree_range(4), 4..5);
-	assert_eq!(pmmr::bintree_range(5), 5..6);
-	assert_eq!(pmmr::bintree_range(6), 4..7);
-	assert_eq!(pmmr::bintree_range(7), 1..8);
+	assert_eq!(pmmr::bintree_range(5), 3..6);
+	assert_eq!(pmmr::bintree_range(6), 0..7);
 }
 
 // The pos of the rightmost leaf for the provided MMR size (last leaf in subtree).
@@ -199,7 +199,6 @@ fn test_pmmr_leaf_to_insertion_index() {
 fn test_n_leaves() {
 	// make sure we handle an empty MMR correctly
 	assert_eq!(pmmr::n_leaves(0), 0);
-
 	// and various sizes on non-empty MMRs
 	assert_eq!(pmmr::n_leaves(1), 1);
 	assert_eq!(pmmr::n_leaves(2), 2);
@@ -211,6 +210,21 @@ fn test_n_leaves() {
 	assert_eq!(pmmr::n_leaves(8), 5);
 	assert_eq!(pmmr::n_leaves(9), 6);
 	assert_eq!(pmmr::n_leaves(10), 6);
+}
+
+#[test]
+fn test_round_up_to_leaf_pos() {
+	assert_eq!(pmmr::round_up_to_leaf_pos(0), 0);
+	assert_eq!(pmmr::round_up_to_leaf_pos(1), 1);
+	assert_eq!(pmmr::round_up_to_leaf_pos(2), 3);
+	assert_eq!(pmmr::round_up_to_leaf_pos(3), 3);
+	assert_eq!(pmmr::round_up_to_leaf_pos(4), 4);
+	assert_eq!(pmmr::round_up_to_leaf_pos(5), 7);
+	assert_eq!(pmmr::round_up_to_leaf_pos(6), 7);
+	assert_eq!(pmmr::round_up_to_leaf_pos(7), 7);
+	assert_eq!(pmmr::round_up_to_leaf_pos(8), 8);
+	assert_eq!(pmmr::round_up_to_leaf_pos(9), 10);
+	assert_eq!(pmmr::round_up_to_leaf_pos(10), 10);
 }
 
 /// Find parent and sibling positions for various node positions.

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -217,14 +217,14 @@ fn test_n_leaves() {
 #[test]
 fn various_families() {
 	// 0 0 1 0 0 1 2 0 0 1 0 0 1 2 3
-	assert_eq!(pmmr::family(1), (3, 2));
-	assert_eq!(pmmr::family(2), (3, 1));
-	assert_eq!(pmmr::family(3), (7, 6));
-	assert_eq!(pmmr::family(4), (6, 5));
-	assert_eq!(pmmr::family(5), (6, 4));
-	assert_eq!(pmmr::family(6), (7, 3));
-	assert_eq!(pmmr::family(7), (15, 14));
-	assert_eq!(pmmr::family(1_000), (1_001, 997));
+	assert_eq!(pmmr::family(0), (2, 1));
+	assert_eq!(pmmr::family(1), (2, 0));
+	assert_eq!(pmmr::family(2), (6, 5));
+	assert_eq!(pmmr::family(3), (5, 4));
+	assert_eq!(pmmr::family(4), (5, 3));
+	assert_eq!(pmmr::family(5), (6, 2));
+	assert_eq!(pmmr::family(6), (14, 13));
+	assert_eq!(pmmr::family(999), (1_000, 996));
 }
 
 #[test]

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -236,9 +236,9 @@ fn test_paths() {
 
 #[test]
 fn test_is_left_sibling() {
-	assert_eq!(pmmr::is_left_sibling(1), true);
-	assert_eq!(pmmr::is_left_sibling(2), false);
-	assert_eq!(pmmr::is_left_sibling(3), true);
+	assert_eq!(pmmr::is_left_sibling(0), true);
+	assert_eq!(pmmr::is_left_sibling(1), false);
+	assert_eq!(pmmr::is_left_sibling(2), true);
 }
 
 #[test]

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -140,15 +140,15 @@ fn test_bintree_leaf_pos_iter() {
 
 #[test]
 fn test_bintree_pos_iter() {
+	assert_eq!(pmmr::bintree_pos_iter(0).collect::<Vec<_>>(), [0]);
 	assert_eq!(pmmr::bintree_pos_iter(1).collect::<Vec<_>>(), [1]);
-	assert_eq!(pmmr::bintree_pos_iter(2).collect::<Vec<_>>(), [2]);
-	assert_eq!(pmmr::bintree_pos_iter(3).collect::<Vec<_>>(), [1, 2, 3]);
+	assert_eq!(pmmr::bintree_pos_iter(2).collect::<Vec<_>>(), [0, 1, 2]);
+	assert_eq!(pmmr::bintree_pos_iter(3).collect::<Vec<_>>(), [3]);
 	assert_eq!(pmmr::bintree_pos_iter(4).collect::<Vec<_>>(), [4]);
-	assert_eq!(pmmr::bintree_pos_iter(5).collect::<Vec<_>>(), [5]);
-	assert_eq!(pmmr::bintree_pos_iter(6).collect::<Vec<_>>(), [4, 5, 6]);
+	assert_eq!(pmmr::bintree_pos_iter(5).collect::<Vec<_>>(), [3, 4, 5]);
 	assert_eq!(
-		pmmr::bintree_pos_iter(7).collect::<Vec<_>>(),
-		[1, 2, 3, 4, 5, 6, 7]
+		pmmr::bintree_pos_iter(6).collect::<Vec<_>>(),
+		[0, 1, 2, 3, 4, 5, 6]
 	);
 }
 

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -530,7 +530,7 @@ fn pmmr_prune() {
 	// pruning a leaf with no parent should do nothing
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(16).unwrap();
+		pmmr.prune(15).unwrap();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -539,7 +539,7 @@ fn pmmr_prune() {
 	// pruning leaves with no shared parent just removes 1 element
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(2).unwrap();
+		pmmr.prune(1).unwrap();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -547,7 +547,7 @@ fn pmmr_prune() {
 
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(4).unwrap();
+		pmmr.prune(3).unwrap();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -556,7 +556,7 @@ fn pmmr_prune() {
 	// pruning a non-leaf node has no effect
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(3).unwrap_err();
+		pmmr.prune(2).unwrap_err();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -565,7 +565,7 @@ fn pmmr_prune() {
 	// TODO - no longer true (leaves only now) - pruning sibling removes subtree
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(5).unwrap();
+		pmmr.prune(4).unwrap();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -575,7 +575,7 @@ fn pmmr_prune() {
 	// removes all subtree
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		pmmr.prune(1).unwrap();
+		pmmr.prune(0).unwrap();
 		assert_eq!(orig_root, pmmr.root().unwrap());
 	}
 	assert_eq!(ba.hashes.len(), 16);
@@ -584,7 +584,7 @@ fn pmmr_prune() {
 	// pruning everything should only leave us with a single peak
 	{
 		let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut ba, sz);
-		for n in 1..16 {
+		for n in 0..15 {
 			let _ = pmmr.prune(n);
 		}
 		assert_eq!(orig_root, pmmr.root().unwrap());
@@ -640,8 +640,8 @@ fn check_elements_from_pmmr_index() {
 	assert_eq!(res.1[6].0[3], 11);
 
 	// pruning a few nodes should get consistent results
-	pmmr.prune(1 + pmmr::insertion_to_pmmr_index(4)).unwrap();
-	pmmr.prune(1 + pmmr::insertion_to_pmmr_index(19)).unwrap();
+	pmmr.prune(pmmr::insertion_to_pmmr_index(4)).unwrap();
+	pmmr.prune(pmmr::insertion_to_pmmr_index(19)).unwrap();
 
 	let res = pmmr
 		.readonly_pmmr()

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -242,13 +242,6 @@ fn various_families() {
 }
 
 #[test]
-fn test_paths() {
-	assert_eq!(pmmr::path(0, 3).collect::<Vec<_>>(), [0, 2]);
-	assert_eq!(pmmr::path(1, 3).collect::<Vec<_>>(), [1, 2]);
-	assert_eq!(pmmr::path(3, 16).collect::<Vec<_>>(), [3, 5, 6, 14]);
-}
-
-#[test]
 fn test_is_left_sibling() {
 	assert_eq!(pmmr::is_left_sibling(0), true);
 	assert_eq!(pmmr::is_left_sibling(1), false);

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -126,15 +126,15 @@ fn test_bintree_leftmost() {
 
 #[test]
 fn test_bintree_leaf_pos_iter() {
+	assert_eq!(pmmr::bintree_leaf_pos_iter(0).collect::<Vec<_>>(), [0]);
 	assert_eq!(pmmr::bintree_leaf_pos_iter(1).collect::<Vec<_>>(), [1]);
-	assert_eq!(pmmr::bintree_leaf_pos_iter(2).collect::<Vec<_>>(), [2]);
-	assert_eq!(pmmr::bintree_leaf_pos_iter(3).collect::<Vec<_>>(), [1, 2]);
+	assert_eq!(pmmr::bintree_leaf_pos_iter(2).collect::<Vec<_>>(), [0, 1]);
+	assert_eq!(pmmr::bintree_leaf_pos_iter(3).collect::<Vec<_>>(), [3]);
 	assert_eq!(pmmr::bintree_leaf_pos_iter(4).collect::<Vec<_>>(), [4]);
-	assert_eq!(pmmr::bintree_leaf_pos_iter(5).collect::<Vec<_>>(), [5]);
-	assert_eq!(pmmr::bintree_leaf_pos_iter(6).collect::<Vec<_>>(), [4, 5]);
+	assert_eq!(pmmr::bintree_leaf_pos_iter(5).collect::<Vec<_>>(), [3, 4]);
 	assert_eq!(
-		pmmr::bintree_leaf_pos_iter(7).collect::<Vec<_>>(),
-		[1, 2, 4, 5]
+		pmmr::bintree_leaf_pos_iter(6).collect::<Vec<_>>(),
+		[0, 1, 3, 4]
 	);
 }
 

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -229,9 +229,9 @@ fn various_families() {
 
 #[test]
 fn test_paths() {
-	assert_eq!(pmmr::path(1, 3).collect::<Vec<_>>(), [1, 3]);
-	assert_eq!(pmmr::path(2, 3).collect::<Vec<_>>(), [2, 3]);
-	assert_eq!(pmmr::path(4, 16).collect::<Vec<_>>(), [4, 6, 7, 15]);
+	assert_eq!(pmmr::path0(0, 3).collect::<Vec<_>>(), [0, 2]);
+	assert_eq!(pmmr::path0(1, 3).collect::<Vec<_>>(), [1, 2]);
+	assert_eq!(pmmr::path0(3, 16).collect::<Vec<_>>(), [3, 5, 6, 14]);
 }
 
 #[test]
@@ -244,26 +244,26 @@ fn test_is_left_sibling() {
 #[test]
 fn various_branches() {
 	// the two leaf nodes in a 3 node tree (height 1)
-	assert_eq!(pmmr::family_branch(1, 3), [(3, 2)]);
-	assert_eq!(pmmr::family_branch(2, 3), [(3, 1)]);
+	assert_eq!(pmmr::family_branch(0, 3), [(2, 1)]);
+	assert_eq!(pmmr::family_branch(1, 3), [(2, 0)]);
 
 	// the root node in a 3 node tree
-	assert_eq!(pmmr::family_branch(3, 3), []);
+	assert_eq!(pmmr::family_branch(2, 3), []);
 
 	// leaf node in a larger tree of 7 nodes (height 2)
-	assert_eq!(pmmr::family_branch(1, 7), [(3, 2), (7, 6)]);
+	assert_eq!(pmmr::family_branch(0, 7), [(2, 1), (6, 5)]);
 
 	// note these only go as far up as the local peak, not necessarily the single
 	// root
-	assert_eq!(pmmr::family_branch(1, 4), [(3, 2)]);
+	assert_eq!(pmmr::family_branch(0, 4), [(2, 1)]);
 	// pos 4 in a tree of size 4 is a local peak
-	assert_eq!(pmmr::family_branch(4, 4), []);
+	assert_eq!(pmmr::family_branch(3, 4), []);
 	// pos 4 in a tree of size 5 is also still a local peak
-	assert_eq!(pmmr::family_branch(4, 5), []);
+	assert_eq!(pmmr::family_branch(3, 5), []);
 	// pos 4 in a tree of size 6 has a parent and a sibling
-	assert_eq!(pmmr::family_branch(4, 6), [(6, 5)]);
+	assert_eq!(pmmr::family_branch(3, 6), [(5, 4)]);
 	// a tree of size 7 is all under a single root
-	assert_eq!(pmmr::family_branch(4, 7), [(6, 5), (7, 3)]);
+	assert_eq!(pmmr::family_branch(3, 7), [(5, 4), (6, 2)]);
 
 	// ok now for a more realistic one, a tree with over a million nodes in it
 	// find the "family path" back up the tree from a leaf node at 0
@@ -272,27 +272,27 @@ fn various_branches() {
 	// largest possible list of peaks before we start combining them into larger
 	// peaks.
 	assert_eq!(
-		pmmr::family_branch(1, 1_049_000),
+		pmmr::family_branch(0, 1_049_000),
 		[
-			(3, 2),
-			(7, 6),
-			(15, 14),
-			(31, 30),
-			(63, 62),
-			(127, 126),
-			(255, 254),
-			(511, 510),
-			(1023, 1022),
-			(2047, 2046),
-			(4095, 4094),
-			(8191, 8190),
-			(16383, 16382),
-			(32767, 32766),
-			(65535, 65534),
-			(131071, 131070),
-			(262143, 262142),
-			(524287, 524286),
-			(1048575, 1048574),
+			(2, 1),
+			(6, 5),
+			(14, 13),
+			(30, 29),
+			(62, 61),
+			(126, 125),
+			(254, 253),
+			(510, 509),
+			(1022, 1021),
+			(2046, 2045),
+			(4094, 4093),
+			(8190, 8189),
+			(16382, 16381),
+			(32766, 32765),
+			(65534, 65533),
+			(131070, 131069),
+			(262142, 262141),
+			(524286, 524285),
+			(1048574, 1048573),
 		]
 	);
 }

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -103,25 +103,25 @@ fn test_bintree_range() {
 // The pos of the rightmost leaf for the provided MMR size (last leaf in subtree).
 #[test]
 fn test_bintree_rightmost() {
+	assert_eq!(pmmr::bintree_rightmost(0), 0);
 	assert_eq!(pmmr::bintree_rightmost(1), 1);
-	assert_eq!(pmmr::bintree_rightmost(2), 2);
-	assert_eq!(pmmr::bintree_rightmost(3), 2);
+	assert_eq!(pmmr::bintree_rightmost(2), 1);
+	assert_eq!(pmmr::bintree_rightmost(3), 3);
 	assert_eq!(pmmr::bintree_rightmost(4), 4);
-	assert_eq!(pmmr::bintree_rightmost(5), 5);
-	assert_eq!(pmmr::bintree_rightmost(6), 5);
-	assert_eq!(pmmr::bintree_rightmost(7), 5);
+	assert_eq!(pmmr::bintree_rightmost(5), 4);
+	assert_eq!(pmmr::bintree_rightmost(6), 4);
 }
 
 // The pos of the leftmost leaf for the provided MMR size (first leaf in subtree).
 #[test]
 fn test_bintree_leftmost() {
+	assert_eq!(pmmr::bintree_leftmost(0), 0);
 	assert_eq!(pmmr::bintree_leftmost(1), 1);
-	assert_eq!(pmmr::bintree_leftmost(2), 2);
-	assert_eq!(pmmr::bintree_leftmost(3), 1);
+	assert_eq!(pmmr::bintree_leftmost(2), 0);
+	assert_eq!(pmmr::bintree_leftmost(3), 3);
 	assert_eq!(pmmr::bintree_leftmost(4), 4);
-	assert_eq!(pmmr::bintree_leftmost(5), 5);
-	assert_eq!(pmmr::bintree_leftmost(6), 4);
-	assert_eq!(pmmr::bintree_leftmost(7), 1);
+	assert_eq!(pmmr::bintree_leftmost(5), 3);
+	assert_eq!(pmmr::bintree_leftmost(6), 0);
 }
 
 #[test]

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -321,21 +321,21 @@ fn some_peaks() {
 	assert_eq!(pmmr::peaks(0), empty);
 
 	// and various non-empty MMRs
-	assert_eq!(pmmr::peaks(1), [1]);
+	assert_eq!(pmmr::peaks(1), [0]);
 	assert_eq!(pmmr::peaks(2), empty);
-	assert_eq!(pmmr::peaks(3), [3]);
-	assert_eq!(pmmr::peaks(4), [3, 4]);
+	assert_eq!(pmmr::peaks(3), [2]);
+	assert_eq!(pmmr::peaks(4), [2, 3]);
 	assert_eq!(pmmr::peaks(5), empty);
 	assert_eq!(pmmr::peaks(6), empty);
-	assert_eq!(pmmr::peaks(7), [7]);
-	assert_eq!(pmmr::peaks(8), [7, 8]);
+	assert_eq!(pmmr::peaks(7), [6]);
+	assert_eq!(pmmr::peaks(8), [6, 7]);
 	assert_eq!(pmmr::peaks(9), empty);
-	assert_eq!(pmmr::peaks(10), [7, 10]);
-	assert_eq!(pmmr::peaks(11), [7, 10, 11]);
-	assert_eq!(pmmr::peaks(22), [15, 22]);
-	assert_eq!(pmmr::peaks(32), [31, 32]);
-	assert_eq!(pmmr::peaks(35), [31, 34, 35]);
-	assert_eq!(pmmr::peaks(42), [31, 38, 41, 42]);
+	assert_eq!(pmmr::peaks(10), [6, 9]);
+	assert_eq!(pmmr::peaks(11), [6, 9, 10]);
+	assert_eq!(pmmr::peaks(22), [14, 21]);
+	assert_eq!(pmmr::peaks(32), [30, 31]);
+	assert_eq!(pmmr::peaks(35), [30, 33, 34]);
+	assert_eq!(pmmr::peaks(42), [30, 37, 40, 41]);
 
 	// large realistic example with almost 1.5 million nodes
 	// note the distance between peaks decreases toward the right (trees get
@@ -343,8 +343,8 @@ fn some_peaks() {
 	assert_eq!(
 		pmmr::peaks(1048555),
 		[
-			524287, 786430, 917501, 983036, 1015803, 1032186, 1040377, 1044472, 1046519, 1047542,
-			1048053, 1048308, 1048435, 1048498, 1048529, 1048544, 1048551, 1048554, 1048555,
+			524286, 786429, 917500, 983035, 1015802, 1032185, 1040376, 1044471, 1046518, 1047541,
+			1048052, 1048307, 1048434, 1048497, 1048528, 1048543, 1048550, 1048553, 1048554,
 		],
 	);
 }

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -154,13 +154,13 @@ fn test_bintree_pos_iter() {
 
 #[test]
 fn test_is_leaf() {
+	assert_eq!(pmmr::is_leaf(0), true);
 	assert_eq!(pmmr::is_leaf(1), true);
-	assert_eq!(pmmr::is_leaf(2), true);
-	assert_eq!(pmmr::is_leaf(3), false);
+	assert_eq!(pmmr::is_leaf(2), false);
+	assert_eq!(pmmr::is_leaf(3), true);
 	assert_eq!(pmmr::is_leaf(4), true);
-	assert_eq!(pmmr::is_leaf(5), true);
+	assert_eq!(pmmr::is_leaf(5), false);
 	assert_eq!(pmmr::is_leaf(6), false);
-	assert_eq!(pmmr::is_leaf(7), false);
 }
 
 #[test]

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -581,14 +581,14 @@ fn pmmr_prune() {
 
 #[test]
 fn check_insertion_to_pmmr_index() {
+	assert_eq!(pmmr::insertion_to_pmmr_index(0), 0);
 	assert_eq!(pmmr::insertion_to_pmmr_index(1), 1);
-	assert_eq!(pmmr::insertion_to_pmmr_index(2), 2);
+	assert_eq!(pmmr::insertion_to_pmmr_index(2), 3);
 	assert_eq!(pmmr::insertion_to_pmmr_index(3), 4);
-	assert_eq!(pmmr::insertion_to_pmmr_index(4), 5);
+	assert_eq!(pmmr::insertion_to_pmmr_index(4), 7);
 	assert_eq!(pmmr::insertion_to_pmmr_index(5), 8);
-	assert_eq!(pmmr::insertion_to_pmmr_index(6), 9);
+	assert_eq!(pmmr::insertion_to_pmmr_index(6), 10);
 	assert_eq!(pmmr::insertion_to_pmmr_index(7), 11);
-	assert_eq!(pmmr::insertion_to_pmmr_index(8), 12);
 }
 
 #[test]
@@ -626,8 +626,8 @@ fn check_elements_from_pmmr_index() {
 	assert_eq!(res.1[6].0[3], 11);
 
 	// pruning a few nodes should get consistent results
-	pmmr.prune(pmmr::insertion_to_pmmr_index(5)).unwrap();
-	pmmr.prune(pmmr::insertion_to_pmmr_index(20)).unwrap();
+	pmmr.prune(1 + pmmr::insertion_to_pmmr_index(4)).unwrap();
+	pmmr.prune(1 + pmmr::insertion_to_pmmr_index(19)).unwrap();
 
 	let res = pmmr
 		.readonly_pmmr()

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -76,7 +76,7 @@ fn first_100_mmr_heights() {
 	                     0 0 1 0 0 1 2 0 0 1 0 0 1 2 3 0 0 1 0 0 1 2 0 0 1 0 0 1 2 3 4 5 \
 	                     0 0 1 0 0 1 2 0 0 1 0 0 1 2 3 0 0 1 0 0 1 2 0 0 1 0 0 1 2 3 4 0 0 1 0 0";
 	let first_100 = first_100_str.split(' ').map(|n| n.parse::<u64>().unwrap());
-	let mut count = 1;
+	let mut count = 0;
 	for n in first_100 {
 		assert_eq!(
 			n,
@@ -165,30 +165,30 @@ fn test_is_leaf() {
 
 #[test]
 fn test_pmmr_leaf_to_insertion_index() {
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(1), Some(0));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(2), Some(1));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(4), Some(2));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(5), Some(3));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(8), Some(4));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(9), Some(5));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(11), Some(6));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(12), Some(7));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(16), Some(8));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(17), Some(9));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(19), Some(10));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(20), Some(11));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(23), Some(12));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(24), Some(13));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(26), Some(14));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(27), Some(15));
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(32), Some(16));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(0), Some(0));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(1), Some(1));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(3), Some(2));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(4), Some(3));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(7), Some(4));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(8), Some(5));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(10), Some(6));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(11), Some(7));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(15), Some(8));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(16), Some(9));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(18), Some(10));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(19), Some(11));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(22), Some(12));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(23), Some(13));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(25), Some(14));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(26), Some(15));
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(31), Some(16));
 
 	// Not a leaf node
-	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(31), None);
+	assert_eq!(pmmr::pmmr_leaf_to_insertion_index(30), None);
 
 	// Sanity check to make sure we don't get an explosion around the u64 max
 	// number of leaves
-	let n_leaves_max_u64 = pmmr::n_leaves(u64::MAX - 256);
+	let n_leaves_max_u64 = pmmr::n_leaves(u64::MAX - 257);
 	assert_eq!(
 		pmmr::pmmr_leaf_to_insertion_index(n_leaves_max_u64),
 		Some(4611686018427387884)

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -243,9 +243,9 @@ fn various_families() {
 
 #[test]
 fn test_paths() {
-	assert_eq!(pmmr::path0(0, 3).collect::<Vec<_>>(), [0, 2]);
-	assert_eq!(pmmr::path0(1, 3).collect::<Vec<_>>(), [1, 2]);
-	assert_eq!(pmmr::path0(3, 16).collect::<Vec<_>>(), [3, 5, 6, 14]);
+	assert_eq!(pmmr::path(0, 3).collect::<Vec<_>>(), [0, 2]);
+	assert_eq!(pmmr::path(1, 3).collect::<Vec<_>>(), [1, 2]);
+	assert_eq!(pmmr::path(3, 16).collect::<Vec<_>>(), [3, 5, 6, 14]);
 }
 
 #[test]

--- a/core/tests/segment.rs
+++ b/core/tests/segment.rs
@@ -44,7 +44,7 @@ fn test_unprunable_size(height: u8, n_leaves: u32) {
 		if idx < n_segments - 1 || (n_leaves as u64) % size == 0 {
 			// Check if the reconstructed subtree root matches with the hash stored in the mmr
 			let subtree_root = segment.root(last_pos, None).unwrap().unwrap();
-			let last = 1 + pmmr::insertion_to_pmmr_index((idx + 1) * size - 1) + (height as u64);
+			let last = pmmr::insertion_to_pmmr_index((idx + 1) * size - 1) + (height as u64);
 			assert_eq!(subtree_root, mmr.get_hash(last).unwrap());
 			println!(" ROOT OK");
 		}

--- a/core/tests/segment.rs
+++ b/core/tests/segment.rs
@@ -44,7 +44,7 @@ fn test_unprunable_size(height: u8, n_leaves: u32) {
 		if idx < n_segments - 1 || (n_leaves as u64) % size == 0 {
 			// Check if the reconstructed subtree root matches with the hash stored in the mmr
 			let subtree_root = segment.root(last_pos, None).unwrap().unwrap();
-			let last = pmmr::insertion_to_pmmr_index((idx + 1) * size) + (height as u64);
+			let last = 1 + pmmr::insertion_to_pmmr_index((idx + 1) * size - 1) + (height as u64);
 			assert_eq!(subtree_root, mmr.get_hash(last).unwrap());
 			println!(" ROOT OK");
 		}

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -37,7 +37,7 @@ fn leaf_pos_and_idx_iter_test() {
 		pmmr.leaf_idx_iter(0).collect::<Vec<_>>()
 	);
 	assert_eq!(
-		vec![1, 2, 4, 5, 8],
+		vec![0, 1, 3, 4, 7],
 		pmmr.leaf_pos_iter().collect::<Vec<_>>()
 	);
 }
@@ -61,7 +61,7 @@ fn leaf_pos_and_idx_iter_hash_only_test() {
 		pmmr.leaf_idx_iter(0).collect::<Vec<_>>()
 	);
 	assert_eq!(
-		vec![1, 2, 4, 5, 8],
+		vec![0, 1, 3, 4, 7],
 		pmmr.leaf_pos_iter().collect::<Vec<_>>()
 	);
 }

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -187,8 +187,8 @@ impl LeafSet {
 	}
 
 	/// Whether the leaf_set includes the provided position.
-	pub fn includes(&self, pos: u64) -> bool {
-		self.bitmap.contains(pos as u32)
+	pub fn includes(&self, pos0: u64) -> bool {
+		self.bitmap.contains(1 + pos0 as u32)
 	}
 
 	/// Number of positions stored in the leaf_set.

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -96,7 +96,7 @@ impl LeafSet {
 	/// Only applicable for the output MMR.
 	fn unpruned_pre_cutoff(&self, cutoff_pos: u64, prune_list: &PruneList) -> Bitmap {
 		(1..=cutoff_pos)
-			.filter(|&x| pmmr::is_leaf(x - 1) && !prune_list.is_pruned(x))
+			.filter(|&x| pmmr::is_leaf(x - 1) && !prune_list.is_pruned(x - 1))
 			.map(|x| x as u32)
 			.collect()
 	}

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -142,13 +142,13 @@ impl LeafSet {
 	}
 
 	/// Append a new position to the leaf_set.
-	pub fn add(&mut self, pos: u64) {
-		self.bitmap.add(pos as u32);
+	pub fn add(&mut self, pos0: u64) {
+		self.bitmap.add(1 + pos0 as u32);
 	}
 
 	/// Remove the provided position from the leaf_set.
-	pub fn remove(&mut self, pos: u64) {
-		self.bitmap.remove(pos as u32);
+	pub fn remove(&mut self, pos0: u64) {
+		self.bitmap.remove(1 + pos0 as u32);
 	}
 
 	/// Saves the utxo file tagged with block hash as filename suffix.

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -96,7 +96,7 @@ impl LeafSet {
 	/// Only applicable for the output MMR.
 	fn unpruned_pre_cutoff(&self, cutoff_pos: u64, prune_list: &PruneList) -> Bitmap {
 		(1..=cutoff_pos)
-			.filter(|&x| pmmr::is_leaf(x) && !prune_list.is_pruned(x))
+			.filter(|&x| pmmr::is_leaf(x - 1) && !prune_list.is_pruned(x))
 			.map(|x| x as u32)
 			.collect()
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -132,8 +132,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Return None if pos is a leaf and it has been removed (or pruned or
 	/// compacted).
 	fn get_hash(&self, pos0: u64) -> Option<Hash> {
-		// sucks that leaf_set is 1-based:-(
-		if self.prunable && pmmr::is_leaf(pos0) && !self.leaf_set.includes(1 + pos0) {
+		if self.prunable && pmmr::is_leaf(pos0) && !self.leaf_set.includes(pos0) {
 			return None;
 		}
 		self.get_from_file(pos0)
@@ -145,7 +144,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if !pmmr::is_leaf(pos0) {
 			return None;
 		}
-		if self.prunable && !self.leaf_set.includes(1 + pos0) {
+		if self.prunable && !self.leaf_set.includes(pos0) {
 			return None;
 		}
 		self.get_data_from_file(pos0)
@@ -311,11 +310,11 @@ impl<T: PMMRable> PMMRBackend<T> {
 	// Checking for pruned root is faster so we do this check first.
 	// We can do a fast initial check as well -
 	// if its in the current leaf_set then we know it is not compacted.
-	fn is_compacted(&self, pos: u64) -> bool {
-		if self.leaf_set.includes(pos) {
+	fn is_compacted(&self, pos1: u64) -> bool {
+		if self.leaf_set.includes(pos1 - 1) {
 			return false;
 		}
-		!self.is_pruned_root(pos) && self.is_pruned(pos)
+		!self.is_pruned_root(pos1) && self.is_pruned(pos1)
 	}
 
 	/// Number of hashes in the PMMR stored by this backend. Only produces the

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -156,7 +156,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
 		if self.prunable {
-			Box::new(self.leaf_set.iter())
+			Box::new(self.leaf_set.iter().map(|x| x - 1))
 		} else {
 			panic!("leaf_pos_iter not implemented for non-prunable PMMR")
 		}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -103,12 +103,12 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		Ok(())
 	}
 
-	fn get_from_file(&self, position: u64) -> Option<Hash> {
-		if self.is_compacted(position) {
+	fn get_from_file(&self, pos0: u64) -> Option<Hash> {
+		if self.is_compacted(1 + pos0) {
 			return None;
 		}
-		let shift = self.prune_list.get_shift(position);
-		self.hash_file.read(position - shift)
+		let shift = self.prune_list.get_shift(1 + pos0);
+		self.hash_file.read(1 + pos0 - shift)
 	}
 
 	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
@@ -135,7 +135,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.prunable && pmmr::is_leaf(pos1 - 1) && !self.leaf_set.includes(pos1) {
 			return None;
 		}
-		self.get_from_file(pos1)
+		self.get_from_file(pos1 - 1)
 	}
 
 	/// Get the data at pos.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -212,9 +212,9 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	}
 
 	/// Remove by insertion position.
-	fn remove(&mut self, pos: u64) -> Result<(), String> {
+	fn remove(&mut self, pos0: u64) -> Result<(), String> {
 		assert!(self.prunable, "Remove on non-prunable MMR");
-		self.leaf_set.remove(pos);
+		self.leaf_set.remove(1 + pos0);
 		Ok(())
 	}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -88,7 +88,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	// Supports appending a pruned subtree (single root hash) to an existing hash file.
 	// Update the prune_list "shift cache" to reflect the new pruned leaf pos in the subtree.
-	fn append_pruned_subtree(&mut self, hash: Hash, pos: u64) -> Result<(), String> {
+	fn append_pruned_subtree(&mut self, hash: Hash, pos1: u64) -> Result<(), String> {
 		if !self.prunable {
 			return Err("Not prunable, cannot append pruned subtree.".into());
 		}
@@ -97,7 +97,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			.append(&hash)
 			.map_err(|e| format!("Failed to append subtree hash to file. {}", e))?;
 
-		self.prune_list.append(pos);
+		self.prune_list.append(pos1 - 1);
 
 		Ok(())
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -88,7 +88,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	// Supports appending a pruned subtree (single root hash) to an existing hash file.
 	// Update the prune_list "shift cache" to reflect the new pruned leaf pos in the subtree.
-	fn append_pruned_subtree(&mut self, hash: Hash, pos1: u64) -> Result<(), String> {
+	fn append_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
 		if !self.prunable {
 			return Err("Not prunable, cannot append pruned subtree.".into());
 		}
@@ -97,7 +97,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 			.append(&hash)
 			.map_err(|e| format!("Failed to append subtree hash to file. {}", e))?;
 
-		self.prune_list.append(pos1 - 1);
+		self.prune_list.append(pos0);
 
 		Ok(())
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -451,19 +451,19 @@ impl<T: PMMRable> PMMRBackend<T> {
 			expanded.add(x);
 			let mut current = x as u64;
 			loop {
-				let (parent, sibling) = family(current);
-				let sibling_pruned = self.is_pruned_root(sibling);
+				let (parent0, sibling0) = family(current - 1);
+				let sibling_pruned = self.is_pruned_root(sibling0 + 1);
 
 				// if sibling previously pruned
 				// push it back onto list of pos to remove
 				// so we can remove it and traverse up to parent
 				if sibling_pruned {
-					expanded.add(sibling as u32);
+					expanded.add(1 + sibling0 as u32);
 				}
 
-				if sibling_pruned || expanded.contains(sibling as u32) {
-					expanded.add(parent as u32);
-					current = parent;
+				if sibling_pruned || expanded.contains(1 + sibling0 as u32) {
+					expanded.add(1 + parent0 as u32);
+					current = 1 + parent0;
 				} else {
 					break;
 				}
@@ -479,8 +479,8 @@ fn removed_excl_roots(removed: &Bitmap) -> Bitmap {
 	removed
 		.iter()
 		.filter(|pos| {
-			let (parent_pos, _) = family(*pos as u64);
-			removed.contains(parent_pos as u32)
+			let (parent_pos0, _) = family(*pos as u64 - 1);
+			removed.contains(1 + parent_pos0 as u32)
 		})
 		.collect()
 }

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -78,9 +78,8 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.prunable {
 			// (Re)calculate the latest pos given updated size of data file
 			// and the total leaf_shift, and add to our leaf_set.
-			let pos = 1 + pmmr::insertion_to_pmmr_index(
-				size + self.prune_list.get_total_leaf_shift() - 1,
-			);
+			let pos =
+				pmmr::insertion_to_pmmr_index(size + self.prune_list.get_total_leaf_shift() - 1);
 			self.leaf_set.add(pos);
 		}
 
@@ -213,7 +212,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Remove by insertion position.
 	fn remove(&mut self, pos0: u64) -> Result<(), String> {
 		assert!(self.prunable, "Remove on non-prunable MMR");
-		self.leaf_set.remove(1 + pos0);
+		self.leaf_set.remove(pos0);
 		Ok(())
 	}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -78,7 +78,9 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.prunable {
 			// (Re)calculate the latest pos given updated size of data file
 			// and the total leaf_shift, and add to our leaf_set.
-			let pos = pmmr::insertion_to_pmmr_index(size + self.prune_list.get_total_leaf_shift());
+			let pos = 1 + pmmr::insertion_to_pmmr_index(
+				size + self.prune_list.get_total_leaf_shift() - 1,
+			);
 			self.leaf_set.add(pos);
 		}
 
@@ -175,7 +177,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		// iterate, skipping everything prior to this
 		// pass in from_idx=0 then we want to convert to pos=1
 
-		let from_pos = pmmr::insertion_to_pmmr_index(from_idx + 1);
+		let from_pos = 1 + pmmr::insertion_to_pmmr_index(from_idx);
 
 		if self.prunable {
 			Box::new(

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -111,9 +111,9 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.hash_file.read(position - shift)
 	}
 
-	fn get_peak_from_file(&self, position: u64) -> Option<Hash> {
-		let shift = self.prune_list.get_shift(position);
-		self.hash_file.read(position - shift)
+	fn get_peak_from_file(&self, pos0: u64) -> Option<Hash> {
+		let shift = self.prune_list.get_shift(1 + pos0);
+		self.hash_file.read(1 + pos0 - shift)
 	}
 
 	fn get_data_from_file(&self, pos1: u64) -> Option<T::E> {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -103,7 +103,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	}
 
 	fn get_from_file(&self, pos0: u64) -> Option<Hash> {
-		if self.is_compacted(1 + pos0) {
+		if self.is_compacted(pos0) {
 			return None;
 		}
 		let shift = self.prune_list.get_shift(1 + pos0);
@@ -119,7 +119,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if !pmmr::is_leaf(pos0) {
 			return None;
 		}
-		if self.is_compacted(1 + pos0) {
+		if self.is_compacted(pos0) {
 			return None;
 		}
 		let flatfile_pos = pmmr::n_leaves(pos0 + 1);
@@ -297,23 +297,23 @@ impl<T: PMMRable> PMMRBackend<T> {
 		})
 	}
 
-	fn is_pruned(&self, pos: u64) -> bool {
-		self.prune_list.is_pruned(pos)
+	fn is_pruned(&self, pos0: u64) -> bool {
+		self.prune_list.is_pruned(pos0)
 	}
 
-	fn is_pruned_root(&self, pos: u64) -> bool {
-		self.prune_list.is_pruned_root(pos)
+	fn is_pruned_root(&self, pos0: u64) -> bool {
+		self.prune_list.is_pruned_root(pos0)
 	}
 
 	// Check if pos is pruned but not a pruned root itself.
 	// Checking for pruned root is faster so we do this check first.
 	// We can do a fast initial check as well -
 	// if its in the current leaf_set then we know it is not compacted.
-	fn is_compacted(&self, pos1: u64) -> bool {
-		if self.leaf_set.includes(pos1 - 1) {
+	fn is_compacted(&self, pos0: u64) -> bool {
+		if self.leaf_set.includes(pos0) {
 			return false;
 		}
-		!self.is_pruned_root(pos1) && self.is_pruned(pos1)
+		!self.is_pruned_root(pos0) && self.is_pruned(pos0)
 	}
 
 	/// Number of hashes in the PMMR stored by this backend. Only produces the
@@ -451,7 +451,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			let mut current = x as u64;
 			loop {
 				let (parent0, sibling0) = family(current - 1);
-				let sibling_pruned = self.is_pruned_root(sibling0 + 1);
+				let sibling_pruned = self.is_pruned_root(sibling0);
 
 				// if sibling previously pruned
 				// push it back onto list of pos to remove

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -116,15 +116,15 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.hash_file.read(1 + pos0 - shift)
 	}
 
-	fn get_data_from_file(&self, pos1: u64) -> Option<T::E> {
-		if !pmmr::is_leaf(pos1 - 1) {
+	fn get_data_from_file(&self, pos0: u64) -> Option<T::E> {
+		if !pmmr::is_leaf(pos0) {
 			return None;
 		}
-		if self.is_compacted(pos1) {
+		if self.is_compacted(1 + pos0) {
 			return None;
 		}
-		let flatfile_pos = pmmr::n_leaves(pos1);
-		let shift = self.prune_list.get_leaf_shift(pos1);
+		let flatfile_pos = pmmr::n_leaves(pos0 + 1);
+		let shift = self.prune_list.get_leaf_shift(1 + pos0);
 		self.data_file.read(flatfile_pos - shift)
 	}
 
@@ -147,7 +147,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		if self.prunable && !self.leaf_set.includes(pos1) {
 			return None;
 		}
-		self.get_data_from_file(pos1)
+		self.get_data_from_file(pos1 - 1)
 	}
 
 	/// Returns an iterator over all the leaf positions.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -140,14 +140,14 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 	/// Get the data at pos.
 	/// Return None if it has been removed or if pos is not a leaf node.
-	fn get_data(&self, pos1: u64) -> Option<T::E> {
-		if !pmmr::is_leaf(pos1 - 1) {
+	fn get_data(&self, pos0: u64) -> Option<T::E> {
+		if !pmmr::is_leaf(pos0) {
 			return None;
 		}
-		if self.prunable && !self.leaf_set.includes(pos1) {
+		if self.prunable && !self.leaf_set.includes(1 + pos0) {
 			return None;
 		}
-		self.get_data_from_file(pos1 - 1)
+		self.get_data_from_file(pos0)
 	}
 
 	/// Returns an iterator over all the leaf positions.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -131,11 +131,12 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	/// Get the hash at pos.
 	/// Return None if pos is a leaf and it has been removed (or pruned or
 	/// compacted).
-	fn get_hash(&self, pos1: u64) -> Option<Hash> {
-		if self.prunable && pmmr::is_leaf(pos1 - 1) && !self.leaf_set.includes(pos1) {
+	fn get_hash(&self, pos0: u64) -> Option<Hash> {
+		// sucks that leaf_set is 1-based:-(
+		if self.prunable && pmmr::is_leaf(pos0) && !self.leaf_set.includes(1 + pos0) {
 			return None;
 		}
-		self.get_from_file(pos1 - 1)
+		self.get_from_file(pos0)
 	}
 
 	/// Get the data at pos.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -166,11 +166,11 @@ impl PruneList {
 
 		self.shift_cache.clear();
 		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
-			let pos1 = pos1 as u64;
-			let prev_shift = self.get_shift(pos1.saturating_sub(1));
+			let pos0 = pos1 as u64 - 1;
+			let prev_shift = self.get_shift(pos0);
 
-			let curr_shift = if self.is_pruned_root(pos1 - 1) {
-				let height = bintree_postorder_height(pos1 - 1);
+			let curr_shift = if self.is_pruned_root(pos0) {
+				let height = bintree_postorder_height(pos0);
 				2 * ((1 << height) - 1)
 			} else {
 				0
@@ -220,11 +220,11 @@ impl PruneList {
 		self.leaf_shift_cache.clear();
 
 		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
-			let pos1 = pos1 as u64;
-			let prev_shift = self.get_leaf_shift(pos1.saturating_sub(1));
+			let pos0 = pos1 as u64 - 1;
+			let prev_shift = self.get_leaf_shift(pos0);
 
-			let curr_shift = if self.is_pruned_root(pos1 - 1) {
-				let height = bintree_postorder_height(pos1 - 1);
+			let curr_shift = if self.is_pruned_root(pos0) {
+				let height = bintree_postorder_height(pos0);
 				if height == 0 {
 					0
 				} else {

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -280,20 +280,19 @@ impl PruneList {
 
 	/// Push the node at the provided position in the prune list.
 	/// Assumes rollup of siblings and children has already been handled.
-	fn append_single(&mut self, pos1: u64) {
-		assert!(pos1 > 0, "prune list 1-indexed, 0 not valid pos");
+	fn append_single(&mut self, pos0: u64) {
 		assert!(
-			pos1 > self.bitmap.maximum().unwrap_or(0) as u64,
+			pos0 >= self.bitmap.maximum().unwrap_or(0) as u64,
 			"prune list append only"
 		);
 
 		// Add this pos to the bitmap (leaf or subtree root)
-		self.bitmap.add(pos1 as u32);
+		self.bitmap.add(1 + pos0 as u32);
 
 		// Calculate shift and leaf_shift for this pos.
-		self.shift_cache.push(self.calculate_next_shift(pos1));
+		self.shift_cache.push(self.calculate_next_shift(1 + pos0));
 		self.leaf_shift_cache
-			.push(self.calculate_next_leaf_shift(pos1 - 1));
+			.push(self.calculate_next_leaf_shift(pos0));
 	}
 
 	/// Push the node at the provided position in the prune list.
@@ -317,7 +316,7 @@ impl PruneList {
 			// Make sure we roll anything beneath this up into this higher level pruned subtree root.
 			// We should have no nested entries in the prune_list.
 			self.cleanup_subtree(1 + pos0);
-			self.append_single(1 + pos0);
+			self.append_single(pos0);
 		}
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -259,7 +259,7 @@ impl PruneList {
 	fn cleanup_subtree(&mut self, pos: u64) {
 		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
 
-		let lc = bintree_leftmost(pos) as u32;
+		let lc = 1 + bintree_leftmost(pos - 1) as u32;
 		let last_pos = self.bitmap.maximum().unwrap_or(1);
 
 		// If this subtree does not intersect with existing bitmap then nothing to cleanup.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -389,7 +389,8 @@ impl PruneList {
 	/// Note this is not necessarily the same as the "leaf_set" as an output
 	/// can be spent but not yet pruned.
 	pub fn unpruned_leaf_iter(&self, cutoff_pos: u64) -> impl Iterator<Item = u64> + '_ {
-		self.unpruned_iter(cutoff_pos).filter(|x| pmmr::is_leaf(*x))
+		self.unpruned_iter(cutoff_pos)
+			.filter(|x| pmmr::is_leaf(*x - 1))
 	}
 
 	/// Return a clone of our internal bitmap.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -165,12 +165,12 @@ impl PruneList {
 		}
 
 		self.shift_cache.clear();
-		for pos in self.bitmap.iter().filter(|x| *x > 0) {
-			let pos = pos as u64;
-			let prev_shift = self.get_shift(pos.saturating_sub(1));
+		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
+			let pos1 = pos1 as u64;
+			let prev_shift = self.get_shift(pos1.saturating_sub(1));
 
-			let curr_shift = if self.is_pruned_root(pos) {
-				let height = bintree_postorder_height(pos);
+			let curr_shift = if self.is_pruned_root(pos1) {
+				let height = bintree_postorder_height(pos1 - 1);
 				2 * ((1 << height) - 1)
 			} else {
 				0
@@ -181,10 +181,10 @@ impl PruneList {
 	}
 
 	// Calculate the next shift based on provided pos and the previous shift.
-	fn calculate_next_shift(&self, pos: u64) -> u64 {
-		let prev_shift = self.get_shift(pos.saturating_sub(1));
-		let shift = if self.is_pruned_root(pos) {
-			let height = bintree_postorder_height(pos);
+	fn calculate_next_shift(&self, pos1: u64) -> u64 {
+		let prev_shift = self.get_shift(pos1.saturating_sub(1));
+		let shift = if self.is_pruned_root(pos1) {
+			let height = bintree_postorder_height(pos1 - 1);
 			2 * ((1 << height) - 1)
 		} else {
 			0
@@ -219,12 +219,12 @@ impl PruneList {
 
 		self.leaf_shift_cache.clear();
 
-		for pos in self.bitmap.iter().filter(|x| *x > 0) {
-			let pos = pos as u64;
-			let prev_shift = self.get_leaf_shift(pos.saturating_sub(1));
+		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
+			let pos1 = pos1 as u64;
+			let prev_shift = self.get_leaf_shift(pos1.saturating_sub(1));
 
-			let curr_shift = if self.is_pruned_root(pos) {
-				let height = bintree_postorder_height(pos);
+			let curr_shift = if self.is_pruned_root(pos1) {
+				let height = bintree_postorder_height(pos1 - 1);
 				if height == 0 {
 					0
 				} else {
@@ -239,10 +239,10 @@ impl PruneList {
 	}
 
 	// Calculate the next leaf shift based on provided pos and the previous leaf shift.
-	fn calculate_next_leaf_shift(&self, pos: u64) -> u64 {
-		let prev_shift = self.get_leaf_shift(pos.saturating_sub(1) as u64);
-		let shift = if self.is_pruned_root(pos) {
-			let height = bintree_postorder_height(pos);
+	fn calculate_next_leaf_shift(&self, pos1: u64) -> u64 {
+		let prev_shift = self.get_leaf_shift(pos1.saturating_sub(1) as u64);
+		let shift = if self.is_pruned_root(pos1) {
+			let height = bintree_postorder_height(pos1 - 1);
 			if height == 0 {
 				0
 			} else {

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -153,9 +153,9 @@ impl PruneList {
 		}
 
 		if idx > self.shift_cache.len() as u64 {
-			self.shift_cache[self.shift_cache.len().saturating_sub(1)]
+			self.shift_cache[self.shift_cache.len() - 1]
 		} else {
-			self.shift_cache[(idx as usize).saturating_sub(1)]
+			self.shift_cache[(idx as usize) - 1]
 		}
 	}
 
@@ -195,20 +195,20 @@ impl PruneList {
 	/// As above, but only returning the number of leaf nodes to skip for a
 	/// given leaf. Helpful if, for instance, data for each leaf is being stored
 	/// separately in a continuous flat-file.
-	pub fn get_leaf_shift(&self, pos: u64) -> u64 {
+	pub fn get_leaf_shift(&self, pos1: u64) -> u64 {
 		if self.bitmap.is_empty() {
 			return 0;
 		}
 
-		let idx = self.bitmap.rank(pos as u32);
+		let idx = self.bitmap.rank(pos1 as u32);
 		if idx == 0 {
 			return 0;
 		}
 
 		if idx > self.leaf_shift_cache.len() as u64 {
-			self.leaf_shift_cache[self.leaf_shift_cache.len().saturating_sub(1)]
+			self.leaf_shift_cache[self.leaf_shift_cache.len() - 1]
 		} else {
-			self.leaf_shift_cache[(idx as usize).saturating_sub(1)]
+			self.leaf_shift_cache[idx as usize - 1]
 		}
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -181,10 +181,10 @@ impl PruneList {
 	}
 
 	// Calculate the next shift based on provided pos and the previous shift.
-	fn calculate_next_shift(&self, pos1: u64) -> u64 {
-		let prev_shift = self.get_shift(pos1.saturating_sub(1));
-		let shift = if self.is_pruned_root(pos1 - 1) {
-			let height = bintree_postorder_height(pos1 - 1);
+	fn calculate_next_shift(&self, pos0: u64) -> u64 {
+		let prev_shift = self.get_shift(pos0);
+		let shift = if self.is_pruned_root(pos0) {
+			let height = bintree_postorder_height(pos0);
 			2 * ((1 << height) - 1)
 		} else {
 			0
@@ -290,7 +290,7 @@ impl PruneList {
 		self.bitmap.add(1 + pos0 as u32);
 
 		// Calculate shift and leaf_shift for this pos.
-		self.shift_cache.push(self.calculate_next_shift(1 + pos0));
+		self.shift_cache.push(self.calculate_next_shift(pos0));
 		self.leaf_shift_cache
 			.push(self.calculate_next_leaf_shift(pos0));
 	}

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -300,24 +300,24 @@ impl PruneList {
 	/// Handles rollup of siblings and children as we go (relatively slow).
 	/// Once we find a subtree root that can not be rolled up any further
 	/// we cleanup everything beneath it and replace it with a single appended node.
-	pub fn append(&mut self, pos: u64) {
-		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
+	pub fn append(&mut self, pos1: u64) {
+		assert!(pos1 > 0, "prune list 1-indexed, 0 not valid pos");
 		assert!(
-			pos > self.bitmap.maximum().unwrap_or(0) as u64,
+			pos1 > self.bitmap.maximum().unwrap_or(0) as u64,
 			"prune list append only - pos={} bitmap.maximum={}",
-			pos,
+			pos1,
 			self.bitmap.maximum().unwrap_or(0)
 		);
 
-		let (parent, sibling) = family(pos);
-		if self.is_pruned(sibling) {
+		let (parent0, sibling0) = family(pos1 - 1);
+		if self.is_pruned(sibling0 + 1) {
 			// Recursively append the parent (removing our sibling in the process).
-			self.append(parent)
+			self.append(parent0 + 1)
 		} else {
 			// Make sure we roll anything beneath this up into this higher level pruned subtree root.
 			// We should have no nested entries in the prune_list.
-			self.cleanup_subtree(pos);
-			self.append_single(pos);
+			self.cleanup_subtree(pos1);
+			self.append_single(pos1);
 		}
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -341,8 +341,8 @@ impl PruneList {
 		}
 		let rank = self.bitmap.rank(pos as u32);
 		if let Some(root) = self.bitmap.select(rank as u32) {
-			let range = pmmr::bintree_range(root as u64);
-			range.contains(&pos)
+			let range = pmmr::bintree_range(root as u64 - 1);
+			range.contains(&(pos - 1))
 		} else {
 			false
 		}
@@ -376,7 +376,10 @@ impl PruneList {
 
 	/// Iterator over the pruned "bintree range" for each pruned root.
 	pub fn pruned_bintree_range_iter(&self) -> impl Iterator<Item = Range<u64>> + '_ {
-		self.iter().map(|x| pmmr::bintree_range(x))
+		self.iter().map(|x| {
+			let rng = pmmr::bintree_range(x - 1);
+			(1 + rng.start)..(1 + rng.end)
+		})
 	}
 
 	/// Iterator over all pos that are *not* pruned based on current prune_list.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -64,8 +64,8 @@ impl PruneList {
 			leaf_shift_cache: vec![],
 		};
 
-		for pos in bitmap.iter().filter(|x| *x > 0) {
-			prune_list.append(pos as u64)
+		for pos1 in bitmap.iter().filter(|x| *x > 0) {
+			prune_list.append(pos1 as u64 - 1)
 		}
 
 		prune_list.bitmap.run_optimize();
@@ -300,24 +300,24 @@ impl PruneList {
 	/// Handles rollup of siblings and children as we go (relatively slow).
 	/// Once we find a subtree root that can not be rolled up any further
 	/// we cleanup everything beneath it and replace it with a single appended node.
-	pub fn append(&mut self, pos1: u64) {
-		assert!(pos1 > 0, "prune list 1-indexed, 0 not valid pos");
+	pub fn append(&mut self, pos0: u64) {
+		let max = self.bitmap.maximum().unwrap_or(0) as u64;
 		assert!(
-			pos1 > self.bitmap.maximum().unwrap_or(0) as u64,
+			pos0 >= max,
 			"prune list append only - pos={} bitmap.maximum={}",
-			pos1,
-			self.bitmap.maximum().unwrap_or(0)
+			pos0,
+			max
 		);
 
-		let (parent0, sibling0) = family(pos1 - 1);
+		let (parent0, sibling0) = family(pos0);
 		if self.is_pruned(sibling0) {
 			// Recursively append the parent (removing our sibling in the process).
-			self.append(parent0 + 1)
+			self.append(parent0)
 		} else {
 			// Make sure we roll anything beneath this up into this higher level pruned subtree root.
 			// We should have no nested entries in the prune_list.
-			self.cleanup_subtree(pos1);
-			self.append_single(pos1);
+			self.cleanup_subtree(1 + pos0);
+			self.append_single(1 + pos0);
 		}
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -239,10 +239,10 @@ impl PruneList {
 	}
 
 	// Calculate the next leaf shift based on provided pos and the previous leaf shift.
-	fn calculate_next_leaf_shift(&self, pos1: u64) -> u64 {
-		let prev_shift = self.get_leaf_shift(pos1.saturating_sub(1) as u64);
-		let shift = if self.is_pruned_root(pos1 - 1) {
-			let height = bintree_postorder_height(pos1 - 1);
+	fn calculate_next_leaf_shift(&self, pos0: u64) -> u64 {
+		let prev_shift = self.get_leaf_shift(pos0);
+		let shift = if self.is_pruned_root(pos0) {
+			let height = bintree_postorder_height(pos0);
 			if height == 0 {
 				0
 			} else {
@@ -280,20 +280,20 @@ impl PruneList {
 
 	/// Push the node at the provided position in the prune list.
 	/// Assumes rollup of siblings and children has already been handled.
-	fn append_single(&mut self, pos: u64) {
-		assert!(pos > 0, "prune list 1-indexed, 0 not valid pos");
+	fn append_single(&mut self, pos1: u64) {
+		assert!(pos1 > 0, "prune list 1-indexed, 0 not valid pos");
 		assert!(
-			pos > self.bitmap.maximum().unwrap_or(0) as u64,
+			pos1 > self.bitmap.maximum().unwrap_or(0) as u64,
 			"prune list append only"
 		);
 
 		// Add this pos to the bitmap (leaf or subtree root)
-		self.bitmap.add(pos as u32);
+		self.bitmap.add(pos1 as u32);
 
 		// Calculate shift and leaf_shift for this pos.
-		self.shift_cache.push(self.calculate_next_shift(pos));
+		self.shift_cache.push(self.calculate_next_shift(pos1));
 		self.leaf_shift_cache
-			.push(self.calculate_next_leaf_shift(pos));
+			.push(self.calculate_next_leaf_shift(pos1 - 1));
 	}
 
 	/// Push the node at the provided position in the prune list.

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -54,9 +54,10 @@ pub struct PruneList {
 }
 
 impl PruneList {
-	/// Instantiate a new prune list from the provided path and bitmap.
+	/// Instantiate a new prune list from the provided path and 1-based bitmap.
 	/// Note: Does not flush the bitmap to disk. Caller is responsible for doing this.
 	pub fn new(path: Option<PathBuf>, bitmap: Bitmap) -> PruneList {
+		assert!(!bitmap.contains(0));
 		let mut prune_list = PruneList {
 			path,
 			bitmap: Bitmap::create(),
@@ -64,7 +65,7 @@ impl PruneList {
 			leaf_shift_cache: vec![],
 		};
 
-		for pos1 in bitmap.iter().filter(|x| *x > 0) {
+		for pos1 in bitmap.iter() {
 			prune_list.append(pos1 as u64 - 1)
 		}
 
@@ -86,6 +87,7 @@ impl PruneList {
 		} else {
 			Bitmap::create()
 		};
+		assert!(!bitmap.contains(0));
 
 		let mut prune_list = PruneList::new(Some(file_path), bitmap);
 
@@ -165,7 +167,7 @@ impl PruneList {
 		}
 
 		self.shift_cache.clear();
-		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
+		for pos1 in self.bitmap.iter() {
 			let pos0 = pos1 as u64 - 1;
 			let prev_shift = self.get_shift(pos0);
 
@@ -219,7 +221,7 @@ impl PruneList {
 
 		self.leaf_shift_cache.clear();
 
-		for pos1 in self.bitmap.iter().filter(|x| *x > 0) {
+		for pos1 in self.bitmap.iter() {
 			let pos0 = pos1 as u64 - 1;
 			let prev_shift = self.get_leaf_shift(pos0);
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -309,7 +309,7 @@ where
 			let offset = if next_pos == 0 {
 				0
 			} else {
-				let prev_entry = size_file.read_as_elmt(next_pos.saturating_sub(1))?;
+				let prev_entry = size_file.read_as_elmt(next_pos - 1)?;
 				prev_entry.offset + prev_entry.size as u64
 			};
 			size_file.append_elmt(&SizeEntry {
@@ -374,8 +374,7 @@ where
 				if self.buffer_start_pos == 0 {
 					file.set_len(0)?;
 				} else {
-					let (offset, size) =
-						self.offset_and_size(self.buffer_start_pos.saturating_sub(1))?;
+					let (offset, size) = self.offset_and_size(self.buffer_start_pos - 1)?;
 					file.set_len(offset + size as u64)?;
 				};
 			}

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -166,10 +166,10 @@ fn pmmr_compact_leaf_sibling() {
 		// prune pos 1
 		{
 			let mut pmmr = PMMR::at(&mut backend, mmr_size);
-			pmmr.prune(1).unwrap();
+			pmmr.prune(0).unwrap();
 
 			// prune pos 8 as well to push the remove list past the cutoff
-			pmmr.prune(8).unwrap();
+			pmmr.prune(7).unwrap();
 		}
 		backend.sync().unwrap();
 
@@ -235,9 +235,9 @@ fn pmmr_prune_compact() {
 		// pruning some choice nodes
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-			pmmr.prune(1).unwrap();
+			pmmr.prune(0).unwrap();
+			pmmr.prune(3).unwrap();
 			pmmr.prune(4).unwrap();
-			pmmr.prune(5).unwrap();
 		}
 		backend.sync().unwrap();
 
@@ -296,7 +296,7 @@ fn pmmr_reload() {
 			// prune a node so we have prune data
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-				pmmr.prune(1).unwrap();
+				pmmr.prune(0).unwrap();
 			}
 			backend.sync().unwrap();
 			assert_eq!(backend.unpruned_size(), mmr_size);
@@ -310,8 +310,8 @@ fn pmmr_reload() {
 			// prune another node to force compact to actually do something
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-				pmmr.prune(4).unwrap();
-				pmmr.prune(2).unwrap();
+				pmmr.prune(3).unwrap();
+				pmmr.prune(1).unwrap();
 			}
 			backend.sync().unwrap();
 			assert_eq!(backend.unpruned_size(), mmr_size);
@@ -324,7 +324,7 @@ fn pmmr_reload() {
 			// prune some more to get rm log data
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-				pmmr.prune(5).unwrap();
+				pmmr.prune(4).unwrap();
 			}
 			backend.sync().unwrap();
 			assert_eq!(backend.unpruned_size(), mmr_size);
@@ -406,10 +406,10 @@ fn pmmr_rewind() {
 		// prune the first 4 elements (leaves at pos 1, 2, 4, 5)
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
+			pmmr.prune(0).unwrap();
 			pmmr.prune(1).unwrap();
-			pmmr.prune(2).unwrap();
+			pmmr.prune(3).unwrap();
 			pmmr.prune(4).unwrap();
-			pmmr.prune(5).unwrap();
 		}
 		backend.sync().unwrap();
 
@@ -500,8 +500,8 @@ fn pmmr_compact_single_leaves() {
 
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-			pmmr.prune(1).unwrap();
-			pmmr.prune(4).unwrap();
+			pmmr.prune(0).unwrap();
+			pmmr.prune(3).unwrap();
 		}
 
 		backend.sync().unwrap();
@@ -511,8 +511,8 @@ fn pmmr_compact_single_leaves() {
 
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-			pmmr.prune(2).unwrap();
-			pmmr.prune(5).unwrap();
+			pmmr.prune(1).unwrap();
+			pmmr.prune(4).unwrap();
 		}
 
 		backend.sync().unwrap();
@@ -542,10 +542,10 @@ fn pmmr_compact_entire_peak() {
 		// prune all leaves under the peak at pos 7
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
+			pmmr.prune(0).unwrap();
 			pmmr.prune(1).unwrap();
-			pmmr.prune(2).unwrap();
+			pmmr.prune(3).unwrap();
 			pmmr.prune(4).unwrap();
-			pmmr.prune(5).unwrap();
 		}
 
 		backend.sync().unwrap();
@@ -611,10 +611,10 @@ fn pmmr_compact_horizon() {
 			// pruning some choice nodes
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
+				pmmr.prune(3).unwrap();
 				pmmr.prune(4).unwrap();
-				pmmr.prune(5).unwrap();
+				pmmr.prune(0).unwrap();
 				pmmr.prune(1).unwrap();
-				pmmr.prune(2).unwrap();
 			}
 			backend.sync().unwrap();
 
@@ -697,8 +697,8 @@ fn pmmr_compact_horizon() {
 			{
 				let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 
+				pmmr.prune(7).unwrap();
 				pmmr.prune(8).unwrap();
-				pmmr.prune(9).unwrap();
 			}
 
 			// compact some more
@@ -758,9 +758,9 @@ fn compact_twice() {
 		// pruning some choice nodes
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
+			pmmr.prune(0).unwrap();
 			pmmr.prune(1).unwrap();
-			pmmr.prune(2).unwrap();
-			pmmr.prune(4).unwrap();
+			pmmr.prune(3).unwrap();
 		}
 		backend.sync().unwrap();
 
@@ -786,9 +786,9 @@ fn compact_twice() {
 		// now prune some more nodes
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
-			pmmr.prune(5).unwrap();
+			pmmr.prune(4).unwrap();
+			pmmr.prune(7).unwrap();
 			pmmr.prune(8).unwrap();
-			pmmr.prune(9).unwrap();
 		}
 		backend.sync().unwrap();
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -189,7 +189,7 @@ fn pmmr_compact_leaf_sibling() {
 
 		// check we can still retrieve the "removed" element at pos 1
 		// from the backend hash file.
-		assert_eq!(backend.get_from_file(1).unwrap(), pos_1_hash);
+		assert_eq!(backend.get_from_file(0).unwrap(), pos_1_hash);
 
 		// aggressively compact the PMMR files
 		backend.check_compact(1, &Bitmap::create()).unwrap();
@@ -208,7 +208,7 @@ fn pmmr_compact_leaf_sibling() {
 
 		// Check we can still retrieve the "removed" hash at pos 1 from the hash file.
 		// It should still be available even after pruning and compacting.
-		assert_eq!(backend.get_from_file(1).unwrap(), pos_1_hash);
+		assert_eq!(backend.get_from_file(0).unwrap(), pos_1_hash);
 	}
 
 	teardown(data_dir);
@@ -356,15 +356,15 @@ fn pmmr_reload() {
 
 			// now check contents of the hash file
 			// pos 1 and pos 2 are no longer in the hash file
+			assert_eq!(backend.get_from_file(0), None);
 			assert_eq!(backend.get_from_file(1), None);
-			assert_eq!(backend.get_from_file(2), None);
 
 			// pos 3 is still in there
-			assert_eq!(backend.get_from_file(3), Some(pos_3_hash));
+			assert_eq!(backend.get_from_file(2), Some(pos_3_hash));
 
 			// pos 4 and pos 5 are also still in there
-			assert_eq!(backend.get_from_file(4), Some(pos_4_hash));
-			assert_eq!(backend.get_from_file(5), Some(pos_5_hash));
+			assert_eq!(backend.get_from_file(3), Some(pos_4_hash));
+			assert_eq!(backend.get_from_file(4), Some(pos_5_hash));
 		}
 	}
 
@@ -556,12 +556,12 @@ fn pmmr_compact_entire_peak() {
 		// now check we have pruned up to and including the peak at pos 7
 		// hash still available in underlying hash file
 		assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+		assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 		// now check we still have subsequent hash and data where we expect
 		assert_eq!(backend.get_data(8), Some(pos_8));
 		assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-		assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
+		assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 	}
 
 	teardown(data_dir);
@@ -621,21 +621,21 @@ fn pmmr_compact_horizon() {
 			// check we can read hashes and data correctly after pruning
 			{
 				// assert_eq!(backend.get_hash(3), None);
-				assert_eq!(backend.get_from_file(3), Some(pos_3_hash));
+				assert_eq!(backend.get_from_file(2), Some(pos_3_hash));
 
 				// assert_eq!(backend.get_hash(6), None);
-				assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
+				assert_eq!(backend.get_from_file(5), Some(pos_6_hash));
 
 				// assert_eq!(backend.get_hash(7), None);
-				assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+				assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 				assert_eq!(backend.get_hash(8), Some(pos_8_hash));
 				assert_eq!(backend.get_data(8), Some(pos_8));
-				assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
+				assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 
 				assert_eq!(backend.get_hash(11), Some(pos_11_hash));
 				assert_eq!(backend.get_data(11), Some(pos_11));
-				assert_eq!(backend.get_from_file(11), Some(pos_11_hash));
+				assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
 			}
 
 			// compact
@@ -645,10 +645,10 @@ fn pmmr_compact_horizon() {
 			// check we can read a hash by pos correctly after compaction
 			{
 				assert_eq!(backend.get_hash(1), None);
-				assert_eq!(backend.get_from_file(1), Some(pos_1_hash));
+				assert_eq!(backend.get_from_file(0), Some(pos_1_hash));
 
 				assert_eq!(backend.get_hash(2), None);
-				assert_eq!(backend.get_from_file(2), Some(pos_2_hash));
+				assert_eq!(backend.get_from_file(1), Some(pos_2_hash));
 
 				assert_eq!(backend.get_hash(3), Some(pos_3_hash));
 
@@ -656,10 +656,10 @@ fn pmmr_compact_horizon() {
 				assert_eq!(backend.get_hash(5), None);
 				assert_eq!(backend.get_hash(6), Some(pos_6_hash));
 
-				assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+				assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 				assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-				assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
+				assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 			}
 		}
 
@@ -679,10 +679,10 @@ fn pmmr_compact_horizon() {
 
 			// check we can read a hash by pos correctly from recreated backend
 			assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-			assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+			assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 			assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-			assert_eq!(backend.get_from_file(8), Some(pos_8_hash));
+			assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 		}
 
 		{
@@ -725,11 +725,11 @@ fn pmmr_compact_horizon() {
 			// get_hash() and get_from_file() should return the same value
 			// and we only store leaves in the leaf_set so pos 7 still has a hash in there
 			assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-			assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
+			assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 			assert_eq!(backend.get_hash(11), Some(pos_11_hash));
 			assert_eq!(backend.get_data(11), Some(pos_11));
-			assert_eq!(backend.get_from_file(11), Some(pos_11_hash));
+			assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
 		}
 	}
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -73,8 +73,8 @@ fn pmmr_append() {
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 
 			assert_eq!(pmmr.n_unpruned_leaves(), 4);
-			assert_eq!(pmmr.get_data(1), Some(elems[0]));
-			assert_eq!(pmmr.get_data(2), Some(elems[1]));
+			assert_eq!(pmmr.get_data(0), Some(elems[0]));
+			assert_eq!(pmmr.get_data(1), Some(elems[1]));
 
 			assert_eq!(pmmr.get_hash(1), Some(pos_0));
 			assert_eq!(pmmr.get_hash(2), Some(pos_1));
@@ -111,16 +111,16 @@ fn pmmr_append() {
 			assert_eq!(pmmr.n_unpruned_leaves(), 9);
 
 			// First pair of leaves.
-			assert_eq!(pmmr.get_data(1), Some(elems[0]));
-			assert_eq!(pmmr.get_data(2), Some(elems[1]));
+			assert_eq!(pmmr.get_data(0), Some(elems[0]));
+			assert_eq!(pmmr.get_data(1), Some(elems[1]));
 
 			// Second pair of leaves.
-			assert_eq!(pmmr.get_data(4), Some(elems[2]));
-			assert_eq!(pmmr.get_data(5), Some(elems[3]));
+			assert_eq!(pmmr.get_data(3), Some(elems[2]));
+			assert_eq!(pmmr.get_data(4), Some(elems[3]));
 
 			// Third pair of leaves.
-			assert_eq!(pmmr.get_data(8), Some(elems[4]));
-			assert_eq!(pmmr.get_data(9), Some(elems[5]));
+			assert_eq!(pmmr.get_data(7), Some(elems[4]));
+			assert_eq!(pmmr.get_data(8), Some(elems[5]));
 			assert_eq!(pmmr.get_hash(10), Some(pos_9));
 		}
 
@@ -246,9 +246,9 @@ fn pmmr_prune_compact() {
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
 			// check we can still retrieve same element from leaf index 2
-			assert_eq!(pmmr.get_data(2).unwrap(), TestElem(2));
+			assert_eq!(pmmr.get_data(1).unwrap(), TestElem(2));
 			// and the same for leaf index 7
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 
 		// compact
@@ -258,8 +258,8 @@ fn pmmr_prune_compact() {
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
-			assert_eq!(pmmr.get_data(2).unwrap(), TestElem(2));
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(1).unwrap(), TestElem(2));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 	}
 
@@ -436,26 +436,26 @@ fn pmmr_rewind() {
 		}
 
 		// Also check the data file looks correct.
-		// pos 1, 2, 4, 5 are all leaves but these have been pruned.
-		for pos in vec![1, 2, 4, 5] {
+		// pos 0, 1, 3, 4 are all leaves but these have been pruned.
+		for pos in vec![0, 1, 3, 4] {
 			assert_eq!(backend.get_data(pos), None);
 		}
-		// pos 3, 6, 7 are non-leaves so we have no data for these
-		for pos in vec![3, 6, 7] {
+		// pos 2, 5, 6 are non-leaves so we have no data for these
+		for pos in vec![2, 5, 6] {
 			assert_eq!(backend.get_data(pos), None);
 		}
 
-		// pos 8 and 9 are both leaves and should be unaffected by prior pruning
+		// pos 7 and 8 are both leaves and should be unaffected by prior pruning
 
-		assert_eq!(backend.get_data(8), Some(elems[4]));
+		assert_eq!(backend.get_data(7), Some(elems[4]));
 		assert_eq!(backend.get_hash(8), Some(elems[4].hash_with_index(7)));
 
-		assert_eq!(backend.get_data(9), Some(elems[5]));
+		assert_eq!(backend.get_data(8), Some(elems[5]));
 		assert_eq!(backend.get_hash(9), Some(elems[5].hash_with_index(8)));
 
 		// TODO - Why is this 2 here?
 		println!("***** backend size here: {}", backend.data_size());
-		// assert_eq!(backend.data_size(), 2);
+		assert_eq!(backend.data_size(), 2);
 
 		{
 			let mut pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, 10);
@@ -470,9 +470,9 @@ fn pmmr_rewind() {
 		}
 
 		// also check the data file looks correct
-		// everything up to and including pos 7 should be pruned from the data file
-		// but we have rewound to pos 5 so everything after that should be None
-		for pos in 1..17 {
+		// everything up to and including pos 6 should be pruned from the data file
+		// but we have rewound to pos 4 so everything after that should be None
+		for pos in 0..16 {
 			assert_eq!(backend.get_data(pos), None);
 		}
 
@@ -536,7 +536,7 @@ fn pmmr_compact_entire_peak() {
 
 		let pos_7_hash = backend.get_hash(7).unwrap();
 
-		let pos_8 = backend.get_data(8).unwrap();
+		let pos_8 = backend.get_data(7).unwrap();
 		let pos_8_hash = backend.get_hash(8).unwrap();
 
 		// prune all leaves under the peak at pos 7
@@ -559,7 +559,7 @@ fn pmmr_compact_entire_peak() {
 		assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 		// now check we still have subsequent hash and data where we expect
-		assert_eq!(backend.get_data(8), Some(pos_8));
+		assert_eq!(backend.get_data(7), Some(pos_8));
 		assert_eq!(backend.get_hash(8), Some(pos_8_hash));
 		assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 	}
@@ -602,10 +602,10 @@ fn pmmr_compact_horizon() {
 			pos_6_hash = backend.get_hash(6).unwrap();
 			pos_7_hash = backend.get_hash(7).unwrap();
 
-			pos_8 = backend.get_data(8).unwrap();
+			pos_8 = backend.get_data(7).unwrap();
 			pos_8_hash = backend.get_hash(8).unwrap();
 
-			pos_11 = backend.get_data(11).unwrap();
+			pos_11 = backend.get_data(10).unwrap();
 			pos_11_hash = backend.get_hash(11).unwrap();
 
 			// pruning some choice nodes
@@ -630,11 +630,11 @@ fn pmmr_compact_horizon() {
 				assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 				assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-				assert_eq!(backend.get_data(8), Some(pos_8));
+				assert_eq!(backend.get_data(7), Some(pos_8));
 				assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
 
 				assert_eq!(backend.get_hash(11), Some(pos_11_hash));
-				assert_eq!(backend.get_data(11), Some(pos_11));
+				assert_eq!(backend.get_data(10), Some(pos_11));
 				assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
 			}
 
@@ -728,7 +728,7 @@ fn pmmr_compact_horizon() {
 			assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
 
 			assert_eq!(backend.get_hash(11), Some(pos_11_hash));
-			assert_eq!(backend.get_data(11), Some(pos_11));
+			assert_eq!(backend.get_data(10), Some(pos_11));
 			assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
 		}
 	}
@@ -768,8 +768,8 @@ fn compact_twice() {
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
-			assert_eq!(pmmr.get_data(5).unwrap(), TestElem(4));
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(4).unwrap(), TestElem(4));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 
 		// compact
@@ -779,8 +779,8 @@ fn compact_twice() {
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
-			assert_eq!(pmmr.get_data(5).unwrap(), TestElem(4));
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(4).unwrap(), TestElem(4));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 
 		// now prune some more nodes
@@ -796,7 +796,7 @@ fn compact_twice() {
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 
 		// compact
@@ -806,7 +806,7 @@ fn compact_twice() {
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
 			assert_eq!(root, pmmr.root().unwrap());
-			assert_eq!(pmmr.get_data(11).unwrap(), TestElem(7));
+			assert_eq!(pmmr.get_data(10).unwrap(), TestElem(7));
 		}
 	}
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -76,9 +76,9 @@ fn pmmr_append() {
 			assert_eq!(pmmr.get_data(0), Some(elems[0]));
 			assert_eq!(pmmr.get_data(1), Some(elems[1]));
 
-			assert_eq!(pmmr.get_hash(1), Some(pos_0));
-			assert_eq!(pmmr.get_hash(2), Some(pos_1));
-			assert_eq!(pmmr.get_hash(3), Some(pos_2));
+			assert_eq!(pmmr.get_hash(0), Some(pos_0));
+			assert_eq!(pmmr.get_hash(1), Some(pos_1));
+			assert_eq!(pmmr.get_hash(2), Some(pos_2));
 		}
 
 		// adding the rest and sync again
@@ -121,12 +121,12 @@ fn pmmr_append() {
 			// Third pair of leaves.
 			assert_eq!(pmmr.get_data(7), Some(elems[4]));
 			assert_eq!(pmmr.get_data(8), Some(elems[5]));
-			assert_eq!(pmmr.get_hash(10), Some(pos_9));
+			assert_eq!(pmmr.get_hash(9), Some(pos_9));
 		}
 
 		// check the resulting backend store and the computation of the root
 		let node_hash = elems[0].hash_with_index(0);
-		assert_eq!(backend.get_hash(1).unwrap(), node_hash);
+		assert_eq!(backend.get_hash(0).unwrap(), node_hash);
 
 		{
 			let pmmr: PMMR<'_, TestElem, _> = PMMR::at(&mut backend, mmr_size);
@@ -154,12 +154,12 @@ fn pmmr_compact_leaf_sibling() {
 		// pos 1 and 2 are leaves (and siblings)
 		// the parent is pos 3
 
-		let (pos_1_hash, pos_2_hash, pos_3_hash) = {
+		let (pos_0_hash, pos_1_hash, pos_2_hash) = {
 			let pmmr = PMMR::at(&mut backend, mmr_size);
 			(
+				pmmr.get_hash(0).unwrap(),
 				pmmr.get_hash(1).unwrap(),
 				pmmr.get_hash(2).unwrap(),
-				pmmr.get_hash(3).unwrap(),
 			)
 		};
 
@@ -179,36 +179,36 @@ fn pmmr_compact_leaf_sibling() {
 
 			assert_eq!(pmmr.n_unpruned_leaves(), 17);
 
-			// check that pos 1 is "removed"
-			assert_eq!(pmmr.get_hash(1), None);
+			// check that pos 0 is "removed"
+			assert_eq!(pmmr.get_hash(0), None);
 
-			// check that pos 2 and 3 are unchanged
+			// check that pos 1 and 2 are unchanged
+			assert_eq!(pmmr.get_hash(1).unwrap(), pos_1_hash);
 			assert_eq!(pmmr.get_hash(2).unwrap(), pos_2_hash);
-			assert_eq!(pmmr.get_hash(3).unwrap(), pos_3_hash);
 		}
 
-		// check we can still retrieve the "removed" element at pos 1
+		// check we can still retrieve the "removed" element at pos 0
 		// from the backend hash file.
-		assert_eq!(backend.get_from_file(0).unwrap(), pos_1_hash);
+		assert_eq!(backend.get_from_file(0).unwrap(), pos_0_hash);
 
 		// aggressively compact the PMMR files
 		backend.check_compact(1, &Bitmap::create()).unwrap();
 
-		// check pos 1, 2, 3 are in the state we expect after compacting
+		// check pos 0, 1, 2 are in the state we expect after compacting
 		{
 			let pmmr = PMMR::at(&mut backend, mmr_size);
 
-			// check that pos 1 is "removed"
-			assert_eq!(pmmr.get_hash(1), None);
+			// check that pos 0 is "removed"
+			assert_eq!(pmmr.get_hash(0), None);
 
-			// check that pos 2 and 3 are unchanged
+			// check that pos 1 and 2 are unchanged
+			assert_eq!(pmmr.get_hash(1).unwrap(), pos_1_hash);
 			assert_eq!(pmmr.get_hash(2).unwrap(), pos_2_hash);
-			assert_eq!(pmmr.get_hash(3).unwrap(), pos_3_hash);
 		}
 
 		// Check we can still retrieve the "removed" hash at pos 1 from the hash file.
 		// It should still be available even after pruning and compacting.
-		assert_eq!(backend.get_from_file(0).unwrap(), pos_1_hash);
+		assert_eq!(backend.get_from_file(0).unwrap(), pos_0_hash);
 	}
 
 	teardown(data_dir);
@@ -279,9 +279,9 @@ fn pmmr_reload() {
 		let mmr_size = load(0, &elems[..], &mut backend);
 
 		// retrieve entries from the hash file for comparison later
+		let pos_2_hash = backend.get_hash(2).unwrap();
 		let pos_3_hash = backend.get_hash(3).unwrap();
 		let pos_4_hash = backend.get_hash(4).unwrap();
-		let pos_5_hash = backend.get_hash(5).unwrap();
 
 		// save the root
 		let root = {
@@ -342,29 +342,29 @@ fn pmmr_reload() {
 				assert_eq!(root, pmmr.root().unwrap());
 			}
 
-			// pos 1 and pos 2 are both removed (via parent pos 3 in prune list)
+			// pos 0 and pos 1 are both removed (via parent pos 2 in prune list)
+			assert_eq!(backend.get_hash(0), None);
 			assert_eq!(backend.get_hash(1), None);
-			assert_eq!(backend.get_hash(2), None);
 
-			// pos 3 is "removed" but we keep the hash around for root of pruned subtree
-			assert_eq!(backend.get_hash(3), Some(pos_3_hash));
+			// pos 2 is "removed" but we keep the hash around for root of pruned subtree
+			assert_eq!(backend.get_hash(2), Some(pos_2_hash));
 
-			// pos 4 is removed (via prune list)
+			// pos 3 is removed (via prune list)
+			assert_eq!(backend.get_hash(3), None);
+			// pos 4 is removed (via leaf_set)
 			assert_eq!(backend.get_hash(4), None);
-			// pos 5 is removed (via leaf_set)
-			assert_eq!(backend.get_hash(5), None);
 
 			// now check contents of the hash file
-			// pos 1 and pos 2 are no longer in the hash file
+			// pos 0 and pos 1 are no longer in the hash file
 			assert_eq!(backend.get_from_file(0), None);
 			assert_eq!(backend.get_from_file(1), None);
 
-			// pos 3 is still in there
-			assert_eq!(backend.get_from_file(2), Some(pos_3_hash));
+			// pos 2 is still in there
+			assert_eq!(backend.get_from_file(2), Some(pos_2_hash));
 
-			// pos 4 and pos 5 are also still in there
-			assert_eq!(backend.get_from_file(3), Some(pos_4_hash));
-			assert_eq!(backend.get_from_file(4), Some(pos_5_hash));
+			// pos 3 and pos 4 are also still in there
+			assert_eq!(backend.get_from_file(3), Some(pos_3_hash));
+			assert_eq!(backend.get_from_file(4), Some(pos_4_hash));
 		}
 	}
 
@@ -448,10 +448,10 @@ fn pmmr_rewind() {
 		// pos 7 and 8 are both leaves and should be unaffected by prior pruning
 
 		assert_eq!(backend.get_data(7), Some(elems[4]));
-		assert_eq!(backend.get_hash(8), Some(elems[4].hash_with_index(7)));
+		assert_eq!(backend.get_hash(7), Some(elems[4].hash_with_index(7)));
 
 		assert_eq!(backend.get_data(8), Some(elems[5]));
-		assert_eq!(backend.get_hash(9), Some(elems[5].hash_with_index(8)));
+		assert_eq!(backend.get_hash(8), Some(elems[5].hash_with_index(8)));
 
 		// TODO - Why is this 2 here?
 		println!("***** backend size here: {}", backend.data_size());
@@ -534,10 +534,10 @@ fn pmmr_compact_entire_peak() {
 		let mmr_size = load(0, &elems[0..5], &mut backend);
 		backend.sync().unwrap();
 
-		let pos_7_hash = backend.get_hash(7).unwrap();
+		let pos_6_hash = backend.get_hash(6).unwrap();
 
-		let pos_8 = backend.get_data(7).unwrap();
-		let pos_8_hash = backend.get_hash(8).unwrap();
+		let pos_7 = backend.get_data(7).unwrap();
+		let pos_7_hash = backend.get_hash(7).unwrap();
 
 		// prune all leaves under the peak at pos 7
 		{
@@ -555,13 +555,13 @@ fn pmmr_compact_entire_peak() {
 
 		// now check we have pruned up to and including the peak at pos 7
 		// hash still available in underlying hash file
-		assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-		assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
+		assert_eq!(backend.get_hash(6), Some(pos_6_hash));
+		assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 
 		// now check we still have subsequent hash and data where we expect
-		assert_eq!(backend.get_data(7), Some(pos_8));
-		assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-		assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
+		assert_eq!(backend.get_data(7), Some(pos_7));
+		assert_eq!(backend.get_hash(7), Some(pos_7_hash));
+		assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 	}
 
 	teardown(data_dir);
@@ -571,17 +571,17 @@ fn pmmr_compact_entire_peak() {
 fn pmmr_compact_horizon() {
 	let (data_dir, elems) = setup("compact_horizon");
 	{
+		let pos_0_hash;
 		let pos_1_hash;
 		let pos_2_hash;
-		let pos_3_hash;
+		let pos_5_hash;
 		let pos_6_hash;
+
+		let pos_7;
 		let pos_7_hash;
 
-		let pos_8;
-		let pos_8_hash;
-
-		let pos_11;
-		let pos_11_hash;
+		let pos_10;
+		let pos_10_hash;
 
 		let mmr_size;
 		{
@@ -596,17 +596,17 @@ fn pmmr_compact_horizon() {
 			assert_eq!(backend.data_size(), 19);
 			assert_eq!(backend.hash_size(), 35);
 
+			pos_0_hash = backend.get_hash(0).unwrap();
 			pos_1_hash = backend.get_hash(1).unwrap();
 			pos_2_hash = backend.get_hash(2).unwrap();
-			pos_3_hash = backend.get_hash(3).unwrap();
+			pos_5_hash = backend.get_hash(5).unwrap();
 			pos_6_hash = backend.get_hash(6).unwrap();
+
+			pos_7 = backend.get_data(7).unwrap();
 			pos_7_hash = backend.get_hash(7).unwrap();
 
-			pos_8 = backend.get_data(7).unwrap();
-			pos_8_hash = backend.get_hash(8).unwrap();
-
-			pos_11 = backend.get_data(10).unwrap();
-			pos_11_hash = backend.get_hash(11).unwrap();
+			pos_10 = backend.get_data(10).unwrap();
+			pos_10_hash = backend.get_hash(10).unwrap();
 
 			// pruning some choice nodes
 			{
@@ -621,21 +621,21 @@ fn pmmr_compact_horizon() {
 			// check we can read hashes and data correctly after pruning
 			{
 				// assert_eq!(backend.get_hash(3), None);
-				assert_eq!(backend.get_from_file(2), Some(pos_3_hash));
+				assert_eq!(backend.get_from_file(2), Some(pos_2_hash));
 
 				// assert_eq!(backend.get_hash(6), None);
-				assert_eq!(backend.get_from_file(5), Some(pos_6_hash));
+				assert_eq!(backend.get_from_file(5), Some(pos_5_hash));
 
 				// assert_eq!(backend.get_hash(7), None);
-				assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
+				assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 
-				assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-				assert_eq!(backend.get_data(7), Some(pos_8));
-				assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
+				assert_eq!(backend.get_hash(7), Some(pos_7_hash));
+				assert_eq!(backend.get_data(7), Some(pos_7));
+				assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 
-				assert_eq!(backend.get_hash(11), Some(pos_11_hash));
-				assert_eq!(backend.get_data(10), Some(pos_11));
-				assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
+				assert_eq!(backend.get_hash(10), Some(pos_10_hash));
+				assert_eq!(backend.get_data(10), Some(pos_10));
+				assert_eq!(backend.get_from_file(10), Some(pos_10_hash));
 			}
 
 			// compact
@@ -644,22 +644,22 @@ fn pmmr_compact_horizon() {
 
 			// check we can read a hash by pos correctly after compaction
 			{
+				assert_eq!(backend.get_hash(0), None);
+				assert_eq!(backend.get_from_file(0), Some(pos_0_hash));
+
 				assert_eq!(backend.get_hash(1), None);
-				assert_eq!(backend.get_from_file(0), Some(pos_1_hash));
+				assert_eq!(backend.get_from_file(1), Some(pos_1_hash));
 
-				assert_eq!(backend.get_hash(2), None);
-				assert_eq!(backend.get_from_file(1), Some(pos_2_hash));
+				assert_eq!(backend.get_hash(2), Some(pos_2_hash));
 
-				assert_eq!(backend.get_hash(3), Some(pos_3_hash));
-
+				assert_eq!(backend.get_hash(3), None);
 				assert_eq!(backend.get_hash(4), None);
-				assert_eq!(backend.get_hash(5), None);
-				assert_eq!(backend.get_hash(6), Some(pos_6_hash));
+				assert_eq!(backend.get_hash(5), Some(pos_5_hash));
 
-				assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
+				assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 
-				assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-				assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
+				assert_eq!(backend.get_hash(7), Some(pos_7_hash));
+				assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 			}
 		}
 
@@ -678,11 +678,11 @@ fn pmmr_compact_horizon() {
 			assert_eq!(backend.hash_size(), 35);
 
 			// check we can read a hash by pos correctly from recreated backend
-			assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-			assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
+			assert_eq!(backend.get_hash(6), Some(pos_6_hash));
+			assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 
-			assert_eq!(backend.get_hash(8), Some(pos_8_hash));
-			assert_eq!(backend.get_from_file(7), Some(pos_8_hash));
+			assert_eq!(backend.get_hash(7), Some(pos_7_hash));
+			assert_eq!(backend.get_from_file(7), Some(pos_7_hash));
 		}
 
 		{
@@ -724,12 +724,12 @@ fn pmmr_compact_horizon() {
 			// check we can read a hash by pos correctly from recreated backend
 			// get_hash() and get_from_file() should return the same value
 			// and we only store leaves in the leaf_set so pos 7 still has a hash in there
-			assert_eq!(backend.get_hash(7), Some(pos_7_hash));
-			assert_eq!(backend.get_from_file(6), Some(pos_7_hash));
+			assert_eq!(backend.get_hash(6), Some(pos_6_hash));
+			assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 
-			assert_eq!(backend.get_hash(11), Some(pos_11_hash));
-			assert_eq!(backend.get_data(10), Some(pos_11));
-			assert_eq!(backend.get_from_file(10), Some(pos_11_hash));
+			assert_eq!(backend.get_hash(10), Some(pos_10_hash));
+			assert_eq!(backend.get_data(10), Some(pos_10));
+			assert_eq!(backend.get_from_file(10), Some(pos_10_hash));
 		}
 	}
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -46,7 +46,7 @@ fn pmmr_leaf_idx_iter() {
 
 			// The first 5 leaves [0,1,2,3,4] are at pos [1,2,4,5,8] in the MMR.
 			assert_eq!(leaf_idx, vec![0, 1, 2, 3, 4]);
-			assert_eq!(leaf_pos, vec![1, 2, 4, 5, 8]);
+			assert_eq!(leaf_pos, vec![0, 1, 3, 4, 7]);
 		}
 	}
 	teardown(data_dir);
@@ -723,7 +723,7 @@ fn pmmr_compact_horizon() {
 
 			// check we can read a hash by pos correctly from recreated backend
 			// get_hash() and get_from_file() should return the same value
-			// and we only store leaves in the leaf_set so pos 7 still has a hash in there
+			// and we only store leaves in the leaf_set so pos 6 still has a hash in there
 			assert_eq!(backend.get_hash(6), Some(pos_6_hash));
 			assert_eq!(backend.get_from_file(6), Some(pos_6_hash));
 

--- a/store/tests/prune_list.rs
+++ b/store/tests/prune_list.rs
@@ -17,21 +17,6 @@ use grin_store as store;
 use crate::store::prune_list::PruneList;
 use croaring::Bitmap;
 
-// Prune list is 1-indexed but we implement this internally with a bitmap that supports a 0 value.
-// We need to make sure we safely handle 0 safely.
-#[test]
-fn test_zero_value() {
-	// Create a bitmap with a 0 value in it.
-	let mut bitmap = Bitmap::create();
-	bitmap.add(0);
-
-	// Instantiate a prune list from our existing bitmap.
-	let pl = PruneList::new(None, bitmap);
-
-	// Our prune list should be empty (0 filtered out during creation).
-	assert!(pl.is_empty());
-}
-
 #[test]
 fn test_is_pruned() {
 	let mut pl = PruneList::empty();

--- a/store/tests/prune_list.rs
+++ b/store/tests/prune_list.rs
@@ -37,18 +37,18 @@ fn test_is_pruned() {
 	let mut pl = PruneList::empty();
 
 	assert_eq!(pl.len(), 0);
+	assert_eq!(pl.is_pruned(0), false);
 	assert_eq!(pl.is_pruned(1), false);
 	assert_eq!(pl.is_pruned(2), false);
-	assert_eq!(pl.is_pruned(3), false);
 
 	pl.append(2);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
-	assert_eq!(pl.is_pruned(1), false);
-	assert_eq!(pl.is_pruned(2), true);
+	assert_eq!(pl.is_pruned(0), false);
+	assert_eq!(pl.is_pruned(1), true);
+	assert_eq!(pl.is_pruned(2), false);
 	assert_eq!(pl.is_pruned(3), false);
-	assert_eq!(pl.is_pruned(4), false);
 
 	let mut pl = PruneList::empty();
 	pl.append(1);
@@ -57,10 +57,10 @@ fn test_is_pruned() {
 
 	assert_eq!(pl.len(), 1);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [3]);
+	assert_eq!(pl.is_pruned(0), true);
 	assert_eq!(pl.is_pruned(1), true);
 	assert_eq!(pl.is_pruned(2), true);
-	assert_eq!(pl.is_pruned(3), true);
-	assert_eq!(pl.is_pruned(4), false);
+	assert_eq!(pl.is_pruned(3), false);
 
 	pl.append(4);
 
@@ -70,11 +70,11 @@ fn test_is_pruned() {
 
 	assert_eq!(pl.len(), 2);
 	assert_eq!(pl.to_vec(), [3, 4]);
+	assert_eq!(pl.is_pruned(0), true);
 	assert_eq!(pl.is_pruned(1), true);
 	assert_eq!(pl.is_pruned(2), true);
 	assert_eq!(pl.is_pruned(3), true);
-	assert_eq!(pl.is_pruned(4), true);
-	assert_eq!(pl.is_pruned(5), false);
+	assert_eq!(pl.is_pruned(4), false);
 }
 
 #[test]
@@ -224,7 +224,7 @@ fn test_get_shift() {
 
 	// prune a bunch more
 	for x in 6..1000 {
-		if !pl.is_pruned(x) {
+		if !pl.is_pruned(x - 1) {
 			pl.append(x);
 		}
 	}

--- a/store/tests/prune_list.rs
+++ b/store/tests/prune_list.rs
@@ -41,7 +41,7 @@ fn test_is_pruned() {
 	assert_eq!(pl.is_pruned(1), false);
 	assert_eq!(pl.is_pruned(2), false);
 
-	pl.append(2);
+	pl.append(1);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
@@ -51,8 +51,8 @@ fn test_is_pruned() {
 	assert_eq!(pl.is_pruned(3), false);
 
 	let mut pl = PruneList::empty();
+	pl.append(0);
 	pl.append(1);
-	pl.append(2);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 1);
@@ -62,7 +62,7 @@ fn test_is_pruned() {
 	assert_eq!(pl.is_pruned(2), true);
 	assert_eq!(pl.is_pruned(3), false);
 
-	pl.append(4);
+	pl.append(3);
 
 	// Flushing the prune_list removes any individual leaf positions.
 	// This assumes we will track these outside the prune_list via the leaf_set.
@@ -91,7 +91,7 @@ fn test_get_leaf_shift() {
 	// now add a single leaf pos to the prune list
 	// leaves will not shift shift anything
 	// we only start shifting after pruning a parent
-	pl.append(1);
+	pl.append(0);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [1]);
@@ -102,7 +102,7 @@ fn test_get_leaf_shift() {
 
 	// now add the sibling leaf pos (pos 2) which will prune the parent
 	// at pos 3 this in turn will "leaf shift" the leaf at pos 3 by 2
-	pl.append(2);
+	pl.append(1);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 1);
@@ -115,7 +115,7 @@ fn test_get_leaf_shift() {
 	// now prune an additional leaf at pos 4
 	// leaf offset of subsequent pos will be 2
 	// 00100120
-	pl.append(4);
+	pl.append(3);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 2);
@@ -133,7 +133,7 @@ fn test_get_leaf_shift() {
 	// the two smaller subtrees (pos 3 and pos 6) are rolled up to larger subtree
 	// (pos 7) the leaf offset is now 4 to cover entire subtree containing first
 	// 4 leaves 00100120
-	pl.append(5);
+	pl.append(4);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 1);
@@ -151,10 +151,10 @@ fn test_get_leaf_shift() {
 	// now check we can prune some unconnected nodes
 	// and that leaf_shift is correct for various pos
 	let mut pl = PruneList::empty();
+	pl.append(3);
 	pl.append(4);
-	pl.append(5);
+	pl.append(10);
 	pl.append(11);
-	pl.append(12);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.len(), 2);
@@ -178,7 +178,7 @@ fn test_get_shift() {
 	// prune a single leaf node
 	// pruning only a leaf node does not shift any subsequent pos
 	// we will only start shifting when a parent can be pruned
-	pl.append(1);
+	pl.append(0);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [1]);
@@ -186,7 +186,7 @@ fn test_get_shift() {
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_shift(3), 0);
 
-	pl.append(2);
+	pl.append(1);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [3]);
@@ -197,7 +197,7 @@ fn test_get_shift() {
 	assert_eq!(pl.get_shift(5), 2);
 	assert_eq!(pl.get_shift(6), 2);
 
-	pl.append(4);
+	pl.append(3);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
@@ -208,7 +208,7 @@ fn test_get_shift() {
 	assert_eq!(pl.get_shift(5), 2);
 	assert_eq!(pl.get_shift(6), 2);
 
-	pl.append(5);
+	pl.append(4);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [7]);
@@ -223,8 +223,8 @@ fn test_get_shift() {
 	assert_eq!(pl.get_shift(9), 6);
 
 	// prune a bunch more
-	for x in 6..1000 {
-		if !pl.is_pruned(x - 1) {
+	for x in 5..999 {
+		if !pl.is_pruned(x) {
 			pl.append(x);
 		}
 	}
@@ -235,10 +235,10 @@ fn test_get_shift() {
 
 	// now check we can do some sparse pruning
 	let mut pl = PruneList::empty();
+	pl.append(3);
 	pl.append(4);
-	pl.append(5);
+	pl.append(7);
 	pl.append(8);
-	pl.append(9);
 	pl.flush().unwrap();
 
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [6, 10]);
@@ -259,33 +259,33 @@ fn test_get_shift() {
 #[test]
 pub fn test_iter() {
 	let mut pl = PruneList::empty();
+	pl.append(0);
 	pl.append(1);
-	pl.append(2);
-	pl.append(4);
+	pl.append(3);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 4]);
 
 	let mut pl = PruneList::empty();
+	pl.append(0);
 	pl.append(1);
-	pl.append(2);
-	pl.append(5);
+	pl.append(4);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [3, 5]);
 }
 
 #[test]
 pub fn test_pruned_bintree_range_iter() {
 	let mut pl = PruneList::empty();
+	pl.append(0);
 	pl.append(1);
-	pl.append(2);
-	pl.append(4);
+	pl.append(3);
 	assert_eq!(
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
 		[1..4, 4..5]
 	);
 
 	let mut pl = PruneList::empty();
+	pl.append(0);
 	pl.append(1);
-	pl.append(2);
-	pl.append(5);
+	pl.append(4);
 	assert_eq!(
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
 		[1..4, 5..6]
@@ -298,15 +298,15 @@ pub fn test_unpruned_iter() {
 	assert_eq!(pl.unpruned_iter(5).collect::<Vec<_>>(), [1, 2, 3, 4, 5]);
 
 	let mut pl = PruneList::empty();
-	pl.append(2);
+	pl.append(1);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
 	assert_eq!(pl.pruned_bintree_range_iter().collect::<Vec<_>>(), [2..3]);
 	assert_eq!(pl.unpruned_iter(4).collect::<Vec<_>>(), [1, 3, 4]);
 
 	let mut pl = PruneList::empty();
-	pl.append(2);
+	pl.append(1);
+	pl.append(3);
 	pl.append(4);
-	pl.append(5);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2, 6]);
 	assert_eq!(
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
@@ -324,15 +324,15 @@ fn test_unpruned_leaf_iter() {
 	);
 
 	let mut pl = PruneList::empty();
-	pl.append(2);
+	pl.append(1);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2]);
 	assert_eq!(pl.pruned_bintree_range_iter().collect::<Vec<_>>(), [2..3]);
 	assert_eq!(pl.unpruned_leaf_iter(5).collect::<Vec<_>>(), [1, 4, 5]);
 
 	let mut pl = PruneList::empty();
-	pl.append(2);
+	pl.append(1);
+	pl.append(3);
 	pl.append(4);
-	pl.append(5);
 	assert_eq!(pl.iter().collect::<Vec<_>>(), [2, 6]);
 	assert_eq!(
 		pl.pruned_bintree_range_iter().collect::<Vec<_>>(),
@@ -345,13 +345,13 @@ pub fn test_append_pruned_subtree() {
 	let mut pl = PruneList::empty();
 
 	// append a pruned leaf pos (shift and leaf shift are unaffected).
-	pl.append(1);
+	pl.append(0);
 
 	assert_eq!(pl.to_vec(), [1]);
 	assert_eq!(pl.get_shift(2), 0);
 	assert_eq!(pl.get_leaf_shift(2), 0);
 
-	pl.append(3);
+	pl.append(2);
 
 	// subtree beneath root at 3 is pruned
 	// pos 4 is shifted by 2 pruned hashes [1, 2]
@@ -361,7 +361,7 @@ pub fn test_append_pruned_subtree() {
 	assert_eq!(pl.get_leaf_shift(4), 2);
 
 	// append another pruned subtree (ancester of previous one)
-	pl.append(7);
+	pl.append(6);
 
 	// subtree beneath root at 7 is pruned
 	// pos 8 is shifted by 6 pruned hashes [1, 2, 3, 4, 5, 6]
@@ -371,7 +371,7 @@ pub fn test_append_pruned_subtree() {
 	assert_eq!(pl.get_leaf_shift(8), 4);
 
 	// now append another pruned leaf pos
-	pl.append(8);
+	pl.append(7);
 
 	// additional pruned leaf does not affect the shift or leaf shift
 	// pos 9 is shifted by 6 pruned hashes [1, 2, 3, 4, 5, 6]
@@ -384,9 +384,9 @@ pub fn test_append_pruned_subtree() {
 #[test]
 fn test_recreate_prune_list() {
 	let mut pl = PruneList::empty();
+	pl.append(3);
 	pl.append(4);
-	pl.append(5);
-	pl.append(11);
+	pl.append(10);
 
 	let pl2 = PruneList::new(None, vec![4, 5, 11].into_iter().collect());
 

--- a/store/tests/segment.rs
+++ b/store/tests/segment.rs
@@ -281,7 +281,7 @@ fn pruned_segment() {
 			.first_unpruned_parent(last_pos, Some(&bitmap))
 			.unwrap()
 			.1,
-		segment.segment_pos_range(last_pos).1
+		1 + segment.segment_pos_range(last_pos).1
 	);
 	assert!(segment.root(last_pos, Some(&bitmap)).unwrap().is_some());
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
@@ -317,7 +317,7 @@ fn pruned_segment() {
 			.first_unpruned_parent(last_pos, Some(&bitmap))
 			.unwrap()
 			.1,
-		segment.segment_pos_range(last_pos).1
+		1 + segment.segment_pos_range(last_pos).1
 	);
 	assert!(segment.root(last_pos, Some(&bitmap)).unwrap().is_some());
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();

--- a/store/tests/segment.rs
+++ b/store/tests/segment.rs
@@ -378,7 +378,7 @@ where
 	B: Backend<T>,
 {
 	for &leaf_idx in leaf_idxs {
-		mmr.prune(pmmr::insertion_to_pmmr_index(leaf_idx + 1))
+		mmr.prune(1 + pmmr::insertion_to_pmmr_index(leaf_idx))
 			.unwrap();
 		bitmap.remove(leaf_idx as u32);
 	}

--- a/store/tests/segment.rs
+++ b/store/tests/segment.rs
@@ -56,7 +56,7 @@ fn prunable_mmr() {
 	let segment = Segment::from_pmmr(id, &mmr, true).unwrap();
 	assert_eq!(
 		segment.root(last_pos, Some(&bitmap)).unwrap().unwrap(),
-		mmr.get_hash(30).unwrap()
+		mmr.get_hash(29).unwrap()
 	);
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
 
@@ -72,7 +72,7 @@ fn prunable_mmr() {
 	let segment = Segment::from_pmmr(id, &mmr, true).unwrap();
 	assert_eq!(
 		segment.root(last_pos, Some(&bitmap)).unwrap().unwrap(),
-		mmr.get_hash(30).unwrap()
+		mmr.get_hash(29).unwrap()
 	);
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
 
@@ -88,7 +88,7 @@ fn prunable_mmr() {
 	let segment = Segment::from_pmmr(id, &mmr, true).unwrap();
 	assert_eq!(
 		segment.root(last_pos, Some(&bitmap)).unwrap().unwrap(),
-		mmr.get_hash(30).unwrap()
+		mmr.get_hash(29).unwrap()
 	);
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
 
@@ -104,7 +104,7 @@ fn prunable_mmr() {
 	let segment = Segment::from_pmmr(id, &mmr, true).unwrap();
 	assert_eq!(
 		segment.root(last_pos, Some(&bitmap)).unwrap().unwrap(),
-		mmr.get_hash(30).unwrap()
+		mmr.get_hash(29).unwrap()
 	);
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
 
@@ -191,7 +191,7 @@ fn pruned_segment() {
 		segment
 			.first_unpruned_parent(last_pos, Some(&bitmap))
 			.unwrap(),
-		(ba.get_hash(14).unwrap(), 14)
+		(ba.get_hash(13).unwrap(), 14)
 	);
 	assert!(segment.root(last_pos, Some(&bitmap)).unwrap().is_none());
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
@@ -213,7 +213,7 @@ fn pruned_segment() {
 		segment
 			.first_unpruned_parent(last_pos, Some(&bitmap))
 			.unwrap(),
-		(ba.get_hash(15).unwrap(), 15)
+		(ba.get_hash(14).unwrap(), 15)
 	);
 	assert!(segment.root(last_pos, Some(&bitmap)).unwrap().is_none());
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();
@@ -266,7 +266,7 @@ fn pruned_segment() {
 		segment
 			.first_unpruned_parent(last_pos, Some(&bitmap))
 			.unwrap(),
-		(ba.get_hash(38).unwrap(), 38)
+		(ba.get_hash(37).unwrap(), 38)
 	);
 	assert!(segment.root(last_pos, Some(&bitmap)).unwrap().is_none());
 	segment.validate(last_pos, Some(&bitmap), root).unwrap();

--- a/store/tests/segment.rs
+++ b/store/tests/segment.rs
@@ -378,8 +378,7 @@ where
 	B: Backend<T>,
 {
 	for &leaf_idx in leaf_idxs {
-		mmr.prune(1 + pmmr::insertion_to_pmmr_index(leaf_idx))
-			.unwrap();
+		mmr.prune(pmmr::insertion_to_pmmr_index(leaf_idx)).unwrap();
 		bitmap.remove(leaf_idx as u32);
 	}
 }

--- a/store/tests/utxo_set_perf.rs
+++ b/store/tests/utxo_set_perf.rs
@@ -53,7 +53,7 @@ fn test_leaf_set_performance() {
 	// Simulate looking up existence of a large number of pos in the leaf_set.
 	let now = Instant::now();
 	for x in 0..1_000_000 {
-		assert!(leaf_set.includes(x + 1));
+		assert!(leaf_set.includes(x));
 	}
 	println!(
 		"Checking 1,000,000 inclusions in leaf_set took {}ms",

--- a/store/tests/utxo_set_perf.rs
+++ b/store/tests/utxo_set_perf.rs
@@ -39,7 +39,7 @@ fn test_leaf_set_performance() {
 	let now = Instant::now();
 	for x in 0..1_000 {
 		for y in 0..1_000 {
-			let pos = (x * 1_000) + y + 1;
+			let pos = (x * 1_000) + y;
 			leaf_set.add(pos);
 		}
 		leaf_set.flush().unwrap();
@@ -65,7 +65,7 @@ fn test_leaf_set_performance() {
 	let now = Instant::now();
 	for x in 0..1_000 {
 		for y in 0..1_000 {
-			let pos = (x * 1_000) + y + 1;
+			let pos = (x * 1_000) + y;
 			leaf_set.remove(pos);
 		}
 		leaf_set.flush().unwrap();


### PR DESCRIPTION
---
name: fixmmr_part2
about: Pull Request checklist
title: 'Fixmmr part2
labels: ''
assignees: ''

---
The MMR (Merkle Mountain Range) was originally designed with 0-based leaf and node indices.
This is reflected in the consensus model since hashes are computed with a 0-based node index prepended to the leaf data or the two child hashes.
0-based indices also simplify conversion of a leaf to a node index, which becomes
2 * leaf_index - count_ones(leaf_index).
The other C++ Grin code base, grinplusplus, uses 0-bases indices exclusively.
Unfortunately, 1-based indices have crept into the Grin code base resulting in a mix of both.
Use of 1-based indices has the downside that we often need to test that an index argument isn't 0.
This PR tries to convert as many uses of 1-based indices as possible to 0-based indices.
A few instances remain in storage related code where bitmaps and leaf sets are read from and written to disk.
The changes are not consensus breaking.
Each changed method is in its own commit, except for some pairs of related methods.
Tested with a regular sync as well as a sync from scratch.