### PR TITLE
[PIBD_IMPL] Introduce PIBD state into sync workflow

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -923,6 +923,17 @@ impl Chain {
 		self.get_header_by_height(txhashset_height)
 	}
 
+	/// Return the Block Header at the txhashset horizon, considering only the
+	/// contents of the header PMMR
+	pub fn txhashset_archive_header_header_only(&self) -> Result<BlockHeader, Error> {
+		let header_head = self.header_head()?;
+		let threshold = global::state_sync_threshold() as u64;
+		let archive_interval = global::txhashset_archive_interval();
+		let mut txhashset_height = header_head.height.saturating_sub(threshold);
+		txhashset_height = txhashset_height.saturating_sub(txhashset_height % archive_interval);
+		self.get_header_by_height(txhashset_height)
+	}
+
 	// Special handling to make sure the whole kernel set matches each of its
 	// roots in each block header, without truncation. We go back header by
 	// header, rewind and check each root. This fixes a potential weakness in

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -135,6 +135,10 @@ pub enum ErrorKind {
 	/// Error from underlying block handling
 	#[fail(display = "Block Validation Error: {:?}", _0)]
 	Block(block::Error),
+	/// Attempt to retrieve a header at a height greater than
+	/// the max allowed by u64 limits
+	#[fail(display = "Invalid Header Height: {}", _0)]
+	InvalidHeaderHeight(u64),
 	/// Anything else
 	#[fail(display = "Other Error: {}", _0)]
 	Other(String),

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -194,10 +194,11 @@ impl BitmapAccumulator {
 	/// Return a raw in-memory bitmap of this accumulator
 	pub fn as_bitmap(&self) -> Result<Bitmap, Error> {
 		let mut bitmap = Bitmap::create();
-		for (chunk_count, chunk_index) in self.backend.leaf_idx_iter(0).enumerate() {
+		for (chunk_index, chunk_pos) in self.backend.leaf_pos_iter().enumerate() {
 			//TODO: Unwrap
-			let chunk = self.backend.get_data(chunk_index).unwrap();
-			bitmap.add_many(&chunk.set_iter(chunk_count * 1024).collect::<Vec<u32>>());
+			let chunk = self.backend.get_data(chunk_pos as u64).unwrap();
+			let additive = chunk.set_iter(chunk_index * 1024).collect::<Vec<u32>>();
+			bitmap.add_many(&additive);
 		}
 		Ok(bitmap)
 	}

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -133,9 +133,9 @@ impl Desegmenter {
 			1 + pmmr::peaks(pmmr::insertion_to_pmmr_index(self.bitmap_mmr_leaf_count))
 				.last()
 				.unwrap_or(
-					&(1 + pmmr::peaks(
-						pmmr::insertion_to_pmmr_index(self.bitmap_mmr_leaf_count) - 1,
-					)
+					&(pmmr::peaks(pmmr::insertion_to_pmmr_index(
+						self.bitmap_mmr_leaf_count - 1,
+					))
 					.last()
 					.unwrap()),
 				)

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -30,6 +30,10 @@ use crate::txhashset;
 
 use croaring::Bitmap;
 
+/// States that the desegmenter can be in, to keep track of what
+/// parts are needed next in the proces
+pub enum DesegmenterState {}
+
 /// Desegmenter for rebuilding a txhashset from PIBD segments
 #[derive(Clone)]
 pub struct Desegmenter {

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -129,10 +129,18 @@ impl Desegmenter {
 			self.bitmap_mmr_leaf_count
 		);
 		// Total size of Bitmap PMMR
-		self.bitmap_mmr_size = pmmr::peaks(self.bitmap_mmr_leaf_count)
-			.last()
-			.unwrap_or(&pmmr::insertion_to_pmmr_index(self.bitmap_mmr_leaf_count))
-			.clone();
+		self.bitmap_mmr_size =
+			1 + pmmr::peaks(pmmr::insertion_to_pmmr_index(self.bitmap_mmr_leaf_count))
+				.last()
+				.unwrap_or(
+					&(1 + pmmr::peaks(
+						pmmr::insertion_to_pmmr_index(self.bitmap_mmr_leaf_count) - 1,
+					)
+					.last()
+					.unwrap()),
+				)
+				.clone();
+
 		debug!(
 			"pibd_desgmenter - expected size of bitmap MMR: {}",
 			self.bitmap_mmr_size

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -110,6 +110,9 @@ impl PMMRHandle<BlockHeader> {
 
 	/// Get the header hash at the specified height based on the current header MMR state.
 	pub fn get_header_hash_by_height(&self, height: u64) -> Result<Hash, Error> {
+		if height >= self.size {
+			return Err(ErrorKind::InvalidHeaderHeight(height).into());
+		}
 		let pos = pmmr::insertion_to_pmmr_index(height);
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.size);
 		if let Some(entry) = header_pmmr.get_data(pos) {

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -602,6 +602,16 @@ impl ChainAdapter for TrackingAdapter {
 	) -> Result<Segment<RangeProof>, chain::Error> {
 		self.adapter.get_rangeproof_segment(hash, id)
 	}
+
+	fn receive_bitmap_segment(
+		&self,
+		block_hash: Hash,
+		output_root: Hash,
+		segment: Segment<BitmapChunk>,
+	) -> Result<bool, chain::Error> {
+		self.adapter
+			.receive_bitmap_segment(block_hash, output_root, segment)
+	}
 }
 
 impl NetAdapter for TrackingAdapter {

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -31,7 +31,9 @@ use crate::core::pow::Difficulty;
 use crate::core::ser::Writeable;
 use crate::core::{core, global};
 use crate::handshake::Handshake;
-use crate::msg::{self, BanReason, GetPeerAddrs, Locator, Msg, Ping, TxHashSetRequest, Type};
+use crate::msg::{
+	self, BanReason, GetPeerAddrs, Locator, Msg, Ping, SegmentRequest, TxHashSetRequest, Type,
+};
 use crate::protocol::Protocol;
 use crate::types::{
 	Capabilities, ChainAdapter, Error, NetAdapter, P2PConfig, PeerAddr, PeerInfo, ReasonForBan,
@@ -368,6 +370,20 @@ impl Peer {
 		self.send(
 			&TxHashSetRequest { hash, height },
 			msg::Type::TxHashSetRequest,
+		)
+	}
+
+	pub fn send_bitmap_segment_request(
+		&self,
+		h: Hash,
+		identifier: SegmentIdentifier,
+	) -> Result<(), Error> {
+		self.send(
+			&SegmentRequest {
+				block_hash: h,
+				identifier,
+			},
+			msg::Type::GetOutputBitmapSegment,
 		)
 	}
 

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -669,6 +669,16 @@ impl ChainAdapter for Peers {
 	) -> Result<Segment<RangeProof>, chain::Error> {
 		self.adapter.get_rangeproof_segment(hash, id)
 	}
+
+	fn receive_bitmap_segment(
+		&self,
+		block_hash: Hash,
+		output_root: Hash,
+		segment: Segment<BitmapChunk>,
+	) -> Result<bool, chain::Error> {
+		self.adapter
+			.receive_bitmap_segment(block_hash, output_root, segment)
+	}
 }
 
 impl NetAdapter for Peers {

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -371,8 +371,20 @@ impl MessageHandler for Protocol {
 					Consumed::None
 				}
 			}
-			Message::OutputBitmapSegment(_)
-			| Message::OutputSegment(_)
+			Message::OutputBitmapSegment(req) => {
+				let OutputBitmapSegmentResponse {
+					block_hash,
+					segment,
+					output_root,
+				} = req;
+				debug!(
+					"Received Output Bitmap Segment: bh, output_root: {}, {}",
+					block_hash, output_root
+				);
+				adapter.receive_bitmap_segment(block_hash, output_root, segment.into())?;
+				Consumed::None
+			}
+			Message::OutputSegment(_)
 			| Message::RangeProofSegment(_)
 			| Message::KernelSegment(_) => Consumed::None,
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -410,6 +410,15 @@ impl ChainAdapter for DummyAdapter {
 	) -> Result<Segment<RangeProof>, chain::Error> {
 		unimplemented!()
 	}
+
+	fn receive_bitmap_segment(
+		&self,
+		block_hash: Hash,
+		output_root: Hash,
+		segment: Segment<BitmapChunk>,
+	) -> Result<bool, chain::Error> {
+		unimplemented!()
+	}
 }
 
 impl NetAdapter for DummyAdapter {

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -667,6 +667,13 @@ pub trait ChainAdapter: Sync + Send {
 		hash: Hash,
 		id: SegmentIdentifier,
 	) -> Result<Segment<RangeProof>, chain::Error>;
+
+	fn receive_bitmap_segment(
+		&self,
+		block_hash: Hash,
+		output_root: Hash,
+		segment: Segment<BitmapChunk>,
+	) -> Result<bool, chain::Error>;
 }
 
 /// Additional methods required by the protocol that don't need to be

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -564,6 +564,24 @@ where
 		}
 		segmenter.rangeproof_segment(id)
 	}
+
+	fn receive_bitmap_segment(
+		&self,
+		block_hash: Hash,
+		output_root: Hash,
+		segment: Segment<BitmapChunk>,
+	) -> Result<bool, chain::Error> {
+		debug!(
+			"RECEIVED BITMAP SEGMENT FOR block_hash: {}, output_root: {}",
+			block_hash, output_root
+		);
+		// TODO: Entire process needs to be restarted if the horizon block
+		// has changed (not here, NB for somewhere)
+		let archive_header = self.chain().txhashset_archive_header()?;
+		let mut desegmenter = self.chain().desegmenter(&archive_header)?;
+		desegmenter.add_bitmap_segment(segment, output_root)?;
+		Ok(true)
+	}
 }
 
 impl<B, P> NetToChainAdapter<B, P>

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -576,8 +576,8 @@ where
 			block_hash, output_root
 		);
 		// TODO: Entire process needs to be restarted if the horizon block
-		// has changed (not here, NB for somewhere)
-		let archive_header = self.chain().txhashset_archive_header()?;
+		// has changed (perhaps not here, NB for somewhere)
+		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let mut desegmenter = self.chain().desegmenter(&archive_header)?;
 		desegmenter.add_bitmap_segment(segment, output_root)?;
 		Ok(true)

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -454,9 +454,15 @@ impl Server {
 					// We need to query again for the actual block hash, as
 					// the difficulty iterator doesn't contain enough info to
 					// create a hash
-					let block_hash = match self.chain.get_header_by_height(height as u64) {
-						Ok(h) => h.hash(),
-						Err(_) => ZERO_HASH,
+					// The diff iterator returns 59 block headers 'before' 0 to give callers
+					// enough detail to calculate initial block difficulties. Ignore these.
+					let block_hash = if height < 0 {
+						ZERO_HASH
+					} else {
+						match self.chain.get_header_by_height(height as u64) {
+							Ok(h) => h.hash(),
+							Err(_) => ZERO_HASH,
+						}
 					};
 
 					DiffBlock {

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -137,7 +137,7 @@ impl StateSync {
 						.update(SyncStatus::TxHashsetPibd { aborted: false });
 				}
 				// Continue our PIBD process
-				self.continue_pibd(&header_head);
+				self.continue_pibd();
 			} else {
 				let (go, download_timeout) = self.state_sync_due();
 
@@ -170,16 +170,12 @@ impl StateSync {
 		true
 	}
 
-	fn continue_pibd(&mut self, header_head: &chain::Tip) {
+	fn continue_pibd(&mut self) {
 		// Check the state of our chain to figure out what we should be requesting next
 		// TODO: Just faking a single request for testing
 		if !self.sent_test_pibd_message {
 			debug!("Sending test PIBD message");
-			let threshold = global::state_sync_threshold() as u64;
-			let archive_interval = global::txhashset_archive_interval();
-			let mut txhashset_height = header_head.height.saturating_sub(threshold);
-			txhashset_height = txhashset_height.saturating_sub(txhashset_height % archive_interval);
-			let archive_header = self.chain.get_header_by_height(txhashset_height).unwrap();
+			let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 
 			let target_segment_height = 11;
 			//let archive_header = self.chain.txhashset_archive_header().unwrap();


### PR DESCRIPTION
First in a continuing series of PRs into the `pibd_impl` branch, the overall goal of which is to create an initial usable implementation of PIBD on the test network.

Note the current state of code is unlikely to be useful to anyone except me at the moment. Will make a note in later PRs when things are ready to try.

This:

* Adds a `TxHashsetPibd` state to sync status, which is 
* Defaults to attempting PIBD after header sync when running on testnet (note this will remain in this state indefinitely at present pending more implementation)
* Modifies sync thread to call into a `pibd_continue` function which will ultimately check the state of PIBD and either call the desegmenter and peers with next steps or update sync state. For now it just sends a single message to a listening peer.
* Adds p2p functions to peers, adapters and network related code to perform PIBD requests to peers
* Fix to desegmenter PMMR size calc function
* Fix to `BitmapAccumulator` -> raw `croaring::Bitmap` conversion function
* Add function to chain to select archive block header without reference to anything but stored headers (essentially move code from syncer into somewhere more common.
