### PR TITLE
`verify-chain` node client arg

### DIFF
--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -25,6 +25,33 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::runtime::Builder;
 
+// Client Request Timeout
+pub struct TimeOut {
+	pub connect: Duration,
+	pub read: Duration,
+	pub write: Duration,
+}
+
+impl TimeOut {
+	pub fn new(connect: u64, read: u64, write: u64) -> Self {
+		Self {
+			connect: Duration::from_secs(connect),
+			read: Duration::from_secs(read),
+			write: Duration::from_secs(write),
+		}
+	}
+}
+
+impl Default for TimeOut {
+	fn default() -> TimeOut {
+		TimeOut {
+			connect: Duration::from_secs(20),
+			read: Duration::from_secs(20),
+			write: Duration::from_secs(20),
+		}
+	}
+}
+
 /// Helper function to easily issue a HTTP GET request against a given URL that
 /// returns a JSON object. Handles request building, JSON deserialization and
 /// response code checking.
@@ -35,7 +62,10 @@ pub fn get<T>(url: &str, api_secret: Option<String>) -> Result<T, Error>
 where
 	for<'de> T: Deserialize<'de>,
 {
-	handle_request(build_request(url, "GET", api_secret, None)?, None)
+	handle_request(
+		build_request(url, "GET", api_secret, None)?,
+		TimeOut::default(),
+	)
 }
 
 /// Helper function to easily issue an async HTTP GET request against a given
@@ -52,7 +82,10 @@ where
 /// on a given URL that returns nothing. Handles request
 /// building and response code checking.
 pub fn get_no_ret(url: &str, api_secret: Option<String>) -> Result<(), Error> {
-	send_request(build_request(url, "GET", api_secret, None)?, None)?;
+	send_request(
+		build_request(url, "GET", api_secret, None)?,
+		TimeOut::default(),
+	)?;
 	Ok(())
 }
 
@@ -64,14 +97,14 @@ pub fn post<IN, OUT>(
 	url: &str,
 	api_secret: Option<String>,
 	input: &IN,
-	read_timeout: Option<u64>,
+	timeout: TimeOut,
 ) -> Result<OUT, Error>
 where
 	IN: Serialize,
 	for<'de> OUT: Deserialize<'de>,
 {
 	let req = create_post_request(url, api_secret, input)?;
-	handle_request(req, read_timeout)
+	handle_request(req, timeout)
 }
 
 /// Helper function to easily issue an async HTTP POST request with the
@@ -99,7 +132,10 @@ pub fn post_no_ret<IN>(url: &str, api_secret: Option<String>, input: &IN) -> Res
 where
 	IN: Serialize,
 {
-	send_request(create_post_request(url, api_secret, input)?, None)?;
+	send_request(
+		create_post_request(url, api_secret, input)?,
+		TimeOut::default(),
+	)?;
 	Ok(())
 }
 
@@ -115,7 +151,11 @@ pub async fn post_no_ret_async<IN>(
 where
 	IN: Serialize,
 {
-	send_request_async(create_post_request(url, api_secret, input)?, None).await?;
+	send_request_async(
+		create_post_request(url, api_secret, input)?,
+		TimeOut::default(),
+	)
+	.await?;
 	Ok(())
 }
 
@@ -160,11 +200,11 @@ where
 	build_request(url, "POST", api_secret, Some(json))
 }
 
