### PR TITLE
[PIBD_IMPL] BitmapAccumulator Serialization Fix

### DIFF
--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -421,6 +421,8 @@ impl Writeable for BitmapBlock {
 		let count_pos = self.inner.iter().filter(|&v| v).count() as u32;
 		let count_neg = Self::NBITS - count_pos;
 
+		// Negative count needs to be adjusted if the block is not full,
+		// which affects the choice of serialization mode and size written
 		let count_neg_adjust = Self::NBITS - length as u32;
 		let count_neg = count_neg - count_neg_adjust;
 

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -418,12 +418,10 @@ impl Writeable for BitmapBlock {
 		writer.write_u8((length / BitmapChunk::LEN_BITS) as u8)?;
 
 		let count_pos = self.inner.iter().filter(|&v| v).count() as u32;
-		let count_neg = Self::NBITS - count_pos;
 
 		// Negative count needs to be adjusted if the block is not full,
 		// which affects the choice of serialization mode and size written
-		let count_neg_adjust = Self::NBITS - length as u32;
-		let count_neg = count_neg - count_neg_adjust;
+		let count_neg = length as u32 - count_pos;
 
 		let threshold = Self::NBITS / 16;
 		if count_pos < threshold {

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -413,7 +413,6 @@ impl BitmapBlock {
 impl Writeable for BitmapBlock {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		let length = self.inner.len();
-
 		assert!(length <= Self::NBITS as usize);
 		assert_eq!(length % BitmapChunk::LEN_BITS, 0);
 		writer.write_u8((length / BitmapChunk::LEN_BITS) as u8)?;
@@ -478,12 +477,9 @@ impl Readable for BitmapBlock {
 				inner
 			}
 			BitmapBlockSerialization::Negative => {
-				// Bug fix adjustment, sender is sending the wrong length
-
 				// Negative indices
 				let mut inner = BitVec::from_elem(n_bits, true);
 				let n = reader.read_u16()?;
-
 				for _ in 0..n {
 					inner.set(reader.read_u16()? as usize, false);
 				}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -389,10 +389,10 @@ bitflags! {
 		const TX_KERNEL_HASH = 0b0000_1000;
 		/// Can provide PIBD segments during initial byte download (fast sync).
 		const PIBD_HIST = 0b0001_0000;
-		/// As above, with crucial serialization fix #3705 applied
-		const PIBD_HIST_1 = 0b0001_0001;
 		/// Can provide historical blocks for archival sync.
 		const BLOCK_HIST = 0b0010_0000;
+		/// As above, with crucial serialization fix #3705 applied
+		const PIBD_HIST_1 = 0b0100_0000;
 	}
 }
 

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -389,6 +389,8 @@ bitflags! {
 		const TX_KERNEL_HASH = 0b0000_1000;
 		/// Can provide PIBD segments during initial byte download (fast sync).
 		const PIBD_HIST = 0b0001_0000;
+		/// As above, with crucial serialization fix #3705 applied
+		const PIBD_HIST_1 = 0b0001_0001;
 		/// Can provide historical blocks for archival sync.
 		const BLOCK_HIST = 0b0010_0000;
 	}
@@ -402,6 +404,7 @@ impl Default for Capabilities {
 			| Capabilities::PEER_LIST
 			| Capabilities::TX_KERNEL_HASH
 			| Capabilities::PIBD_HIST
+			| Capabilities::PIBD_HIST_1
 	}
 }
 

--- a/p2p/tests/capabilities.rs
+++ b/p2p/tests/capabilities.rs
@@ -42,6 +42,7 @@ fn default_capabilities() {
 	assert!(x.contains(Capabilities::PEER_LIST));
 	assert!(x.contains(Capabilities::TX_KERNEL_HASH));
 	assert!(x.contains(Capabilities::PIBD_HIST));
+	assert!(x.contains(Capabilities::PIBD_HIST_1));
 
 	assert_eq!(
 		x,
@@ -50,5 +51,6 @@ fn default_capabilities() {
 			| Capabilities::PEER_LIST
 			| Capabilities::TX_KERNEL_HASH
 			| Capabilities::PIBD_HIST
+			| Capabilities::PIBD_HIST_1
 	);
 }

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -55,11 +55,7 @@ fn test_capabilities() {
 
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b11111 as u32),
-	);
-	assert_eq!(
-		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b00011111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b1011111 as u32),
 	);
 
 	assert_eq!(

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -305,10 +305,10 @@ impl StateSync {
 			let max_diff = peers_iter().max_difficulty().unwrap_or(Difficulty::zero());
 			let peers_iter_max = || peers_iter().with_difficulty(|x| x >= max_diff);
 
-			// Then, further filter by PIBD capabilities
+			// Then, further filter by PIBD capabilities v1
 			let peers_iter_pibd = || {
 				peers_iter_max()
-					.with_capabilities(Capabilities::PIBD_HIST)
+					.with_capabilities(Capabilities::PIBD_HIST_1)
 					.connected()
 			};
 

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -335,10 +335,10 @@ impl StateSync {
 			}
 
 			// Choose a random "most work" peer, preferring outbound if at all possible.
-			let peer = peers_iter_pibd().outbound().choose_random().or_else(|| {
-				warn!("no suitable outbound peer for pibd message, considering inbound");
-				peers_iter_pibd().inbound().choose_random()
-			});
+			let peer = peers_iter_pibd()
+				.outbound()
+				.choose_random()
+				.or_else(|| peers_iter_pibd().inbound().choose_random());
 			trace!("Chosen peer is {:?}", peer);
 
 			if let Some(p) = peer {


### PR DESCRIPTION
Fixes a crucial issue in which peers serializing BitmapAccumulator blocks could potentially either select the incorrect serialization mode for the block or write an incorrect length for the number of negative entries written. (This, in turn could potentially cause a panic on deserialization causing PIBD to fail).

When sending an block that isn't full (i.e. contains less than 2^16 bits), the previous version of the code was failing to remove the unused bits from calculations concerning the number of entries, causing the read length to be incorrectly written (or the wrong serialization mode to be chosen). This fix adjusts the calculation with the difference between the max block size and the actual.

Also adds another capability, `PIBD_HIST_1`, which peers will now need to respond with before another peer can request a PIBD segment from them, to ensure they have this fix.

Also adds unit tests to exercise the negative failure case for non-full blocks, (as well as the positive instance). 