### PR TITLE
[PIBD_IMPL] Finalize PIBD download and move state to chain validation

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -383,27 +383,6 @@ impl Chain {
 		Err(ErrorKind::Orphan.into())
 	}
 
-	/// For PIBD, change reported sizes of PMMRs back to last inserted index
-	pub fn rewind_mmrs_to_last_inserted_leaves(
-		&self,
-		archive_header: &BlockHeader,
-	) -> Result<(), Error> {
-		let mut header_pmmr = self.header_pmmr.write();
-		let mut batch = self.store.batch()?;
-		let mut txhashset = self.txhashset.write();
-		txhashset::extending(
-			&mut header_pmmr,
-			&mut txhashset,
-			&mut batch,
-			|ext, _batch| {
-				let extension = &mut ext.extension;
-				extension.rewind_mmrs_to_last_inserted_leaves(archive_header)?;
-				Ok(())
-			},
-		)?;
-		Ok(())
-	}
-
 	/// Attempt to add a new block to the chain.
 	/// Returns true if it has been added to the longest chain
 	/// or false if it has added to a fork (or orphan?).

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -37,6 +37,7 @@ use crate::{
 	core::core::hash::{Hash, Hashed},
 	store::Batch,
 	txhashset::{ExtensionPair, HeaderExtension},
+	SyncState,
 };
 use grin_store::Error::NotFoundErr;
 use std::collections::HashMap;
