### PR TITLE
[HEADER SYNC PERF] Static cache for Difficulty Iterator

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -24,6 +24,9 @@
 extern crate bitflags;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate enum_primitive;
 
 #[macro_use]

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -27,7 +27,7 @@ use croaring::Bitmap;
 use grin_core::ser;
 use grin_store as store;
 use grin_store::{option_to_not_found, to_key, Error};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -560,14 +560,14 @@ impl<'a> Iterator for DifficultyIter<'a> {
 /// Required as difficulty iterator lookups from the DB are extremely expensive
 /// accounting for a large percentage of time spent in validation. See #3671 for context.
 pub struct DifficultyIterCache {
-	cache: BTreeMap<Hash, Option<BlockHeader>>,
+	cache: HashMap<Hash, Option<BlockHeader>>,
 }
 
 impl DifficultyIterCache {
 	/// Create with an empty hashmap
 	pub fn new() -> Self {
 		Self {
-			cache: BTreeMap::new(),
+			cache: HashMap::new(),
 		}
 	}
 	/// Add an element to the cache

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -488,7 +488,6 @@ impl<'a> Iterator for DifficultyIter<'a> {
 		// difficulty information
 		// Get a lock on the cache
 		//let mut cache_has_start_header = false;
-		let mut cache_has_prev_header = false;
 
 		self.header = if self.header.is_none() {
 			let cache_handle = DIFF_ITER_CACHE.read();
@@ -509,8 +508,14 @@ impl<'a> Iterator for DifficultyIter<'a> {
 			self.prev_header.clone()
 		};
 
+		/*if !cache_has_start_header {
+			let mut cache_handle = DIFF_ITER_CACHE.write();
+			cache_handle.add(self.start, self.header.clone());
+		}*/
+
 		// If we have a header we can do this iteration.
 		// Otherwise we are done.
+		let mut cache_has_prev_header = false;
 		if let Some(header) = self.header.clone() {
 			{
 				let cache_handle = DIFF_ITER_CACHE.read();
@@ -536,10 +541,7 @@ impl<'a> Iterator for DifficultyIter<'a> {
 			let scaling = header.pow.secondary_scaling;
 
 			// Insert into cache if needed
-			/*if !cache_has_start_header {
-				let mut cache_handle = self.cache.write();
-				cache_handle.add(self.start, self.header.clone());
-			}*/
+
 			if !cache_has_prev_header {
 				let mut cache_handle = DIFF_ITER_CACHE.write();
 				cache_handle.add(header.prev_hash, self.prev_header.clone());
@@ -573,7 +575,7 @@ impl DifficultyIterCache {
 	/// Add an element to the cache
 	pub fn add(&mut self, hash: Hash, bh: Option<BlockHeader>) {
 		self.cache.insert(hash, bh);
-		if self.cache.len() > 1000 {
+		if self.cache.len() > 10000 {
 			self.cache.clear();
 		}
 	}

--- a/chain/tests/test_header_perf.rs
+++ b/chain/tests/test_header_perf.rs
@@ -105,7 +105,7 @@ fn test_header_perf_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir:
 }
 
 #[test]
-#[ignore]
+//#[ignore]
 // Ignored during CI, but use this to run this test on a real instance of a chain pointed where you like
 fn test_header_perf() {
 	util::init_test_logger();

--- a/chain/tests/test_header_perf.rs
+++ b/chain/tests/test_header_perf.rs
@@ -105,7 +105,7 @@ fn test_header_perf_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir:
 }
 
 #[test]
-//#[ignore]
+#[ignore]
 // Ignored during CI, but use this to run this test on a real instance of a chain pointed where you like
 fn test_header_perf() {
 	util::init_test_logger();


### PR DESCRIPTION
WIPish but parking this here for now. This is a very quick and dumb performance enhancement for header validation, which implements a simple static cache in the Difficulty iterator, which caches block headers read from the database as they're read one-by-one to avoid the need to read them again on the next set of difficulty calculations when validating headers sequentially. There is no logic to how headers are cached, and there's a simple limit of 10k headers for the time being. When the limit is hit the iterator will simple read from the DB again for the next iterator.

Advantage of this is that it's simple and gives an additional 5 second speed-up from the results in #3671, bringing the 100k test to about 19 seconds on the test hardware. Further performance enhancements will likely require more careful changes to consensus code.

Flamegraph without this cache (all enhancements to #3671 merged): about 24 seconds for 100k test:

![image](https://user-images.githubusercontent.com/7074070/145816084-25823bbf-89c4-4cd7-8cb1-e765f0b3ae2a.png)

And with this change (about 19 seconds), note the time spent on mdb_lock is now reduced to a sliver:

![image](https://user-images.githubusercontent.com/7074070/145816643-817a5c92-e8e3-49ca-bc23-68339d8d81c3.png)


