### PR TITLE
[SYNC PERFORMANCE] Replace header proof serialisation with more efficient algorithm

### DIFF
--- a/chain/tests/test_header_perf.rs
+++ b/chain/tests/test_header_perf.rs
@@ -1,0 +1,119 @@
+// Copyright 2021 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use grin_chain as chain;
+use grin_core as core;
+use grin_util as util;
+
+#[macro_use]
+extern crate log;
+
+use std::sync::Arc;
+
+use crate::chain::types::{NoopAdapter, Options};
+use crate::core::core::hash::Hashed;
+use crate::core::{genesis, global, pow};
+
+use self::chain_test_helper::clean_output_dir;
+
+mod chain_test_helper;
+
+fn test_header_perf_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &str) {
+	global::set_local_chain_type(global::ChainTypes::Mainnet);
+	let mut genesis = genesis::genesis_main();
+
+	if is_test_chain {
+		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+		genesis = pow::mine_genesis_block().unwrap();
+	}
+
+	{
+		debug!("Reading Chain, genesis block: {}", genesis.hash());
+		let dummy_adapter = Arc::new(NoopAdapter {});
+
+		// The original chain we're reading from
+		let src_chain = Arc::new(
+			chain::Chain::init(
+				src_root_dir.into(),
+				dummy_adapter.clone(),
+				genesis.clone(),
+				pow::verify_size,
+				false,
+			)
+			.unwrap(),
+		);
+
+		// And the output chain we're writing to
+		let dest_chain = Arc::new(
+			chain::Chain::init(
+				dest_root_dir.into(),
+				dummy_adapter,
+				genesis.clone(),
+				pow::verify_size,
+				false,
+			)
+			.unwrap(),
+		);
+
+		let sh = src_chain.get_header_by_height(0).unwrap();
+		debug!("Source Genesis - {}", sh.hash());
+
+		let dh = dest_chain.get_header_by_height(0).unwrap();
+		debug!("Destination Genesis - {}", dh.hash());
+
+		let horizon_header = src_chain.txhashset_archive_header().unwrap();
+
+		debug!("Horizon header: {:?}", horizon_header);
+
+		// Copy the headers from source to output in chunks
+		let dest_sync_head = dest_chain.header_head().unwrap();
+		let copy_chunk_size = 1000;
+		let mut copied_header_index = 1;
+		let mut src_headers = vec![];
+		while copied_header_index <= 100000 {
+			let h = src_chain.get_header_by_height(copied_header_index).unwrap();
+			src_headers.push(h);
+			copied_header_index += 1;
+			if copied_header_index % copy_chunk_size == 0 {
+				debug!(
+					"Copying headers to {} of {}",
+					copied_header_index, horizon_header.height
+				);
+				dest_chain
+					.sync_block_headers(&src_headers, dest_sync_head, Options::NONE)
+					.unwrap();
+				src_headers = vec![];
+			}
+		}
+		if !src_headers.is_empty() {
+			dest_chain
+				.sync_block_headers(&src_headers, dest_sync_head, Options::NONE)
+				.unwrap();
+		}
+	}
+}
+
+#[test]
+#[ignore]
+// Ignored during CI, but use this to run this test on a real instance of a chain pointed where you like
+fn test_header_perf() {
+	util::init_test_logger();
+	// if testing against a real chain, insert location here
+	// NOTE: Modify to point at your own paths
+	let src_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/chain_data");
+	let dest_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/.chain_data_copy");
+	clean_output_dir(&dest_root_dir);
+	test_header_perf_impl(false, &src_root_dir, &dest_root_dir);
+	clean_output_dir(&dest_root_dir);
+}

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -25,7 +25,7 @@ use crate::consensus::{
 use crate::core::block::HeaderVersion;
 use crate::pow::{
 	self, new_cuckaroo_ctx, new_cuckarood_ctx, new_cuckaroom_ctx, new_cuckarooz_ctx,
-	new_cuckatoo_ctx, no_cuckaroo_ctx, proof_unpack_len, PoWContext,
+	new_cuckatoo_ctx, no_cuckaroo_ctx, PoWContext, Proof,
 };
 use crate::ser::ProtocolVersion;
 use std::cell::Cell;
@@ -488,7 +488,7 @@ where
 #[inline]
 pub fn header_size_bytes(edge_bits: u8) -> usize {
 	let size = 2 + 2 * 8 + 5 * 32 + 32 + 2 * 8;
-	let proof_size = 8 + 4 + 8 + 1 + proof_unpack_len(edge_bits as usize * proofsize());
+	let proof_size = 8 + 4 + 8 + 1 + Proof::pack_len(edge_bits);
 	size + proof_size
 }
 

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -25,7 +25,7 @@ use crate::consensus::{
 use crate::core::block::HeaderVersion;
 use crate::pow::{
 	self, new_cuckaroo_ctx, new_cuckarood_ctx, new_cuckaroom_ctx, new_cuckarooz_ctx,
-	new_cuckatoo_ctx, no_cuckaroo_ctx, BitVec, PoWContext,
+	new_cuckatoo_ctx, no_cuckaroo_ctx, proof_unpack_len, PoWContext,
 };
 use crate::ser::ProtocolVersion;
 use std::cell::Cell;
@@ -488,7 +488,7 @@ where
 #[inline]
 pub fn header_size_bytes(edge_bits: u8) -> usize {
 	let size = 2 + 2 * 8 + 5 * 32 + 32 + 2 * 8;
-	let proof_size = 8 + 4 + 8 + 1 + BitVec::bytes_len(edge_bits as usize * proofsize());
+	let proof_size = 8 + 4 + 8 + 1 + proof_unpack_len(edge_bits as usize * proofsize());
 	size + proof_size
 }
 

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -21,7 +21,7 @@ use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
 /// proof of work within a block header.
-use std::cmp::{max, min};
+use std::cmp::{max, min, Ordering};
 use std::ops::{Add, Div, Mul, Sub};
 use std::u64;
 use std::{fmt, iter};
@@ -405,11 +405,20 @@ impl Proof {
 	/// Pack the nonces of the proof to their exact bit size as described above
 	pub fn pack_nonces(&self) -> Vec<u8> {
 		let mut compressed = vec![0u8; Proof::pack_len(self.edge_bits)];
+		pack_bits_old(
+			self.edge_bits,
+			&self.nonces[0..self.nonces.len()],
+			&mut compressed,
+		);
+		println!("PACK OLD: {:?}", compressed);
+
+		let mut compressed = vec![0u8; Proof::pack_len(self.edge_bits)];
 		pack_bits(
 			self.edge_bits,
 			&self.nonces[0..self.nonces.len()],
 			&mut compressed,
 		);
+		println!("PACK NEW: {:?}", compressed);
 		compressed
 	}
 
@@ -439,9 +448,58 @@ fn pack_bits(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
 			remaining = 64 + remaining - bit_width;
 		}
 	}
-	let remainder = compressed.len() % 8;
-	if remainder > 0 {
-		compressed[..remainder].copy_from_slice(&mini_buffer.to_le_bytes()[..remainder]);
+	let mut remainder = compressed.len() % 8;
+	if remainder == 0 {
+		remainder = 8;
+	}
+	if mini_buffer > 0 {
+		compressed[..].copy_from_slice(&mini_buffer.to_le_bytes()[..remainder]);
+	}
+}
+
+/// Pack an array of u64s into `compressed` at the specified bit width. Caller
+/// must ensure `compressed` is the right size
+fn pack_bits_old(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
+	// We will use a `u64` as a mini buffer of 64 bits.
+	// We accumulate bits in it until capacity, at which point we just copy this
+	// mini buffer to compressed.
+	let mut mini_buffer: u64 = 0u64;
+	let mut cursor = 0; //< number of bits written in the mini_buffer.
+	let mut pack_bytes_remaining = compressed.len();
+	for el in uncompressed {
+		let remaining = 64 - cursor;
+		match bit_width.cmp(&remaining) {
+			Ordering::Less => {
+				// Plenty of room remaining in our mini buffer.
+				mini_buffer |= el << cursor;
+				cursor += bit_width;
+			}
+			Ordering::Equal => {
+				mini_buffer |= el << cursor;
+				// We have completed our minibuffer exactly.
+				// Let's write it to `compressed`.
+				compressed[..8].copy_from_slice(&mini_buffer.to_le_bytes());
+				compressed = &mut compressed[8..];
+				pack_bytes_remaining -= 8;
+				mini_buffer = 0u64;
+				cursor = 0;
+			}
+			Ordering::Greater => {
+				mini_buffer |= el << cursor;
+				// We have completed our minibuffer.
+				// Let's write it to `compressed` and set the fresh mini_buffer
+				// with the remaining bits.
+				compressed[..8].copy_from_slice(&mini_buffer.to_le_bytes());
+				compressed = &mut compressed[8..];
+				pack_bytes_remaining -= 8;
+				cursor = bit_width - remaining;
+				mini_buffer = el >> remaining;
+			}
+		}
+	}
+	if pack_bytes_remaining > 0 {
+		compressed[..pack_bytes_remaining]
+			.copy_from_slice(&mini_buffer.to_le_bytes()[..pack_bytes_remaining]);
 	}
 }
 
@@ -533,6 +591,7 @@ mod tests {
 		for edge_bits in 10..63 {
 			let mut proof = Proof::new(gen_proof(edge_bits as u32));
 			proof.edge_bits = edge_bits;
+			println!("EDGE BITS: {}", edge_bits);
 			let mut buf = Cursor::new(Vec::new());
 			let mut w = BinWriter::new(&mut buf, ProtocolVersion::local());
 			if let Err(e) = proof.write(&mut w) {

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -494,10 +494,12 @@ pub fn proof_unpack_len(bits_len: usize) -> usize {
 
 /// Number of bytes required store a proof of given edge bits
 fn proof_pack_len(bit_width: u8) -> usize {
-	((bit_width as f32 * global::proofsize() as f32) / 8f32).ceil() as usize
+	(bit_width as usize * global::proofsize() + 7) / 8
 }
 
-pub fn bitpack(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
+/// Pack an array of u64s into `compressed` at the specified bit width. Caller
+/// must ensure `compressed` is the right size
+fn bitpack(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
 	// We will use a `u64` as a mini buffer of 64 bits.
 	// We accumulate bits in it until capacity, at which point we just copy this
 	// mini buffer to compressed.

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -405,20 +405,11 @@ impl Proof {
 	/// Pack the nonces of the proof to their exact bit size as described above
 	pub fn pack_nonces(&self) -> Vec<u8> {
 		let mut compressed = vec![0u8; Proof::pack_len(self.edge_bits)];
-		pack_bits_old(
-			self.edge_bits,
-			&self.nonces[0..self.nonces.len()],
-			&mut compressed,
-		);
-		println!("PACK OLD: {:?}", compressed);
-
-		let mut compressed = vec![0u8; Proof::pack_len(self.edge_bits)];
 		pack_bits(
 			self.edge_bits,
 			&self.nonces[0..self.nonces.len()],
 			&mut compressed,
 		);
-		println!("PACK NEW: {:?}", compressed);
 		compressed
 	}
 
@@ -454,52 +445,6 @@ fn pack_bits(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
 	}
 	if mini_buffer > 0 {
 		compressed[..].copy_from_slice(&mini_buffer.to_le_bytes()[..remainder]);
-	}
-}
-
-/// Pack an array of u64s into `compressed` at the specified bit width. Caller
-/// must ensure `compressed` is the right size
-fn pack_bits_old(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
-	// We will use a `u64` as a mini buffer of 64 bits.
-	// We accumulate bits in it until capacity, at which point we just copy this
-	// mini buffer to compressed.
-	let mut mini_buffer: u64 = 0u64;
-	let mut cursor = 0; //< number of bits written in the mini_buffer.
-	let mut pack_bytes_remaining = compressed.len();
-	for el in uncompressed {
-		let remaining = 64 - cursor;
-		match bit_width.cmp(&remaining) {
-			Ordering::Less => {
-				// Plenty of room remaining in our mini buffer.
-				mini_buffer |= el << cursor;
-				cursor += bit_width;
-			}
-			Ordering::Equal => {
-				mini_buffer |= el << cursor;
-				// We have completed our minibuffer exactly.
-				// Let's write it to `compressed`.
-				compressed[..8].copy_from_slice(&mini_buffer.to_le_bytes());
-				compressed = &mut compressed[8..];
-				pack_bytes_remaining -= 8;
-				mini_buffer = 0u64;
-				cursor = 0;
-			}
-			Ordering::Greater => {
-				mini_buffer |= el << cursor;
-				// We have completed our minibuffer.
-				// Let's write it to `compressed` and set the fresh mini_buffer
-				// with the remaining bits.
-				compressed[..8].copy_from_slice(&mini_buffer.to_le_bytes());
-				compressed = &mut compressed[8..];
-				pack_bytes_remaining -= 8;
-				cursor = bit_width - remaining;
-				mini_buffer = el >> remaining;
-			}
-		}
-	}
-	if pack_bytes_remaining > 0 {
-		compressed[..pack_bytes_remaining]
-			.copy_from_slice(&mini_buffer.to_le_bytes()[..pack_bytes_remaining]);
 	}
 }
 
@@ -591,7 +536,6 @@ mod tests {
 		for edge_bits in 10..63 {
 			let mut proof = Proof::new(gen_proof(edge_bits as u32));
 			proof.edge_bits = edge_bits;
-			println!("EDGE BITS: {}", edge_bits);
 			let mut buf = Cursor::new(Vec::new());
 			let mut w = BinWriter::new(&mut buf, ProtocolVersion::local());
 			if let Err(e) = proof.write(&mut w) {

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -21,7 +21,7 @@ use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
 /// proof of work within a block header.
-use std::cmp::{max, min, Ordering};
+use std::cmp::{max, min};
 use std::ops::{Add, Div, Mul, Sub};
 use std::u64;
 use std::{fmt, iter};

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -21,7 +21,7 @@ use rand::{thread_rng, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 /// Types for a Cuck(at)oo proof of work and its encapsulation as a fully usable
 /// proof of work within a block header.
-use std::cmp::{max, min, Ordering};
+use std::cmp::{max, min};
 use std::ops::{Add, Div, Mul, Sub};
 use std::u64;
 use std::{fmt, iter};
@@ -430,7 +430,7 @@ fn pack_bits(bit_width: u8, uncompressed: &[u64], mut compressed: &mut [u8]) {
 	let mut remaining = 64;
 	for el in uncompressed {
 		mini_buffer |= el << (64 - remaining);
-		if bit_width.cmp(&remaining) == Ordering::Less {
+		if bit_width < remaining {
 			remaining -= bit_width;
 		} else {
 			compressed[..8].copy_from_slice(&mini_buffer.to_le_bytes());


### PR DESCRIPTION
In performing test for PIBD work, it's become evident that header validation is not as efficient as it could be. There are a few reasons for this (with more to be addressed in coming PRs), but much of it comes down to the number of calls to the difficulty iterator in `store::DifficultyIter`, which deserialises several entire headers from the DB each time it's called. This iterator next method is called 60 times on each header validation to get the block's expected difficulty, which uncovered a large performance issue around the inefficient 'BitVec' struct.

A test (ignored in CI, meant to be run manually against live chain data) is included that copies and validates 100k headers from one chain to another. Before this change, this test in release mode (Mac, 2.3 Ghz 8-Core Intel i9) took about 76 seconds. With this change, the test takes 35 seconds. Flamegraphs are attached demonstrating the before and after (note the huge amount of time spent in `DifficultyIter::next()`)

Before:
![image](https://user-images.githubusercontent.com/7074070/144083128-a4cadd28-f769-4c65-b75a-1fee1cb7ec6d.png)

After:
![image](https://user-images.githubusercontent.com/7074070/144083280-8070aa56-f2b5-4f7e-a651-dee61ce53d4e.png)

Note there's still more to do here performance wise, but was an obvious first candidate for optimisation. Also investigated the use of a bitpacking lib https://github.com/quickwit-inc/bitpacking that actually uses SSE and AVX2 instructions to optimise further if available, but it unfortunately only supports packing up to u32.

Exact Changes: 
* Remove BitVec
* Add `pack_bits` function, which packs an array of u64s to a specified bit length more efficiently than the previous bitvec implementation
* Add `Proof::pack_nonces` function, which packs an array of u64s to a specified bit length more efficiently
* Add `Proof::pack_len` helper function and use instead of previous bitvec
