### PR TITLE
Handle attempts to get block headers at invalid heights

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -135,6 +135,10 @@ pub enum ErrorKind {
 	/// Error from underlying block handling
 	#[fail(display = "Block Validation Error: {:?}", _0)]
 	Block(block::Error),
+	/// Attempt to retrieve a header at a height greater than
+	/// the max allowed by u64 limits
+	#[fail(display = "Invalid Header Height: {}", _0)]
+	InvalidHeaderHeight(u64),
 	/// Anything else
 	#[fail(display = "Other Error: {}", _0)]
 	Other(String),

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -50,6 +50,8 @@ const KERNEL_SUBDIR: &str = "kernel";
 
 const TXHASHSET_ZIP: &str = "txhashset_snapshot";
 
+const HALF_U64_MAX: u64 = u64::MAX / 2;
+
 /// Convenience wrapper around a single prunable MMR backend.
 pub struct PMMRHandle<T: PMMRable> {
 	/// The backend storage for the MMR.
@@ -110,6 +112,9 @@ impl PMMRHandle<BlockHeader> {
 
 	/// Get the header hash at the specified height based on the current header MMR state.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
+		if height >= HALF_U64_MAX {
+			return Err(ErrorKind::InvalidHeaderHeight(height).into());
+		}
 		let pos = pmmr::insertion_to_pmmr_index(height);
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.size);
 		if let Some(entry) = header_pmmr.get_data(pos) {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -110,7 +110,7 @@ impl PMMRHandle<BlockHeader> {
 
 	/// Get the header hash at the specified height based on the current header MMR state.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		if height > self.size {
+		if height >= self.size {
 			return Err(ErrorKind::InvalidHeaderHeight(height).into());
 		}
 		let pos = pmmr::insertion_to_pmmr_index(height);

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -50,8 +50,6 @@ const KERNEL_SUBDIR: &str = "kernel";
 
 const TXHASHSET_ZIP: &str = "txhashset_snapshot";
 
-const HALF_U64_MAX: u64 = u64::MAX / 2;
-
 /// Convenience wrapper around a single prunable MMR backend.
 pub struct PMMRHandle<T: PMMRable> {
 	/// The backend storage for the MMR.
@@ -112,7 +110,7 @@ impl PMMRHandle<BlockHeader> {
 
 	/// Get the header hash at the specified height based on the current header MMR state.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
-		if height >= HALF_U64_MAX {
+		if height > self.size {
 			return Err(ErrorKind::InvalidHeaderHeight(height).into());
 		}
 		let pos = pmmr::insertion_to_pmmr_index(height);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -454,9 +454,15 @@ impl Server {
 					// We need to query again for the actual block hash, as
 					// the difficulty iterator doesn't contain enough info to
 					// create a hash
-					let block_hash = match self.chain.get_header_by_height(height as u64) {
-						Ok(h) => h.hash(),
-						Err(_) => ZERO_HASH,
+					// The diff iterator returns 59 block headers 'before' 0 to give callers
+					// enough detail to calculate initial block difficulties. Ignore these.
+					let block_hash = if height < 0 {
+						ZERO_HASH
+					} else {
+						match self.chain.get_header_by_height(height as u64) {
+							Ok(h) => h.hash(),
+							Err(_) => ZERO_HASH,
+						}
 					};
 
 					DiffBlock {


### PR DESCRIPTION
Twofold 'belt and suspender' fix for #3681:

* First, add an error check into `get_header_hash_by_height` in `txhashset` to return an error if the header height requested is too large for `pmmr::insertion_to_pmmr_index` to handle. Note there's no error handling in the core pmmr functions (which all assume arguments are correct, rightly or wrongly), so this check is placed as close to it as possible.
* Second, manually handle negative heights from the difficulty iterator in `get_server_stats` code. Note the call to `get_header_by_height` is now needed here due to earlier performance optimizations on DifficultyIterator that removed the deserialization of proof nonces and left iterator entries unable to calculate their hash.

Either fix on its own would work, but `get_header_by_height` should be returning an error for invalid heights, while the call to it from `get_server_stats` shouldn't be attempting to provide invalid heights via an incorrect cast. (Note that casting from i64 to u64 is allowed in rust regardless of value, meaning that -59i64 to u64 results in 18446744073709551557).

