### PR TITLE
Make fn rewind_hash pub

### DIFF
--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -94,7 +94,7 @@ impl ViewKey {
 		})
 	}
 
-	fn rewind_hash(secp: &Secp256k1, public_root_key: PublicKey) -> Vec<u8> {
+	pub fn rewind_hash(secp: &Secp256k1, public_root_key: PublicKey) -> Vec<u8> {
 		let ser = public_root_key.serialize_vec(secp, true);
 		blake2b(32, &[], &ser[..]).as_bytes().to_vec()
 	}


### PR DESCRIPTION
Following phyro suggestion on the [grin-wallet #630](https://github.com/mimblewimble/grin-wallet/pull/630#discussion_r767196139). 
We need to make the rewind_hash function in ViewKey public in order to use it directly in the get_rewind_hash function on the wallet.
