### PR TITLE
Spdupverifypow

### DIFF
--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -68,10 +68,10 @@ impl PoWContext for CuckarooContext {
 		}
 		let nonces = &proof.nonces;
 		let mut uvs = vec![0u64; 2 * size];
-		let mask = u64::MAX >> size.leading_zeros(); // round size up to 2-power - 1
 		let mut xor0: u64 = 0;
 		let mut xor1: u64 = 0;
-		// the next two arrays form a linked list of nodes with matching bits 6..1
+		let mask = u64::MAX >> size.leading_zeros(); // round size up to 2-power - 1
+											 // the next three arrays form a linked list of nodes with matching bits 6..1
 		let mut headu = vec![2 * size; 1 + mask as usize];
 		let mut headv = vec![2 * size; 1 + mask as usize];
 		let mut prev = vec![0usize; 2 * size];

--- a/core/src/pow/cuckarood.rs
+++ b/core/src/pow/cuckarood.rs
@@ -56,18 +56,24 @@ impl PoWContext for CuckaroodContext {
 	}
 
 	fn verify(&self, proof: &Proof) -> Result<(), Error> {
-		if proof.proof_size() != global::proofsize() {
+		let size = proof.proof_size();
+		if size != global::proofsize() {
 			return Err(ErrorKind::Verification("wrong cycle length".to_owned()).into());
 		}
 		let nonces = &proof.nonces;
-		let mut uvs = vec![0u64; 2 * proof.proof_size()];
+		let mut uvs = vec![0u64; 2 * size];
 		let mut ndir = vec![0usize; 2];
 		let mut xor0: u64 = 0;
 		let mut xor1: u64 = 0;
+		let mask = u64::MAX >> size.leading_zeros(); // round size up to 2-power - 1
+											 // the next two arrays form a linked list of nodes with matching bits 4..0|dir
+		let mut headu = vec![2 * size; 1 + mask as usize];
+		let mut headv = vec![2 * size; 1 + mask as usize];
+		let mut prev = vec![0usize; 2 * size];
 
-		for n in 0..proof.proof_size() {
+		for n in 0..size {
 			let dir = (nonces[n] & 1) as usize;
-			if ndir[dir] >= proof.proof_size() / 2 {
+			if ndir[dir] >= size / 2 {
 				return Err(ErrorKind::Verification("edges not balanced".to_owned()).into());
 			}
 			if nonces[n] > self.params.edge_mask {
@@ -79,10 +85,21 @@ impl PoWContext for CuckaroodContext {
 			// cuckarood uses a non-standard siphash rotation constant 25 as anti-ASIC tweak
 			let edge: u64 = siphash_block(&self.params.siphash_keys, nonces[n], 25, false);
 			let idx = 4 * ndir[dir] + 2 * dir;
-			uvs[idx] = edge & self.params.node_mask;
-			xor0 ^= uvs[idx];
-			uvs[idx + 1] = (edge >> 32) & self.params.node_mask;
-			xor1 ^= uvs[idx + 1];
+			let u = edge & self.params.node_mask;
+			let v = (edge >> 32) & self.params.node_mask;
+
+			uvs[idx] = u;
+			let ubits = ((u << 1 | dir as u64) & mask) as usize;
+			prev[idx] = headu[ubits];
+			headu[ubits] = idx;
+
+			uvs[idx + 1] = v;
+			let vbits = ((v << 1 | dir as u64) & mask) as usize;
+			prev[idx + 1] = headv[vbits];
+			headv[vbits] = idx + 1;
+
+			xor0 ^= u;
+			xor1 ^= v;
 			ndir[dir] += 1;
 		}
 		if xor0 | xor1 != 0 {
@@ -94,7 +111,12 @@ impl PoWContext for CuckaroodContext {
 		loop {
 			// follow cycle
 			j = i;
-			for k in (((i % 4) ^ 2)..(2 * self.params.proof_size)).step_by(4) {
+			let mut k = if i & 1 == 0 {
+				headu[((uvs[i] << 1 | 1) & mask) as usize]
+			} else {
+				headv[((uvs[i] << 1 | 0) & mask) as usize]
+			};
+			while k != 2 * size {
 				if uvs[k] == uvs[i] {
 					// find reverse edge endpoint identical to one at i
 					if j != i {
@@ -102,6 +124,7 @@ impl PoWContext for CuckaroodContext {
 					}
 					j = k;
 				}
+				k = prev[k];
 			}
 			if j == i {
 				return Err(ErrorKind::Verification("cycle dead ends".to_owned()).into());
@@ -112,7 +135,7 @@ impl PoWContext for CuckaroodContext {
 				break;
 			}
 		}
-		if n == self.params.proof_size {
+		if n == size {
 			Ok(())
 		} else {
 			Err(ErrorKind::Verification("cycle too short".to_owned()).into())

--- a/core/src/pow/cuckaroom.rs
+++ b/core/src/pow/cuckaroom.rs
@@ -55,17 +55,21 @@ impl PoWContext for CuckaroomContext {
 	}
 
 	fn verify(&self, proof: &Proof) -> Result<(), Error> {
-		let proofsize = proof.proof_size();
-		if proofsize != global::proofsize() {
+		let size = proof.proof_size();
+		if size != global::proofsize() {
 			return Err(ErrorKind::Verification("wrong cycle length".to_owned()).into());
 		}
 		let nonces = &proof.nonces;
-		let mut from = vec![0u64; proofsize];
-		let mut to = vec![0u64; proofsize];
+		let mut from = vec![0u64; size];
+		let mut to = vec![0u64; size];
 		let mut xor_from: u64 = 0;
 		let mut xor_to: u64 = 0;
+		let mask = u64::MAX >> size.leading_zeros(); // round size up to 2-power - 1
+											 // the next two arrays form a linked list of nodes with matching bits 6..1
+		let mut head = vec![size; 1 + mask as usize];
+		let mut prev = vec![0usize; size];
 
-		for n in 0..proofsize {
+		for n in 0..size {
 			if nonces[n] > self.params.edge_mask {
 				return Err(ErrorKind::Verification("edge too big".to_owned()).into());
 			}
@@ -74,15 +78,20 @@ impl PoWContext for CuckaroomContext {
 			}
 			// 21 is standard siphash rotation constant
 			let edge: u64 = siphash_block(&self.params.siphash_keys, nonces[n], 21, true);
-			from[n] = edge & self.params.node_mask;
+			let u = edge & self.params.node_mask;
+			let v = (edge >> 32) & self.params.node_mask;
+			from[n] = u;
+			let bits = (u & mask) as usize;
+			prev[n] = head[bits];
+			head[bits] = n;
+			to[n] = v;
 			xor_from ^= from[n];
-			to[n] = (edge >> 32) & self.params.node_mask;
 			xor_to ^= to[n];
 		}
 		if xor_from != xor_to {
 			return Err(ErrorKind::Verification("endpoints don't match up".to_owned()).into());
 		}
-		let mut visited = vec![false; proofsize];
+		let mut visited = vec![false; size];
 		let mut n = 0;
 		let mut i = 0;
 		loop {
@@ -91,21 +100,24 @@ impl PoWContext for CuckaroomContext {
 				return Err(ErrorKind::Verification("branch in cycle".to_owned()).into());
 			}
 			visited[i] = true;
-			let mut nexti = 0;
-			while from[nexti] != to[i] {
-				nexti += 1;
-				if nexti == proofsize {
+			let mut k = head[(to[i] & mask) as usize];
+			loop {
+				if k == size {
 					return Err(ErrorKind::Verification("cycle dead ends".to_owned()).into());
 				}
+				if from[k] == to[i] {
+					break;
+				}
+				k = prev[k];
 			}
-			i = nexti;
+			i = k;
 			n += 1;
 			if i == 0 {
 				// must cycle back to start or find branch
 				break;
 			}
 		}
-		if n == proofsize {
+		if n == size {
 			Ok(())
 		} else {
 			Err(ErrorKind::Verification("cycle too short".to_owned()).into())

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -262,7 +262,7 @@ impl CuckatooContext {
 		let nonces = &proof.nonces;
 		let mut uvs = vec![0u64; 2 * size];
 		let mask = u64::MAX >> size.leading_zeros(); // round size up to 2-power - 1
-		let mut xor0: u64 = (self.params.proof_size as u64 / 2) & 1;
+		let mut xor0: u64 = (size as u64 / 2) & 1;
 		let mut xor1: u64 = xor0;
 		// the next two arrays form a linked list of nodes with matching bits 6..1
 		let mut headu = vec![2 * size; 1 + mask as usize];
@@ -335,7 +335,7 @@ impl CuckatooContext {
 				break;
 			}
 		}
-		if n == self.params.proof_size {
+		if n == size {
 			Ok(())
 		} else {
 			Err(ErrorKind::Verification("cycle too short".to_owned()).into())
@@ -485,13 +485,13 @@ mod test {
 		let mut header = [0u8; 80];
 		header[0] = 1u8;
 		ctx.set_header_nonce(header.to_vec(), Some(20), false)?;
-		assert!(!ctx.verify(&Proof::new(V1_29.to_vec())).is_ok());
+		assert!(ctx.verify(&Proof::new(V1_29.to_vec())).is_err());
 		header[0] = 0u8;
 		ctx.set_header_nonce(header.to_vec(), Some(20), false)?;
 		assert!(ctx.verify(&Proof::new(V1_29.to_vec())).is_ok());
 		let mut bad_proof = V1_29;
 		bad_proof[0] = 0x48a9e1;
-		assert!(!ctx.verify(&Proof::new(bad_proof.to_vec())).is_ok());
+		assert!(ctx.verify(&Proof::new(bad_proof.to_vec())).is_err());
 		Ok(())
 	}
 


### PR DESCRIPTION
---
name: Spdupverifypow
about: Speed up all 5 PoW verification functions about 5x
title: Speed up PoW verify
labels: 
assignees: 

---
Profiling an initial header sync found about 20% of time was spent in cuckaroo::verify
The old code for all 5 verify functions was quadratic in cycle length, taking on average 42/2 iterations of an inner loop to find the next edge in the cycle.
The new code uses 2 or 3 extra arrays of length O(proof_size) that allows the next edge in the cycle to be found in O(1) iterations on average.

Tested with a full sync from scratch on mainnet.