### PR TITLE
[PIBD_IMPL] Bitmap accumulator reconstruction + TxHashset set reconstruction

### DIFF
--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -386,10 +386,20 @@ impl Desegmenter {
 			let txhashset = self.txhashset.read();
 			local_output_mmr_size = txhashset.output_mmr_size();
 		}
-		let cur_segment_count = SegmentIdentifier::count_segments_required(
-			local_output_mmr_size,
-			self.default_output_segment_height,
-		);
+
+		// Special case here. If the mmr size is 1, this is a fresh chain
+		// with naught but a humble genesis block. We need segment 0, (and
+		// also need to skip the genesis block when applying the segment)
+
+		let cur_segment_count = if local_output_mmr_size == 1 {
+			0
+		} else {
+			SegmentIdentifier::count_segments_required(
+				local_output_mmr_size,
+				self.default_output_segment_height,
+			)
+		};
+
 		let total_segment_count = SegmentIdentifier::count_segments_required(
 			self.archive_header.output_mmr_size,
 			self.default_output_segment_height,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1258,8 +1258,13 @@ impl<'a> Extension<'a> {
 		&mut self,
 		segment: Segment<OutputIdentifier>,
 	) -> Result<(), Error> {
-		let (_sid, _hash_pos, _hashes, _leaf_pos, leaf_data, _proof) = segment.parts();
-		for output_identifier in leaf_data {
+		let (sid, _hash_pos, _hashes, _leaf_pos, leaf_data, _proof) = segment.parts();
+		for (index, output_identifier) in leaf_data.iter().enumerate() {
+			// Special case, if this is segment 0, skip the genesis block which should
+			// already be applied
+			if sid.idx == 0 && index == 0 {
+				continue;
+			}
 			self.output_pmmr
 				.push(&output_identifier)
 				.map_err(&ErrorKind::TxHashSetErr)?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -347,11 +347,6 @@ impl TxHashSet {
 			.elements_from_pmmr_index(start_index, max_count, max_index)
 	}
 
-	/// number of outputs
-	pub fn output_mmr_size(&self) -> u64 {
-		self.output_pmmr_h.size
-	}
-
 	/// As above, for rangeproofs
 	pub fn rangeproofs_by_pmmr_index(
 		&self,
@@ -361,6 +356,21 @@ impl TxHashSet {
 	) -> (u64, Vec<RangeProof>) {
 		ReadonlyPMMR::at(&self.rproof_pmmr_h.backend, self.rproof_pmmr_h.size)
 			.elements_from_pmmr_index(start_index, max_count, max_index)
+	}
+
+	/// size of output mmr
+	pub fn output_mmr_size(&self) -> u64 {
+		self.output_pmmr_h.size
+	}
+
+	/// size of kernel mmr
+	pub fn kernel_mmr_size(&self) -> u64 {
+		self.kernel_pmmr_h.size
+	}
+
+	/// size of rangeproof mmr (can differ from output mmr size during PIBD sync)
+	pub fn rangeproof_mmr_size(&self) -> u64 {
+		self.rproof_pmmr_h.size
 	}
 
 	/// Find a kernel with a given excess. Work backwards from `max_index` to `min_index`

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -387,6 +387,48 @@ impl Peer {
 		)
 	}
 
+	pub fn send_output_segment_request(
+		&self,
+		h: Hash,
+		identifier: SegmentIdentifier,
+	) -> Result<(), Error> {
+		self.send(
+			&SegmentRequest {
+				block_hash: h,
+				identifier,
+			},
+			msg::Type::GetOutputSegment,
+		)
+	}
+
+	pub fn send_rangeproof_segment_request(
+		&self,
+		h: Hash,
+		identifier: SegmentIdentifier,
+	) -> Result<(), Error> {
+		self.send(
+			&SegmentRequest {
+				block_hash: h,
+				identifier,
+			},
+			msg::Type::GetRangeProofSegment,
+		)
+	}
+
+	pub fn send_kernel_segment_request(
+		&self,
+		h: Hash,
+		identifier: SegmentIdentifier,
+	) -> Result<(), Error> {
+		self.send(
+			&SegmentRequest {
+				block_hash: h,
+				identifier,
+			},
+			msg::Type::GetKernelSegment,
+		)
+	}
+
 	/// Stops the peer
 	pub fn stop(&self) {
 		debug!("Stopping peer {:?}", self.info.addr);

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -384,10 +384,40 @@ impl MessageHandler for Protocol {
 				adapter.receive_bitmap_segment(block_hash, output_root, segment.into())?;
 				Consumed::None
 			}
-			Message::OutputSegment(_)
-			| Message::RangeProofSegment(_)
-			| Message::KernelSegment(_) => Consumed::None,
-
+			Message::OutputSegment(req) => {
+				let OutputSegmentResponse {
+					response,
+					output_bitmap_root,
+				} = req;
+				debug!(
+					"Received Output Segment: bh, bitmap_root: {}, {}",
+					response.block_hash, output_bitmap_root
+				);
+				adapter.receive_output_segment(
+					response.block_hash,
+					output_bitmap_root,
+					response.segment.into(),
+				)?;
+				Consumed::None
+			}
+			Message::RangeProofSegment(req) => {
+				let SegmentResponse {
+					block_hash,
+					segment,
+				} = req;
+				debug!("Received Rangeproof Segment: bh: {}", block_hash);
+				adapter.receive_rangeproof_segment(block_hash, segment.into())?;
+				Consumed::None
+			}
+			Message::KernelSegment(req) => {
+				let SegmentResponse {
+					block_hash,
+					segment,
+				} = req;
+				debug!("Received Kernel Segment: bh: {}", block_hash);
+				adapter.receive_kernel_segment(block_hash, segment.into())?;
+				Consumed::None
+			}
 			Message::Unknown(_) => Consumed::None,
 		};
 		Ok(consumed)

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -172,10 +172,19 @@ impl StateSync {
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
 
+		// Apply segments... TODO: figure out how this should be called, might
+		// need to be a separate thread.
+		if let Some(mut de) = desegmenter.try_write() {
+			if let Some(d) = de.as_mut() {
+				d.apply_next_segments().unwrap();
+			}
+		}
+
 		// TODO and consider: number here depends on how many simultaneous
 		// requests we want to send to peers
 		let mut next_segment_ids = vec![];
-		if let Some(d) = desegmenter.read().as_ref() {
+		if let Some(d) = desegmenter.write().as_mut() {
+			// Figure out the next segments we need
 			next_segment_ids = d.next_desired_segments(10);
 		}
 

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -17,10 +17,7 @@ use chrono::Duration;
 use std::sync::Arc;
 
 use crate::chain::{self, SyncState, SyncStatus};
-use crate::core::core::{
-	hash::Hashed,
-	pmmr::segment::{SegmentIdentifier, SegmentType},
-};
+use crate::core::core::{hash::Hashed, pmmr::segment::SegmentType};
 use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::p2p::{self, Capabilities, Peer};
@@ -216,7 +213,7 @@ impl StateSync {
 				warn!("no suitable outbound peer for pibd message, considering inbound");
 				peers_iter().inbound().choose_random()
 			});
-			debug!("Chosen peer is {:?}", peer);
+			trace!("Chosen peer is {:?}", peer);
 			if let Some(p) = peer {
 				match seg_id.segment_type {
 					SegmentType::Bitmap => p


### PR DESCRIPTION
Still WIP, Goal of this PR is to have all mmrs in the txhashset reconstructed via p2p messaging, (with no kernel or rangeproof validation just yet)

* Reconstruct and `finalize` the desegmenter's BitmapAccumulator once all segments have been received
* Add ability to find and request the next output mmr segments in `Desegmenter::next_desired_segments`
* `apply_next_segments` function, which applies the next set of downloaded segments to the underlying pmmrs as and when they become available. (Note this is currently being called once per sync loop iteration and 'pops' off the next segments on each call, this is not the final timing strategy)
* Add remaining peer and p2p functions