-fn handle_request<T>(req: Request<Body>, read_timeout: Option<u64>) -> Result<T, Error>
+fn handle_request<T>(req: Request<Body>, timeout: TimeOut) -> Result<T, Error>
 where
 	for<'de> T: Deserialize<'de>,
 {
-	let data = send_request(req, read_timeout)?;
+	let data = send_request(req, timeout)?;
 	serde_json::from_str(&data).map_err(|e| {
 		e.context(ErrorKind::ResponseError("Cannot parse response".to_owned()))
 			.into()
@@ -175,25 +215,23 @@ async fn handle_request_async<T>(req: Request<Body>) -> Result<T, Error>
 where
 	for<'de> T: Deserialize<'de> + Send + 'static,
 {
-	let data = send_request_async(req, None).await?;
+	let data = send_request_async(req, TimeOut::default()).await?;
 	let ser = serde_json::from_str(&data)
 		.map_err(|e| e.context(ErrorKind::ResponseError("Cannot parse response".to_owned())))?;
 	Ok(ser)
 }
 
-async fn send_request_async(
-	req: Request<Body>,
-	read_timeout: Option<u64>,
-) -> Result<String, Error> {
+async fn send_request_async(req: Request<Body>, timeout: TimeOut) -> Result<String, Error> {
 	let https = hyper_rustls::HttpsConnector::new();
-	let read_timeout = match read_timeout {
-		Some(v) => Duration::from_secs(v),
-		None => Duration::from_secs(20),
-	};
+	let (connect, read, write) = (
+		Some(timeout.connect),
+		Some(timeout.read),
+		Some(timeout.write),
+	);
 	let mut connector = TimeoutConnector::new(https);
-	connector.set_connect_timeout(Some(Duration::from_secs(20)));
-	connector.set_read_timeout(Some(read_timeout));
-	connector.set_write_timeout(Some(Duration::from_secs(20)));
+	connector.set_connect_timeout(connect);
+	connector.set_read_timeout(read);
+	connector.set_write_timeout(write);
 	let client = Client::builder().build::<_, Body>(connector);
 
 	let resp = client
@@ -217,11 +255,11 @@ async fn send_request_async(
 	Ok(String::from_utf8_lossy(&raw).to_string())
 }
 
-pub fn send_request(req: Request<Body>, read_timeout: Option<u64>) -> Result<String, Error> {
+pub fn send_request(req: Request<Body>, timeout: TimeOut) -> Result<String, Error> {
 	let mut rt = Builder::new()
 		.basic_scheduler()
 		.enable_all()
 		.build()
 		.map_err(|e| ErrorKind::RequestError(format!("{}", e)))?;
-	rt.block_on(send_request_async(req, read_timeout))
+	rt.block_on(send_request_async(req, timeout))
 }

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -53,9 +53,9 @@ pub struct ChainValidationHandler {
 }
 
 impl ChainValidationHandler {
-	pub fn validate_chain(&self) -> Result<(), Error> {
+	pub fn validate_chain(&self, fast_validation: bool) -> Result<(), Error> {
 		w(&self.chain)?
-			.validate(true)
+			.validate(fast_validation)
 			.map_err(|_| ErrorKind::Internal("chain error".to_owned()).into())
 	}
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -80,17 +80,20 @@ impl Owner {
 
 	/// Trigger a validation of the chain state.
 	///
+	/// # Arguments
+	/// * `fast_validation` - if false verify the rangeproof associated with each unspent output and all kernels
+	///
 	/// # Returns
 	/// * Result Containing:
 	/// * `Ok(())` if the validation was done successfully
 	/// * or [`Error`](struct.Error.html) if an error is encountered.
 	///
 
-	pub fn validate_chain(&self) -> Result<(), Error> {
+	pub fn validate_chain(&self, fast_validation: bool) -> Result<(), Error> {
 		let chain_validation_handler = ChainValidationHandler {
 			chain: self.chain.clone(),
 		};
-		chain_validation_handler.validate_chain()
+		chain_validation_handler.validate_chain(fast_validation)
 	}
 
 	/// Trigger a compaction of the chain state to regain storage space.

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -81,7 +81,7 @@ impl Owner {
 	/// Trigger a validation of the chain state.
 	///
 	/// # Arguments
-	/// * `fast_validation` - if false verify the rangeproof associated with each unspent output and all kernels
+	/// * `assume_valid_rangeproofs_kernels` -  if false, will validate rangeproofs, kernel signatures and sum of kernel excesses. if true, will only validate the sum of kernel excesses should equal the sum of unspent outputs minus total supply.
 	///
 	/// # Returns
 	/// * Result Containing:
@@ -89,11 +89,11 @@ impl Owner {
 	/// * or [`Error`](struct.Error.html) if an error is encountered.
 	///
 
-	pub fn validate_chain(&self, fast_validation: bool) -> Result<(), Error> {
+	pub fn validate_chain(&self, assume_valid_rangeproofs_kernels: bool) -> Result<(), Error> {
 		let chain_validation_handler = ChainValidationHandler {
 			chain: self.chain.clone(),
 		};
-		chain_validation_handler.validate_chain(fast_validation)
+		chain_validation_handler.validate_chain(assume_valid_rangeproofs_kernels)
 	}
 
 	/// Trigger a compaction of the chain state to regain storage space.

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -83,7 +83,7 @@ pub trait OwnerRpc: Sync + Send {
 	{
 		"jsonrpc": "2.0",
 		"method": "validate_chain",
-		"params": [],
+		"params": ["false"],
 		"id": 1
 	}
 	# "#
@@ -100,7 +100,7 @@ pub trait OwnerRpc: Sync + Send {
 	# );
 	```
 	 */
-	fn validate_chain(&self) -> Result<(), ErrorKind>;
+	fn validate_chain(&self, fast_validation: bool) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::compact_chain](struct.Owner.html#method.compact_chain).
@@ -363,8 +363,8 @@ impl OwnerRpc for Owner {
 		Owner::get_status(self).map_err(|e| e.kind().clone())
 	}
 
-	fn validate_chain(&self) -> Result<(), ErrorKind> {
-		Owner::validate_chain(self).map_err(|e| e.kind().clone())
+	fn validate_chain(&self, fast_validation: bool) -> Result<(), ErrorKind> {
+		Owner::validate_chain(self, fast_validation).map_err(|e| e.kind().clone())
 	}
 
 	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind> {
@@ -403,7 +403,7 @@ macro_rules! doctest_helper_json_rpc_owner_assert_response {
 		// create temporary grin server, run jsonrpc request on node api, delete server, return
 		// json response.
 
-			{
+		{
 			/*use grin_servers::test_framework::framework::run_doctest;
 			use grin_util as util;
 			use serde_json;
@@ -437,6 +437,6 @@ macro_rules! doctest_helper_json_rpc_owner_assert_response {
 					serde_json::to_string_pretty(&expected_response).unwrap()
 				);
 				}*/
-			}
+		}
 	};
 }

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -100,7 +100,7 @@ pub trait OwnerRpc: Sync + Send {
 	# );
 	```
 	 */
-	fn validate_chain(&self, fast_validation: bool) -> Result<(), ErrorKind>;
+	fn validate_chain(&self, assume_valid_rangeproofs_kernels: bool) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::compact_chain](struct.Owner.html#method.compact_chain).
@@ -363,8 +363,8 @@ impl OwnerRpc for Owner {
 		Owner::get_status(self).map_err(|e| e.kind().clone())
 	}
 
-	fn validate_chain(&self, fast_validation: bool) -> Result<(), ErrorKind> {
-		Owner::validate_chain(self, fast_validation).map_err(|e| e.kind().clone())
+	fn validate_chain(&self, assume_valid_rangeproofs_kernels: bool) -> Result<(), ErrorKind> {
+		Owner::validate_chain(self, assume_valid_rangeproofs_kernels).map_err(|e| e.kind().clone())
 	}
 
 	fn reset_chain_head(&self, hash: String) -> Result<(), ErrorKind> {

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -262,7 +262,7 @@ fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Error> 
 
 	trace!("Sending build_coinbase request: {}", req_body);
 	let req = api::client::create_post_request(url.as_str(), None, &req_body)?;
-	let res: String = api::client::send_request(req).map_err(|e| {
+	let res: String = api::client::send_request(req, None).map_err(|e| {
 		let report = format!(
 			"Failed to get coinbase from {}. Is the wallet listening? {}",
 			dest, e

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -262,7 +262,8 @@ fn create_coinbase(dest: &str, block_fees: &BlockFees) -> Result<CbData, Error> 
 
 	trace!("Sending build_coinbase request: {}", req_body);
 	let req = api::client::create_post_request(url.as_str(), None, &req_body)?;
-	let res: String = api::client::send_request(req, None).map_err(|e| {
+	let timeout = api::client::TimeOut::default();
+	let res: String = api::client::send_request(req, timeout).map_err(|e| {
 		let report = format!(
 			"Failed to get coinbase from {}. Is the wallet listening? {}",
 			dest, e

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -158,9 +158,9 @@ impl HTTPNodeClient {
 		e.reset().unwrap();
 	}
 
-	pub fn verify_chain(&self, fast_validation: bool) {
+	pub fn verify_chain(&self, assume_valid_rangeproofs_kernels: bool) {
 		let mut e = term::stdout().unwrap();
-		let params = json!([fast_validation]);
+		let params = json!([assume_valid_rangeproofs_kernels]);
 		writeln!(
 			e,
 			"Checking the state of the chain. This might take time..."
@@ -168,7 +168,7 @@ impl HTTPNodeClient {
 		.unwrap();
 		match self.send_json_request::<()>("validate_chain", &params) {
 			Ok(_) => {
-				if fast_validation {
+				if assume_valid_rangeproofs_kernels {
 					writeln!(e, "Successfully validated the sum of kernel excesses! [fast_verification enabled]").unwrap()
 				} else {
 					writeln!(e, "Successfully validated the sum of kernel excesses, kernel signature and rangeproofs!").unwrap()
@@ -222,8 +222,8 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 			node_client.invalidate_header(hash.to_string());
 		}
 		("verify-chain", Some(args)) => {
-			let fast_validation = args.is_present("fast");
-			node_client.verify_chain(fast_validation);
+			let assume_valid_rangeproofs_kernels = args.is_present("fast");
+			node_client.verify_chain(assume_valid_rangeproofs_kernels);
 		}
 		("ban", Some(peer_args)) => {
 			let peer = peer_args.value_of("peer").unwrap();

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -46,7 +46,9 @@ impl HTTPNodeClient {
 		params: &serde_json::Value,
 	) -> Result<D, Error> {
 		let read_timeout: Option<u64> = match method {
-			"validate_chain" => Some(5000),
+			// 2hours
+			"validate_chain" => Some(7200),
+			// (default) 20sec
 			_ => None,
 		};
 		let url = format!("http://{}{}", self.node_url, ENDPOINT);

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -45,10 +45,18 @@ impl HTTPNodeClient {
 		method: &str,
 		params: &serde_json::Value,
 	) -> Result<D, Error> {
+		let read_timeout: Option<u64> = match method {
+			"validate_chain" => Some(5000),
+			_ => None,
+		};
 		let url = format!("http://{}{}", self.node_url, ENDPOINT);
 		let req = build_request(method, params);
-		let res =
-			client::post::<Request, Response>(url.as_str(), self.node_api_secret.clone(), &req);
+		let res = client::post::<Request, Response>(
+			url.as_str(),
+			self.node_api_secret.clone(),
+			&req,
+			read_timeout,
+		);
 
 		match res {
 			Err(e) => {

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -149,6 +149,21 @@ impl HTTPNodeClient {
 		e.reset().unwrap();
 	}
 
+	pub fn validate_chain(&self, fast_validation: bool) {
+		let mut e = term::stdout().unwrap();
+		let params = json!([fast_validation]);
+		writeln!(
+			e,
+			"Checking the state of the chain. This might take time..."
+		)
+		.unwrap();
+		match self.send_json_request::<()>("validate_chain", &params) {
+			Ok(_) => writeln!(e, "Successfully validated chain.").unwrap(),
+			Err(err) => writeln!(e, "Failed to validate chain: {:?}", err).unwrap(),
+		}
+		e.reset().unwrap();
+	}
+
 	pub fn ban_peer(&self, peer_addr: &SocketAddr) {
 		let mut e = term::stdout().unwrap();
 		let params = json!([peer_addr]);
@@ -190,6 +205,10 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 		("invalidateheader", Some(args)) => {
 			let hash = args.value_of("hash").unwrap();
 			node_client.invalidate_header(hash.to_string());
+		}
+		("verify-chain", Some(args)) => {
+			let fast_validation = if args.is_present("fast") { false } else { true };
+			node_client.validate_chain(fast_validation);
 		}
 		("ban", Some(peer_args)) => {
 			let peer = peer_args.value_of("peer").unwrap();

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -79,10 +79,10 @@ subcommands:
                     help: The header hash to reset to
                     required: true
         - verify-chain:
-            about: Verify the chain state
+            about: Trigger a verication of the rangeproofs, kernel signatures and excesses.
             args:
                 - fast:
-                    help:  if present, skip validation of the rangeproof associated with each unspent output and all kernels
+                    help:  if present, will skip verification of rangeproofs, kernel signatures and will only validate the sum of kernel excesses. 
                     short: f
                     long: fast
                     takes_value: false

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -78,6 +78,14 @@ subcommands:
                 - hash:
                     help: The header hash to reset to
                     required: true
+        - verify-chain:
+            about: Verify the chain state
+            args:
+                - fast:
+                    help:  if present, skip validation of the rangeproof associated with each unspent output and all kernels
+                    short: f
+                    long: fast
+                    takes_value: false
         - invalidateheader:
             about: Adds header hash to denylist
             args:


### PR DESCRIPTION
Following this feature suggestion https://github.com/mimblewimble/grin/issues/3609
- Add the parameter on the api `fast_validation`
- Add verify-chain node client argurment

Usage:
Full chain validation
```grin client verify-chain```

Partial chain validation
```grin client verify-chain --fast```

PS: This PR need the API to gracefully shutdown, need to merge https://github.com/mimblewimble/grin/pull/3677