### PR TITLE
[PIBD_IMPL] Collect all pibd-related parameters into single location

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -38,6 +38,7 @@ use grin_util as util;
 mod chain;
 mod error;
 pub mod linked_list;
+pub mod pibd_params;
 pub mod pipe;
 pub mod store;
 pub mod txhashset;

--- a/chain/src/pibd_params.rs
+++ b/chain/src/pibd_params.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Set of static definitions for all parameters related to PIBD and Desegmentation
+//! Note these are for experimentation via compilation, not meant to be exposed as
+//! configuration parameters anywhere
+
+/// Bitmap segment height assumed for requests and segment calculation
+pub const BITMAP_SEGMENT_HEIGHT: u8 = 9;
+
+/// Output segment height assumed for requests and segment calculation
+pub const OUTPUT_SEGMENT_HEIGHT: u8 = 11;
+
+/// Rangeproof segment height assumed for requests and segment calculation
+pub const RANGEPROOF_SEGMENT_HEIGHT: u8 = 11;
+
+/// Kernel segment height assumed for requests and segment calculation
+pub const KERNEL_SEGMENT_HEIGHT: u8 = 11;
+
+/// Maximum number of received segments to cache (across all trees) before we stop requesting others
+pub const MAX_CACHED_SEGMENTS: usize = 15;
+
+/// How long the state sync should wait after requesting a segment from a peer before
+/// deciding the segment isn't going to arrive. The syncer will then re-request the segment
+pub const SEGMENT_REQUEST_TIMEOUT_SECS: i64 = 60;
+
+/// Number of simultaneous requests for segments we should make. Note this is currently
+/// divisible by 3 to try and evenly spread requests amount the 3 main MMRs (Bitmap segments
+/// will always be requested first)
+pub const SEGMENT_REQUEST_COUNT: usize = 15;
+
+/// If the syncer hasn't seen a max work peer that supports PIBD in this number of seconds
+/// give up and revert back to the txhashset.zip download method
+pub const TXHASHSET_ZIP_FALLBACK_TIME_SECS: i64 = 60;

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -30,6 +30,7 @@ use crate::util::secp::pedersen::RangeProof;
 use crate::util::{RwLock, StopState};
 use crate::SyncState;
 
+use crate::pibd_params;
 use crate::store;
 use crate::txhashset;
 
@@ -86,10 +87,10 @@ impl Desegmenter {
 			store,
 			genesis,
 			bitmap_accumulator: BitmapAccumulator::new(),
-			default_bitmap_segment_height: 9,
-			default_output_segment_height: 11,
-			default_rangeproof_segment_height: 11,
-			default_kernel_segment_height: 11,
+			default_bitmap_segment_height: pibd_params::BITMAP_SEGMENT_HEIGHT,
+			default_output_segment_height: pibd_params::OUTPUT_SEGMENT_HEIGHT,
+			default_rangeproof_segment_height: pibd_params::RANGEPROOF_SEGMENT_HEIGHT,
+			default_kernel_segment_height: pibd_params::KERNEL_SEGMENT_HEIGHT,
 			bitmap_segment_cache: vec![],
 			output_segment_cache: vec![],
 			rangeproof_segment_cache: vec![],
@@ -98,7 +99,7 @@ impl Desegmenter {
 			bitmap_mmr_leaf_count: 0,
 			bitmap_mmr_size: 0,
 
-			max_cached_segments: 15,
+			max_cached_segments: pibd_params::MAX_CACHED_SEGMENTS,
 
 			bitmap_cache: None,
 


### PR DESCRIPTION
* Adds module `chain/pibd_params`
* Collects all static PIBD related constants into `pibd_params` to allow for easier identification, tweaking and field testing of the various parameters used throughout the PIBD sync process.