### PR TITLE
Visibility DNSSeed scope tweaks to aid seed test utilities

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -44,7 +44,7 @@ mod peer;
 mod peers;
 mod protocol;
 mod serv;
-mod store;
+pub mod store;
 pub mod types;
 
 pub use crate::conn::SEND_CHANNEL_CAP;

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -33,8 +33,8 @@ use crate::p2p::types::PeerAddr;
 use crate::p2p::ChainAdapter;
 use crate::util::StopState;
 
-// DNS Seeds with contact email associated
-const MAINNET_DNS_SEEDS: &[&str] = &[
+/// DNS Seeds with contact email associated - Mainnet
+pub const MAINNET_DNS_SEEDS: &[&str] = &[
 	"mainnet.seed.grin.icu",           // gary.peverell@protonmail.com
 	"mainnet.seed.713.mw",             // jasper@713.mw
 	"mainnet.seed.grin.lesceller.com", // q.lesceller@gmail.com
@@ -42,7 +42,8 @@ const MAINNET_DNS_SEEDS: &[&str] = &[
 	"grinseed.yeastplume.org",         // yeastplume@protonmail.com
 	"mainnet-seed.grinnode.live",      // info@grinnode.live
 ];
-const TESTNET_DNS_SEEDS: &[&str] = &[
+/// DNS Seeds with contact email associated - Testnet
+pub const TESTNET_DNS_SEEDS: &[&str] = &[
 	"floonet.seed.grin.icu",           // gary.peverell@protonmail.com
 	"floonet.seed.713.mw",             // jasper@713.mw
 	"floonet.seed.grin.lesceller.com", // q.lesceller@gmail.com
@@ -393,7 +394,8 @@ pub fn default_dns_seeds() -> Box<dyn Fn() -> Vec<PeerAddr> + Send> {
 	})
 }
 
-fn resolve_dns_to_addrs(dns_records: &Vec<String>) -> Vec<PeerAddr> {
+/// Convenience function to resolve dns addresses from DNS records
+pub fn resolve_dns_to_addrs(dns_records: &Vec<String>) -> Vec<PeerAddr> {
 	let mut addresses: Vec<PeerAddr> = vec![];
 	for dns in dns_records {
 		debug!("Retrieving addresses from dns {}", dns);

--- a/servers/src/lib.rs
+++ b/servers/src/lib.rs
@@ -39,6 +39,8 @@ pub mod common;
 mod grin;
 mod mining;
 
+pub use grin::seed::{resolve_dns_to_addrs, MAINNET_DNS_SEEDS, TESTNET_DNS_SEEDS};
+
 pub use crate::common::stats::{DiffBlock, PeerStats, ServerStats, StratumStats, WorkerStats};
 pub use crate::common::types::{ServerConfig, StratumServerConfig};
 pub use crate::grin::server::{Server, ServerTxPool};


### PR DESCRIPTION
Just a few minor scope tweaks to DNSSeed constants and functions to assist with the seed check utility service I'm putting together at:

https://github.com/yeastplume/grin-history-tools/blob/main/crates/seedcheck/src/service/seed.rs
