### PR TITLE
[PIBD_IMPL] Update number of simultaneous peer requests for segments

### DIFF
--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -577,16 +577,11 @@ where
 			block_hash,
 			output_root
 		);
-		// Remove segment from outgoing list TODO: Where is the best place to
-		// do this?
-		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
-			segment_type: SegmentType::Bitmap,
-			identifier: segment.identifier(),
-		});
 		// TODO: Entire process needs to be restarted if the horizon block
 		// has changed (perhaps not here, NB this has to go somewhere)
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
+		let mut retval = Ok(true);
 		if let Some(d) = self
 			.chain()
 			.desegmenter(&archive_header, self.sync_state.clone())?
@@ -599,10 +594,15 @@ where
 					"Validation of incoming bitmap segment failed: {:?}, reason: {}",
 					identifier, e
 				);
-				return Err(e);
+				retval = Err(e);
 			}
 		}
-		Ok(true)
+		// Remove segment from outgoing list
+		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
+			segment_type: SegmentType::Bitmap,
+			identifier,
+		});
+		retval
 	}
 
 	fn receive_output_segment(
@@ -617,14 +617,9 @@ where
 			block_hash,
 			bitmap_root,
 		);
-		// Remove segment from outgoing list TODO: Where is the best place to
-		// do this?
-		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
-			segment_type: SegmentType::Output,
-			identifier: segment.identifier(),
-		});
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
+		let mut retval = Ok(true);
 		if let Some(d) = self
 			.chain()
 			.desegmenter(&archive_header, self.sync_state.clone())?
@@ -637,10 +632,15 @@ where
 					"Validation of incoming output segment failed: {:?}, reason: {}",
 					identifier, e
 				);
-				return Err(e);
+				retval = Err(e);
 			}
 		}
-		Ok(true)
+		// Remove segment from outgoing list
+		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
+			segment_type: SegmentType::Output,
+			identifier,
+		});
+		retval
 	}
 
 	fn receive_rangeproof_segment(
@@ -655,6 +655,7 @@ where
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
+		let mut retval = Ok(true);
 		if let Some(d) = self
 			.chain()
 			.desegmenter(&archive_header, self.sync_state.clone())?
@@ -667,10 +668,15 @@ where
 					"Validation of incoming rangeproof segment failed: {:?}, reason: {}",
 					identifier, e
 				);
-				return Err(e);
+				retval = Err(e);
 			}
 		}
-		Ok(true)
+		// Remove segment from outgoing list
+		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
+			segment_type: SegmentType::RangeProof,
+			identifier,
+		});
+		retval
 	}
 
 	fn receive_kernel_segment(
@@ -685,6 +691,7 @@ where
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
+		let mut retval = Ok(true);
 		if let Some(d) = self
 			.chain()
 			.desegmenter(&archive_header, self.sync_state.clone())?
@@ -697,10 +704,15 @@ where
 					"Validation of incoming rangeproof segment failed: {:?}, reason: {}",
 					identifier, e
 				);
-				return Err(e);
+				retval = Err(e);
 			}
 		}
-		Ok(true)
+		// Remove segment from outgoing list
+		self.sync_state.remove_pibd_segment(&SegmentTypeIdentifier {
+			segment_type: SegmentType::Kernel,
+			identifier,
+		});
+		retval
 	}
 }
 

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -243,7 +243,7 @@ impl StateSync {
 			// Figure out the next segments we need
 			// (12 is divisible by 3, to try and evenly spread the requests among the 3
 			// main pmmrs. Bitmaps segments will always be requested first)
-			next_segment_ids = d.next_desired_segments(12);
+			next_segment_ids = d.next_desired_segments(15);
 		}
 
 		// For each segment, pick a desirable peer and send message

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -271,34 +271,33 @@ impl StateSync {
 			});
 			trace!("Chosen peer is {:?}", peer);
 			if let Some(p) = peer {
-				match seg_id.segment_type {
-					SegmentType::Bitmap => p
-						.send_bitmap_segment_request(
-							archive_header.hash(),
-							seg_id.identifier.clone(),
-						)
-						.unwrap(),
-					SegmentType::Output => p
-						.send_output_segment_request(
-							archive_header.hash(),
-							seg_id.identifier.clone(),
-						)
-						.unwrap(),
-					SegmentType::RangeProof => p
-						.send_rangeproof_segment_request(
-							archive_header.hash(),
-							seg_id.identifier.clone(),
-						)
-						.unwrap(),
-					SegmentType::Kernel => p
-						.send_kernel_segment_request(
-							archive_header.hash(),
-							seg_id.identifier.clone(),
-						)
-						.unwrap(),
-				};
 				// add to list of segments that are being tracked
 				self.sync_state.add_pibd_segment(seg_id);
+				let res = match seg_id.segment_type {
+					SegmentType::Bitmap => p.send_bitmap_segment_request(
+						archive_header.hash(),
+						seg_id.identifier.clone(),
+					),
+					SegmentType::Output => p.send_output_segment_request(
+						archive_header.hash(),
+						seg_id.identifier.clone(),
+					),
+					SegmentType::RangeProof => p.send_rangeproof_segment_request(
+						archive_header.hash(),
+						seg_id.identifier.clone(),
+					),
+					SegmentType::Kernel => p.send_kernel_segment_request(
+						archive_header.hash(),
+						seg_id.identifier.clone(),
+					),
+				};
+				if let Err(e) = res {
+					info!(
+						"Error sending request to peer at {}, reason: {:?}",
+						p.info.addr, e
+					);
+					self.sync_state.remove_pibd_segment(seg_id);
+				}
 			}
 		}
 		false


### PR DESCRIPTION
* Change desegmenter request logic to request up to `max_segments \ 3` of the next required segments
* Remove segment from sync state's list of requested segments if message send to peer errors or times out
* Remove proof and kernel segment requests from sync state on receive
* Change max number of segments to request at once to 15

Note that the case where a message is successfully sent to a peer but no response is received is not yet handled (this will likely jam the entire process)