@@ -891,6 +892,7 @@ impl Chain {
 	pub fn desegmenter(
 		&self,
 		archive_header: &BlockHeader,
+		sync_state: Arc<SyncState>,
 	) -> Result<Arc<RwLock<Option<Desegmenter>>>, Error> {
 		// Use our cached desegmenter if we have one and the associated header matches.
 		if let Some(d) = self.pibd_desegmenter.write().as_ref() {
@@ -905,7 +907,7 @@ impl Chain {
 		}
 		// TODO: (Check whether we can do this.. we *should* be able to modify this as the desegmenter
 		// is in flight and we cross a horizon boundary, but needs more thinking)
-		let desegmenter = self.init_desegmenter(archive_header)?;
+		let desegmenter = self.init_desegmenter(archive_header, sync_state)?;
 		let mut cache = self.pibd_desegmenter.write();
 		*cache = Some(desegmenter.clone());
 
@@ -915,7 +917,11 @@ impl Chain {
 	/// initialize a desegmenter, which is capable of extending the hashset by appending
 	/// PIBD segments of the three PMMR trees + Bitmap PMMR
 	/// header should be the same header as selected for the txhashset.zip archive
-	fn init_desegmenter(&self, header: &BlockHeader) -> Result<Desegmenter, Error> {
+	fn init_desegmenter(
+		&self,
+		header: &BlockHeader,
+		sync_state: Arc<SyncState>,
+	) -> Result<Desegmenter, Error> {
 		debug!(
 			"init_desegmenter: initializing new desegmenter for {} at {}",
 			header.hash(),
@@ -926,7 +932,9 @@ impl Chain {
 			self.txhashset(),
 			self.header_pmmr.clone(),
 			header.clone(),
+			self.genesis.clone(),
 			self.store.clone(),
+			sync_state,
 		))
 	}
 

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -468,7 +468,7 @@ impl Desegmenter {
 			}
 			// TODO: Fix, alternative approach, this is very inefficient
 			let mut output_identifier_iter = SegmentIdentifier::traversal_iter(
-				self.archive_header.output_mmr_size + 1,
+				self.archive_header.output_mmr_size,
 				self.default_output_segment_height,
 			);
 
@@ -492,7 +492,7 @@ impl Desegmenter {
 			}
 
 			let mut rangeproof_identifier_iter = SegmentIdentifier::traversal_iter(
-				self.archive_header.output_mmr_size + 1,
+				self.archive_header.output_mmr_size,
 				self.default_rangeproof_segment_height,
 			);
 
@@ -521,8 +521,7 @@ impl Desegmenter {
 
 			while let Some(k_id) = kernel_identifier_iter.next() {
 				// Advance kernel iterator to next needed position
-				let (_first, last) =
-					k_id.segment_pos_range(self.archive_header.kernel_mmr_size + 1);
+				let (_first, last) = k_id.segment_pos_range(self.archive_header.kernel_mmr_size);
 				// Advance rangeproof iterator to next needed position
 				if last <= local_kernel_mmr_size {
 					continue;

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -184,9 +184,18 @@ impl Desegmenter {
 				local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
 			}
 
-			debug!("Output MMR Size: {}", local_output_mmr_size);
-			debug!("Rangeproof MMR Size: {}", local_rangeproof_mmr_size);
-			debug!("Kernel MMR Size: {}", local_kernel_mmr_size);
+			trace!(
+				"Desegmenter Validation: Output MMR Size: {}",
+				local_output_mmr_size
+			);
+			trace!(
+				"Desegmenter Validation: Rangeproof MMR Size: {}",
+				local_rangeproof_mmr_size
+			);
+			trace!(
+				"Desegmenter Validation: Kernel MMR Size: {}",
+				local_kernel_mmr_size
+			);
 
 			// Find latest 'complete' header.
 			// First take lesser of rangeproof and output mmr sizes
@@ -205,7 +214,10 @@ impl Desegmenter {
 				);
 				if let Some(h) = res {
 					latest_block_height = h.height;
-					debug!("PIBD Desegmenter Validation Loop: Latest block is: {:?}", h);
+					debug!(
+						"PIBD Desegmenter Validation Loop: PMMRs complete up to block {}: {:?}",
+						h.height, h
+					);
 					// TODO: 'In-flight' validation. At the moment the entire tree
 					// will be presented for validation after all segments are downloaded
 					// TODO: Unwraps
@@ -213,7 +225,6 @@ impl Desegmenter {
 					let batch = store.batch().unwrap();
 					batch.save_pibd_head(&tip).unwrap();
 					batch.commit().unwrap();
-					debug!("Archive Header is: {:?}", header_head);
 					if h == header_head {
 						// get out of this loop and move on to validation
 						break;
@@ -255,6 +266,13 @@ impl Desegmenter {
 			let txhashset = txhashset.read();
 			txhashset.roots().validate(header_head)?;
 		}
+
+		//debug!("desegmenter validation: compacting");
+		/*{
+			let mut txhashset = txhashset.write();
+			let batch = store.batch()?;
+			txhashset.compact(header_head, &batch)?;
+		}*/
 
 		status.on_setup();
 

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -301,6 +301,7 @@ impl Desegmenter {
 				&mut batch,
 				|ext, batch| {
 					let extension = &mut ext.extension;
+					extension.rewind(&header_head, batch)?;
 
 					// Validate the extension, generating the utxo_sum and kernel_sum.
 					// Full validation, including rangeproofs and kernel signature verification.

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1624,22 +1624,35 @@ impl<'a> Extension<'a> {
 		Ok(affected_pos)
 	}
 
-	/// Rewind MMRs to ensure they're at the position of the last inserted output
-	pub fn rewind_mmrs_to_last_inserted_leaves(&mut self) -> Result<(), Error> {
+	/// Rewind MMRs slightly to resume pibd
+	pub fn rewind_mmrs_to_last_inserted_leaves(
+		&mut self,
+		archive_header: &BlockHeader,
+	) -> Result<(), Error> {
 		let bitmap: Bitmap = Bitmap::create();
 		// TODO: Unwrap
-		let output_pos = pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.output_pmmr.size - 1));
-		self.output_pmmr
-			.rewind(output_pos, &bitmap)
-			.map_err(&ErrorKind::TxHashSetErr)?;
-		let rp_pos = pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.rproof_pmmr.size - 1));
-		self.rproof_pmmr
-			.rewind(rp_pos, &bitmap)
-			.map_err(&ErrorKind::TxHashSetErr)?;
-		let kernel_pos = pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.kernel_pmmr.size - 1));
-		self.kernel_pmmr
-			.rewind(kernel_pos, &bitmap)
-			.map_err(&ErrorKind::TxHashSetErr)?;
+		// TODO: There is some off-by-one thing somewhere that's making this necessary after resuming,
+		// investigate why
+		if archive_header.output_mmr_size > self.output_pmmr.size && self.output_pmmr.size > 1 {
+			let output_pos =
+				pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.output_pmmr.size - 1));
+			self.output_pmmr
+				.rewind(output_pos, &bitmap)
+				.map_err(&ErrorKind::TxHashSetErr)?;
+		}
+		if archive_header.output_mmr_size > self.rproof_pmmr.size && self.output_pmmr.size > 1 {
+			let rp_pos = pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.rproof_pmmr.size - 1));
+			self.rproof_pmmr
+				.rewind(rp_pos, &bitmap)
+				.map_err(&ErrorKind::TxHashSetErr)?;
+		}
+		if archive_header.kernel_mmr_size > self.kernel_pmmr.size && self.kernel_pmmr.size > 1 {
+			let kernel_pos =
+				pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.kernel_pmmr.size - 1));
+			self.kernel_pmmr
+				.rewind(kernel_pos, &bitmap)
+				.map_err(&ErrorKind::TxHashSetErr)?;
+		}
 		Ok(())
 	}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1642,38 +1642,6 @@ impl<'a> Extension<'a> {
 		Ok(affected_pos)
 	}
 
-	/// Rewind MMRs slightly to resume pibd
-	pub fn rewind_mmrs_to_last_inserted_leaves(
-		&mut self,
-		archive_header: &BlockHeader,
-	) -> Result<(), Error> {
-		let bitmap: Bitmap = Bitmap::create();
-		// TODO: Unwrap
-		// TODO: There is some off-by-one thing somewhere that's making this necessary after resuming,
-		// investigate why
-		if archive_header.output_mmr_size > self.output_pmmr.size && self.output_pmmr.size > 1 {
-			let output_pos =
-				pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.output_pmmr.size - 1));
-			self.output_pmmr
-				.rewind(output_pos, &bitmap)
-				.map_err(&ErrorKind::TxHashSetErr)?;
-		}
-		if archive_header.output_mmr_size > self.rproof_pmmr.size && self.output_pmmr.size > 1 {
-			let rp_pos = pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.rproof_pmmr.size - 1));
-			self.rproof_pmmr
-				.rewind(rp_pos, &bitmap)
-				.map_err(&ErrorKind::TxHashSetErr)?;
-		}
-		if archive_header.kernel_mmr_size > self.kernel_pmmr.size && self.kernel_pmmr.size > 1 {
-			let kernel_pos =
-				pmmr::insertion_to_pmmr_index(pmmr::n_leaves(self.kernel_pmmr.size - 1));
-			self.kernel_pmmr
-				.rewind(kernel_pos, &bitmap)
-				.map_err(&ErrorKind::TxHashSetErr)?;
-		}
-		Ok(())
-	}
-
 	/// Rewinds the MMRs to the provided positions, given the output and
 	/// kernel pos we want to rewind to.
 	fn rewind_mmrs_to_pos(

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -860,7 +860,7 @@ where
 				trees.rproof_pmmr_h.backend.discard();
 				trees.kernel_pmmr_h.backend.discard();
 			} else {
-				debug!("Committing txhashset extension. sizes {:?}", sizes);
+				trace!("Committing txhashset extension. sizes {:?}", sizes);
 				child_batch.commit()?;
 				trees.output_pmmr_h.backend.sync()?;
 				trees.rproof_pmmr_h.backend.sync()?;

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1369,13 +1369,24 @@ impl<'a> Extension<'a> {
 		for insert in self.sort_pmmr_hashes_and_leaves(hash_pos, leaf_pos, Some(0)) {
 			match insert {
 				OrderedHashLeafNode::Hash(idx, pos0) => {
+					//self.output_pmmr.dump(false);
+					//debug!("Position: {}, Hash: {}", pos0, hashes[idx]);
 					if pos0 >= self.output_pmmr.size {
+						if self.output_pmmr.size == 1 {
+							// All initial outputs are spent up to this hash,
+							// Roll back the genesis output
+							self.output_pmmr
+								.rewind(0, &Bitmap::create())
+								.map_err(&ErrorKind::TxHashSetErr)?;
+						}
 						self.output_pmmr
 							.push_pruned_subtree(hashes[idx], pos0)
 							.map_err(&ErrorKind::TxHashSetErr)?;
 					}
 				}
 				OrderedHashLeafNode::Leaf(idx, pos0) => {
+					//self.output_pmmr.dump(false);
+					//debug!("Position: {}, Leaf Data: {:?}", pos0, leaf_data[idx]);
 					if pos0 == self.output_pmmr.size {
 						self.output_pmmr
 							.push(&leaf_data[idx])
@@ -1398,6 +1409,13 @@ impl<'a> Extension<'a> {
 			match insert {
 				OrderedHashLeafNode::Hash(idx, pos0) => {
 					if pos0 >= self.rproof_pmmr.size {
+						if self.rproof_pmmr.size == 1 {
+							// All initial outputs are spent up to this hash,
+							// Roll back the genesis output
+							self.rproof_pmmr
+								.rewind(0, &Bitmap::create())
+								.map_err(&ErrorKind::TxHashSetErr)?;
+						}
 						self.rproof_pmmr
 							.push_pruned_subtree(hashes[idx], pos0)
 							.map_err(&ErrorKind::TxHashSetErr)?;

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -127,15 +127,8 @@ pub trait Committed {
 		// Sum all input|output|overage commitments.
 		let utxo_sum = self.sum_commitments(overage)?;
 
-		debug!("UTXO SUM: {:?}", utxo_sum);
-
 		// Sum the kernel excesses accounting for the kernel offset.
 		let (kernel_sum, kernel_sum_plus_offset) = self.sum_kernel_excesses(&kernel_offset)?;
-
-		debug!(
-			"KERNEL SUM: {:?}, plus offset: {:?}",
-			kernel_sum, kernel_sum_plus_offset
-		);
 
 		if utxo_sum != kernel_sum_plus_offset {
 			return Err(Error::KernelSumMismatch);

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -127,8 +127,15 @@ pub trait Committed {
 		// Sum all input|output|overage commitments.
 		let utxo_sum = self.sum_commitments(overage)?;
 
+		debug!("UTXO SUM: {:?}", utxo_sum);
+
 		// Sum the kernel excesses accounting for the kernel offset.
 		let (kernel_sum, kernel_sum_plus_offset) = self.sum_kernel_excesses(&kernel_offset)?;
+
+		debug!(
+			"KERNEL SUM: {:?}, plus offset: {:?}",
+			kernel_sum, kernel_sum_plus_offset
+		);
 
 		if utxo_sum != kernel_sum_plus_offset {
 			return Err(Error::KernelSumMismatch);

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -78,6 +78,9 @@ pub trait Backend<T: PMMRable> {
 	/// triggered removal).
 	fn remove(&mut self, position: u64) -> Result<(), String>;
 
+	/// Remove a leaf from the leaf set
+	fn remove_from_leaf_set(&mut self, pos0: u64);
+
 	/// Release underlying datafiles and locks
 	fn release_files(&mut self);
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -270,9 +270,14 @@ where
 			self.backend.append_hash(current_hash)?;
 		}
 
-		// Round size up to next leaf
+		// Round size up to next leaf, ready for insertion
 		self.size = crate::core::pmmr::round_up_to_leaf_pos(pos);
 		Ok(())
+	}
+
+	/// Remove the specified position from the leaf set
+	pub fn remove_from_leaf_set(&mut self, pos0: u64) {
+		self.backend.remove_from_leaf_set(pos0);
 	}
 
 	/// Saves a snapshot of the MMR tagged with the block hash.

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -188,12 +188,12 @@ impl<T> Segment<T> {
 	}
 
 	/// Maximum number of leaves in a segment, given by `2**height`
-	fn segment_capacity(&self) -> u64 {
+	fn _segment_capacity(&self) -> u64 {
 		self.identifier.segment_capacity()
 	}
 
 	/// Offset (in leaf idx) of first leaf in the segment
-	fn leaf_offset(&self) -> u64 {
+	fn _leaf_offset(&self) -> u64 {
 		self.identifier.leaf_offset()
 	}
 

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -115,6 +115,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		Ok(())
 	}
 
+	fn remove_from_leaf_set(&mut self, _pos0: u64) {
+		unimplemented!()
+	}
+
 	fn rewind(&mut self, position: u64, _rewind_rm_pos: &Bitmap) -> Result<(), String> {
 		if let Some(data) = &mut self.data {
 			let idx = pmmr::n_leaves(position);

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -587,7 +587,12 @@ where
 		// has changed (perhaps not here, NB this has to go somewhere)
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
-		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+		if let Some(d) = self
+			.chain()
+			.desegmenter(&archive_header, self.sync_state.clone())?
+			.write()
+			.as_mut()
+		{
 			let res = d.add_bitmap_segment(segment, output_root);
 			if let Err(e) = res {
 				debug!(
@@ -620,7 +625,12 @@ where
 		});
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
-		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+		if let Some(d) = self
+			.chain()
+			.desegmenter(&archive_header, self.sync_state.clone())?
+			.write()
+			.as_mut()
+		{
 			let res = d.add_output_segment(segment, Some(bitmap_root));
 			if let Err(e) = res {
 				error!(
@@ -645,7 +655,12 @@ where
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
-		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+		if let Some(d) = self
+			.chain()
+			.desegmenter(&archive_header, self.sync_state.clone())?
+			.write()
+			.as_mut()
+		{
 			let res = d.add_rangeproof_segment(segment);
 			if let Err(e) = res {
 				error!(
@@ -670,7 +685,12 @@ where
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
-		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
+		if let Some(d) = self
+			.chain()
+			.desegmenter(&archive_header, self.sync_state.clone())?
+			.write()
+			.as_mut()
+		{
 			let res = d.add_kernel_segment(segment);
 			if let Err(e) = res {
 				error!(

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -134,12 +134,24 @@ impl StateSync {
 						.update(SyncStatus::TxHashsetPibd { aborted: false });
 					let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 					let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
+
+					// TODO: Find out why this needs to be called
+					if let Err(e) = self
+						.chain
+						.rewind_mmrs_to_last_inserted_leaves(&archive_header)
+					{
+						self.sync_state
+							.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into());
+					}
+
 					if let Some(d) = desegmenter.read().as_ref() {
 						d.launch_validation_thread()
 					};
 				}
-				// Continue our PIBD process
-				self.continue_pibd();
+				// Continue our PIBD process (which returns true if all segments are in)
+				if self.continue_pibd() {
+					return false;
+				}
 			} else {
 				let (go, download_timeout) = self.state_sync_due();
 
@@ -172,7 +184,9 @@ impl StateSync {
 		true
 	}
 
-	fn continue_pibd(&mut self) {
+	/// Continue the PIBD process, returning true if the desegmenter is reporting
+	/// that the process is done
+	fn continue_pibd(&mut self) -> bool {
 		// Check the state of our chain to figure out what we should be requesting next
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
@@ -192,6 +206,15 @@ impl StateSync {
 		// requests we want to send to peers
 		let mut next_segment_ids = vec![];
 		if let Some(d) = desegmenter.write().as_mut() {
+			if d.is_complete() {
+				// Ensure MMR sizes are correct
+				/*if let Err(e) = self.chain.rewind_mmrs_to_last_inserted_leaves() {
+					self
+						.sync_state
+						.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into());
+				}*/
+				return true;
+			}
 			// Figure out the next segments we need
 			// (12 is divisible by 3, to try and evenly spread the requests among the 3
 			// main pmmrs. Bitmaps segments will always be requested first)
@@ -253,6 +276,7 @@ impl StateSync {
 				self.sync_state.add_pibd_segment(seg_id);
 			}
 		}
+		false
 	}
 
 	fn request_state(&self, header_head: &chain::Tip) -> Result<Arc<Peer>, p2p::Error> {

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -138,15 +138,6 @@ impl StateSync {
 						.desegmenter(&archive_header, self.sync_state.clone())
 						.unwrap();
 
-					// TODO: Find out why this needs to be called
-					if let Err(e) = self
-						.chain
-						.rewind_mmrs_to_last_inserted_leaves(&archive_header)
-					{
-						self.sync_state
-							.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into());
-					}
-
 					if let Some(d) = desegmenter.read().as_ref() {
 						d.launch_validation_thread()
 					};

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -83,6 +83,7 @@ impl StateSync {
 				// Only on testing chains for now
 				if global::get_chain_type() != global::ChainTypes::Mainnet {
 					true
+				//false
 				} else {
 					false
 				}
@@ -204,12 +205,6 @@ impl StateSync {
 		let mut next_segment_ids = vec![];
 		if let Some(d) = desegmenter.write().as_mut() {
 			if d.is_complete() {
-				// Ensure MMR sizes are correct
-				/*if let Err(e) = self.chain.rewind_mmrs_to_last_inserted_leaves() {
-					self
-						.sync_state
-						.set_sync_error(chain::ErrorKind::SyncError(format!("{:?}", e)).into());
-				}*/
 				return true;
 			}
 			// Figure out the next segments we need

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -133,7 +133,10 @@ impl StateSync {
 					self.sync_state
 						.update(SyncStatus::TxHashsetPibd { aborted: false });
 					let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
-					let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
+					let desegmenter = self
+						.chain
+						.desegmenter(&archive_header, self.sync_state.clone())
+						.unwrap();
 
 					// TODO: Find out why this needs to be called
 					if let Err(e) = self
@@ -189,7 +192,10 @@ impl StateSync {
 	fn continue_pibd(&mut self) -> bool {
 		// Check the state of our chain to figure out what we should be requesting next
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
-		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
+		let desegmenter = self
+			.chain
+			.desegmenter(&archive_header, self.sync_state.clone())
+			.unwrap();
 
 		// Apply segments... TODO: figure out how this should be called, might
 		// need to be a separate thread.

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -156,6 +156,11 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		self.get_data_from_file(pos0)
 	}
 
+	/// Remove leaf from leaf set
+	fn remove_from_leaf_set(&mut self, pos0: u64) {
+		self.leaf_set.remove(pos0);
+	}
+
 	/// Returns an iterator over all the leaf positions.
 	/// for a prunable PMMR this is an iterator over the leaf_set bitmap.
 	/// For a non-prunable PMMR this is *all* leaves (this is not yet implemented).


### PR DESCRIPTION
As of this PR, the node is able to sync itself fully via PIBD, but only tested on a closed local network under ideal conditions. Note there's very little error handling or retry happening at the moment, and no stats on the progress are output to the TUI. (This will be the focus of the next few PRs)

Specific changes:

* Pass sync_state into desegmenter to allow for tui reporting + progress updates from validation thread
* Add validation logic into desegmenter validation thread. Note there is a lot of copied code here from txhashset validation, however this keeps the logic independent from txhashset and will allow validation to be better integrated into the pibd process over time (e.g. validating while downloading is still going on)
* Ensure genesis-related entries are removed from pmmrs when they don't exist in the hash set
* remove extension rewind function on resume (root cause of issue was related to genesis leaves above)
* Ensure spent but unpruned outputs passed within pibd segments are removed from the underlying leaf set
