### PR TITLE
Derive debug for ServerStats

### DIFF
--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -46,7 +46,7 @@ impl Default for ServerStateInfo {
 }
 /// Simpler thread-unaware version of above to be populated and returned to
 /// consumers might be interested in, such as test results or UI
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ServerStats {
 	/// Number of peers
 	pub peer_count: u32,
@@ -141,7 +141,7 @@ pub struct StratumStats {
 }
 
 /// Stats on the last WINDOW blocks and the difficulty calculation
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DiffStats {
 	/// latest height
 	pub height: u64,


### PR DESCRIPTION
Very tiny change to add `Debug` trait to `ServerStats`, which is required to be able to pass the struct around an `iced-rs` gui.