### PR TITLE
[PIBD_IMPL] Thread simplification + More TUI Updates + Stop State Propagation

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1082,7 +1082,7 @@ impl Chain {
 		txhashset_data: File,
 		status: &dyn TxHashsetWriteStatus,
 	) -> Result<bool, Error> {
-		status.on_setup();
+		status.on_setup(None, None);
 
 		// Initial check whether this txhashset is needed or not
 		let fork_point = self.fork_point()?;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -698,8 +698,14 @@ impl Chain {
 		// ensure the view is consistent.
 		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
 			self.rewind_and_apply_fork(&header, ext, batch)?;
-			ext.extension
-				.validate(&self.genesis, fast_validation, &NoStatus, &header)?;
+			ext.extension.validate(
+				&self.genesis,
+				fast_validation,
+				&NoStatus,
+				None,
+				None,
+				&header,
+			)?;
 			Ok(())
 		})
 	}
@@ -1145,7 +1151,7 @@ impl Chain {
 				// Validate the extension, generating the utxo_sum and kernel_sum.
 				// Full validation, including rangeproofs and kernel signature verification.
 				let (utxo_sum, kernel_sum) =
-					extension.validate(&self.genesis, false, status, &header)?;
+					extension.validate(&self.genesis, false, status, None, None, &header)?;
 
 				// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 				batch.save_block_sums(

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1082,7 +1082,7 @@ impl Chain {
 		txhashset_data: File,
 		status: &dyn TxHashsetWriteStatus,
 	) -> Result<bool, Error> {
-		status.on_setup(None, None);
+		status.on_setup(None, None, None, None);
 
 		// Initial check whether this txhashset is needed or not
 		let fork_point = self.fork_point()?;
@@ -1122,7 +1122,7 @@ impl Chain {
 
 			let header_pmmr = self.header_pmmr.read();
 			let batch = self.store.batch()?;
-			txhashset.verify_kernel_pos_index(&self.genesis, &header_pmmr, &batch)?;
+			txhashset.verify_kernel_pos_index(&self.genesis, &header_pmmr, &batch, None, None)?;
 		}
 
 		// all good, prepare a new batch and update all the required records

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -705,6 +705,7 @@ impl Chain {
 				None,
 				None,
 				&header,
+				None,
 			)?;
 			Ok(())
 		})
