### PR TITLE
Minor update for foreign api docs. Peers seems to be no longer needed…

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -59,7 +59,6 @@ where
 	/// # Arguments
 	/// * `chain` - A non-owning reference of the chain.
 	/// * `tx_pool` - A non-owning reference of the transaction pool.
-	/// * `peers` - A non-owning reference of the peers.
 	/// * `sync_state` - A non-owning reference of the `sync_state`.
 	///
 	/// # Returns


### PR DESCRIPTION
Salutations my lords. Please accept this meager documentation update on my behalf as I journey through your district. If there is fail in formality with your contribution customs please instruct me.  

A summary of this tale:

...seems peers is no longer needed in the Foreign struct of the api. Thus, it has been removed as an argument from the  grin_api::Foreign::new instance function.

