### PR TITLE
[PIBD_IMPL] PIBD Stats + Retry on validation errors

### DIFF
--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -81,7 +81,7 @@ impl ChainResetHandler {
 	pub fn reset_chain_head(&self, hash: Hash) -> Result<(), Error> {
 		let chain = w(&self.chain)?;
 		let header = chain.get_block_header(&hash)?;
-		chain.reset_chain_head(&header)?;
+		chain.reset_chain_head(&header, true)?;
 
 		// Reset the sync status and clear out any sync error.
 		w(&self.sync_state)?.reset();

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -267,6 +267,20 @@ impl Chain {
 		Ok(())
 	}
 
+	/// Reset prune lists (when PIBD resets)
+	pub fn reset_prune_lists(&self) -> Result<(), Error> {
+		let mut header_pmmr = self.header_pmmr.write();
+		let mut txhashset = self.txhashset.write();
+		let mut batch = self.store.batch()?;
+
+		txhashset::extending(&mut header_pmmr, &mut txhashset, &mut batch, |ext, _| {
+			let extension = &mut ext.extension;
+			extension.reset_prune_lists();
+			Ok(())
+		})?;
+		Ok(())
+	}
+
 	/// Reset PIBD head
 	pub fn reset_pibd_head(&self) -> Result<(), Error> {
 		let batch = self.store.batch()?;

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -121,6 +121,7 @@ impl Desegmenter {
 		self.bitmap_mmr_size = 0;
 		self.bitmap_cache = None;
 		self.bitmap_accumulator = BitmapAccumulator::new();
+		self.calc_bitmap_mmr_sizes();
 	}
 
 	/// Return reference to the header used for validation
@@ -253,18 +254,18 @@ impl Desegmenter {
 		}
 
 		// If all done, kick off validation, setting error state if necessary
-		/*if let Err(e) = Desegmenter::validate_complete_state(
+		if let Err(e) = Desegmenter::validate_complete_state(
 			txhashset,
 			store,
 			header_pmmr,
 			&header_head,
 			genesis,
 			status.clone(),
-		) {*/
-		//error!("Error validating pibd hashset: {}", e);
-		status.update_pibd_progress(false, true, latest_block_height, header_head.height);
-		/*}
-		stop_state.stop();*/
+		) {
+			error!("Error validating pibd hashset: {}", e);
+			status.update_pibd_progress(false, true, latest_block_height, header_head.height);
+		}
+		stop_state.stop();
 	}
 
 	/// TODO: This is largely copied from chain.rs txhashset_write and related functions,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1201,6 +1201,12 @@ impl<'a> Extension<'a> {
 		self.rproof_pmmr.readonly_pmmr()
 	}
 
+	/// Reset prune lists
+	pub fn reset_prune_lists(&mut self) {
+		self.output_pmmr.reset_prune_list();
+		self.rproof_pmmr.reset_prune_list();
+	}
+
 	/// Apply a new block to the current txhashet extension (output, rangeproof, kernel MMRs).
 	/// Returns a vec of commit_pos representing the pos and height of the outputs spent
 	/// by this block.

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -63,6 +63,13 @@ pub enum SyncStatus {
 		/// Whether the syncer has determined there's not enough
 		/// data to continue via PIBD
 		aborted: bool,
+		/// whether we got an error anywhere (in which case restart the process)
+		errored: bool,
+		/// 'height', i.e. last 'block' for which there is complete
+		/// pmmr data
+		completed_to_height: u64,
+		/// Total 'height' needed
+		required_height: u64,
 	},
 	/// Downloading the various txhashsets
 	TxHashsetDownload(TxHashsetDownloadStats),
