### PR TITLE
TUI Freeze Fix - Add manually maintained hash to difficulty iterator

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -486,12 +486,12 @@ impl<'a> Iterator for DifficultyIter<'a> {
 			if let Some(ref batch) = self.batch {
 				(
 					batch.get_block_header_skip_proof(&self.start).ok(),
-					Some(self.start.hash()),
+					Some(self.start),
 				)
 			} else if let Some(ref store) = self.store {
 				(
 					store.get_block_header_skip_proof(&self.start).ok(),
-					Some(self.start.hash()),
+					Some(self.start),
 				)
 			} else {
 				(None, None)

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -19,6 +19,7 @@
 //! here.
 
 use crate::core::block::HeaderVersion;
+use crate::core::hash::Hash;
 use crate::global;
 use crate::pow::Difficulty;
 use std::cmp::{max, min};
@@ -231,6 +232,8 @@ pub const INITIAL_DIFFICULTY: u64 = 1_000_000 * UNIT_DIFFICULTY;
 /// the header's PoW proof nonces from being deserialized on read
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HeaderDifficultyInfo {
+	/// Hash of this block
+	pub hash: Option<Hash>,
 	/// Timestamp of the header, 1 when not used (returned info)
 	pub timestamp: u64,
 	/// Network difficulty or next difficulty to use
@@ -244,12 +247,14 @@ pub struct HeaderDifficultyInfo {
 impl HeaderDifficultyInfo {
 	/// Default constructor
 	pub fn new(
+		hash: Option<Hash>,
 		timestamp: u64,
 		difficulty: Difficulty,
 		secondary_scaling: u32,
 		is_secondary: bool,
 	) -> HeaderDifficultyInfo {
 		HeaderDifficultyInfo {
+			hash,
 			timestamp,
 			difficulty,
 			secondary_scaling,
@@ -261,6 +266,7 @@ impl HeaderDifficultyInfo {
 	/// PoW factor
 	pub fn from_ts_diff(timestamp: u64, difficulty: Difficulty) -> HeaderDifficultyInfo {
 		HeaderDifficultyInfo {
+			hash: None,
 			timestamp,
 			difficulty,
 			secondary_scaling: global::initial_graph_weight(),
@@ -276,6 +282,7 @@ impl HeaderDifficultyInfo {
 		secondary_scaling: u32,
 	) -> HeaderDifficultyInfo {
 		HeaderDifficultyInfo {
+			hash: None,
 			timestamp: 1,
 			difficulty,
 			secondary_scaling,

--- a/core/tests/consensus_automated.rs
+++ b/core/tests/consensus_automated.rs
@@ -213,6 +213,7 @@ fn repeat(
 	pairs
 		.map(|(t, d)| {
 			HeaderDifficultyInfo::new(
+				None,
 				cur_time + t as u64,
 				*d,
 				diff.secondary_scaling,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -451,11 +451,7 @@ impl Server {
 
 					height += 1;
 
-					let block_hash = if let Some(nh) = next.hash {
-						nh
-					} else {
-						ZERO_HASH
-					};
+					let block_hash = next.hash.unwrap_or(ZERO_HASH);
 
 					DiffBlock {
 						block_height: height,

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -451,18 +451,10 @@ impl Server {
 
 					height += 1;
 
-					// We need to query again for the actual block hash, as
-					// the difficulty iterator doesn't contain enough info to
-					// create a hash
-					// The diff iterator returns 59 block headers 'before' 0 to give callers
-					// enough detail to calculate initial block difficulties. Ignore these.
-					let block_hash = if height < 0 {
-						ZERO_HASH
+					let block_hash = if let Some(nh) = next.hash {
+						nh
 					} else {
-						match self.chain.get_header_by_height(height as u64) {
-							Ok(h) => h.hash(),
-							Err(_) => ZERO_HASH,
-						}
+						ZERO_HASH
 					};
 
 					DiffBlock {


### PR DESCRIPTION
Due to recent performance optimisations to the difficulty iterator, a call to the chain's `get_header_by_height` needed to be added. Unfortunately, this function relies on a read lock on the txhashset. A write lock is held unyielded for a very long time by validation code after the txhashset is downloaded, leading to a TUI freeze when calling this method.

Fix is to avoid that call by re-adding a hash to the `HeaderDifficultyInfo` struct, populated by maintaining hashes as provided in the `prev_header` field in the Headers themselves. This optionally keeps hashes available in the `HeaderDifficultyInfo` struct while still avoiding the need to deserialize the entire header to derive the hash.

Note this point in the TUI code is the only place where a block's hash is needed from the DifficultyIterator, so impact should be minimal.