@@ -1151,7 +1152,7 @@ impl Chain {
 				// Validate the extension, generating the utxo_sum and kernel_sum.
 				// Full validation, including rangeproofs and kernel signature verification.
 				let (utxo_sum, kernel_sum) =
-					extension.validate(&self.genesis, false, status, None, None, &header)?;
+					extension.validate(&self.genesis, false, status, None, None, &header, None)?;
 
 				// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 				batch.save_block_sums(

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -188,7 +188,7 @@ impl Desegmenter {
 			if stop_state.is_stopped() {
 				break;
 			}
-			thread::sleep(Duration::from_millis(1000));
+			thread::sleep(Duration::from_millis(100));
 
 			trace!("In Desegmenter Validation Loop");
 			let local_output_mmr_size;
@@ -274,21 +274,27 @@ impl Desegmenter {
 			let mut txhashset = txhashset.write();
 			let batch = store.batch();
 			if let Ok(mut b) = batch {
-				txhashset::extending(&mut header_pmmr, &mut txhashset, &mut b, |ext, _batch| {
-					let extension = &mut ext.extension;
-					let res = extension
-						.progressive_validate(
-							stop_state.clone(),
-							last_validated_rangeproof_pos,
-							0,
-							1000,
-							0,
-						)
-						.unwrap_or((0, 0));
-					last_validated_rangeproof_pos = res.0;
-					last_validated_kernel_pos = res.1;
-					Ok(())
-				});
+				// TODO: Throw toys out of pram if validation doesn't succeed
+				let _res = txhashset::extending(
+					&mut header_pmmr,
+					&mut txhashset,
+					&mut b,
+					|ext, _batch| {
+						let extension = &mut ext.extension;
+						let res = extension
+							.progressive_validate(
+								stop_state.clone(),
+								last_validated_rangeproof_pos,
+								0,
+								1000,
+								0,
+							)
+							.unwrap_or((0, 0));
+						last_validated_rangeproof_pos = res.0;
+						last_validated_kernel_pos = res.1;
+						Ok(())
+					},
+				);
 			}
 
 			error!("LAST VALIDATED RP POS: {}", last_validated_rangeproof_pos);

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -16,8 +16,6 @@
 //! segmenter
 
 use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::{pmmr, pmmr::ReadablePMMR};
@@ -44,11 +42,8 @@ pub struct Desegmenter {
 	header_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
 	archive_header: BlockHeader,
 	store: Arc<store::ChainStore>,
-	sync_state: Arc<SyncState>,
 
 	genesis: BlockHeader,
-
-	validator_stop_state: Arc<StopState>,
 
 	default_bitmap_segment_height: u8,
 	default_output_segment_height: u8,
@@ -78,7 +73,6 @@ impl Desegmenter {
 		archive_header: BlockHeader,
 		genesis: BlockHeader,
 		store: Arc<store::ChainStore>,
-		sync_state: Arc<SyncState>,
 	) -> Desegmenter {
 		trace!("Creating new desegmenter");
 		let mut retval = Desegmenter {
@@ -86,9 +80,7 @@ impl Desegmenter {
 			header_pmmr,
 			archive_header,
 			store,
-			sync_state,
 			genesis,
-			validator_stop_state: Arc::new(StopState::new()),
 			bitmap_accumulator: BitmapAccumulator::new(),
 			default_bitmap_segment_height: 9,
 			default_output_segment_height: 11,
@@ -139,169 +131,75 @@ impl Desegmenter {
 		self.all_segments_complete
 	}
 
-	/// Launch a separate validation thread, which will update and validate the body head
-	/// as we go
-	pub fn launch_validation_thread(&mut self, stop_state: Arc<StopState>) {
-		self.validator_stop_state = stop_state.clone();
-		let txhashset = self.txhashset.clone();
-		let header_pmmr = self.header_pmmr.clone();
-		let store = self.store.clone();
-		let genesis = self.genesis.clone();
-		let status = self.sync_state.clone();
-		let desegmenter = Arc::new(RwLock::new(self.clone()));
-		let _ = thread::Builder::new()
-			.name("pibd-validation".to_string())
-			.spawn(move || {
-				Desegmenter::validation_loop(
-					stop_state,
-					txhashset,
-					store,
-					desegmenter,
-					header_pmmr,
-					genesis,
-					status,
-				);
-			});
-	}
-
-	/// Stop the validation loop
-	pub fn stop_validation_thread(&self) {
-		self.validator_stop_state.stop();
-	}
-
-	/// Validation loop
-	fn validation_loop(
-		stop_state: Arc<StopState>,
-		txhashset: Arc<RwLock<TxHashSet>>,
-		store: Arc<store::ChainStore>,
-		desegmenter: Arc<RwLock<Desegmenter>>,
-		header_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
-		genesis: BlockHeader,
-		status: Arc<SyncState>,
-	) {
+	/// Check progress, update status if needed, returns true if all required
+	/// segments are in place
+	pub fn check_progress(&self, status: Arc<SyncState>) -> bool {
 		let mut latest_block_height = 0;
-		let header_head = { desegmenter.read().header().clone() };
-		let mut completed_leaves = 0;
-		let mut last_validated_rangeproof_pos = 0;
-		let mut last_validated_kernel_pos = 0;
-		loop {
-			if stop_state.is_stopped() {
-				break;
-			}
-			thread::sleep(Duration::from_millis(100));
 
-			trace!("In Desegmenter Validation Loop");
-			let local_output_mmr_size;
-			let local_kernel_mmr_size;
-			let local_rangeproof_mmr_size;
-			{
-				let txhashset = txhashset.read();
-				local_output_mmr_size = txhashset.output_mmr_size();
-				local_kernel_mmr_size = txhashset.kernel_mmr_size();
-				local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
-			}
-
-			trace!(
-				"Desegmenter Validation: Output MMR Size: {}",
-				local_output_mmr_size
-			);
-			trace!(
-				"Desegmenter Validation: Rangeproof MMR Size: {}",
-				local_rangeproof_mmr_size
-			);
-			trace!(
-				"Desegmenter Validation: Kernel MMR Size: {}",
-				local_kernel_mmr_size
-			);
-
-			// going to try presenting PIBD progress as total leaves downloaded
-			// total segments probably doesn't make much sense since the segment
-			// sizes will be able to change over time, and representative block height
-			// can be too lopsided if one pmmr completes faster, so perhaps just
-			// use total leaves downloaded and display as a percentage
-			completed_leaves = pmmr::n_leaves(local_output_mmr_size)
-				+ pmmr::n_leaves(local_rangeproof_mmr_size)
-				+ pmmr::n_leaves(local_kernel_mmr_size);
-
-			// Find latest 'complete' header.
-			// First take lesser of rangeproof and output mmr sizes
-			let latest_output_size =
-				std::cmp::min(local_output_mmr_size, local_rangeproof_mmr_size);
-			// Find first header in which 'output_mmr_size' and 'kernel_mmr_size' are greater than
-			// given sizes
-
-			{
-				let header_pmmr = header_pmmr.read();
-				let res = header_pmmr.get_first_header_with(
-					latest_output_size,
-					local_kernel_mmr_size,
-					latest_block_height,
-					store.clone(),
-				);
-				if let Some(h) = res {
-					latest_block_height = h.height;
-					debug!(
-						"PIBD Desegmenter Validation Loop: PMMRs complete up to block {}: {:?}",
-						h.height, h
-					);
-					// TODO: 'In-flight' validation. At the moment the entire tree
-					// will be presented for validation after all segments are downloaded
-					// TODO: Unwraps
-					let tip = Tip::from_header(&h);
-					let batch = store.batch().unwrap();
-					batch.save_pibd_head(&tip).unwrap();
-					batch.commit().unwrap();
-
-					status.update_pibd_progress(
-						false,
-						false,
-						completed_leaves,
-						latest_block_height,
-						&header_head,
-					);
-					if local_kernel_mmr_size == header_head.kernel_mmr_size
-						&& local_output_mmr_size == header_head.output_mmr_size
-						&& local_rangeproof_mmr_size == header_head.output_mmr_size
-					{
-						// get out of this loop and move on to validation
-						break;
-					}
-				}
-			}
-
-			// TODO: Store kernel and output positions in DB to persist between invocations
-			let mut header_pmmr = header_pmmr.write();
-			let mut txhashset = txhashset.write();
-			let batch = store.batch();
-			if let Ok(mut b) = batch {
-				// TODO: Throw toys out of pram if validation doesn't succeed
-				let _res = txhashset::extending(
-					&mut header_pmmr,
-					&mut txhashset,
-					&mut b,
-					|ext, _batch| {
-						let extension = &mut ext.extension;
-						let res = extension
-							.progressive_validate(
-								stop_state.clone(),
-								last_validated_rangeproof_pos,
-								0,
-								1000,
-								0,
-							)
-							.unwrap_or((0, 0));
-						last_validated_rangeproof_pos = res.0;
-						last_validated_kernel_pos = res.1;
-						Ok(())
-					},
-				);
-			}
-
-			error!("LAST VALIDATED RP POS: {}", last_validated_rangeproof_pos);
+		let local_output_mmr_size;
+		let local_kernel_mmr_size;
+		let local_rangeproof_mmr_size;
+		{
+			let txhashset = self.txhashset.read();
+			local_output_mmr_size = txhashset.output_mmr_size();
+			local_kernel_mmr_size = txhashset.kernel_mmr_size();
+			local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
 		}
 
-		// If all done, kick off validation, setting error state if necessary
-		if let Err(e) = Desegmenter::validate_complete_state(
+		// going to try presenting PIBD progress as total leaves downloaded
+		// total segments probably doesn't make much sense since the segment
+		// sizes will be able to change over time, and representative block height
+		// can be too lopsided if one pmmr completes faster, so perhaps just
+		// use total leaves downloaded and display as a percentage
+		let completed_leaves = pmmr::n_leaves(local_output_mmr_size)
+			+ pmmr::n_leaves(local_rangeproof_mmr_size)
+			+ pmmr::n_leaves(local_kernel_mmr_size);
+
+		// Find latest 'complete' header.
+		// First take lesser of rangeproof and output mmr sizes
+		let latest_output_size = std::cmp::min(local_output_mmr_size, local_rangeproof_mmr_size);
+
+		// Find first header in which 'output_mmr_size' and 'kernel_mmr_size' are greater than
+		// given sizes
+
+		let res = {
+			let header_pmmr = self.header_pmmr.read();
+			header_pmmr.get_first_header_with(
+				latest_output_size,
+				local_kernel_mmr_size,
+				latest_block_height,
+				self.store.clone(),
+			)
+		};
+
+		if let Some(h) = res {
+			latest_block_height = h.height;
+
+			// TODO: Unwraps
+			let tip = Tip::from_header(&h);
+			let batch = self.store.batch().unwrap();
+			batch.save_pibd_head(&tip).unwrap();
+			batch.commit().unwrap();
+
+			status.update_pibd_progress(
+				false,
+				false,
+				completed_leaves,
+				latest_block_height,
+				&self.archive_header,
+			);
+			if local_kernel_mmr_size == self.archive_header.kernel_mmr_size
+				&& local_output_mmr_size == self.archive_header.output_mmr_size
+				&& local_rangeproof_mmr_size == self.archive_header.output_mmr_size
+			{
+				// All is complete
+				return true;
+			}
+		}
+
+		false
+
+		/*if let Err(e) = Desegmenter::validate_complete_state(
 			txhashset,
 			store,
 			header_pmmr,
@@ -320,7 +218,7 @@ impl Desegmenter {
 				&header_head,
 			);
 		}
-		stop_state.stop();
+		stop_state.stop();*/
 	}
 
 	/// TODO: This is largely copied from chain.rs txhashset_write and related functions,
@@ -328,30 +226,28 @@ impl Desegmenter {
 	/// segments are still being downloaded and applied. Current validation logic is all tied up
 	/// around unzipping, so re-developing this logic separate from the txhashset version
 	/// will to allow this to happen more cleanly
-	fn validate_complete_state(
-		txhashset: Arc<RwLock<TxHashSet>>,
-		store: Arc<store::ChainStore>,
-		header_pmmr: Arc<RwLock<txhashset::PMMRHandle<BlockHeader>>>,
-		header_head: &BlockHeader,
-		genesis: BlockHeader,
-		last_rangeproof_validation_pos: u64,
+	pub fn validate_complete_state(
+		&self,
 		status: Arc<SyncState>,
 		stop_state: Arc<StopState>,
 	) -> Result<(), Error> {
 		// Quick root check first:
 		{
-			let txhashset = txhashset.read();
-			txhashset.roots().validate(header_head)?;
+			let txhashset = self.txhashset.read();
+			txhashset.roots().validate(&self.archive_header)?;
 		}
 
 		status.on_setup();
 
+		// TODO: Keep track of this in the DB so we can pick up where we left off if needed
+		let last_rangeproof_validation_pos = 0;
+
 		// Validate kernel history
 		{
 			debug!("desegmenter validation: rewinding and validating kernel history (readonly)");
-			let txhashset = txhashset.read();
+			let txhashset = self.txhashset.read();
 			let mut count = 0;
-			let mut current = header_head.clone();
+			let mut current = self.archive_header.clone();
 			txhashset::rewindable_kernel_view(&txhashset, |view, batch| {
 				while current.height > 0 {
 					view.rewind(&current)?;
@@ -371,35 +267,35 @@ impl Desegmenter {
 		// Check NRD relative height rules for full kernel history.
 
 		{
-			let txhashset = txhashset.read();
-			let header_pmmr = header_pmmr.read();
-			let batch = store.batch()?;
-			txhashset.verify_kernel_pos_index(&genesis, &header_pmmr, &batch)?;
+			let txhashset = self.txhashset.read();
+			let header_pmmr = self.header_pmmr.read();
+			let batch = self.store.batch()?;
+			txhashset.verify_kernel_pos_index(&self.genesis, &header_pmmr, &batch)?;
 		}
 
 		// Prepare a new batch and update all the required records
 		{
 			debug!("desegmenter validation: rewinding a 2nd time (writeable)");
-			let mut txhashset = txhashset.write();
-			let mut header_pmmr = header_pmmr.write();
-			let mut batch = store.batch()?;
+			let mut txhashset = self.txhashset.write();
+			let mut header_pmmr = self.header_pmmr.write();
+			let mut batch = self.store.batch()?;
 			txhashset::extending(
 				&mut header_pmmr,
 				&mut txhashset,
 				&mut batch,
 				|ext, batch| {
 					let extension = &mut ext.extension;
-					extension.rewind(&header_head, batch)?;
+					extension.rewind(&self.archive_header, batch)?;
 
 					// Validate the extension, generating the utxo_sum and kernel_sum.
 					// Full validation, including rangeproofs and kernel signature verification.
 					let (utxo_sum, kernel_sum) = extension.validate(
-						&genesis,
+						&self.genesis,
 						false,
 						&*status,
 						Some(last_rangeproof_validation_pos),
 						None,
-						&header_head,
+						&self.archive_header,
 						Some(stop_state.clone()),
 					)?;
 
@@ -409,7 +305,7 @@ impl Desegmenter {
 
 					// Save the block_sums (utxo_sum, kernel_sum) to the db for use later.
 					batch.save_block_sums(
-						&header_head.hash(),
+						&self.archive_header.hash(),
 						BlockSums {
 							utxo_sum,
 							kernel_sum,
@@ -429,7 +325,7 @@ impl Desegmenter {
 
 			{
 				// Save the new head to the db and rebuild the header by height index.
-				let tip = Tip::from_header(&header_head);
+				let tip = Tip::from_header(&self.archive_header);
 				// TODO: Throw error
 				batch.save_body_head(&tip)?;
 

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -293,7 +293,6 @@ impl Desegmenter {
 		}
 
 		status.on_setup(None, None, None, None);
-
 		// Prepare a new batch and update all the required records
 		{
 			debug!("desegmenter validation: rewinding a 2nd time (writeable)");

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -83,6 +83,10 @@ pub enum SyncStatus {
 		headers: Option<u64>,
 		/// headers total
 		headers_total: Option<u64>,
+		/// kernel position portion
+		kernel_pos: Option<u64>,
+		/// total kernel position
+		kernel_pos_total: Option<u64>,
 	},
 	/// Validating the kernels
 	TxHashsetKernelsValidation {
@@ -319,10 +323,18 @@ impl SyncState {
 }
 
 impl TxHashsetWriteStatus for SyncState {
-	fn on_setup(&self, headers: Option<u64>, headers_total: Option<u64>) {
+	fn on_setup(
+		&self,
+		headers: Option<u64>,
+		headers_total: Option<u64>,
+		kernel_pos: Option<u64>,
+		kernel_pos_total: Option<u64>,
+	) {
 		self.update(SyncStatus::TxHashsetSetup {
 			headers,
 			headers_total,
+			kernel_pos,
+			kernel_pos_total,
 		});
 	}
 
@@ -550,7 +562,13 @@ pub trait ChainAdapter {
 /// those values as the processing progresses.
 pub trait TxHashsetWriteStatus {
 	/// First setup of the txhashset
-	fn on_setup(&self, headers: Option<u64>, header_total: Option<u64>);
+	fn on_setup(
+		&self,
+		headers: Option<u64>,
+		header_total: Option<u64>,
+		kernel_pos: Option<u64>,
+		kernel_pos_total: Option<u64>,
+	);
 	/// Starting kernel validation
 	fn on_validation_kernels(&self, kernels: u64, kernel_total: u64);
 	/// Starting rproof validation
@@ -565,7 +583,7 @@ pub trait TxHashsetWriteStatus {
 pub struct NoStatus;
 
 impl TxHashsetWriteStatus for NoStatus {
-	fn on_setup(&self, _hs: Option<u64>, _ht: Option<u64>) {}
+	fn on_setup(&self, _hs: Option<u64>, _ht: Option<u64>, _kp: Option<u64>, _kpt: Option<u64>) {}
 	fn on_validation_kernels(&self, _ks: u64, _kts: u64) {}
 	fn on_validation_rproofs(&self, _rs: u64, _rt: u64) {}
 	fn on_save(&self) {}

--- a/chain/tests/test_pibd_copy.rs
+++ b/chain/tests/test_pibd_copy.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::{fs, io};
 
 use crate::chain::txhashset::BitmapChunk;
-use crate::chain::types::{NoopAdapter, Options, SyncState};
+use crate::chain::types::{NoopAdapter, Options};
 use crate::core::core::{
 	hash::{Hash, Hashed},
 	pmmr::segment::{Segment, SegmentIdentifier, SegmentType},
@@ -177,9 +177,8 @@ impl DesegmenterRequestor {
 	// Emulate `continue_pibd` function, which would be called from state sync
 	// return whether is complete
 	pub fn continue_pibd(&mut self) -> bool {
-		let state = Arc::new(SyncState::new());
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
-		let desegmenter = self.chain.desegmenter(&archive_header, state).unwrap();
+		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
 
 		// Apply segments... TODO: figure out how this should be called, might
 		// need to be a separate thread.

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -68,6 +68,9 @@ pub trait Backend<T: PMMRable> {
 	/// Number of leaves
 	fn n_unpruned_leaves(&self) -> u64;
 
+	/// Number of leaves up to the given leaf index
+	fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64;
+
 	/// Iterator over current (unpruned, unremoved) leaf insertion index.
 	/// Note: This differs from underlying MMR pos - [0, 1, 2, 3, 4] vs. [1, 2, 4, 5, 8].
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_>;

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -58,6 +58,9 @@ pub trait ReadablePMMR {
 	/// Number of leaves in the MMR
 	fn n_unpruned_leaves(&self) -> u64;
 
+	/// Number of leaves in the MMR up to index
+	fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64;
+
 	/// Is the MMR empty?
 	fn is_empty(&self) -> bool {
 		self.unpruned_size() == 0
@@ -484,6 +487,10 @@ where
 
 	fn n_unpruned_leaves(&self) -> u64 {
 		self.backend.n_unpruned_leaves()
+	}
+
+	fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64 {
+		self.backend.n_unpruned_leaves_to_index(to_index)
 	}
 }
 

--- a/core/src/core/pmmr/readonly_pmmr.rs
+++ b/core/src/core/pmmr/readonly_pmmr.rs
@@ -175,4 +175,8 @@ where
 	fn n_unpruned_leaves(&self) -> u64 {
 		self.backend.n_unpruned_leaves()
 	}
+
+	fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64 {
+		self.backend.n_unpruned_leaves_to_index(to_index)
+	}
 }

--- a/core/src/core/pmmr/vec_backend.rs
+++ b/core/src/core/pmmr/vec_backend.rs
@@ -90,6 +90,10 @@ impl<T: PMMRable> Backend<T> for VecBackend<T> {
 		unimplemented!()
 	}
 
+	fn n_unpruned_leaves_to_index(&self, _to_index: u64) -> u64 {
+		unimplemented!()
+	}
+
 	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
 		Box::new(
 			self.hashes

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -582,12 +582,7 @@ where
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
 		let mut retval = Ok(true);
-		if let Some(d) = self
-			.chain()
-			.desegmenter(&archive_header, self.sync_state.clone())?
-			.write()
-			.as_mut()
-		{
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_bitmap_segment(segment, output_root);
 			if let Err(e) = res {
 				error!(
@@ -620,12 +615,7 @@ where
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
 		let mut retval = Ok(true);
-		if let Some(d) = self
-			.chain()
-			.desegmenter(&archive_header, self.sync_state.clone())?
-			.write()
-			.as_mut()
-		{
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_output_segment(segment, Some(bitmap_root));
 			if let Err(e) = res {
 				error!(
@@ -656,12 +646,7 @@ where
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
 		let mut retval = Ok(true);
-		if let Some(d) = self
-			.chain()
-			.desegmenter(&archive_header, self.sync_state.clone())?
-			.write()
-			.as_mut()
-		{
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_rangeproof_segment(segment);
 			if let Err(e) = res {
 				error!(
@@ -692,12 +677,7 @@ where
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
 		let identifier = segment.identifier().clone();
 		let mut retval = Ok(true);
-		if let Some(d) = self
-			.chain()
-			.desegmenter(&archive_header, self.sync_state.clone())?
-			.write()
-			.as_mut()
-		{
+		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_kernel_segment(segment);
 			if let Err(e) = res {
 				error!(

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -21,6 +21,7 @@ use crate::core::core::{hash::Hashed, pmmr::segment::SegmentType};
 use crate::core::global;
 use crate::core::pow::Difficulty;
 use crate::p2p::{self, Capabilities, Peer};
+use crate::util::StopState;
 
 /// Fast sync has 3 "states":
 /// * syncing headers
@@ -61,6 +62,7 @@ impl StateSync {
 		head: &chain::Tip,
 		tail: &chain::Tip,
 		highest_height: u64,
+		stop_state: Arc<StopState>,
 	) -> bool {
 		trace!("state_sync: head.height: {}, tail.height: {}. header_head.height: {}, highest_height: {}",
 			   head.height, tail.height, header_head.height, highest_height,
@@ -171,8 +173,8 @@ impl StateSync {
 						.desegmenter(&archive_header, self.sync_state.clone())
 						.unwrap();
 
-					if let Some(d) = desegmenter.read().as_ref() {
-						d.launch_validation_thread()
+					if let Some(d) = desegmenter.write().as_mut() {
+						d.launch_validation_thread(stop_state.clone())
 					};
 				}
 				// Continue our PIBD process (which returns true if all segments are in)

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -112,7 +112,8 @@ impl StateSync {
 				if let Err(e) = self.chain.reset_prune_lists() {
 					error!("pibd_sync restart: reset prune lists error = {}", e);
 				}
-				self.sync_state.update_pibd_progress(false, false, 1, 1);
+				self.sync_state
+					.update_pibd_progress(false, false, 0, 1, &archive_header);
 				sync_need_restart = true;
 			}
 		}
@@ -164,7 +165,7 @@ impl StateSync {
 				if launch {
 					let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 					self.sync_state
-						.update_pibd_progress(false, false, 1, archive_header.height);
+						.update_pibd_progress(false, false, 0, 1, &archive_header);
 					let desegmenter = self
 						.chain
 						.desegmenter(&archive_header, self.sync_state.clone())
@@ -227,7 +228,8 @@ impl StateSync {
 				let res = d.apply_next_segments();
 				if let Err(e) = res {
 					debug!("error applying segment: {}", e);
-					self.sync_state.update_pibd_progress(false, true, 1, 1);
+					self.sync_state
+						.update_pibd_progress(false, true, 0, 1, &archive_header);
 					return false;
 				}
 			}

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -229,6 +229,11 @@ impl StateSync {
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 		let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
 
+		// Remove stale requests
+		// TODO: verify timing
+		let timeout_time = Utc::now() + Duration::seconds(15);
+		self.sync_state.remove_stale_pibd_requests(timeout_time);
+
 		// Apply segments... TODO: figure out how this should be called, might
 		// need to be a separate thread.
 		if let Some(mut de) = desegmenter.try_write() {

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -161,7 +161,7 @@ impl StateSync {
 					return true;
 				}
 				let (launch, _download_timeout) = self.state_sync_due();
-				let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
+				let archive_header = { self.chain.txhashset_archive_header_header_only().unwrap() };
 				if launch {
 					self.sync_state
 						.update_pibd_progress(false, false, 0, 1, &archive_header);

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -209,7 +209,7 @@ impl SyncRunner {
 			match self.sync_state.status() {
 				SyncStatus::TxHashsetPibd { .. }
 				| SyncStatus::TxHashsetDownload { .. }
-				| SyncStatus::TxHashsetSetup
+				| SyncStatus::TxHashsetSetup { .. }
 				| SyncStatus::TxHashsetRangeProofsValidation { .. }
 				| SyncStatus::TxHashsetKernelsValidation { .. }
 				| SyncStatus::TxHashsetSave

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -229,7 +229,13 @@ impl SyncRunner {
 			}
 
 			if check_state_sync {
-				state_sync.check_run(&header_head, &head, &tail, highest_height);
+				state_sync.check_run(
+					&header_head,
+					&head,
+					&tail,
+					highest_height,
+					self.stop_state.clone(),
+				);
 			}
 		}
 	}

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -53,17 +53,19 @@ impl TUIStatusView {
 			SyncStatus::TxHashsetPibd {
 				aborted: _,
 				errored: _,
-				completed_to_height,
-				required_height,
+				completed_leaves,
+				leaves_required,
+				completed_to_height: _,
+				required_height: _,
 			} => {
-				let percent = if required_height == 0 {
+				let percent = if completed_leaves == 0 {
 					0
 				} else {
-					completed_to_height * 100 / required_height
+					completed_leaves * 100 / leaves_required
 				};
 				Cow::Owned(format!(
-					"Sync step 2/7: Downloading chain state - {} / {} Blocks - {}%",
-					completed_to_height, required_height, percent
+					"Sync step 2/7: Downloading Tx state (PIBD) - {} / {} entries - {}%",
+					completed_leaves, leaves_required, percent
 				))
 			}
 			SyncStatus::TxHashsetDownload(stat) => {

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -93,14 +93,24 @@ impl TUIStatusView {
 			SyncStatus::TxHashsetSetup {
 				headers,
 				headers_total,
+				kernel_pos,
+				kernel_pos_total,
 			} => {
 				if headers.is_some() && headers_total.is_some() {
 					let h = headers.unwrap();
 					let ht = headers_total.unwrap();
 					let percent = h * 100 / ht;
 					Cow::Owned(format!(
-						"Sync step 3/7: Validating kernel history - {}/{} - {}%",
+						"Sync step 3/7: Preparing for validation (kernel history) - {}/{} - {}%",
 						h, ht, percent
+					))
+				} else if kernel_pos.is_some() && kernel_pos_total.is_some() {
+					let k = kernel_pos.unwrap();
+					let kt = kernel_pos_total.unwrap();
+					let percent = k * 100 / kt;
+					Cow::Owned(format!(
+						"Sync step 3/7: Preparing for validation (kernel position) - {}/{} - {}%",
+						k, kt, percent
 					))
 				} else {
 					Cow::Borrowed("Sync step 3/7: Preparing chain state for validation")

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -90,8 +90,21 @@ impl TUIStatusView {
 					))
 				}
 			}
-			SyncStatus::TxHashsetSetup => {
-				Cow::Borrowed("Sync step 3/7: Preparing chain state for validation")
+			SyncStatus::TxHashsetSetup {
+				headers,
+				headers_total,
+			} => {
+				if headers.is_some() && headers_total.is_some() {
+					let h = headers.unwrap();
+					let ht = headers_total.unwrap();
+					let percent = h * 100 / ht;
+					Cow::Owned(format!(
+						"Sync step 3/7: Validating kernel history - {}/{} - {}%",
+						h, ht, percent
+					))
+				} else {
+					Cow::Borrowed("Sync step 3/7: Preparing chain state for validation")
+				}
 			}
 			SyncStatus::TxHashsetRangeProofsValidation {
 				rproofs,

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -196,6 +196,11 @@ impl LeafSet {
 		self.bitmap.cardinality() as usize
 	}
 
+	/// Number of positions up to index n in the leaf set
+	pub fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64 {
+		self.bitmap.range_cardinality(0..to_index)
+	}
+
 	/// Is the leaf_set empty.
 	pub fn is_empty(&self) -> bool {
 		self.len() == 0

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -180,6 +180,14 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		}
 	}
 
+	fn n_unpruned_leaves_to_index(&self, to_index: u64) -> u64 {
+		if self.prunable {
+			self.leaf_set.n_unpruned_leaves_to_index(to_index)
+		} else {
+			pmmr::n_leaves(pmmr::insertion_to_pmmr_index(to_index))
+		}
+	}
+
 	/// Returns an iterator over all the leaf insertion indices (0-indexed).
 	/// If our pos are [1,2,4,5,8] (first 5 leaf pos) then our insertion indices are [0,1,2,3,4]
 	fn leaf_idx_iter(&self, from_idx: u64) -> Box<dyn Iterator<Item = u64> + '_> {


### PR DESCRIPTION
* Simply sync flow by removing the previously added validation thread. All parts of sync now run on a single stateful sync thread as before, simplifying logic.
* Adds more granular state messages and tracking to step 3/7 (preparing chain state for validation) where possible
* Propagate stop_state to ensure ctrl+c can be used throughout most of the validation process
* Add a step to the PIBD request process to clear out requested blocks that haven't been received within 15 seconds (will probably need to adjust this)
* Changes to tx rangeproof validation function in anticipation of allowing the validation process to be stopped and resume where it left off.