@@ -215,6 +222,22 @@ impl SyncState {
 	/// Update txhashset downloading progress
 	pub fn update_txhashset_download(&self, stats: TxHashsetDownloadStats) {
 		*self.current.write() = SyncStatus::TxHashsetDownload(stats);
+	}
+
+	/// Update PIBD progress
+	pub fn update_pibd_progress(
+		&self,
+		aborted: bool,
+		errored: bool,
+		completed_to_height: u64,
+		required_height: u64,
+	) {
+		*self.current.write() = SyncStatus::TxHashsetPibd {
+			aborted,
+			errored,
+			completed_to_height,
+			required_height,
+		};
 	}
 
 	/// Update PIBD segment list

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -84,6 +84,9 @@ pub trait Backend<T: PMMRable> {
 	/// Release underlying datafiles and locks
 	fn release_files(&mut self);
 
+	/// Reset prune list, used when PIBD is reset
+	fn reset_prune_list(&mut self);
+
 	/// Saves a snapshot of the rewound utxo file with the block hash as
 	/// filename suffix. We need this when sending a txhashset zip file to a
 	/// node for fast sync.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -275,6 +275,11 @@ where
 		Ok(())
 	}
 
+	/// Reset prune list
+	pub fn reset_prune_list(&mut self) {
+		self.backend.reset_prune_list();
+	}
+
 	/// Remove the specified position from the leaf set
 	pub fn remove_from_leaf_set(&mut self, pos0: u64) {
 		self.backend.remove_from_leaf_set(pos0);

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -119,6 +119,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
+	fn reset_prune_list(&mut self) {
+		unimplemented!()
+	}
+
 	fn rewind(&mut self, position: u64, _rewind_rm_pos: &Bitmap) -> Result<(), String> {
 		if let Some(data) = &mut self.data {
 			let idx = pmmr::n_leaves(position);

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -595,7 +595,7 @@ where
 		{
 			let res = d.add_bitmap_segment(segment, output_root);
 			if let Err(e) = res {
-				debug!(
+				error!(
 					"Validation of incoming bitmap segment failed: {:?}, reason: {}",
 					identifier, e
 				);

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -89,6 +89,31 @@ impl StateSync {
 				}
 			};
 
+		// Check whether we've errored and should restart pibd
+		if using_pibd {
+			if let SyncStatus::TxHashsetPibd { errored: true, .. } = self.sync_state.status() {
+				let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
+				error!("PIBD Reported Failure - Restarting Sync");
+				// reset desegmenter state
+				let desegmenter = self
+					.chain
+					.desegmenter(&archive_header, self.sync_state.clone())
+					.unwrap();
+
+				if let Some(d) = desegmenter.write().as_mut() {
+					d.reset();
+				};
+				if let Err(e) = self.chain.reset_chain_head(self.chain.genesis(), false) {
+					error!("pibd_sync restart: chain reset error = {}", e);
+				}
+				if let Err(e) = self.chain.reset_pibd_head() {
+					error!("pibd_sync restart: reset pibd_head error = {}", e);
+				}
+				self.sync_state.update_pibd_progress(false, false, 1, 1);
+				sync_need_restart = true;
+			}
+		}
+
 		// check peer connection status of this sync
 		if !using_pibd {
 			if let Some(ref peer) = self.state_sync_peer {
@@ -129,11 +154,14 @@ impl StateSync {
 		// run fast sync if applicable, normally only run one-time, except restart in error
 		if sync_need_restart || header_head.height == highest_height {
 			if using_pibd {
+				if sync_need_restart {
+					return true;
+				}
 				let (launch, _download_timeout) = self.state_sync_due();
 				if launch {
-					self.sync_state
-						.update(SyncStatus::TxHashsetPibd { aborted: false });
 					let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
+					self.sync_state
+						.update_pibd_progress(false, false, 1, archive_header.height);
 					let desegmenter = self
 						.chain
 						.desegmenter(&archive_header, self.sync_state.clone())
@@ -195,7 +223,9 @@ impl StateSync {
 			if let Some(d) = de.as_mut() {
 				let res = d.apply_next_segments();
 				if let Err(e) = res {
-					debug!("error applying segment, continuing: {}", e);
+					debug!("error applying segment: {}", e);
+					self.sync_state.update_pibd_progress(false, true, 1, 1);
+					return false;
 				}
 			}
 		}

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -109,6 +109,9 @@ impl StateSync {
 				if let Err(e) = self.chain.reset_pibd_head() {
 					error!("pibd_sync restart: reset pibd_head error = {}", e);
 				}
+				if let Err(e) = self.chain.reset_prune_lists() {
+					error!("pibd_sync restart: reset prune lists error = {}", e);
+				}
 				self.sync_state.update_pibd_progress(false, false, 1, 1);
 				sync_need_restart = true;
 			}

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -50,8 +50,21 @@ impl TUIStatusView {
 				};
 				Cow::Owned(format!("Sync step 1/7: Downloading headers: {}%", percent))
 			}
-			SyncStatus::TxHashsetPibd { .. } => {
-				Cow::Borrowed("Sync step 2/7: Performing PIBD Body Sync (experimental)")
+			SyncStatus::TxHashsetPibd {
+				aborted: _,
+				errored: _,
+				completed_to_height,
+				required_height,
+			} => {
+				let percent = if required_height == 0 {
+					0
+				} else {
+					completed_to_height * 100 / required_height
+				};
+				Cow::Owned(format!(
+					"Sync step 2/7: Downloading chain state - {} / {} Blocks - {}%",
+					completed_to_height, required_height, percent
+				))
 			}
 			SyncStatus::TxHashsetDownload(stat) => {
 				if stat.total_size > 0 {

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -229,6 +229,14 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		Ok(())
 	}
 
+	fn reset_prune_list(&mut self) {
+		let bitmap = Bitmap::create();
+		self.prune_list = PruneList::new(Some(self.data_dir.join(PMMR_PRUN_FILE)), bitmap);
+		if let Err(e) = self.prune_list.flush() {
+			error!("Flushing reset prune list: {}", e);
+		}
+	}
+
 	/// Remove by insertion position.
 	fn remove(&mut self, pos0: u64) -> Result<(), String> {
 		assert!(self.prunable, "Remove on non-prunable MMR");

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -129,21 +129,6 @@ impl PruneList {
 		Ok(())
 	}
 
-	/// Save the prune_list to disk, without temp file
-	pub fn flush_hard(&mut self) -> io::Result<()> {
-		// Run the optimization step on the bitmap.
-		self.bitmap.run_optimize();
-
-		// Write the updated bitmap file to disk.
-		if let Some(ref path) = self.path {
-			save_via_temp_file(path, ".tmp", |file| {
-				file.write_all(&self.bitmap.serialize())
-			})?;
-		}
-
-		Ok(())
-	}
-
 	/// Return the total shift from all entries in the prune_list.
 	/// This is the shift we need to account for when adding new entries to our PMMR.
 	pub fn get_total_shift(&self) -> u64 {

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -129,6 +129,21 @@ impl PruneList {
 		Ok(())
 	}
 
+	/// Save the prune_list to disk, without temp file
+	pub fn flush_hard(&mut self) -> io::Result<()> {
+		// Run the optimization step on the bitmap.
+		self.bitmap.run_optimize();
+
+		// Write the updated bitmap file to disk.
+		if let Some(ref path) = self.path {
+			save_via_temp_file(path, ".tmp", |file| {
+				file.write_all(&self.bitmap.serialize())
+			})?;
+		}
+
+		Ok(())
+	}
+
 	/// Return the total shift from all entries in the prune_list.
 	/// This is the shift we need to account for when adding new entries to our PMMR.
 	pub fn get_total_shift(&self) -> u64 {


### PR DESCRIPTION
Adds sync stats for use in TUI, and resets the chain body to genesis and restarts if an error is detected during validation. Note this does not yet cover all error conditions and it's still very possible for the pibd process to stall. However, I have been able to successfully sync a node to testnet after these changes.

* Update to show pibd progress stats in tui. Note it's currently showing the percentage as the number of complete 'blocks' represented by the current PIBD progress, which is probably not ideal (should discuss)
* add parameter to `reset_chain_head` to allow for only rolling back the body without rolling back headers
* Functions to clear out the prune list after a reset, which is currently not being rolled back on rewind for some reason. Note I'm not entirely happy with this approach, and the real fix of rewinding the prunelist properly should be done before this is deployed on mainnet. 
* Add error state to pibd state enum
* Function to reset state of desegmenter when an error is reported
* Reset chain, prune list and desegmenter when an error is reported.