### PR TITLE
[PIBD_IMPL] TxHashset Fallback Implementation

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -157,6 +157,10 @@ pub enum ErrorKind {
 	/// PIBD segment related error
 	#[fail(display = "Segment error")]
 	SegmentError(segment::SegmentError),
+	/// We've decided to halt the PIBD process due to lack of supporting peers or
+	/// otherwise failing to progress for a certain amount of time
+	#[fail(display = "Aborting PIBD error")]
+	AbortingPIBDError,
 	/// The segmenter is associated to a different block header
 	#[fail(display = "Segmenter header mismatch")]
 	SegmenterHeaderMismatch,


### PR DESCRIPTION
* Abort PIBD attempt and fall back to downloading TxHashset.zip if the node has not been able to determine a single PIBD capable peer advertising the greatest work chain for 60 seconds. There is no real justification for this duration, so it may be tweaked in future.
* Also a fix to re-request segments if they have not been received and applied within 60 seconds (to prevent stalling a PMMR reconstruction due to a single unresponsive node). Again, no justification for this duration.

Also tested a full sync on mainnet with latest code, all working (though we won't be turning on mainnet PIBD sync just yet)