### PR TITLE
[PIBD_IMPL] PMMR Reassembly from Segments

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -163,6 +163,9 @@ pub enum ErrorKind {
 	/// Segment height not within allowed range
 	#[fail(display = "Invalid segment height")]
 	InvalidSegmentHeight,
+	/// Other issue with segment
+	#[fail(display = "Invalid segment: {}", _0)]
+	InvalidSegment(String),
 }
 
 impl Display for Error {

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -43,17 +43,21 @@ pub struct Desegmenter {
 
 	default_bitmap_segment_height: u8,
 	default_output_segment_height: u8,
+	default_rangeproof_segment_height: u8,
 
 	bitmap_accumulator: BitmapAccumulator,
 	bitmap_segment_cache: Vec<Segment<BitmapChunk>>,
 	output_segment_cache: Vec<Segment<OutputIdentifier>>,
-	_rangeproof_segment_cache: Vec<Segment<RangeProof>>,
+	rangeproof_segment_cache: Vec<Segment<RangeProof>>,
 	_kernel_segments: Vec<Segment<TxKernel>>,
 
 	bitmap_mmr_leaf_count: u64,
 	bitmap_mmr_size: u64,
-	// In-memory 'raw' bitmap corresponding to contents of bitmap accumulator
+	/// In-memory 'raw' bitmap corresponding to contents of bitmap accumulator
 	bitmap_cache: Option<Bitmap>,
+
+	/// Flag indicating there are no more segments to request
+	all_segments_complete: bool,
 }
 
 impl Desegmenter {
@@ -73,15 +77,18 @@ impl Desegmenter {
 			bitmap_accumulator: BitmapAccumulator::new(),
 			default_bitmap_segment_height: 9,
 			default_output_segment_height: 11,
+			default_rangeproof_segment_height: 7,
 			bitmap_segment_cache: vec![],
 			output_segment_cache: vec![],
-			_rangeproof_segment_cache: vec![],
+			rangeproof_segment_cache: vec![],
 			_kernel_segments: vec![],
 
 			bitmap_mmr_leaf_count: 0,
 			bitmap_mmr_size: 0,
 
 			bitmap_cache: None,
+
+			all_segments_complete: false,
 		};
 		retval.calc_bitmap_mmr_sizes();
 		retval
@@ -91,9 +98,15 @@ impl Desegmenter {
 	pub fn header(&self) -> &BlockHeader {
 		&self.archive_header
 	}
+
 	/// Return size of bitmap mmr
 	pub fn expected_bitmap_mmr_size(&self) -> u64 {
 		self.bitmap_mmr_size
+	}
+
+	/// Whether we have all the segments we need
+	pub fn is_complete(&self) -> bool {
+		self.all_segments_complete
 	}
 
 	/// Apply next set of segments that are ready to be appended to their respective trees,
@@ -118,7 +131,7 @@ impl Desegmenter {
 			}
 			// Check if we can apply the next output segment
 			if let Some(next_output_idx) = self.next_required_output_segment_index() {
-				debug!("Next output index to apply: {}", next_output_idx);
+				trace!("Next output index to apply: {}", next_output_idx);
 				if let Some((idx, _seg)) = self
 					.output_segment_cache
 					.iter()
@@ -128,14 +141,26 @@ impl Desegmenter {
 					self.apply_output_segment(idx)?;
 				}
 			}
-			// TODO: Ditto RP, kernel
+			// Check if we can apply the next rangeproof segment
+			if let Some(next_rangeproof_idx) = self.next_required_rangeproof_segment_index() {
+				trace!("Next rangeproof index to apply: {}", next_rangeproof_idx);
+				if let Some((idx, _seg)) = self
+					.rangeproof_segment_cache
+					.iter()
+					.enumerate()
+					.find(|s| s.1.identifier().idx == next_rangeproof_idx)
+				{
+					self.apply_rangeproof_segment(idx)?;
+				}
+			}
+			// TODO: Kernel
 		}
 		Ok(())
 	}
 
 	/// Return list of the next preferred segments the desegmenter needs based on
 	/// the current real state of the underlying elements
-	pub fn next_desired_segments(&self, max_elements: usize) -> Vec<SegmentTypeIdentifier> {
+	pub fn next_desired_segments(&mut self, max_elements: usize) -> Vec<SegmentTypeIdentifier> {
 		let mut return_vec = vec![];
 		// First check for required bitmap elements
 		if self.bitmap_cache.is_none() {
@@ -164,12 +189,12 @@ impl Desegmenter {
 			// requests among the 3 PMMRs
 			let local_output_mmr_size;
 			let mut _local_kernel_mmr_size;
-			let mut _local_rangeproof_mmr_size;
+			let local_rangeproof_mmr_size;
 			{
 				let txhashset = self.txhashset.read();
 				local_output_mmr_size = txhashset.output_mmr_size();
 				_local_kernel_mmr_size = txhashset.kernel_mmr_size();
-				_local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
+				local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
 			}
 			// TODO: Fix, alternative approach, this is very inefficient
 			let mut output_identifier_iter = SegmentIdentifier::traversal_iter(
@@ -196,6 +221,34 @@ impl Desegmenter {
 					break;
 				}
 			}
+
+			let mut rangeproof_identifier_iter = SegmentIdentifier::traversal_iter(
+				self.archive_header.output_mmr_size,
+				self.default_rangeproof_segment_height,
+			);
+
+			while let Some(rp_id) = rangeproof_identifier_iter.next() {
+				// Advance output iterator to next needed position
+				if rp_id
+					.segment_pos_range(self.archive_header.output_mmr_size)
+					.1 <= local_rangeproof_mmr_size
+				{
+					continue;
+				}
+				// Break if we're full
+				if return_vec.len() > max_elements {
+					break;
+				}
+
+				if !self.has_rangeproof_segment_with_id(rp_id) {
+					return_vec.push(SegmentTypeIdentifier::new(SegmentType::RangeProof, rp_id));
+					// Let other trees have a chance to put in a segment request
+					break;
+				}
+			}
+		}
+		if return_vec.is_empty() && self.bitmap_cache.is_some() {
+			self.all_segments_complete = true;
 		}
 		return_vec
 	}
@@ -298,7 +351,6 @@ impl Desegmenter {
 	}
 
 	/// Adds and validates a bitmap chunk
-	/// TODO: Still experimenting, this expects chunks received to be in order
 	pub fn add_bitmap_segment(
 		&mut self,
 		segment: Segment<BitmapChunk>,
@@ -402,9 +454,10 @@ impl Desegmenter {
 			self.archive_header.output_mmr_size,
 			self.default_output_segment_height,
 		);
-		debug!(
+		trace!(
 			"Next required output segment is {} of {}",
-			cur_segment_count, total_segment_count
+			cur_segment_count,
+			total_segment_count
 		);
 		if cur_segment_count == total_segment_count {
 			None
@@ -437,15 +490,33 @@ impl Desegmenter {
 		Ok(())
 	}
 
-	/// Adds a Rangeproof segment
-	/// TODO: Still experimenting, expects chunks received to be in order
-	pub fn add_rangeproof_segment(&self, segment: Segment<RangeProof>) -> Result<(), Error> {
-		debug!("pibd_desegmenter: add rangeproof segment");
-		segment.validate(
-			self.archive_header.output_mmr_size, // Last MMR pos at the height being validated
-			self.bitmap_cache.as_ref(),
-			self.archive_header.range_proof_root, // Range proof root we're checking for
-		)?;
+	/// Whether our list already contains this rangeproof segment
+	fn has_rangeproof_segment_with_id(&self, seg_id: SegmentIdentifier) -> bool {
+		self.rangeproof_segment_cache
+			.iter()
+			.find(|i| i.identifier() == seg_id)
+			.is_some()
+	}
+
+	/// Cache a RangeProof segment if we don't already have it
+	fn cache_rangeproof_segment(&mut self, in_seg: Segment<RangeProof>) {
+		if self
+			.rangeproof_segment_cache
+			.iter()
+			.find(|i| i.identifier() == in_seg.identifier())
+			.is_none()
+		{
+			self.rangeproof_segment_cache.push(in_seg);
+		}
+	}
+
+	/// Apply a rangeproof segment at the index cache
+	pub fn apply_rangeproof_segment(&mut self, idx: usize) -> Result<(), Error> {
+		let segment = self.rangeproof_segment_cache.remove(idx);
+		debug!(
+			"pibd_desegmenter: applying rangeproof segment at segment idx {}",
+			segment.identifier().idx
+		);
 		let mut header_pmmr = self.header_pmmr.write();
 		let mut txhashset = self.txhashset.write();
 		let mut batch = self.store.batch()?;
@@ -459,6 +530,55 @@ impl Desegmenter {
 				Ok(())
 			},
 		)?;
+		Ok(())
+	}
+
+	/// Return an identifier for the next segment we need for the rangeproof pmmr
+	fn next_required_rangeproof_segment_index(&self) -> Option<u64> {
+		let local_rangeproof_mmr_size;
+		{
+			let txhashset = self.txhashset.read();
+			local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
+		}
+
+		// Special case here. If the mmr size is 1, this is a fresh chain
+		// with naught but a humble genesis block. We need segment 0, (and
+		// also need to skip the genesis block when applying the segment)
+
+		let cur_segment_count = if local_rangeproof_mmr_size == 1 {
+			0
+		} else {
+			SegmentIdentifier::count_segments_required(
+				local_rangeproof_mmr_size,
+				self.default_rangeproof_segment_height,
+			)
+		};
+
+		let total_segment_count = SegmentIdentifier::count_segments_required(
+			self.archive_header.output_mmr_size,
+			self.default_rangeproof_segment_height,
+		);
+		trace!(
+			"Next required rangeproof segment is {} of {}",
+			cur_segment_count,
+			total_segment_count
+		);
+		if cur_segment_count == total_segment_count {
+			None
+		} else {
+			Some(cur_segment_count as u64)
+		}
+	}
+
+	/// Adds a Rangeproof segment
+	pub fn add_rangeproof_segment(&mut self, segment: Segment<RangeProof>) -> Result<(), Error> {
+		debug!("pibd_desegmenter: add rangeproof segment");
+		segment.validate(
+			self.archive_header.output_mmr_size, // Last MMR pos at the height being validated
+			self.bitmap_cache.as_ref(),
+			self.archive_header.range_proof_root, // Range proof root we're checking for
+		)?;
+		self.cache_rangeproof_segment(segment);
 		Ok(())
 	}
 

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -210,7 +210,7 @@ impl Desegmenter {
 	/// being shut down and restarted
 	pub fn finalize_bitmap(&mut self) -> Result<(), Error> {
 		debug!(
-			"pibd_desgmenter: finalizing and caching bitmap - accumulator root: {}",
+			"pibd_desegmenter: finalizing and caching bitmap - accumulator root: {}",
 			self.bitmap_accumulator.root()
 		);
 		self.bitmap_cache = Some(self.bitmap_accumulator.as_bitmap()?);
@@ -239,7 +239,7 @@ impl Desegmenter {
 		self.bitmap_mmr_leaf_count =
 			(pmmr::n_leaves(self.archive_header.output_mmr_size) + 1023) / 1024;
 		debug!(
-			"pibd_desgmenter - expected number of leaves in bitmap MMR: {}",
+			"pibd_desegmenter - expected number of leaves in bitmap MMR: {}",
 			self.bitmap_mmr_leaf_count
 		);
 		// Total size of Bitmap PMMR
@@ -256,7 +256,7 @@ impl Desegmenter {
 				.clone();
 
 		debug!(
-			"pibd_desgmenter - expected size of bitmap MMR: {}",
+			"pibd_desegmenter - expected size of bitmap MMR: {}",
 			self.bitmap_mmr_size
 		);
 	}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1258,8 +1258,99 @@ impl<'a> Extension<'a> {
 		&mut self,
 		segment: Segment<OutputIdentifier>,
 	) -> Result<(), Error> {
-		let (sid, _hash_pos, _hashes, _leaf_pos, leaf_data, _proof) = segment.parts();
-		for (index, output_identifier) in leaf_data.iter().enumerate() {
+		let (sid, hash_pos, hashes, leaf_pos, leaf_data, _proof) = segment.parts();
+
+		let mut leaf_pos_iter = leaf_pos.iter().enumerate();
+		let mut hash_pos_iter = hash_pos.iter().enumerate();
+
+		// get first leaf
+		let mut next_leaf = leaf_pos_iter.next();
+		// get first hash
+		let mut next_hash = hash_pos_iter.next();
+
+		while next_leaf.is_some() || next_hash.is_some() {
+			if let Some(l) = next_leaf {
+				if let Some(h) = next_hash {
+					if *l.1 < *h.1 {
+						debug!(
+							"Merging leaf, pmmr size: {}, {}",
+							*l.1,
+							self.output_pmmr.unpruned_size()
+						);
+						debug!("BEFORE");
+						self.output_pmmr.dump(true);
+						// Don't re-push genesis output
+						if *l.1 != 0 {
+							self.output_pmmr
+								.push(&leaf_data[l.0])
+								.map_err(&ErrorKind::TxHashSetErr)?;
+						}
+						debug!("AFTER");
+						self.output_pmmr.dump(true);
+						next_leaf = leaf_pos_iter.next();
+
+						continue;
+					} else {
+						if *h.1 >= self.output_pmmr.unpruned_size() {
+							debug!(
+								"Merging hash at {}, {} pmmr size: {}",
+								h.1,
+								hashes[h.0],
+								self.output_pmmr.unpruned_size()
+							);
+							debug!("BEFORE");
+							self.output_pmmr.dump(true);
+							self.output_pmmr
+								.push_pruned_subtree(hashes[h.0], *h.1)
+								.map_err(&ErrorKind::TxHashSetErr)?;
+							debug!("AFTER");
+							self.output_pmmr.dump(true);
+						}
+						next_hash = hash_pos_iter.next();
+						continue;
+					}
+				} else {
+					if *l.1 != 0 {
+						self.output_pmmr
+							.push(&leaf_data[l.0])
+							.map_err(&ErrorKind::TxHashSetErr)?;
+					}
+					next_leaf = leaf_pos_iter.next();
+					continue;
+				}
+			}
+			if let Some(h) = next_hash {
+				if let Some(l) = next_leaf {
+					if *h.1 < *l.1 {
+						if *h.1 >= self.output_pmmr.unpruned_size() {
+							self.output_pmmr
+								.push_pruned_subtree(hashes[h.0], *h.1)
+								.map_err(&ErrorKind::TxHashSetErr)?;
+						}
+						next_hash = hash_pos_iter.next();
+						continue;
+					} else {
+						if *l.1 != 0 {
+							self.output_pmmr
+								.push(&leaf_data[l.0])
+								.map_err(&ErrorKind::TxHashSetErr)?;
+						}
+						next_leaf = leaf_pos_iter.next();
+						continue;
+					}
+				} else {
+					if *h.1 >= self.output_pmmr.unpruned_size() {
+						self.output_pmmr
+							.push_pruned_subtree(hashes[h.0], *h.1)
+							.map_err(&ErrorKind::TxHashSetErr)?;
+					}
+					next_hash = hash_pos_iter.next();
+					continue;
+				}
+			}
+		}
+
+		/*(for (index, output_identifier) in leaf_data.iter().enumerate() {
 			// Special case, if this is segment 0, skip the genesis block which should
 			// already be applied
 			if sid.idx == 0 && index == 0 {
@@ -1268,7 +1359,7 @@ impl<'a> Extension<'a> {
 			self.output_pmmr
 				.push(&output_identifier)
 				.map_err(&ErrorKind::TxHashSetErr)?;
-		}
+		}*/
 		Ok(())
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1293,30 +1293,30 @@ impl<'a> Extension<'a> {
 		for insert in ordered_inserts {
 			match insert {
 				OrderedHashLeafNode::Hash(idx, pos0) => {
-					if pos0 >= self.output_pmmr.unpruned_size() {
+					if pos0 >= self.output_pmmr.size {
 						debug!(
 							"Merging hash at {}, {} pmmr size: {}",
-							pos0,
-							hashes[idx],
-							self.output_pmmr.unpruned_size()
+							pos0, hashes[idx], self.output_pmmr.size
 						);
 						debug!("BEFORE");
-						self.output_pmmr.dump(false);
+						self.output_pmmr.dump(true);
 						self.output_pmmr
 							.push_pruned_subtree(hashes[idx], pos0)
 							.map_err(&ErrorKind::TxHashSetErr)?;
 						debug!("AFTER");
-						self.output_pmmr.dump(false);
+						debug!("Hash at {} is {:?}", pos0, self.output_pmmr.get_hash(pos0));
+						self.output_pmmr.dump(true);
+					} else {
+						debug!("Not merging {} at {}, redundant", hashes[idx], pos0);
 					}
 				}
 				OrderedHashLeafNode::Leaf(idx, pos0) => {
 					debug!(
 						"Merging leaf, pmmr size: {}, {}",
-						pos0,
-						self.output_pmmr.unpruned_size()
+						pos0, self.output_pmmr.size
 					);
 					debug!("BEFORE");
-					self.output_pmmr.dump(false);
+					self.output_pmmr.dump(true);
 					// Don't re-push genesis output
 					if pos0 != 0 {
 						self.output_pmmr
@@ -1324,7 +1324,7 @@ impl<'a> Extension<'a> {
 							.map_err(&ErrorKind::TxHashSetErr)?;
 					}
 					debug!("AFTER");
-					self.output_pmmr.dump(false);
+					self.output_pmmr.dump(true);
 				}
 			}
 		}

--- a/chain/tests/test_pibd_copy.rs
+++ b/chain/tests/test_pibd_copy.rs
@@ -219,6 +219,17 @@ impl DesegmenterRequestor {
 			};
 		}
 	}
+
+	pub fn check_roots(&self) {
+		let roots = self.chain.txhashset().read().roots();
+		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
+		debug!("Archive Header is {:?}", archive_header);
+		debug!("TXHashset output root is {:?}", roots);
+		debug!(
+			"TXHashset merged output root is {:?}",
+			roots.output_roots.root(&archive_header)
+		);
+	}
 }
 fn test_pibd_copy_impl(
 	is_test_chain: bool,
@@ -256,9 +267,11 @@ fn test_pibd_copy_impl(
 		}
 
 		// Just peform a set number of times for now
-		for _ in 0..100 {
+		for _ in 0..10000 {
 			dest_requestor.continue_pibd();
 		}
+
+		dest_requestor.check_roots();
 
 		/*let horizon_header = src_chain.txhashset_archive_header().unwrap();
 

--- a/chain/tests/test_pibd_copy.rs
+++ b/chain/tests/test_pibd_copy.rs
@@ -19,74 +19,253 @@ use grin_util as util;
 #[macro_use]
 extern crate log;
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fs, io};
 
+use crate::chain::txhashset::BitmapChunk;
 use crate::chain::types::{NoopAdapter, Options};
-use crate::core::core::{hash::Hashed, pmmr::segment::SegmentIdentifier};
+use crate::core::core::{
+	hash::{Hash, Hashed},
+	pmmr::segment::{Segment, SegmentIdentifier, SegmentType},
+	Block, OutputIdentifier,
+};
 use crate::core::{genesis, global, pow};
 
 use self::chain_test_helper::clean_output_dir;
 
 mod chain_test_helper;
 
-fn test_pibd_copy_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &str) {
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+	fs::create_dir_all(&dst)?;
+	for entry in fs::read_dir(src)? {
+		let entry = entry?;
+		let ty = entry.file_type()?;
+		if ty.is_dir() {
+			copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+		} else {
+			fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+		}
+	}
+	Ok(())
+}
+
+// Canned segmenter responder, which will simulate feeding back segments as requested
+// by the desegmenter
+struct SegmenterResponder {
+	chain: Arc<chain::Chain>,
+}
+
+impl SegmenterResponder {
+	pub fn new(chain_src_dir: &str, genesis: Block) -> Self {
+		let dummy_adapter = Arc::new(NoopAdapter {});
+		debug!(
+			"Reading SegmenterResponder chain, genesis block: {}",
+			genesis.hash()
+		);
+
+		// The original chain we're reading from
+		let res = SegmenterResponder {
+			chain: Arc::new(
+				chain::Chain::init(
+					chain_src_dir.into(),
+					dummy_adapter.clone(),
+					genesis,
+					pow::verify_size,
+					false,
+				)
+				.unwrap(),
+			),
+		};
+		let sh = res.chain.get_header_by_height(0).unwrap();
+		debug!("Source Genesis - {}", sh.hash());
+		res
+	}
+
+	pub fn chain(&self) -> Arc<chain::Chain> {
+		self.chain.clone()
+	}
+
+	pub fn get_bitmap_segment(&self, seg_id: SegmentIdentifier) -> (Segment<BitmapChunk>, Hash) {
+		let segmenter = self.chain.segmenter().unwrap();
+		segmenter.bitmap_segment(seg_id).unwrap()
+	}
+
+	pub fn get_output_segment(
+		&self,
+		seg_id: SegmentIdentifier,
+	) -> (Segment<OutputIdentifier>, Hash) {
+		let segmenter = self.chain.segmenter().unwrap();
+		segmenter.output_segment(seg_id).unwrap()
+	}
+}
+
+// Canned segmenter 'peer', building up its local chain from requested PIBD segments
+struct DesegmenterRequestor {
+	chain: Arc<chain::Chain>,
+	responder: Arc<SegmenterResponder>,
+}
+
+impl DesegmenterRequestor {
+	pub fn new(chain_src_dir: &str, genesis: Block, responder: Arc<SegmenterResponder>) -> Self {
+		let dummy_adapter = Arc::new(NoopAdapter {});
+		debug!(
+			"Reading DesegmenterRequestor chain, genesis block: {}",
+			genesis.hash()
+		);
+
+		// The original chain we're reading from
+		let res = DesegmenterRequestor {
+			chain: Arc::new(
+				chain::Chain::init(
+					chain_src_dir.into(),
+					dummy_adapter.clone(),
+					genesis,
+					pow::verify_size,
+					false,
+				)
+				.unwrap(),
+			),
+			responder,
+		};
+		let sh = res.chain.get_header_by_height(0).unwrap();
+		debug!("Dest Genesis - {}", sh.hash());
+		res
+	}
+
+	/// Copy headers, hopefully bringing the requestor to a state where PIBD is the next step
+	pub fn copy_headers_from_responder(&mut self) {
+		let src_chain = self.responder.chain();
+		let tip = src_chain.header_head().unwrap();
+		let dest_sync_head = self.chain.header_head().unwrap();
+		let copy_chunk_size = 1000;
+		let mut copied_header_index = 1;
+		let mut src_headers = vec![];
+		while copied_header_index <= tip.height {
+			let h = src_chain.get_header_by_height(copied_header_index).unwrap();
+			src_headers.push(h);
+			copied_header_index += 1;
+			if copied_header_index % copy_chunk_size == 0 {
+				debug!(
+					"Copying headers to {} of {}",
+					copied_header_index, tip.height
+				);
+				self.chain
+					.sync_block_headers(&src_headers, dest_sync_head, Options::SKIP_POW)
+					.unwrap();
+				src_headers = vec![];
+			}
+		}
+		if !src_headers.is_empty() {
+			self.chain
+				.sync_block_headers(&src_headers, dest_sync_head, Options::NONE)
+				.unwrap();
+		}
+	}
+
+	// Emulate `continue_pibd` function, which would be called from state sync
+	pub fn continue_pibd(&mut self) {
+		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
+		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
+
+		// Apply segments... TODO: figure out how this should be called, might
+		// need to be a separate thread.
+		if let Some(mut de) = desegmenter.try_write() {
+			if let Some(d) = de.as_mut() {
+				d.apply_next_segments().unwrap();
+			}
+		}
+
+		let mut next_segment_ids = vec![];
+		if let Some(d) = desegmenter.write().as_mut() {
+			// Figure out the next segments we need
+			// (12 is divisible by 3, to try and evenly spread the requests among the 3
+			// main pmmrs. Bitmaps segments will always be requested first)
+			next_segment_ids = d.next_desired_segments(12);
+		}
+
+		debug!("Next segment IDS: {:?}", next_segment_ids);
+
+		// For each segment, pick a desirable peer and send message
+		for seg_id in next_segment_ids.iter() {
+			// Perform request and response
+			match seg_id.segment_type {
+				SegmentType::Bitmap => {
+					let (seg, output_root) =
+						self.responder.get_bitmap_segment(seg_id.identifier.clone());
+					if let Some(d) = desegmenter.write().as_mut() {
+						d.add_bitmap_segment(seg, output_root).unwrap();
+					}
+				}
+				SegmentType::Output => {
+					let (seg, bitmap_root) =
+						self.responder.get_output_segment(seg_id.identifier.clone());
+					if let Some(d) = desegmenter.write().as_mut() {
+						d.add_output_segment(seg, Some(bitmap_root)).unwrap();
+					}
+				}
+				_ => {} /*SegmentType::RangeProof => p
+							.send_rangeproof_segment_request(
+								archive_header.hash(),
+								seg_id.identifier.clone(),
+							)
+							.unwrap(),
+						SegmentType::Kernel => p
+							.send_kernel_segment_request(
+								archive_header.hash(),
+								seg_id.identifier.clone(),
+							)
+							.unwrap(),*/
+			};
+		}
+	}
+}
+fn test_pibd_copy_impl(
+	is_test_chain: bool,
+	src_root_dir: &str,
+	dest_root_dir: &str,
+	dest_template_dir: Option<&str>,
+) {
 	global::set_local_chain_type(global::ChainTypes::Mainnet);
 	let mut genesis = genesis::genesis_main();
-	// Height at which to read kernel segments (lower than thresholds defined in spec - for testing)
-	let mut target_segment_height = 11;
 
 	if is_test_chain {
 		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
 		genesis = pow::mine_genesis_block().unwrap();
-		target_segment_height = 3;
+	}
+
+	// Copy a starting point over for the destination, e.g. a copy of chain
+	// with all headers pre-applied
+	if let Some(td) = dest_template_dir {
+		debug!(
+			"Copying template dir for destination from {} to {}",
+			td, dest_root_dir
+		);
+		copy_dir_all(td, dest_root_dir).unwrap();
 	}
 
 	{
-		debug!("Reading Chain, genesis block: {}", genesis.hash());
-		let dummy_adapter = Arc::new(NoopAdapter {});
+		let src_responder = Arc::new(SegmenterResponder::new(src_root_dir, genesis.clone()));
+		let mut dest_requestor =
+			DesegmenterRequestor::new(dest_root_dir, genesis.clone(), src_responder);
 
-		// The original chain we're reading from
-		let src_chain = Arc::new(
-			chain::Chain::init(
-				src_root_dir.into(),
-				dummy_adapter.clone(),
-				genesis.clone(),
-				pow::verify_size,
-				false,
-			)
-			.unwrap(),
-		);
+		// No template provided so copy headers from source
+		if dest_template_dir.is_none() {
+			dest_requestor.copy_headers_from_responder();
+			return;
+		}
 
-		// And the output chain we're writing to
-		let dest_chain = Arc::new(
-			chain::Chain::init(
-				dest_root_dir.into(),
-				dummy_adapter,
-				genesis.clone(),
-				pow::verify_size,
-				false,
-			)
-			.unwrap(),
-		);
+		// Just peform a set number of times for now
+		for _ in 0..100 {
+			dest_requestor.continue_pibd();
+		}
 
-		// For test compaction purposes
-		/*src_chain.compact().unwrap();
-		src_chain
-		.validate(true)
-		.expect("Source chain validation failed, stop");*/
+		/*let horizon_header = src_chain.txhashset_archive_header().unwrap();
 
-		let sh = src_chain.get_header_by_height(0).unwrap();
-		debug!("Source Genesis - {}", sh.hash());
-
-		let dh = dest_chain.get_header_by_height(0).unwrap();
-		debug!("Destination Genesis - {}", dh.hash());
-
-		let horizon_header = src_chain.txhashset_archive_header().unwrap();
-
-		debug!("Horizon header: {:?}", horizon_header);
+		debug!("Horizon header: {:?}", horizon_header);*/
 
 		// Copy the headers from source to output in chunks
-		let dest_sync_head = dest_chain.header_head().unwrap();
+		/*let dest_sync_head = dest_chain.header_head().unwrap();
 		let copy_chunk_size = 1000;
 		let mut copied_header_index = 1;
 		let mut src_headers = vec![];
@@ -109,11 +288,11 @@ fn test_pibd_copy_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &
 			dest_chain
 				.sync_block_headers(&src_headers, dest_sync_head, Options::NONE)
 				.unwrap();
-		}
+		}*/
 
 		// Init segmenter, (note this still has to be lazy init somewhere on a peer)
 		// This is going to use the same block as horizon_header
-		let segmenter = src_chain.segmenter().unwrap();
+		/*klet segmenter = src_chain.segmenter().unwrap();
 		// Init desegmenter
 		let desegmenter_lock = dest_chain.desegmenter(&horizon_header).unwrap();
 		let mut desegmenter_write = desegmenter_lock.write();
@@ -141,6 +320,9 @@ fn test_pibd_copy_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &
 			if let Err(e) = desegmenter.add_bitmap_segment(bitmap_segment, output_root_hash) {
 				panic!("Unable to add bitmap segment: {}", e);
 			}
+			if let Err(e) = desegmenter.apply_next_segments() {
+				panic!("Unable to apply bitmap segment: {}", e);
+			}
 		}
 
 		// Finalize segmenter bitmap, which means we've recieved all bitmap MMR chunks and
@@ -164,10 +346,13 @@ fn test_pibd_copy_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &
 			if let Err(e) = desegmenter.add_output_segment(output_segment, None) {
 				panic!("Unable to add output segment: {}", e);
 			}
-		}
+			if let Err(e) = desegmenter.apply_next_segments() {
+				panic!("Unable to apply output segment: {}", e);
+			}
+		}*/
 
 		// PROOFS  - Read + Validate
-		let identifier_iter = SegmentIdentifier::traversal_iter(
+		/*let identifier_iter = SegmentIdentifier::traversal_iter(
 			horizon_header.output_mmr_size,
 			target_segment_height,
 		);
@@ -200,6 +385,7 @@ fn test_pibd_copy_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir: &
 
 		let dest_txhashset = dest_chain.txhashset();
 		debug!("Dest TxHashset Roots: {:?}", dest_txhashset.read().roots());
+		*/
 	}
 }
 
@@ -214,24 +400,42 @@ fn test_pibd_copy_sample() {
 	let src_root_dir = format!("./tests/test_data/chain_raw");
 	let dest_root_dir = format!("./tests/test_output/.segment_copy");
 	clean_output_dir(&dest_root_dir);
-	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir);
+	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir, None);
 	let src_root_dir = format!("./tests/test_data/chain_compacted");
 	clean_output_dir(&dest_root_dir);
-	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir);
+	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir, None);
 	clean_output_dir(&dest_root_dir);
 }
 
 #[test]
-#[ignore]
+//#[ignore]
 // Note this test is intended to be run manually, as testing the copy of an
 // entire live chain is beyond the capability of current CI
 // As above, but run on a real instance of a chain pointed where you like
 fn test_pibd_copy_real() {
 	util::init_test_logger();
+	// If set, just copy headers from source to target template dir and exit
+	// Used to set up a chain state simulating the start of PIBD to continue manual testing
+	let copy_headers_to_template = false;
+
 	// if testing against a real chain, insert location here
-	let src_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/chain_data");
-	let dest_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/.chain_data_copy");
-	clean_output_dir(&dest_root_dir);
-	test_pibd_copy_impl(false, &src_root_dir, &dest_root_dir);
-	clean_output_dir(&dest_root_dir);
+	let src_root_dir = format!("/home/yeastplume/Projects/grin-project/servers/sync-1/chain_data");
+	let dest_template_dir =
+		format!("/home/yeastplume/Projects/grin-project/servers/sync-1/chain_data_headers_applied");
+	let dest_root_dir =
+		format!("/home/yeastplume/Projects/grin-project/servers/sync-1/chain_data_copy");
+	if copy_headers_to_template {
+		clean_output_dir(&dest_template_dir);
+		test_pibd_copy_impl(false, &src_root_dir, &dest_template_dir, None);
+	} else {
+		clean_output_dir(&dest_root_dir);
+		test_pibd_copy_impl(
+			false,
+			&src_root_dir,
+			&dest_root_dir,
+			Some(&dest_template_dir),
+		);
+	}
+
+	//clean_output_dir(&dest_root_dir);
 }

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -33,6 +33,9 @@ pub trait Backend<T: PMMRable> {
 	/// This allows us to append an existing pruned subtree directly without the underlying leaf nodes.
 	fn append_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String>;
 
+	/// Append a single hash to the pmmr
+	fn append_hash(&mut self, hash: Hash) -> Result<(), String>;
+
 	/// Rewind the backend state to a previous position, as if all append
 	/// operations after that had been canceled. Expects a position in the PMMR
 	/// to rewind to as well as bitmaps representing the positions added and

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -243,9 +243,37 @@ where
 
 	/// Push a pruned subtree into the PMMR
 	pub fn push_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
-		self.backend.append_pruned_subtree(hash, pos0)?;
-		self.size = crate::core::pmmr::round_up_to_leaf_pos(pos0);
-		debug!("Hash at {} is: {:?}", pos0, self.backend.get_hash(pos0));
+		self.backend.append_pruned_subtree(hash, pos0);
+		self.size = pos0 + 1;
+
+		let mut pos = pos0;
+		let mut current_hash = hash;
+
+		let (peak_map, _) = peak_map_height(pos);
+
+		// hash with all immediately preceding peaks, as indicated by peak map
+		let mut peak = 1;
+
+		while (peak_map & peak) != 0 {
+			let (parent, sibling) = family(pos);
+			peak *= 2;
+			if sibling > pos {
+				// is right sibling, abort
+				continue;
+			}
+			let left_hash = self
+				.backend
+				.get_hash(sibling)
+				.ok_or("missing left sibling in tree, should not have been pruned")?;
+			pos = parent;
+			current_hash = (left_hash, current_hash).hash_with_index(parent);
+			debug!("adding hash at {}, {}", pos, current_hash);
+			self.backend.append_hash(current_hash)?;
+		}
+
+		//self.backend.append_pruned_subtree(current_hash, pos)?;
+
+		self.size = crate::core::pmmr::round_up_to_leaf_pos(pos);
 		Ok(())
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -245,6 +245,7 @@ where
 	pub fn push_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
 		self.backend.append_pruned_subtree(hash, pos0)?;
 		self.size = crate::core::pmmr::round_up_to_leaf_pos(pos0);
+		debug!("Hash at {} is: {:?}", pos0, self.backend.get_hash(pos0));
 		Ok(())
 	}
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -241,6 +241,13 @@ where
 		Ok(leaf_pos)
 	}
 
+	/// Push a pruned subtree into the PMMR
+	pub fn push_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
+		self.backend.append_pruned_subtree(hash, pos0)?;
+		self.size = crate::core::pmmr::round_up_to_leaf_pos(pos0);
+		Ok(())
+	}
+
 	/// Saves a snapshot of the MMR tagged with the block hash.
 	/// Specifically - snapshots the utxo file as we need this rewound before
 	/// sending the txhashset zip file to another node for fast-sync.
@@ -323,15 +330,15 @@ where
 				if m >= sz {
 					break;
 				}
-				idx.push_str(&format!("{:>8} ", m + 1));
+				idx.push_str(&format!("{:>8} ", m));
 				let ohs = self.get_hash(m);
 				match ohs {
 					Some(hs) => hashes.push_str(&format!("{} ", hs)),
 					None => hashes.push_str(&format!("{:>8} ", "??")),
 				}
 			}
-			trace!("{}", idx);
-			trace!("{}", hashes);
+			debug!("{}", idx);
+			debug!("{}", hashes);
 		}
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -47,6 +47,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
+	fn append_hash(&mut self, _hash: Hash) -> Result<(), String> {
+		unimplemented!()
+	}
+
 	fn get_hash(&self, pos0: u64) -> Option<Hash> {
 		if self.removed.contains(&pos0) {
 			None

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -623,7 +623,7 @@ where
 		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_output_segment(segment, Some(bitmap_root));
 			if let Err(e) = res {
-				debug!(
+				error!(
 					"Validation of incoming output segment failed: {:?}, reason: {}",
 					identifier, e
 				);
@@ -639,9 +639,16 @@ where
 		segment: Segment<RangeProof>,
 	) -> Result<bool, chain::Error> {
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let desegmenter = self.chain().desegmenter(&archive_header)?;
-		if let Some(d) = desegmenter.write().as_ref() {
-			d.add_rangeproof_segment(segment)?;
+		let identifier = segment.identifier().clone();
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+			let res = d.add_rangeproof_segment(segment);
+			if let Err(e) = res {
+				error!(
+					"Validation of incoming rangeproof segment failed: {:?}, reason: {}",
+					identifier, e
+				);
+				return Err(e);
+			}
 		}
 		Ok(true)
 	}
@@ -652,9 +659,16 @@ where
 		segment: Segment<TxKernel>,
 	) -> Result<bool, chain::Error> {
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let desegmenter = self.chain().desegmenter(&archive_header)?;
-		if let Some(d) = desegmenter.write().as_ref() {
-			d.add_kernel_segment(segment)?;
+		let identifier = segment.identifier().clone();
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+			let res = d.add_kernel_segment(segment);
+			if let Err(e) = res {
+				error!(
+					"Validation of incoming rangeproof segment failed: {:?}, reason: {}",
+					identifier, e
+				);
+				return Err(e);
+			}
 		}
 		Ok(true)
 	}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -89,6 +89,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	// Supports appending a pruned subtree (single root hash) to an existing hash file.
 	// Update the prune_list "shift cache" to reflect the new pruned leaf pos in the subtree.
 	fn append_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
+		debug!("Append pruned subtree, add {} at position {}", hash, pos0);
 		if !self.prunable {
 			return Err("Not prunable, cannot append pruned subtree.".into());
 		}

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -89,7 +89,6 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	// Supports appending a pruned subtree (single root hash) to an existing hash file.
 	// Update the prune_list "shift cache" to reflect the new pruned leaf pos in the subtree.
 	fn append_pruned_subtree(&mut self, hash: Hash, pos0: u64) -> Result<(), String> {
-		debug!("Append pruned subtree, add {} at position {}", hash, pos0);
 		if !self.prunable {
 			return Err("Not prunable, cannot append pruned subtree.".into());
 		}
@@ -100,6 +99,13 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 		self.prune_list.append(pos0);
 
+		Ok(())
+	}
+
+	fn append_hash(&mut self, hash: Hash) -> Result<(), String> {
+		self.hash_file
+			.append(&hash)
+			.map_err(|e| format!("Failed to append hash to file. {}", e))?;
 		Ok(())
 	}
 


### PR DESCRIPTION
This PR is focused on reconstructing txhashset PMMRs from segment data. Txhashset reconstruction via segments is now in its initially working state, with next steps being to finish hooking up desegmenter functionality to the sync process. (Note that sync will never still never exit the PIBD stage of sync, that's for the next PR.)

* Add `push_pruned_subtree` to core/pmmr, which pushes a given hash representing a fully-pruned subtree to a pmmr. This function then calculates all needed hashes up to the leftmost parent and moves the mmr size to the next available leaf position.
* Add functions to `TxHashset` that apply segments to the appropriate PMMRs. Note that when a pruned subtree is added, the `push_pruned_subtree` function above calculates all missing hashes and moves the pmmr size to the next leaf insertion position. These segment application functions then skip any intermediate hashes that have already been calculated, which means they're only attempting to push hashes that represent pruned subtrees.
* Add `append_hash` to pmmr backend to support the above
* Add `OrderedHashLeafNode` struct and supporting functions to sort lists of hashes and leaves from segments into insertion order.
* Additions to desegmenter to request and apply kernel and rangeproof segments. Note there's a lot of redundancy in these functions, but rust being rust refactoring them into more generic functions might be a bit of a project given the number of Traits involved. 
* Updates to `test_pibd_copy` to exercise all of the above manually on live chain data. Note this test is not intended to be run during CI but are meant to be triggered manually for development/debugging
