### PR TITLE
refactor: simplify some exact instances of Option/Result combinators

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -68,14 +68,14 @@ impl Handler for BasicAuthMiddleware {
 		if req.headers().contains_key(AUTHORIZATION)
 			&& verify_slices_are_equal(
 				req.headers()[AUTHORIZATION].as_bytes(),
-				&self.api_basic_auth.as_bytes(),
+				self.api_basic_auth.as_bytes(),
 			)
 			.is_ok()
 		{
 			next_handler.call(req, handlers)
 		} else {
 			// Unauthorized 401
-			unauthorized_response(&self.basic_realm)
+			unauthorized_response(self.basic_realm)
 		}
 	}
 }
@@ -118,14 +118,14 @@ impl Handler for BasicAuthURIMiddleware {
 			if req.headers().contains_key(AUTHORIZATION)
 				&& verify_slices_are_equal(
 					req.headers()[AUTHORIZATION].as_bytes(),
-					&self.api_basic_auth.as_bytes(),
+					self.api_basic_auth.as_bytes(),
 				)
 				.is_ok()
 			{
 				next_handler.call(req, handlers)
 			} else {
 				// Unauthorized 401
-				unauthorized_response(&self.basic_realm)
+				unauthorized_response(self.basic_realm)
 			}
 		} else {
 			next_handler.call(req, handlers)

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -755,7 +755,7 @@ where
 		let mut parsed_hash: Option<Hash> = None;
 		if let Some(hash) = hash {
 			let vec = util::from_hex(&hash)
-				.map_err(|e| Error::Argument(format!("invalid block hash: {}", e)))?;
+				.map_err(|e| Error::Argument(format!("invalid block hash: {e}")))?;
 			parsed_hash = Some(Hash::from_vec(&vec));
 		}
 		Foreign::get_header(self, height, parsed_hash, commit)
@@ -769,7 +769,7 @@ where
 		let mut parsed_hash: Option<Hash> = None;
 		if let Some(hash) = hash {
 			let vec = util::from_hex(&hash)
-				.map_err(|e| Error::Argument(format!("invalid block hash: {}", e)))?;
+				.map_err(|e| Error::Argument(format!("invalid block hash: {e}")))?;
 			parsed_hash = Some(Hash::from_vec(&vec));
 		}
 		Foreign::get_block(self, height, parsed_hash, commit)

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -277,7 +277,7 @@ fn create_error_response(e: Error) -> Response<Body> {
 			"access-control-allow-headers",
 			"Content-Type, Authorization",
 		)
-		.body(format!("{}", e).into())
+		.body(format!("{e}").into())
 		.unwrap()
 }
 

--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -47,7 +47,7 @@ impl HeaderHandler {
 		}
 		check_block_param(&input)?;
 		let vec =
-			util::from_hex(&input).map_err(|e| Error::Argument(format!("invalid input: {}", e)))?;
+			util::from_hex(&input).map_err(|e| Error::Argument(format!("invalid input: {e}")))?;
 		let h = Hash::from_vec(&vec);
 		let header = w(&self.chain)?
 			.get_block_header(&h)
@@ -155,7 +155,7 @@ impl BlockHandler {
 		}
 		check_block_param(&input)?;
 		let vec =
-			util::from_hex(&input).map_err(|e| Error::Argument(format!("invalid input: {}", e)))?;
+			util::from_hex(&input).map_err(|e| Error::Argument(format!("invalid input: {e}")))?;
 		Ok(Hash::from_vec(&vec))
 	}
 
@@ -195,7 +195,7 @@ fn check_block_param(input: &str) -> Result<(), Error> {
 	lazy_static! {
 		static ref RE: Regex = Regex::new(r"[0-9a-fA-F]{64}").unwrap();
 	}
-	if !RE.is_match(&input) {
+	if !RE.is_match(input) {
 		return Err(Error::Argument("Not a valid hash or height.".to_owned()));
 	}
 	Ok(())
@@ -208,7 +208,7 @@ impl Handler for BlockHandler {
 			Err(e) => {
 				return response(
 					StatusCode::BAD_REQUEST,
-					format!("failed to parse input: {}", e),
+					format!("failed to parse input: {e}"),
 				);
 			}
 			Ok(h) => h,
@@ -227,7 +227,7 @@ impl Handler for BlockHandler {
 					_ => {
 						return response(
 							StatusCode::BAD_REQUEST,
-							format!("unsupported query parameter: {}", param),
+							format!("unsupported query parameter: {param}"),
 						)
 					}
 				}

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -427,7 +427,7 @@ impl KernelHandler {
 					.parse()
 					.map_err(|_| Error::RequestError("invalid minimum height".into()))?;
 				// Default is genesis
-				min_height = if h == 0 { None } else { Some(h) };
+				min_height = (h != 0).then_some(h);
 			}
 			if let Some(h) = params.get("max_height") {
 				let h = h
@@ -438,7 +438,7 @@ impl KernelHandler {
 					.head()
 					.map_err(|e| Error::Internal(format!("{}", e)))?
 					.height;
-				max_height = if h >= head_height { None } else { Some(h) };
+				max_height = (h < head_height).then_some(h);
 			}
 		}
 

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -34,7 +34,7 @@ impl ChainHandler {
 	pub fn get_tip(&self) -> Result<Tip, Error> {
 		let head = w(&self.chain)?
 			.head()
-			.map_err(|e| Error::Internal(format!("can't get head: {}", e)))?;
+			.map_err(|e| Error::Internal(format!("can't get head: {e}")))?;
 		Ok(Tip::from_tip(head))
 	}
 }
@@ -65,7 +65,7 @@ impl Handler for ChainValidationHandler {
 			Ok(_) => response(StatusCode::OK, "{}"),
 			Err(e) => response(
 				StatusCode::INTERNAL_SERVER_ERROR,
-				format!("validate failed: {}", e),
+				format!("validate failed: {e}"),
 			),
 		}
 	}
@@ -115,7 +115,7 @@ impl Handler for ChainCompactHandler {
 			Ok(_) => response(StatusCode::OK, "{}"),
 			Err(e) => response(
 				StatusCode::INTERNAL_SERVER_ERROR,
-				format!("compact failed: {}", e),
+				format!("compact failed: {e}"),
 			),
 		}
 	}
@@ -144,8 +144,7 @@ impl OutputHandler {
 			for commit in &commits {
 				if commit.len() != 66 {
 					return Err(Error::RequestError(format!(
-						"invalid commit length for {}",
-						commit
+						"invalid commit length for {commit}"
 					)));
 				}
 			}
@@ -276,7 +275,7 @@ impl OutputHandler {
 
 		Ok(BlockOutputs {
 			header: BlockHeaderDifficultyInfo::from_header(&header),
-			outputs: outputs,
+			outputs,
 		})
 	}
 
@@ -436,7 +435,7 @@ impl KernelHandler {
 				// Default is current head
 				let head_height = chain
 					.head()
-					.map_err(|e| Error::Internal(format!("{}", e)))?
+					.map_err(|e| Error::Internal(format!("{e}")))?
 					.height;
 				max_height = (h < head_height).then_some(h);
 			}
@@ -444,7 +443,7 @@ impl KernelHandler {
 
 		let kernel = chain
 			.get_kernel_height(&excess, min_height, max_height)
-			.map_err(|e| Error::Internal(format!("{}", e)))?
+			.map_err(|e| Error::Internal(format!("{e}")))?
 			.map(|(tx_kernel, height, mmr_index)| LocatedTxKernel {
 				tx_kernel,
 				height,
@@ -469,7 +468,7 @@ impl KernelHandler {
 		let chain = w(&self.chain)?;
 		let kernel = chain
 			.get_kernel_height(&excess, min_height, max_height)
-			.map_err(|e| Error::Internal(format!("{}", e)))?
+			.map_err(|e| Error::Internal(format!("{e}")))?
 			.map(|(tx_kernel, height, mmr_index)| LocatedTxKernel {
 				tx_kernel,
 				height,

--- a/api/src/handlers/peers_api.rs
+++ b/api/src/handlers/peers_api.rs
@@ -74,7 +74,7 @@ impl PeerHandler {
 		if let Some(addr) = addr {
 			let peer_addr = PeerAddr(addr);
 			let peer_data: PeerData = w(&self.peers)?.get_peer(peer_addr).map_err(|e| {
-				let e: Error = Error::Internal(format!("get peer error: {:?}", e));
+				let e: Error = Error::Internal(format!("get peer error: {e:?}"));
 				e
 			})?;
 			return Ok(vec![peer_data]);
@@ -87,14 +87,14 @@ impl PeerHandler {
 		let peer_addr = PeerAddr(addr);
 		w(&self.peers)?
 			.ban_peer(peer_addr, ReasonForBan::ManualBan)
-			.map_err(|e| Error::Internal(format!("ban peer error: {:?}", e)))
+			.map_err(|e| Error::Internal(format!("ban peer error: {e:?}")))
 	}
 
 	pub fn unban_peer(&self, addr: SocketAddr) -> Result<(), Error> {
 		let peer_addr = PeerAddr(addr);
 		w(&self.peers)?
 			.unban_peer(peer_addr)
-			.map_err(|e| Error::Internal(format!("unban peer error: {:?}", e)))
+			.map_err(|e| Error::Internal(format!("unban peer error: {e:?}")))
 	}
 }
 
@@ -149,14 +149,14 @@ impl Handler for PeerHandler {
 				Ok(_) => response(StatusCode::OK, "{}"),
 				Err(e) => response(
 					StatusCode::INTERNAL_SERVER_ERROR,
-					format!("ban failed: {:?}", e),
+					format!("ban failed: {e:?}"),
 				),
 			},
 			"unban" => match w_fut!(&self.peers).unban_peer(addr) {
 				Ok(_) => response(StatusCode::OK, "{}"),
 				Err(e) => response(
 					StatusCode::INTERNAL_SERVER_ERROR,
-					format!("unban failed: {:?}", e),
+					format!("unban failed: {e:?}"),
 				),
 			},
 			_ => response(StatusCode::BAD_REQUEST, "invalid command"),

--- a/api/src/handlers/pool_api.rs
+++ b/api/src/handlers/pool_api.rs
@@ -96,10 +96,10 @@ where
 		let header = tx_pool
 			.blockchain
 			.chain_head()
-			.map_err(|e| Error::Internal(format!("Failed to get chain head: {}", e)))?;
+			.map_err(|e| Error::Internal(format!("Failed to get chain head: {e}")))?;
 		tx_pool
 			.add_to_pool(source, tx, !fluff.unwrap_or(false), &header)
-			.map_err(|e| Error::Internal(format!("Failed to update pool: {}", e)))?;
+			.map_err(|e| Error::Internal(format!("Failed to update pool: {e}")))?;
 		Ok(())
 	}
 }
@@ -133,13 +133,13 @@ where
 
 	let wrapper: TxWrapper = parse_body(req).await?;
 	let tx_bin = util::from_hex(&wrapper.tx_hex)
-		.map_err(|e| Error::RequestError(format!("Bad request: {}", e)))?;
+		.map_err(|e| Error::RequestError(format!("Bad request: {e}")))?;
 
 	// All wallet api interaction explicitly uses protocol version 1 for now.
 	let version = ProtocolVersion(1);
 	let tx: Transaction =
 		ser::deserialize(&mut &tx_bin[..], version, DeserializationMode::default())
-			.map_err(|e| Error::RequestError(format!("Bad request: {}", e)))?;
+			.map_err(|e| Error::RequestError(format!("Bad request: {e}")))?;
 
 	let source = pool::TxSource::PushApi;
 	info!(
@@ -155,10 +155,10 @@ where
 	let header = tx_pool
 		.blockchain
 		.chain_head()
-		.map_err(|e| Error::Internal(format!("Failed to get chain head: {}", e)))?;
+		.map_err(|e| Error::Internal(format!("Failed to get chain head: {e}")))?;
 	tx_pool
 		.add_to_pool(source, tx, !fluff, &header)
-		.map_err(|e| Error::Internal(format!("Failed to update pool: {}", e)))?;
+		.map_err(|e| Error::Internal(format!("Failed to update pool: {e}")))?;
 	Ok(())
 }
 
@@ -172,9 +172,7 @@ where
 		Box::pin(async move {
 			let res = match update_pool(pool, req).await {
 				Ok(_) => just_response(StatusCode::OK, ""),
-				Err(e) => {
-					just_response(StatusCode::INTERNAL_SERVER_ERROR, format!("failed: {}", e))
-				}
+				Err(e) => just_response(StatusCode::INTERNAL_SERVER_ERROR, format!("failed: {e}")),
 			};
 			Ok(res)
 		})

--- a/api/src/handlers/server_api.rs
+++ b/api/src/handlers/server_api.rs
@@ -50,7 +50,7 @@ impl StatusHandler {
 	pub fn get_status(&self) -> Result<Status, Error> {
 		let head = w(&self.chain)?
 			.head()
-			.map_err(|e| Error::Internal(format!("can't get head: {}", e)))?;
+			.map_err(|e| Error::Internal(format!("can't get head: {e}")))?;
 		let sync_status = w(&self.sync_state)?.status();
 		let (api_sync_status, api_sync_info) = sync_status_to_api(sync_status);
 		Ok(Status::from_tip_and_peers(

--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -48,7 +48,7 @@ impl TxHashSetHandler {
 	fn get_roots(&self) -> Result<TxHashSet, Error> {
 		let chain = w(&self.chain)?;
 		TxHashSet::from_head(&chain)
-			.map_err(|e| Error::Internal(format!("failed to read roots from txhashset: {}", e)))
+			.map_err(|e| Error::Internal(format!("failed to read roots from txhashset: {e}")))
 	}
 
 	// gets last n outputs inserted in to the tree
@@ -92,7 +92,7 @@ impl TxHashSetHandler {
 				.iter()
 				.map(|x| OutputPrintable::from_output(x, &chain, None, true, true))
 				.collect::<Result<Vec<_>, _>>()
-				.map_err(|e| Error::Internal(format!("chain error: {}", e)))?,
+				.map_err(|e| Error::Internal(format!("chain error: {e}")))?,
 		};
 		Ok(out)
 	}
@@ -119,7 +119,7 @@ impl TxHashSetHandler {
 	// (to avoid having to create a new type to pass around)
 	fn get_merkle_proof_for_output(&self, id: &str) -> Result<OutputPrintable, Error> {
 		let c = util::from_hex(id)
-			.map_err(|_| Error::Argument(format!("Not a valid commitment: {}", id)))?;
+			.map_err(|_| Error::Argument(format!("Not a valid commitment: {id}")))?;
 		let commit = Commitment::from_vec(c);
 		let chain = w(&self.chain)?;
 		let output_pos = chain.get_output_pos(&commit).map_err(|_| Error::NotFound)?;

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -34,8 +34,8 @@ fn get_unspent(
 	chain: &Arc<chain::Chain>,
 	id: &str,
 ) -> Result<Option<(OutputIdentifier, CommitPos)>, Error> {
-	let c = util::from_hex(id)
-		.map_err(|_| Error::Argument(format!("Not a valid commitment: {}", id)))?;
+	let c =
+		util::from_hex(id).map_err(|_| Error::Argument(format!("Not a valid commitment: {id}")))?;
 	let commit = Commitment::from_vec(c);
 	let res = chain.get_unspent(commit)?;
 	Ok(res)

--- a/api/src/handlers/version_api.rs
+++ b/api/src/handlers/version_api.rs
@@ -33,7 +33,7 @@ impl VersionHandler {
 	pub fn get_version(&self) -> Result<Version, Error> {
 		let head = w(&self.chain)?
 			.head_header()
-			.map_err(|e| Error::Internal(format!("can't get head: {}", e)))?;
+			.map_err(|e| Error::Internal(format!("can't get head: {e}")))?;
 
 		Ok(Version {
 			node_version: CRATE_VERSION.to_owned(),

--- a/api/src/json_rpc.rs
+++ b/api/src/json_rpc.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 pub fn build_request<'a, 'b>(name: &'a str, params: &'b serde_json::Value) -> Request<'a, 'b> {
 	Request {
 		method: name,
-		params: params,
+		params,
 		id: From::from(1),
 		jsonrpc: Some("2.0"),
 	}
@@ -135,14 +135,14 @@ impl From<RpcError> for Error {
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
-			Error::Json(ref e) => write!(f, "JSON decode error: {}", e),
-			Error::Hyper(ref e) => write!(f, "Hyper error: {}", e),
-			Error::Rpc(ref r) => write!(f, "RPC error response: {:?}", r),
+			Error::Json(ref e) => write!(f, "JSON decode error: {e}"),
+			Error::Hyper(ref e) => write!(f, "Hyper error: {e}"),
+			Error::Rpc(ref r) => write!(f, "RPC error response: {r:?}"),
 			Error::_BatchDuplicateResponseId(ref v) => {
-				write!(f, "duplicate RPC batch response ID: {}", v)
+				write!(f, "duplicate RPC batch response ID: {v}")
 			}
-			Error::_WrongBatchResponseId(ref v) => write!(f, "wrong RPC batch response ID: {}", v),
-			_ => write!(f, "{}", self),
+			Error::_WrongBatchResponseId(ref v) => write!(f, "wrong RPC batch response ID: {v}"),
+			_ => write!(f, "{self}"),
 		}
 	}
 }
@@ -228,27 +228,27 @@ pub fn _standard_error(code: StandardError, data: Option<serde_json::Value>) -> 
 		StandardError::ParseError => RpcError {
 			code: -32700,
 			message: "Parse error".to_string(),
-			data: data,
+			data,
 		},
 		StandardError::InvalidRequest => RpcError {
 			code: -32600,
 			message: "Invalid Request".to_string(),
-			data: data,
+			data,
 		},
 		StandardError::MethodNotFound => RpcError {
 			code: -32601,
 			message: "Method not found".to_string(),
-			data: data,
+			data,
 		},
 		StandardError::InvalidParams => RpcError {
 			code: -32602,
 			message: "Invalid params".to_string(),
-			data: data,
+			data,
 		},
 		StandardError::InternalError => RpcError {
 			code: -32603,
 			message: "Internal error".to_string(),
-			data: data,
+			data,
 		},
 	}
 }
@@ -262,13 +262,13 @@ pub fn _result_to_response(
 		Ok(data) => Response {
 			result: Some(data),
 			error: None,
-			id: id,
+			id,
 			jsonrpc: Some(String::from("2.0")),
 		},
 		Err(err) => Response {
 			result: None,
 			error: Some(err),
-			id: id,
+			id,
 			jsonrpc: Some(String::from("2.0")),
 		},
 	}

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -89,7 +89,7 @@ impl TLSConfig {
 
 	fn load_private_key(&self) -> Result<rustls::PrivateKey, Error> {
 		let keyfile = File::open(&self.private_key)
-			.map_err(|e| Error::Internal(format!("failed to open private key file {}", e)))?;
+			.map_err(|e| Error::Internal(format!("failed to open private key file {e}")))?;
 		let mut reader = io::BufReader::new(keyfile);
 
 		let keys = pemfile::pkcs8_private_keys(&mut reader)
@@ -105,7 +105,7 @@ impl TLSConfig {
 		let key = self.load_private_key()?;
 		let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
 		cfg.set_single_cert(certs, key)
-			.map_err(|e| Error::Internal(format!("set single certificate failed {}", e)))?;
+			.map_err(|e| Error::Internal(format!("set single certificate failed {e}")))?;
 		Ok(Arc::new(cfg))
 	}
 }
@@ -176,10 +176,10 @@ impl ApiServer {
 				};
 
 				let mut rt = Runtime::new()
-					.map_err(|e| eprintln!("HTTP API server error: {}", e))
+					.map_err(|e| eprintln!("HTTP API server error: {e}"))
 					.unwrap();
 				if let Err(e) = rt.block_on(server) {
-					eprintln!("HTTP API server error: {}", e)
+					eprintln!("HTTP API server error: {e}")
 				}
 			})
 			.map_err(|_| Error::Internal("failed to spawn API thread".to_string()))
@@ -233,10 +233,10 @@ impl ApiServer {
 				};
 
 				let mut rt = Runtime::new()
-					.map_err(|e| eprintln!("HTTP API server error: {}", e))
+					.map_err(|e| eprintln!("HTTP API server error: {e}"))
 					.unwrap();
 				if let Err(e) = rt.block_on(server) {
-					eprintln!("HTTP API server error: {}", e)
+					eprintln!("HTTP API server error: {e}")
 				}
 			})
 			.map_err(|_| Error::Internal("failed to spawn API thread".to_string()))

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -317,12 +317,12 @@ mod tests {
 		let h1 = Arc::new(HandlerImpl(1));
 		let h2 = Arc::new(HandlerImpl(2));
 		let h3 = Arc::new(HandlerImpl(3));
-		routes.add_route("/v1/users", h1.clone()).unwrap();
+		routes.add_route("/v1/users", h1).unwrap();
 		assert!(routes.add_route("/v1/users", h2.clone()).is_err());
 		routes.add_route("/v1/users/xxx", h3.clone()).unwrap();
 		routes.add_route("/v1/users/xxx/yyy", h3.clone()).unwrap();
-		routes.add_route("/v1/zzz/*", h3.clone()).unwrap();
-		assert!(routes.add_route("/v1/zzz/ccc", h2.clone()).is_err());
+		routes.add_route("/v1/zzz/*", h3).unwrap();
+		assert!(routes.add_route("/v1/zzz/ccc", h2).is_err());
 		routes
 			.add_route("/v1/zzz/*/zzz", Arc::new(HandlerImpl(6)))
 			.unwrap();

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -246,10 +246,7 @@ impl Node {
 	}
 
 	fn value(&self) -> Option<HandlerObj> {
-		match &self.value {
-			None => None,
-			Some(v) => Some(v.clone()),
-		}
+		self.value.as_ref().cloned()
 	}
 
 	fn set_value(&mut self, value: HandlerObj) {

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -304,11 +304,7 @@ impl OutputPrintable {
 			.map(|(_, x)| x.height)
 			.or(block_header.map(|x| x.height));
 
-		let proof = if include_proof {
-			Some(output.proof_bytes().to_hex())
-		} else {
-			None
-		};
+		let proof = (include_proof).then(|| output.proof_bytes().to_hex());
 
 		// Get the Merkle proof for all unspent coinbase outputs (to verify maturity on
 		// spend). We obtain the Merkle proof by rewinding the PMMR.

--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -16,10 +16,10 @@ where
 {
 	let raw = body::to_bytes(req.into_body())
 		.await
-		.map_err(|e| Error::RequestError(format!("Failed to read request: {}", e)))?;
+		.map_err(|e| Error::RequestError(format!("Failed to read request: {e}")))?;
 
 	serde_json::from_reader(raw.bytes())
-		.map_err(|e| Error::RequestError(format!("Invalid request body: {}", e)))
+		.map_err(|e| Error::RequestError(format!("Invalid request body: {e}")))
 }
 
 /// Convert Result to ResponseFuture
@@ -30,11 +30,11 @@ where
 	match res {
 		Ok(s) => json_response_pretty(&s),
 		Err(e) => match e {
-			Error::Argument(msg) => response(StatusCode::BAD_REQUEST, msg.clone()),
-			Error::RequestError(msg) => response(StatusCode::BAD_REQUEST, msg.clone()),
+			Error::Argument(msg) => response(StatusCode::BAD_REQUEST, msg),
+			Error::RequestError(msg) => response(StatusCode::BAD_REQUEST, msg),
 			Error::NotFound => response(StatusCode::NOT_FOUND, ""),
-			Error::Internal(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
-			Error::ResponseError(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+			Error::Internal(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg),
+			Error::ResponseError(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg),
 			// place holder
 			Error::Router { .. } => response(StatusCode::INTERNAL_SERVER_ERROR, ""),
 		},
@@ -62,7 +62,7 @@ where
 		Ok(json) => response(StatusCode::OK, json),
 		Err(e) => response(
 			StatusCode::INTERNAL_SERVER_ERROR,
-			format!("can't create json response: {}", e),
+			format!("can't create json response: {e}"),
 		),
 	}
 }
@@ -107,7 +107,7 @@ impl From<&str> for QueryParams {
 		let params = form_urlencoded::parse(query_string.as_bytes())
 			.into_owned()
 			.fold(HashMap::new(), |mut hm, (k, v)| {
-				hm.entry(k).or_insert_with(|| vec![]).push(v);
+				hm.entry(k).or_insert_with(std::vec::Vec::new).push(v);
 				hm
 			});
 		QueryParams { params }

--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -143,10 +143,7 @@ macro_rules! right_path_element(
 #[macro_export]
 macro_rules! must_get_query(
 	($req: expr) =>(
-		match $req.uri().query() {
-			Some(q) => q,
-			None => return Err(Error::RequestError("no query string".to_owned())),
-		}
+		$req.uri().query().ok_or_else(|| Error::RequestError("no query string".to_owned()))?
 	));
 
 #[macro_export]

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -75,7 +75,7 @@ fn test_start_api() {
 	let api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>) =
 		Box::leak(Box::new(oneshot::channel::<()>()));
 	assert!(server.start(addr, router, None, api_chan).is_ok());
-	let url = format!("http://{}/v1/", server_addr);
+	let url = format!("http://{server_addr}/v1/");
 	let index = request_with_retry(url.as_str()).unwrap();
 	assert_eq!(index.len(), 2);
 	assert_eq!(counter.value(), 1);

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1483,10 +1483,9 @@ impl Chain {
 	pub fn get_header_for_output(&self, commit: Commitment) -> Result<BlockHeader, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
-		let (_, pos) = match txhashset.get_unspent(commit)? {
-			Some(o) => o,
-			None => return Err(Error::OutputNotFound),
-		};
+		let (_, pos) = txhashset
+			.get_unspent(commit)?
+			.ok_or_else(|| Error::OutputNotFound)?;
 		let hash = header_pmmr.get_header_hash_by_height(pos.height)?;
 		Ok(self.get_block_header(&hash)?)
 	}

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -211,7 +211,7 @@ impl Error {
 
 impl From<store::Error> for Error {
 	fn from(error: store::Error) -> Error {
-		Error::StoreErr(error.clone(), format!("{:?}", error))
+		Error::StoreErr(error.clone(), format!("{error:?}"))
 	}
 }
 

--- a/chain/src/linked_list.rs
+++ b/chain/src/linked_list.rs
@@ -234,11 +234,11 @@ where
 	type Entry = ListEntry<T>;
 
 	fn list_key(&self, commit: Commitment) -> Vec<u8> {
-		to_key(self.list_prefix, &mut commit.as_ref().to_vec())
+		to_key(self.list_prefix, commit.as_ref())
 	}
 
 	fn entry_key(&self, commit: Commitment, pos: u64) -> Vec<u8> {
-		to_key_u64(self.entry_prefix, &mut commit.as_ref().to_vec(), pos)
+		to_key_u64(self.entry_prefix, commit.as_ref(), pos)
 	}
 
 	fn peek_pos(&self, batch: &Batch<'_>, commit: Commitment) -> Result<Option<T>, Error> {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -94,7 +94,7 @@ impl ChainStore {
 	/// Get full block.
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, h), None), || {
-			format!("BLOCK: {}", h)
+			format!("BLOCK: {h}")
 		})
 	}
 
@@ -106,7 +106,7 @@ impl ChainStore {
 	/// Get block_sums for the block hash.
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, h), None), || {
-			format!("Block sums for block: {}", h)
+			format!("Block sums for block: {h}")
 		})
 	}
 
@@ -127,7 +127,7 @@ impl ChainStore {
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_HEADER_PREFIX, h), None),
-			|| format!("BLOCK HEADER: {}", h),
+			|| format!("BLOCK HEADER: {h}"),
 		)
 	}
 
@@ -139,7 +139,7 @@ impl ChainStore {
 				&to_key(BLOCK_HEADER_PREFIX, h),
 				Some(ser::DeserializationMode::SkipPow),
 			),
-			|| format!("BLOCK HEADER: {}", h),
+			|| format!("BLOCK HEADER: {h}"),
 		)
 	}
 
@@ -148,8 +148,7 @@ impl ChainStore {
 		match self.get_output_pos_height(commit)? {
 			Some(pos) => Ok(pos.pos - 1),
 			None => Err(Error::NotFoundErr(format!(
-				"Output position for: {:?}",
-				commit
+				"Output position for: {commit:?}"
 			))),
 		}
 	}
@@ -220,7 +219,7 @@ impl<'a> Batch<'a> {
 	/// get block
 	pub fn get_block(&self, h: &Hash) -> Result<Block, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_PREFIX, h), None), || {
-			format!("Block with hash: {}", h)
+			format!("Block with hash: {h}")
 		})
 	}
 
@@ -317,8 +316,7 @@ impl<'a> Batch<'a> {
 		match self.get_output_pos_height(commit)? {
 			Some(pos) => Ok(pos.pos - 1),
 			None => Err(Error::NotFoundErr(format!(
-				"Output position for: {:?}",
-				commit
+				"Output position for: {commit:?}"
 			))),
 		}
 	}
@@ -346,7 +344,7 @@ impl<'a> Batch<'a> {
 	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_HEADER_PREFIX, h), None),
-			|| format!("BLOCK HEADER: {}", h),
+			|| format!("BLOCK HEADER: {h}"),
 		)
 	}
 
@@ -358,7 +356,7 @@ impl<'a> Batch<'a> {
 				&to_key(BLOCK_HEADER_PREFIX, h),
 				Some(ser::DeserializationMode::SkipPow),
 			),
-			|| format!("BLOCK HEADER: {}", h),
+			|| format!("BLOCK HEADER: {h}"),
 		)
 	}
 
@@ -375,7 +373,7 @@ impl<'a> Batch<'a> {
 	/// Get block_sums for the block.
 	pub fn get_block_sums(&self, h: &Hash) -> Result<BlockSums, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(BLOCK_SUMS_PREFIX, h), None), || {
-			format!("Block sums for block: {}", h)
+			format!("Block sums for block: {h}")
 		})
 	}
 
@@ -400,7 +398,7 @@ impl<'a> Batch<'a> {
 	pub fn get_spent_index(&self, bh: &Hash) -> Result<Vec<CommitPos>, Error> {
 		option_to_not_found(
 			self.db.get_ser(&to_key(BLOCK_SPENT_PREFIX, bh), None),
-			|| format!("spent index: {}", bh),
+			|| format!("spent index: {bh}"),
 		)
 	}
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -83,10 +83,7 @@ impl ChainStore {
 			"PIBD_HEAD".to_owned()
 		});
 
-		match res {
-			Ok(r) => Ok(r),
-			Err(_) => Ok(Tip::from_header(&global::get_genesis_block().header)),
-		}
+		res.or_else(|_| Ok(Tip::from_header(&global::get_genesis_block().header)))
 	}
 
 	/// Header of the block at the head of the block chain (not the same thing as header_head).

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -196,7 +196,7 @@ impl BitmapAccumulator {
 		let mut bitmap = Bitmap::create();
 		for (chunk_index, chunk_pos) in self.backend.leaf_pos_iter().enumerate() {
 			//TODO: Unwrap
-			let chunk = self.backend.get_data(chunk_pos as u64).unwrap();
+			let chunk = self.backend.get_data(chunk_pos).unwrap();
 			let additive = chunk.set_iter(chunk_index * 1024).collect::<Vec<u32>>();
 			bitmap.add_many(&additive);
 		}
@@ -529,7 +529,7 @@ mod tests {
 			block.inner.negate();
 		}
 
-		let range_size = n_blocks * BitmapChunk::LEN_BITS as usize;
+		let range_size = n_blocks * BitmapChunk::LEN_BITS;
 
 		// Flip `entries` bits in random spots
 		let mut count = 0;

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -642,11 +642,7 @@ impl Desegmenter {
 			self.bitmap_mmr_size,
 			self.default_bitmap_segment_height,
 		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		(cur_segment_count != total_segment_count).then(|| cur_segment_count as u64)
 	}
 
 	/// Adds and validates a bitmap chunk
@@ -767,11 +763,7 @@ impl Desegmenter {
 			cur_segment_count,
 			total_segment_count
 		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		(cur_segment_count != total_segment_count).then(|| cur_segment_count as u64)
 	}
 
 	/// Adds a output segment
@@ -878,11 +870,7 @@ impl Desegmenter {
 			cur_segment_count,
 			total_segment_count
 		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		(cur_segment_count != total_segment_count).then(|| cur_segment_count as u64)
 	}
 
 	/// Adds a Rangeproof segment
@@ -973,11 +961,7 @@ impl Desegmenter {
 			cur_segment_count,
 			total_segment_count
 		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		(cur_segment_count != total_segment_count).then(|| cur_segment_count as u64)
 	}
 
 	/// Adds a Kernel segment

--- a/chain/src/txhashset/rewindable_kernel_view.rs
+++ b/chain/src/txhashset/rewindable_kernel_view.rs
@@ -40,7 +40,7 @@ impl<'a> RewindableKernelView<'a> {
 	pub fn rewind(&mut self, header: &BlockHeader) -> Result<(), Error> {
 		self.pmmr
 			.rewind(header.kernel_mmr_size)
-			.map_err(&Error::TxHashSetErr)?;
+			.map_err(Error::TxHashSetErr)?;
 
 		// Update our header to reflect the one we rewound to.
 		self.header = header.clone();
@@ -62,8 +62,7 @@ impl<'a> RewindableKernelView<'a> {
 			return Err(Error::InvalidTxHashSet(format!(
 				"Kernel root at {} does not match",
 				self.header.height
-			))
-			.into());
+			)));
 		}
 		Ok(())
 	}

--- a/chain/src/txhashset/segmenter.rs
+++ b/chain/src/txhashset/segmenter.rs
@@ -74,14 +74,14 @@ impl Segmenter {
 	fn output_root(&self) -> Result<Hash, Error> {
 		let txhashset = self.txhashset.read();
 		let pmmr = txhashset.output_pmmr_at(&self.header);
-		let root = pmmr.root().map_err(&Error::TxHashSetErr)?;
+		let root = pmmr.root().map_err(Error::TxHashSetErr)?;
 		Ok(root)
 	}
 
 	/// The root of the bitmap snapshot PMMR.
 	fn bitmap_root(&self) -> Result<Hash, Error> {
 		let pmmr = self.bitmap_snapshot.readonly_pmmr();
-		let root = pmmr.root().map_err(&Error::TxHashSetErr)?;
+		let root = pmmr.root().map_err(Error::TxHashSetErr)?;
 		Ok(root)
 	}
 

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -180,13 +180,7 @@ impl<'a> UTXOView<'a> {
 		// Find the max pos of any coinbase being spent.
 		let pos = spent?
 			.iter()
-			.filter_map(|(out, pos)| {
-				if out.features.is_coinbase() {
-					Some(pos.pos)
-				} else {
-					None
-				}
-			})
+			.filter_map(|(out, pos)| (out.features.is_coinbase()).then(|| pos.pos))
 			.max();
 
 		if let Some(pos) = pos {

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -87,7 +87,7 @@ impl<'a> UTXOView<'a> {
 					.iter()
 					.map(|input| {
 						self.validate_input(input.commitment(), batch)
-							.and_then(|(out, pos)| Ok((out, pos)))
+							.map(|(out, pos)| (out, pos))
 					})
 					.collect();
 				outputs_spent
@@ -180,7 +180,7 @@ impl<'a> UTXOView<'a> {
 		// Find the max pos of any coinbase being spent.
 		let pos = spent?
 			.iter()
-			.filter_map(|(out, pos)| (out.features.is_coinbase()).then(|| pos.pos))
+			.filter_map(|(out, pos)| (out.features.is_coinbase()).then_some(pos.pos))
 			.max();
 
 		if let Some(pos) = pos {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -529,8 +529,8 @@ impl Default for Tip {
 impl ser::Writeable for Tip {
 	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		writer.write_u64(self.height)?;
-		writer.write_fixed_bytes(&self.last_block_h)?;
-		writer.write_fixed_bytes(&self.prev_block_h)?;
+		writer.write_fixed_bytes(self.last_block_h)?;
+		writer.write_fixed_bytes(self.prev_block_h)?;
 		self.total_difficulty.write(writer)
 	}
 }
@@ -542,7 +542,7 @@ impl ser::Readable for Tip {
 		let prev = Hash::read(reader)?;
 		let diff = Difficulty::read(reader)?;
 		Ok(Tip {
-			height: height,
+			height,
 			last_block_h: last,
 			prev_block_h: prev,
 			total_difficulty: diff,

--- a/chain/tests/chain_test_helper.rs
+++ b/chain/tests/chain_test_helper.rs
@@ -69,7 +69,7 @@ pub fn mine_chain(dir_name: &str, chain_length: u64) -> Chain {
 	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
 	let genesis = genesis_block(&keychain);
-	let mut chain = init_chain(dir_name, genesis.clone());
+	let mut chain = init_chain(dir_name, genesis);
 	mine_some_on_top(&mut chain, chain_length, &keychain);
 	chain
 }

--- a/chain/tests/mine_nrd_kernel.rs
+++ b/chain/tests/mine_nrd_kernel.rs
@@ -37,7 +37,7 @@ where
 	let reward =
 		reward::output(keychain, &ProofBuilder::new(keychain), key_id, fee, false).unwrap();
 
-	let mut block = Block::new(&prev, &txs, next_header_info.clone().difficulty, reward).unwrap();
+	let mut block = Block::new(&prev, &txs, next_header_info.difficulty, reward).unwrap();
 
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
@@ -70,7 +70,7 @@ fn mine_block_with_nrd_kernel_and_nrd_feature_enabled() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let pb = ProofBuilder::new(&keychain);
 	let genesis = genesis_block(&keychain);
-	let chain = init_chain(chain_dir, genesis.clone());
+	let chain = init_chain(chain_dir, genesis);
 
 	for n in 1..9 {
 		let key_id = ExtKeychainPath::new(1, n, 0, 0, 0).to_identifier();
@@ -88,8 +88,8 @@ fn mine_block_with_nrd_kernel_and_nrd_feature_enabled() {
 			relative_height: NRDRelativeHeight::new(1440).unwrap(),
 		},
 		&[
-			build::coinbase_input(consensus::REWARD, key_id1.clone()),
-			build::output(consensus::REWARD - 20000, key_id2.clone()),
+			build::coinbase_input(consensus::REWARD, key_id1),
+			build::output(consensus::REWARD - 20000, key_id2),
 		],
 		&keychain,
 		&pb,
@@ -117,7 +117,7 @@ fn mine_invalid_block_with_nrd_kernel_and_nrd_feature_enabled_before_hf() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let pb = ProofBuilder::new(&keychain);
 	let genesis = genesis_block(&keychain);
-	let chain = init_chain(chain_dir, genesis.clone());
+	let chain = init_chain(chain_dir, genesis);
 
 	for n in 1..8 {
 		let key_id = ExtKeychainPath::new(1, n, 0, 0, 0).to_identifier();
@@ -135,8 +135,8 @@ fn mine_invalid_block_with_nrd_kernel_and_nrd_feature_enabled_before_hf() {
 			relative_height: NRDRelativeHeight::new(1440).unwrap(),
 		},
 		&[
-			build::coinbase_input(consensus::REWARD, key_id1.clone()),
-			build::output(consensus::REWARD - 20000, key_id2.clone()),
+			build::coinbase_input(consensus::REWARD, key_id1),
+			build::output(consensus::REWARD - 20000, key_id2),
 		],
 		&keychain,
 		&pb,

--- a/chain/tests/process_block_cut_through.rs
+++ b/chain/tests/process_block_cut_through.rs
@@ -45,7 +45,7 @@ where
 	let reward =
 		reward::output(keychain, &ProofBuilder::new(keychain), &key_id, fee, false).unwrap();
 
-	let mut block = Block::new(&prev, txs, next_header_info.clone().difficulty, reward)?;
+	let mut block = Block::new(&prev, txs, next_header_info.difficulty, reward)?;
 
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
@@ -88,7 +88,7 @@ fn process_block_cut_through() -> Result<(), chain::Error> {
 	let keychain = ExtKeychain::from_random_seed(false)?;
 	let pb = ProofBuilder::new(&keychain);
 	let genesis = genesis_block(&keychain);
-	let chain = init_chain(chain_dir, genesis.clone());
+	let chain = init_chain(chain_dir, genesis);
 
 	// Mine a few empty blocks.
 	for _ in 1..6 {
@@ -111,8 +111,8 @@ fn process_block_cut_through() -> Result<(), chain::Error> {
 			build::coinbase_input(consensus::REWARD, key_id1.clone()),
 			build::coinbase_input(consensus::REWARD, key_id2.clone()),
 			build::output(60_000_000_000, key_id1.clone()),
-			build::output(50_000_000_000, key_id2.clone()),
-			build::output(10_000_000_000, key_id3.clone()),
+			build::output(50_000_000_000, key_id2),
+			build::output(10_000_000_000, key_id3),
 		],
 		&keychain,
 		&pb,
@@ -141,7 +141,7 @@ fn process_block_cut_through() -> Result<(), chain::Error> {
 	);
 
 	// Build a block with this single invalid transaction.
-	let block = build_block(&chain, &keychain, &[tx.clone()], true)?;
+	let block = build_block(&chain, &keychain, &[tx], true)?;
 
 	// The block is invalid due to cut-through.
 	let prev = chain.head_header()?;

--- a/chain/tests/test_block_known.rs
+++ b/chain/tests/test_block_known.rs
@@ -70,7 +70,7 @@ fn check_known() {
 
 	// reprocess latest block and check the updated head
 	{
-		let chain = init_chain(chain_dir, genesis.clone());
+		let chain = init_chain(chain_dir, genesis);
 		let head = chain
 			.process_block(latest.clone(), chain::Options::NONE)
 			.unwrap();

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -97,7 +97,7 @@ fn test_coinbase_maturity() {
 		let coinbase_txn = build::transaction(
 			KernelFeatures::Plain { fee: 2.into() },
 			&[
-				build::coinbase_input(amount, key_id1.clone()),
+				build::coinbase_input(amount, key_id1),
 				build::output(amount - 2, key_id2.clone()),
 			],
 			&keychain,

--- a/chain/tests/test_header_perf.rs
+++ b/chain/tests/test_header_perf.rs
@@ -59,7 +59,7 @@ fn test_header_perf_impl(is_test_chain: bool, src_root_dir: &str, dest_root_dir:
 			chain::Chain::init(
 				dest_root_dir.into(),
 				dummy_adapter,
-				genesis.clone(),
+				genesis,
 				pow::verify_size,
 				false,
 			)
@@ -111,8 +111,9 @@ fn test_header_perf() {
 	util::init_test_logger();
 	// if testing against a real chain, insert location here
 	// NOTE: Modify to point at your own paths
-	let src_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/chain_data");
-	let dest_root_dir = format!("/Users/yeastplume/Projects/grin_project/server/.chain_data_copy");
+	let src_root_dir = "/Users/yeastplume/Projects/grin_project/server/chain_data".to_string();
+	let dest_root_dir =
+		"/Users/yeastplume/Projects/grin_project/server/.chain_data_copy".to_string();
 	clean_output_dir(&dest_root_dir);
 	test_header_perf_impl(false, &src_root_dir, &dest_root_dir);
 	clean_output_dir(&dest_root_dir);

--- a/chain/tests/test_header_weight_validation.rs
+++ b/chain/tests/test_header_weight_validation.rs
@@ -37,7 +37,7 @@ fn build_block(chain: &Chain) -> Block {
 	let prev = chain.head_header().unwrap();
 	let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 	let reward = reward::output(&keychain, &ProofBuilder::new(&keychain), &pk, 0, false).unwrap();
-	let mut block = Block::new(&prev, &[], next_header_info.clone().difficulty, reward).unwrap();
+	let mut block = Block::new(&prev, &[], next_header_info.difficulty, reward).unwrap();
 
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;

--- a/chain/tests/test_pibd_copy.rs
+++ b/chain/tests/test_pibd_copy.rs
@@ -70,7 +70,7 @@ impl SegmenterResponder {
 			chain: Arc::new(
 				chain::Chain::init(
 					chain_src_dir.into(),
-					dummy_adapter.clone(),
+					dummy_adapter,
 					genesis,
 					pow::verify_size,
 					false,
@@ -130,7 +130,7 @@ impl DesegmenterRequestor {
 			chain: Arc::new(
 				chain::Chain::init(
 					chain_src_dir.into(),
-					dummy_adapter.clone(),
+					dummy_adapter,
 					genesis,
 					pow::verify_size,
 					false,
@@ -205,29 +205,25 @@ impl DesegmenterRequestor {
 			// Perform request and response
 			match seg_id.segment_type {
 				SegmentType::Bitmap => {
-					let (seg, output_root) =
-						self.responder.get_bitmap_segment(seg_id.identifier.clone());
+					let (seg, output_root) = self.responder.get_bitmap_segment(seg_id.identifier);
 					if let Some(d) = desegmenter.write().as_mut() {
 						d.add_bitmap_segment(seg, output_root).unwrap();
 					}
 				}
 				SegmentType::Output => {
-					let (seg, bitmap_root) =
-						self.responder.get_output_segment(seg_id.identifier.clone());
+					let (seg, bitmap_root) = self.responder.get_output_segment(seg_id.identifier);
 					if let Some(d) = desegmenter.write().as_mut() {
 						d.add_output_segment(seg, Some(bitmap_root)).unwrap();
 					}
 				}
 				SegmentType::RangeProof => {
-					let seg = self
-						.responder
-						.get_rangeproof_segment(seg_id.identifier.clone());
+					let seg = self.responder.get_rangeproof_segment(seg_id.identifier);
 					if let Some(d) = desegmenter.write().as_mut() {
 						d.add_rangeproof_segment(seg).unwrap();
 					}
 				}
 				SegmentType::Kernel => {
-					let seg = self.responder.get_kernel_segment(seg_id.identifier.clone());
+					let seg = self.responder.get_kernel_segment(seg_id.identifier);
 					if let Some(d) = desegmenter.write().as_mut() {
 						d.add_kernel_segment(seg).unwrap();
 					}
@@ -279,8 +275,7 @@ fn test_pibd_copy_impl(
 	}
 
 	let src_responder = Arc::new(SegmenterResponder::new(src_root_dir, genesis.clone()));
-	let mut dest_requestor =
-		DesegmenterRequestor::new(dest_root_dir, genesis.clone(), src_responder);
+	let mut dest_requestor = DesegmenterRequestor::new(dest_root_dir, genesis, src_responder);
 
 	// No template provided so copy headers from source
 	if dest_template_dir.is_none() {
@@ -305,11 +300,11 @@ fn test_pibd_copy_sample() {
 	// small test chain with actual transaction data
 
 	// Test on uncompacted and non-compacted chains
-	let src_root_dir = format!("./tests/test_data/chain_raw");
-	let dest_root_dir = format!("./tests/test_output/.segment_copy");
+	let src_root_dir = "./tests/test_data/chain_raw".to_string();
+	let dest_root_dir = "./tests/test_output/.segment_copy".to_string();
 	clean_output_dir(&dest_root_dir);
 	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir, None);
-	let src_root_dir = format!("./tests/test_data/chain_compacted");
+	let src_root_dir = "./tests/test_data/chain_compacted".to_string();
 	clean_output_dir(&dest_root_dir);
 	test_pibd_copy_impl(true, &src_root_dir, &dest_root_dir, None);
 	clean_output_dir(&dest_root_dir);
@@ -327,12 +322,14 @@ fn test_pibd_copy_real() {
 	let copy_headers_to_template = false;
 
 	// if testing against a real chain, insert location here
-	let src_root_dir = format!("/home/yeastplume/Projects/grin-project/servers/floo-1/chain_data");
-	let dest_template_dir = format!(
+	let src_root_dir =
+		"/home/yeastplume/Projects/grin-project/servers/floo-1/chain_data".to_string();
+	let dest_template_dir =
 		"/home/yeastplume/Projects/grin-project/servers/floo-pibd-1/chain_data_headers_only"
-	);
+			.to_string();
 	let dest_root_dir =
-		format!("/home/yeastplume/Projects/grin-project/servers/floo-pibd-1/chain_data_test_copy");
+		"/home/yeastplume/Projects/grin-project/servers/floo-pibd-1/chain_data_test_copy"
+			.to_string();
 	if copy_headers_to_template {
 		clean_output_dir(&dest_template_dir);
 		test_pibd_copy_impl(false, &src_root_dir, &dest_template_dir, None);

--- a/chain/tests/test_txhashset.rs
+++ b/chain/tests/test_txhashset.rs
@@ -35,30 +35,26 @@ fn clean_output_dir(dir_name: &str) {
 #[test]
 fn test_unexpected_zip() {
 	global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
-	let db_root = format!(".grin_txhashset_zip");
+	let db_root = ".grin_txhashset_zip".to_string();
 	clean_output_dir(&db_root);
 	{
 		let chain_store = ChainStore::new(&db_root).unwrap();
 		let store = Arc::new(chain_store);
-		txhashset::TxHashSet::open(db_root.clone(), store.clone(), None).unwrap();
+		txhashset::TxHashSet::open(db_root.clone(), store, None).unwrap();
 		let head = BlockHeader::default();
 		// First check if everything works out of the box
 		assert!(txhashset::zip_read(db_root.clone(), &head).is_ok());
-		let zip_path = Path::new(&db_root).join(format!(
-			"txhashset_snapshot_{}.zip",
-			head.hash().to_string()
-		));
+		let zip_path = Path::new(&db_root).join(format!("txhashset_snapshot_{}.zip", head.hash()));
 		let zip_file = File::open(&zip_path).unwrap();
 		assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &head).is_ok());
 		// Remove temp txhashset dir
-		let _ = fs::remove_dir_all(
-			Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash().to_string())),
-		);
+		let _ =
+			fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash())));
 		// Then add strange files in the original txhashset folder
-		File::create(&Path::new(&db_root).join("txhashset").join("badfile"))
+		File::create(Path::new(&db_root).join("txhashset").join("badfile"))
 			.expect("problem creating a file");
 		File::create(
-			&Path::new(&db_root)
+			Path::new(&db_root)
 				.join("txhashset")
 				.join("output")
 				.join("badfile"),
@@ -79,16 +75,12 @@ fn test_unexpected_zip() {
 		];
 		assert_eq!(
 			files,
-			expected_files
-				.iter()
-				.map(|x| PathBuf::from(x))
-				.collect::<Vec<_>>()
+			expected_files.iter().map(PathBuf::from).collect::<Vec<_>>()
 		);
 
 		assert!(txhashset::zip_read(db_root.clone(), &head).is_ok());
-		let _ = fs::remove_dir_all(
-			Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash().to_string())),
-		);
+		let _ =
+			fs::remove_dir_all(Path::new(&db_root).join(format!("txhashset_zip_{}", head.hash())));
 		let zip_file = File::open(zip_path).unwrap();
 		let _ = fs::remove_dir_all(Path::new(&db_root).join("txhashset"));
 		assert!(txhashset::zip_write(PathBuf::from(db_root.clone()), zip_file, &head).is_ok());
@@ -106,10 +98,7 @@ fn test_unexpected_zip() {
 		];
 		assert_eq!(
 			files,
-			expected_files
-				.iter()
-				.map(|x| PathBuf::from(x))
-				.collect::<Vec<_>>()
+			expected_files.iter().map(PathBuf::from).collect::<Vec<_>>()
 		);
 	}
 	// Cleanup chain directory

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -505,7 +505,7 @@ fn comments() -> HashMap<String, String> {
 
 fn get_key(line: &str) -> String {
 	if line.contains('[') && line.contains(']') {
-		return line.to_owned();
+		line.to_owned()
 	} else if line.contains('=') {
 		return line.split('=').collect::<Vec<&str>>()[0].trim().to_owned();
 	} else {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -162,7 +162,7 @@ impl GlobalConfig {
 	pub fn for_chain(chain_type: &global::ChainTypes) -> GlobalConfig {
 		let mut defaults_conf = GlobalConfig::default();
 		let mut defaults = &mut defaults_conf.members.as_mut().unwrap().server;
-		defaults.chain_type = chain_type.clone();
+		defaults.chain_type = *chain_type;
 
 		match *chain_type {
 			global::ChainTypes::Mainnet => {}
@@ -234,12 +234,12 @@ impl GlobalConfig {
 		match decoded {
 			Ok(gc) => {
 				self.members = Some(gc);
-				return Ok(self);
+				Ok(self)
 			}
 			Err(e) => {
 				return Err(ConfigError::ParseError(
 					self.config_file_path.unwrap().to_str().unwrap().to_string(),
-					format!("{}", e),
+					format!("{e}"),
 				));
 			}
 		}
@@ -292,9 +292,9 @@ impl GlobalConfig {
 		let encoded: Result<String, toml::ser::Error> =
 			toml::to_string(self.members.as_mut().unwrap());
 		match encoded {
-			Ok(enc) => return Ok(enc),
+			Ok(enc) => Ok(enc),
 			Err(e) => {
-				return Err(ConfigError::SerializationError(format!("{}", e)));
+				return Err(ConfigError::SerializationError(format!("{e}")));
 			}
 		}
 	}
@@ -318,7 +318,7 @@ impl GlobalConfig {
 
 		let mut config: ConfigMembers =
 			toml::from_str(&GlobalConfig::fix_warning_level(config_str.clone())).unwrap();
-		if config.config_file_version != None {
+		if config.config_file_version.is_some() {
 			return config_str;
 		}
 

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -42,17 +42,16 @@ impl fmt::Display for ConfigError {
 		match *self {
 			ConfigError::ParseError(ref file_name, ref message) => write!(
 				f,
-				"Error parsing configuration file at {} - {}",
-				file_name, message
+				"Error parsing configuration file at {file_name} - {message}"
 			),
 			ConfigError::FileIOError(ref file_name, ref message) => {
-				write!(f, "{} {}", message, file_name)
+				write!(f, "{message} {file_name}")
 			}
 			ConfigError::FileNotFoundError(ref file_name) => {
-				write!(f, "Configuration file not found: {}", file_name)
+				write!(f, "Configuration file not found: {file_name}")
 			}
 			ConfigError::SerializationError(ref message) => {
-				write!(f, "Error serializing configuration: {}", message)
+				write!(f, "Error serializing configuration: {message}")
 			}
 		}
 	}
@@ -62,7 +61,7 @@ impl From<io::Error> for ConfigError {
 	fn from(error: io::Error) -> ConfigError {
 		ConfigError::FileIOError(
 			String::from(""),
-			format!("Error loading config file: {}", error),
+			format!("Error loading config file: {error}"),
 		)
 	}
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -218,7 +218,7 @@ pub const MIN_AR_SCALE: u64 = AR_SCALE_DAMP_FACTOR;
 
 /// unit difficulty, equal to graph_weight(SECOND_POW_EDGE_BITS)
 pub const UNIT_DIFFICULTY: u64 =
-	((2 as u64) << (SECOND_POW_EDGE_BITS - BASE_EDGE_BITS)) * (SECOND_POW_EDGE_BITS as u64);
+	(2_u64 << (SECOND_POW_EDGE_BITS - BASE_EDGE_BITS)) * (SECOND_POW_EDGE_BITS as u64);
 
 /// The initial difficulty at launch. This should be over-estimated
 /// and difficulty should come down at launch rather than up

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -62,7 +62,7 @@ pub fn amount_from_hr_string(amount: &str) -> Result<u64, Error> {
 }
 
 fn parse_grins(amount: &str) -> Result<u64, Error> {
-	if amount == "" {
+	if amount.is_empty() {
 		Ok(0)
 	} else {
 		amount
@@ -81,7 +81,7 @@ fn parse_ngrins(amount: &str) -> Result<u64, Error> {
 	} else {
 		amount
 	};
-	format!("{:0<width$}", amount, width = WIDTH)
+	format!("{amount:0<WIDTH$}")
 		.parse::<u64>()
 		.map_err(|_| Error::InvalidAmountString)
 }
@@ -89,8 +89,8 @@ fn parse_ngrins(amount: &str) -> Result<u64, Error> {
 /// Common method for converting an amount to a human-readable string
 
 pub fn amount_to_hr_string(amount: u64, truncate: bool) -> String {
-	let amount = (amount as f64 / GRIN_BASE as f64) as f64;
-	let hr = format!("{:.*}", WIDTH, amount);
+	let amount = (amount as f64 / GRIN_BASE as f64);
+	let hr = format!("{amount:.WIDTH$}");
 	if truncate {
 		let nzeros = hr.chars().rev().take_while(|x| x == &'0').count();
 		if nzeros < *WIDTH {

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -683,12 +683,12 @@ impl Block {
 
 	/// Get outputs
 	pub fn outputs(&self) -> &[Output] {
-		&self.body.outputs()
+		self.body.outputs()
 	}
 
 	/// Get kernels
 	pub fn kernels(&self) -> &[TxKernel] {
-		&self.body.kernels()
+		self.body.kernels()
 	}
 
 	/// Sum of all fees (inputs less outputs) in the block

--- a/core/src/core/block_sums.rs
+++ b/core/src/core/block_sums.rs
@@ -34,8 +34,8 @@ pub struct BlockSums {
 
 impl Writeable for BlockSums {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		writer.write_fixed_bytes(&self.utxo_sum)?;
-		writer.write_fixed_bytes(&self.kernel_sum)?;
+		writer.write_fixed_bytes(self.utxo_sum)?;
+		writer.write_fixed_bytes(self.kernel_sum)?;
 		Ok(())
 	}
 }

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -93,7 +93,7 @@ pub trait Committed {
 			let over_commit = {
 				let secp = static_secp_instance();
 				let secp = secp.lock();
-				let overage_abs = overage.checked_abs().ok_or_else(|| Error::InvalidValue)? as u64;
+				let overage_abs = overage.checked_abs().ok_or(Error::InvalidValue)? as u64;
 				secp.commit_value(overage_abs).unwrap()
 			};
 			if overage < 0 {
@@ -173,6 +173,6 @@ pub fn sum_kernel_offsets(
 fn to_secrets(bf: Vec<BlindingFactor>, secp: &secp::Secp256k1) -> Vec<SecretKey> {
 	bf.into_iter()
 		.filter(|x| *x != BlindingFactor::zero())
-		.filter_map(|x| x.secret_key(&secp).ok())
+		.filter_map(|x| x.secret_key(secp).ok())
 		.collect::<Vec<_>>()
 }

--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -115,9 +115,9 @@ impl Writeable for CompactBlockBody {
 	}
 }
 
-impl Into<CompactBlockBody> for CompactBlock {
-	fn into(self) -> CompactBlockBody {
-		self.body
+impl From<CompactBlock> for CompactBlockBody {
+	fn from(val: CompactBlock) -> Self {
+		val.body
 	}
 }
 
@@ -178,7 +178,7 @@ impl From<Block> for CompactBlock {
 
 		for k in block.kernels() {
 			if k.is_coinbase() {
-				kern_full.push(k.clone());
+				kern_full.push(*k);
 			} else {
 				kern_ids.push(k.short_id(&header.hash(), nonce));
 			}

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -73,8 +73,8 @@ impl Hash {
 
 	/// Convert hex string back to hash.
 	pub fn from_hex(hex: &str) -> Result<Hash, Error> {
-		let bytes = util::from_hex(hex)
-			.map_err(|_| Error::HexError(format!("failed to decode {}", hex)))?;
+		let bytes =
+			util::from_hex(hex).map_err(|_| Error::HexError(format!("failed to decode {hex}")))?;
 		Ok(Hash::from_vec(&bytes))
 	}
 
@@ -141,7 +141,7 @@ impl Readable for Hash {
 
 impl Writeable for Hash {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		writer.write_fixed_bytes(&self.0)
+		writer.write_fixed_bytes(self.0)
 	}
 }
 

--- a/core/src/core/id.rs
+++ b/core/src/core/id.rs
@@ -101,7 +101,7 @@ impl Readable for ShortId {
 
 impl Writeable for ShortId {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		writer.write_fixed_bytes(&self.0)
+		writer.write_fixed_bytes(self.0)
 	}
 }
 

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -136,12 +136,12 @@ pub trait ReadablePMMR {
 
 		// check this pos is actually a leaf in the MMR
 		if !is_leaf(pos0) {
-			return Err(format!("not a leaf at pos {}", pos0));
+			return Err(format!("not a leaf at pos {pos0}"));
 		}
 
 		// check we actually have a hash in the MMR at this pos
 		self.get_hash(pos0)
-			.ok_or_else(|| format!("no element at pos {}", pos0))?;
+			.ok_or_else(|| format!("no element at pos {pos0}"))?;
 
 		let family_branch = family_branch(pos0, size);
 
@@ -208,7 +208,7 @@ where
 
 	/// Build a "readonly" view of this PMMR.
 	pub fn readonly_pmmr(&self) -> ReadonlyPMMR<'_, T, B> {
-		ReadonlyPMMR::at(&self.backend, self.size)
+		ReadonlyPMMR::at(self.backend, self.size)
 	}
 
 	/// Push a new element into the MMR. Computes new related peaks at
@@ -222,7 +222,7 @@ where
 
 		let (peak_map, height) = peak_map_height(pos);
 		if height != 0 {
-			return Err(format!("bad mmr size {}", pos));
+			return Err(format!("bad mmr size {pos}"));
 		}
 		// hash with all immediately preceding peaks, as indicated by peak map
 		let mut peak = 1;
@@ -316,7 +316,7 @@ where
 	/// Returns true if pruning is successful.
 	pub fn prune(&mut self, pos0: u64) -> Result<bool, String> {
 		if !is_leaf(pos0) {
-			return Err(format!("Node at {} is not a leaf, can't prune.", pos0));
+			return Err(format!("Node at {pos0} is not a leaf, can't prune."));
 		}
 
 		if self.backend.get_hash(pos0).is_none() {
@@ -370,10 +370,10 @@ where
 				if m >= sz {
 					break;
 				}
-				idx.push_str(&format!("{:>8} ", m));
+				idx.push_str(&format!("{m:>8} "));
 				let ohs = self.get_hash(m);
 				match ohs {
-					Some(hs) => hashes.push_str(&format!("{} ", hs)),
+					Some(hs) => hashes.push_str(&format!("{hs} ")),
 					None => hashes.push_str(&format!("{:>8} ", "??")),
 				}
 			}
@@ -407,7 +407,7 @@ where
 				idx.push_str(&format!("{:>8} ", m + 1));
 				let ohs = self.get_from_file(m);
 				match ohs {
-					Some(hs) => hashes.push_str(&format!("{} ", hs)),
+					Some(hs) => hashes.push_str(&format!("{hs} ")),
 					None => hashes.push_str(&format!("{:>8} ", " .")),
 				}
 			}
@@ -587,7 +587,7 @@ pub fn round_up_to_leaf_pos(pos0: u64) -> u64 {
 	} else {
 		insert_idx + 1
 	};
-	return insertion_to_pmmr_index(leaf_idx);
+	insertion_to_pmmr_index(leaf_idx)
 }
 
 /// Returns the 0-based pmmr index of 0-based leaf index n
@@ -598,7 +598,7 @@ pub fn insertion_to_pmmr_index(nleaf0: u64) -> u64 {
 /// Returns the insertion index of the given leaf index
 pub fn pmmr_leaf_to_insertion_index(pos0: u64) -> Option<u64> {
 	let (insert_idx, height) = peak_map_height(pos0);
-	(height == 0).then(|| insert_idx)
+	(height == 0).then_some(insert_idx)
 }
 
 /// The height of a node in a full binary tree from its postorder traversal
@@ -685,13 +685,13 @@ pub fn bintree_leaf_pos_iter(pos0: u64) -> Box<dyn Iterator<Item = u64>> {
 		Some(l) => l,
 		None => return Box::new(iter::empty::<u64>()),
 	};
-	Box::new((leaf_start..=leaf_end).map(|n| insertion_to_pmmr_index(n)))
+	Box::new((leaf_start..=leaf_end).map(insertion_to_pmmr_index))
 }
 
 /// Iterator over all pos beneath the provided subtree root (including the root itself).
 pub fn bintree_pos_iter(pos0: u64) -> impl Iterator<Item = u64> {
 	let leaf_start = bintree_leftmost(pos0);
-	(leaf_start..=pos0).into_iter()
+	(leaf_start..=pos0)
 }
 
 /// All pos in the subtree beneath the provided root, including root itself.

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -598,11 +598,7 @@ pub fn insertion_to_pmmr_index(nleaf0: u64) -> u64 {
 /// Returns the insertion index of the given leaf index
 pub fn pmmr_leaf_to_insertion_index(pos0: u64) -> Option<u64> {
 	let (insert_idx, height) = peak_map_height(pos0);
-	if height == 0 {
-		Some(insert_idx)
-	} else {
-		None
-	}
+	(height == 0).then(|| insert_idx)
 }
 
 /// The height of a node in a full binary tree from its postorder traversal

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -72,6 +72,6 @@ where
 	/// Intended usage is to create a rewindable PMMR, rewind it,
 	/// then convert to "readonly" and read from it.
 	pub fn as_readonly(&self) -> ReadonlyPMMR<'a, T, B> {
-		ReadonlyPMMR::at(&self.backend, self.last_pos)
+		ReadonlyPMMR::at(self.backend, self.last_pos)
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -172,11 +172,7 @@ impl FeeFields {
 	/// Turn a zero `FeeField` into a `None`, any other value into a `Some`.
 	/// We need this because a zero `FeeField` cannot be deserialized.
 	pub fn as_opt(&self) -> Option<Self> {
-		if self.is_zero() {
-			None
-		} else {
-			Some(*self)
-		}
+		(!self.is_zero()).then(|| *self)
 	}
 
 	/// Check if the `FeeFields` is set to zero

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -428,7 +428,7 @@ pub fn max_block_weight() -> u64 {
 /// Maximum allowed transaction weight (1 weight unit ~= 32 bytes)
 pub fn max_tx_weight() -> u64 {
 	let coinbase_weight = OUTPUT_WEIGHT + KERNEL_WEIGHT;
-	max_block_weight().saturating_sub(coinbase_weight) as u64
+	max_block_weight().saturating_sub(coinbase_weight)
 }
 
 /// Horizon at which we can cut-through and do full local pruning

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -103,7 +103,7 @@ pub fn calculate_partial_sig(
 	//Now calculate signature using message M=fee, nonce in e=nonce_sum
 	let sig = aggsig::sign_single(
 		secp,
-		&msg,
+		msg,
 		sec_key,
 		Some(sec_nonce),
 		None,
@@ -186,8 +186,8 @@ pub fn verify_partial_sig(
 	if !verify_single(
 		secp,
 		sig,
-		&msg,
-		Some(&pub_nonce_sum),
+		msg,
+		Some(pub_nonce_sum),
 		pubkey,
 		pubkey_sum,
 		true,
@@ -260,7 +260,7 @@ where
 	K: Keychain,
 {
 	let skey = k.derive_key(value, key_id, SwitchCommitmentType::Regular)?; // TODO: proper support for different switch commitment schemes
-	let sig = aggsig::sign_single(secp, &msg, &skey, s_nonce, None, None, blind_sum, None)?;
+	let sig = aggsig::sign_single(secp, msg, &skey, s_nonce, None, None, blind_sum, None)?;
 	Ok(sig)
 }
 
@@ -404,7 +404,7 @@ pub fn add_signatures(
 	nonce_sum: &PublicKey,
 ) -> Result<Signature, Error> {
 	// Add public nonces kR*G + kS*G
-	let sig = aggsig::add_signatures_single(&secp, part_sigs, &nonce_sum)?;
+	let sig = aggsig::add_signatures_single(secp, part_sigs, nonce_sum)?;
 	Ok(sig)
 }
 
@@ -416,7 +416,7 @@ pub fn sign_single(
 	snonce: Option<&SecretKey>,
 	pubkey_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error> {
-	let sig = aggsig::sign_single(secp, &msg, skey, snonce, None, None, pubkey_sum, None)?;
+	let sig = aggsig::sign_single(secp, msg, skey, snonce, None, None, pubkey_sum, None)?;
 	Ok(sig)
 }
 
@@ -452,7 +452,7 @@ pub fn sign_with_blinding(
 	blinding: &BlindingFactor,
 	pubkey_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error> {
-	let skey = &blinding.secret_key(&secp)?;
-	let sig = aggsig::sign_single(secp, &msg, skey, None, None, None, pubkey_sum, None)?;
+	let skey = &blinding.secret_key(secp)?;
+	let sig = aggsig::sign_single(secp, msg, skey, None, None, None, pubkey_sum, None)?;
 	Ok(sig)
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -213,11 +213,11 @@ where
 	let msg = kernel.msg_to_sign()?;
 
 	// Generate kernel public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp())?;
+	let excess = BlindingFactor::rand(keychain.secp());
+	let skey = excess.secret_key(keychain.secp())?;
 	kernel.excess = keychain.secp().commit(0, skey)?;
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp())?;
-	kernel.excess_sig = aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey))?;
+	let pubkey = &kernel.excess.to_pubkey(keychain.secp())?;
+	kernel.excess_sig = aggsig::sign_with_blinding(keychain.secp(), &msg, &excess, Some(pubkey))?;
 	kernel.verify()?;
 	transaction_with_kernel(elems, kernel, excess, keychain, builder)
 }
@@ -246,7 +246,7 @@ where
 
 	// Update tx with new kernel and offset.
 	let mut tx = tx.replace_kernel(kernel);
-	tx.offset = blind_sum.split(&excess, &keychain.secp())?;
+	tx.offset = blind_sum.split(&excess, keychain.secp())?;
 	Ok(tx)
 }
 

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -164,7 +164,7 @@ where
 		};
 		let res = blake2b(32, &commit.0, hash);
 		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
-			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {:?}", e)))
+			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {e:?}")))
 	}
 }
 
@@ -277,7 +277,7 @@ where
 	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.root_hash);
 		SecretKey::from_slice(self.keychain.secp(), res.as_bytes())
-			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {:?}", e)))
+			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {e:?}")))
 	}
 }
 
@@ -360,7 +360,7 @@ impl ProofBuild for ViewKey {
 	fn rewind_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.rewind_hash);
 		SecretKey::from_slice(secp, res.as_bytes())
-			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {:?}", e)))
+			.map_err(|e| Error::RangeProof(format!("Unable to create nonce: {e:?}")))
 	}
 
 	fn private_nonce(&self, _secp: &Secp256k1, _commit: &Commitment) -> Result<SecretKey, Error> {
@@ -418,10 +418,10 @@ impl ProofBuild for ViewKey {
 			if child_number.is_hardened() {
 				return Ok(None);
 			}
-			key = key.ckd_pub(&secp, &mut hasher, child_number)?;
+			key = key.ckd_pub(secp, &mut hasher, child_number)?;
 		}
 		let pub_key = key.commit(secp, amount, switch)?;
-		if commit.to_pubkey(&secp)? == pub_key {
+		if commit.to_pubkey(secp)? == pub_key {
 			Ok(Some((id, switch)))
 		} else {
 			Ok(None)

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -64,13 +64,13 @@ where
 				keychain,
 				&msg,
 				value,
-				&key_id,
+				key_id,
 				Some(&test_nonce),
 				Some(&pubkey),
 			)?
 		}
 		false => {
-			aggsig::sign_from_key_id(&secp, keychain, &msg, value, &key_id, None, Some(&pubkey))?
+			aggsig::sign_from_key_id(&secp, keychain, &msg, value, key_id, None, Some(&pubkey))?
 		}
 	};
 

--- a/core/src/libtx/secp_ser.rs
+++ b/core/src/libtx/secp_ser.rs
@@ -204,7 +204,7 @@ pub mod option_commitment_serde {
 		Option::<String>::deserialize(deserializer).and_then(|res| match res {
 			Some(string) => from_hex(&string)
 				.map_err(Error::custom)
-				.and_then(|bytes: Vec<u8>| Ok(Some(Commitment::from_vec(bytes.to_vec())))),
+				.map(|bytes: Vec<u8>| Some(Commitment::from_vec(bytes.to_vec()))),
 			None => Ok(None),
 		})
 	}
@@ -239,7 +239,7 @@ where
 	use serde::de::Error;
 	String::deserialize(deserializer)
 		.and_then(|string| from_hex(&string).map_err(Error::custom))
-		.and_then(|bytes: Vec<u8>| Ok(Commitment::from_vec(bytes.to_vec())))
+		.map(|bytes: Vec<u8>| Commitment::from_vec(bytes.to_vec()))
 }
 
 /// Seralizes a byte string into hex

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -63,12 +63,12 @@ pub fn set_header_nonce(header: &[u8], nonce: Option<u32>) -> Result<[u64; 4], E
 		header.write_u32::<LittleEndian>(n)?;
 		create_siphash_keys(&header)
 	} else {
-		create_siphash_keys(&header)
+		create_siphash_keys(header)
 	}
 }
 
 pub fn create_siphash_keys(header: &[u8]) -> Result<[u64; 4], Error> {
-	let h = blake2b(32, &[], &header);
+	let h = blake2b(32, &[], header);
 	let hb = h.as_bytes();
 	let mut rdr = Cursor::new(hb);
 	Ok([

--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -64,7 +64,7 @@ impl PoWContext for CuckarooContext {
 	fn verify(&self, proof: &Proof) -> Result<(), Error> {
 		let size = proof.proof_size();
 		if size != global::proofsize() {
-			return Err(Error::Verification("wrong cycle length".to_owned()).into());
+			return Err(Error::Verification("wrong cycle length".to_owned()));
 		}
 		let nonces = &proof.nonces;
 		let mut uvs = vec![0u64; 2 * size];

--- a/core/src/pow/cuckarood.rs
+++ b/core/src/pow/cuckarood.rs
@@ -114,7 +114,7 @@ impl PoWContext for CuckaroodContext {
 			let mut k = if i & 1 == 0 {
 				headu[((uvs[i] << 1 | 1) & mask) as usize]
 			} else {
-				headv[((uvs[i] << 1 | 0) & mask) as usize]
+				headv[(uvs[i] << 1 & mask) as usize]
 			};
 			while k != 2 * size {
 				if uvs[k] == uvs[i] {

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -81,7 +81,7 @@ impl Graph {
 		if u >= self.max_nodes || v >= self.max_nodes {
 			return Err(Error::EdgeAddition);
 		}
-		v = v + self.max_nodes;
+		v += self.max_nodes;
 		let adj_u = self.adj_list[(u ^ 1) as usize];
 		let adj_v = self.adj_list[(v ^ 1) as usize];
 		if adj_u != self.nil && adj_v != self.nil {
@@ -243,7 +243,7 @@ impl CuckatooContext {
 			s.nonces.sort_unstable();
 		}
 		for s in &self.graph.solutions {
-			self.verify_impl(&s)?;
+			self.verify_impl(s)?;
 		}
 		if self.graph.solutions.is_empty() {
 			Err(Error::NoSolution)

--- a/core/src/pow/lean.rs
+++ b/core/src/pow/lean.rs
@@ -51,7 +51,7 @@ impl Lean {
 	/// and works well for Cuckatoo size above 18.
 	pub fn trim(&mut self) {
 		// trimming successively
-		while self.edges.cardinality() > (7 * (self.params.num_edges >> 8) / 8) as u64 {
+		while self.edges.cardinality() > (7 * (self.params.num_edges >> 8) / 8) {
 			self.count_and_kill();
 		}
 	}

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -344,7 +344,7 @@ impl fmt::Debug for Proof {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "Cuckoo{}(", self.edge_bits)?;
 		for (i, val) in self.nonces[..].iter().enumerate() {
-			write!(f, "{:x}", val)?;
+			write!(f, "{val:x}")?;
 			if i < self.nonces.len() - 1 {
 				write!(f, " ")?;
 			}

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -76,7 +76,7 @@ pub enum Error {
 
 impl From<io::Error> for Error {
 	fn from(e: io::Error) -> Error {
-		Error::IOErr(format!("{}", e), e.kind())
+		Error::IOErr(format!("{e}"), e.kind())
 	}
 }
 
@@ -89,17 +89,17 @@ impl From<io::ErrorKind> for Error {
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
-			Error::IOErr(ref e, ref _k) => write!(f, "{}", e),
+			Error::IOErr(ref e, ref _k) => write!(f, "{e}"),
 			Error::UnexpectedData {
 				expected: ref e,
 				received: ref r,
-			} => write!(f, "expected {:?}, got {:?}", e, r),
+			} => write!(f, "expected {e:?}, got {r:?}"),
 			Error::CorruptedData => f.write_str("corrupted data"),
 			Error::CountError => f.write_str("count error"),
 			Error::SortError => f.write_str("sort order"),
 			Error::DuplicateError => f.write_str("duplicate"),
 			Error::TooLargeReadErr => f.write_str("too large read"),
-			Error::HexError(ref e) => write!(f, "hex error {:?}", e),
+			Error::HexError(ref e) => write!(f, "hex error {e:?}"),
 			Error::InvalidBlockVersion => f.write_str("invalid block version"),
 			Error::UnsupportedProtocolVersion => f.write_str("unsupported protocol version"),
 		}
@@ -160,42 +160,42 @@ pub trait Writer {
 
 	/// Writes a u8 as bytes
 	fn write_u8(&mut self, n: u8) -> Result<(), Error> {
-		self.write_fixed_bytes(&[n])
+		self.write_fixed_bytes([n])
 	}
 
 	/// Writes a u16 as bytes
 	fn write_u16(&mut self, n: u16) -> Result<(), Error> {
 		let mut bytes = [0; 2];
 		BigEndian::write_u16(&mut bytes, n);
-		self.write_fixed_bytes(&bytes)
+		self.write_fixed_bytes(bytes)
 	}
 
 	/// Writes a u32 as bytes
 	fn write_u32(&mut self, n: u32) -> Result<(), Error> {
 		let mut bytes = [0; 4];
 		BigEndian::write_u32(&mut bytes, n);
-		self.write_fixed_bytes(&bytes)
+		self.write_fixed_bytes(bytes)
 	}
 
 	/// Writes a u32 as bytes
 	fn write_i32(&mut self, n: i32) -> Result<(), Error> {
 		let mut bytes = [0; 4];
 		BigEndian::write_i32(&mut bytes, n);
-		self.write_fixed_bytes(&bytes)
+		self.write_fixed_bytes(bytes)
 	}
 
 	/// Writes a u64 as bytes
 	fn write_u64(&mut self, n: u64) -> Result<(), Error> {
 		let mut bytes = [0; 8];
 		BigEndian::write_u64(&mut bytes, n);
-		self.write_fixed_bytes(&bytes)
+		self.write_fixed_bytes(bytes)
 	}
 
 	/// Writes a i64 as bytes
 	fn write_i64(&mut self, n: i64) -> Result<(), Error> {
 		let mut bytes = [0; 8];
 		BigEndian::write_i64(&mut bytes, n);
-		self.write_fixed_bytes(&bytes)
+		self.write_fixed_bytes(bytes)
 	}
 
 	/// Writes a variable number of bytes. The length is encoded as a 64-bit
@@ -466,7 +466,7 @@ impl<'a, R: Read> BinReader<'a, R> {
 }
 
 fn map_io_err(err: io::Error) -> Error {
-	Error::IOErr(format!("{}", err), err.kind())
+	Error::IOErr(format!("{err}"), err.kind())
 }
 
 /// Utility wrapper for an underlying byte Reader. Defines higher level methods

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -358,7 +358,7 @@ fn remove_coinbase_kernel_flag() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let mut b = new_block(&[], &keychain, &builder, &prev, &key_id);
 
-	let mut kernel = b.kernels()[0].clone();
+	let mut kernel = b.kernels()[0];
 	kernel.features = KernelFeatures::Plain {
 		fee: FeeFields::zero(),
 	};
@@ -877,9 +877,9 @@ fn test_verify_cut_through_plain() -> Result<(), Error> {
 		&[
 			build::input(10, key_id1.clone()),
 			build::input(10, key_id2.clone()),
-			build::output(10, key_id1.clone()),
-			build::output(6, key_id2.clone()),
-			build::output(4, key_id3.clone()),
+			build::output(10, key_id1),
+			build::output(6, key_id2),
+			build::output(4, key_id3),
 		],
 		&keychain,
 		&builder,
@@ -943,9 +943,9 @@ fn test_verify_cut_through_coinbase() -> Result<(), Error> {
 		&[
 			build::coinbase_input(consensus::REWARD, key_id1.clone()),
 			build::coinbase_input(consensus::REWARD, key_id2.clone()),
-			build::output(60_000_000_000, key_id1.clone()),
-			build::output(50_000_000_000, key_id2.clone()),
-			build::output(10_000_000_000, key_id3.clone()),
+			build::output(60_000_000_000, key_id1),
+			build::output(50_000_000_000, key_id2),
+			build::output(10_000_000_000, key_id3),
 		],
 		&keychain,
 		&builder,

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -121,8 +121,8 @@ where
 	B: ProofBuild,
 {
 	let fees = txs.iter().map(|tx| tx.fee()).sum();
-	let reward_output = reward::output(keychain, builder, &key_id, fees, false).unwrap();
-	Block::new(&previous_header, txs, Difficulty::min_dma(), reward_output).unwrap()
+	let reward_output = reward::output(keychain, builder, key_id, fees, false).unwrap();
+	Block::new(previous_header, txs, Difficulty::min_dma(), reward_output).unwrap()
 }
 
 // utility producing a transaction that spends an output with the provided

--- a/core/tests/consensus_automated.rs
+++ b/core/tests/consensus_automated.rs
@@ -58,12 +58,7 @@ fn next_dma_difficulty_adjustment() {
 	hi.difficulty = Difficulty::from_num(500);
 	let sec = DMA_WINDOW / 2;
 	let mut s1 = repeat(BLOCK_TIME_SEC, hi.clone(), sec, Some(cur_time));
-	let mut s2 = repeat_offs(
-		BLOCK_TIME_SEC,
-		1500,
-		sec,
-		cur_time + (sec * BLOCK_TIME_SEC) as u64,
-	);
+	let mut s2 = repeat_offs(BLOCK_TIME_SEC, 1500, sec, cur_time + (sec * BLOCK_TIME_SEC));
 	s2.append(&mut s1);
 	assert_eq!(
 		next_dma_difficulty(1, s2).difficulty,

--- a/core/tests/consensus_mainnet.rs
+++ b/core/tests/consensus_mainnet.rs
@@ -163,10 +163,10 @@ fn get_diff_stats(chain_sim: &[HeaderDifficultyInfo]) -> DiffStats {
 		average_block_time: block_time_sum / DMA_WINDOW,
 		average_difficulty: block_diff_sum / DMA_WINDOW,
 		window_size: DMA_WINDOW,
-		block_time_sum: block_time_sum,
-		block_diff_sum: block_diff_sum,
-		latest_ts: latest_ts,
-		earliest_ts: earliest_ts,
+		block_time_sum,
+		block_diff_sum,
+		latest_ts,
+		earliest_ts,
 		ts_delta: latest_ts - earliest_ts,
 	}
 }
@@ -179,7 +179,7 @@ fn add_block(
 ) -> Vec<(HeaderDifficultyInfo, DiffStats)> {
 	let mut ret_chain_sim = chain_sim.clone();
 	let mut return_chain: Vec<HeaderDifficultyInfo> =
-		chain_sim.clone().iter().map(|e| e.0.clone()).collect();
+		chain_sim.iter().map(|e| e.0.clone()).collect();
 	// get last interval
 	let diff = next_difficulty(1, return_chain.clone());
 	let last_elem = chain_sim.first().unwrap().clone().0;
@@ -217,10 +217,10 @@ fn print_chain_sim(chain_sim: Vec<(HeaderDifficultyInfo, DiffStats)>) {
 	let mut last_time = 0;
 	let mut first = true;
 	println!("Constants");
-	println!("DIFFICULTY_ADJUST_WINDOW: {}", DMA_WINDOW);
-	println!("BLOCK_TIME_WINDOW: {}", BLOCK_TIME_WINDOW);
-	println!("CLAMP_FACTOR: {}", CLAMP_FACTOR);
-	println!("DAMP_FACTOR: {}", DMA_DAMP_FACTOR);
+	println!("DIFFICULTY_ADJUST_WINDOW: {DMA_WINDOW}");
+	println!("BLOCK_TIME_WINDOW: {BLOCK_TIME_WINDOW}");
+	println!("CLAMP_FACTOR: {CLAMP_FACTOR}");
+	println!("DAMP_FACTOR: {DMA_DAMP_FACTOR}");
 	chain_sim.iter().enumerate().for_each(|(i, b)| {
 		let block = b.0.clone();
 		let stats = b.1.clone();
@@ -245,7 +245,7 @@ fn print_chain_sim(chain_sim: Vec<(HeaderDifficultyInfo, DiffStats)>) {
 		let mut sb = stats.last_blocks;
 		sb.reverse();
 		for i in sb {
-			println!("   {}", i);
+			println!("   {i}");
 		}
 		last_time = block.timestamp;
 	});
@@ -287,7 +287,7 @@ fn adjustment_scenarios() {
 
 	// Steady difficulty for a good while, then a sudden drop
 	let chain_sim = create_chain_sim(global::initial_block_difficulty());
-	let chain_sim = add_block_repeated(60, chain_sim, just_enough as usize);
+	let chain_sim = add_block_repeated(60, chain_sim, just_enough);
 	let chain_sim = add_block_repeated(600, chain_sim, 60);
 
 	println!();
@@ -299,7 +299,7 @@ fn adjustment_scenarios() {
 
 	// Sudden increase
 	let chain_sim = create_chain_sim(global::initial_block_difficulty());
-	let chain_sim = add_block_repeated(60, chain_sim, just_enough as usize);
+	let chain_sim = add_block_repeated(60, chain_sim, just_enough);
 	let chain_sim = add_block_repeated(10, chain_sim, 10);
 
 	println!();
@@ -311,7 +311,7 @@ fn adjustment_scenarios() {
 
 	// Oscillations
 	let chain_sim = create_chain_sim(global::initial_block_difficulty());
-	let chain_sim = add_block_repeated(60, chain_sim, just_enough as usize);
+	let chain_sim = add_block_repeated(60, chain_sim, just_enough);
 	let chain_sim = add_block_repeated(10, chain_sim, 10);
 	let chain_sim = add_block_repeated(60, chain_sim, 20);
 	let chain_sim = add_block_repeated(10, chain_sim, 10);

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -192,17 +192,17 @@ fn build_two_half_kernels() {
 	let msg = kernel.msg_to_sign().unwrap();
 
 	// Generate a kernel with public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp()).unwrap();
+	let excess = BlindingFactor::rand(keychain.secp());
+	let skey = excess.secret_key(keychain.secp()).unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+	let pubkey = &kernel.excess.to_pubkey(keychain.secp()).unwrap();
 	kernel.excess_sig =
-		aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
+		aggsig::sign_with_blinding(keychain.secp(), &msg, &excess, Some(pubkey)).unwrap();
 	kernel.verify().unwrap();
 
 	let tx1 = build::transaction_with_kernel(
 		&[input(10, key_id1), output(8, key_id2.clone())],
-		kernel.clone(),
+		kernel,
 		excess.clone(),
 		&keychain,
 		&builder,
@@ -211,8 +211,8 @@ fn build_two_half_kernels() {
 
 	let tx2 = build::transaction_with_kernel(
 		&[input(8, key_id2), output(6, key_id3)],
-		kernel.clone(),
-		excess.clone(),
+		kernel,
+		excess,
 		&keychain,
 		&builder,
 	)
@@ -586,13 +586,7 @@ fn test_block_with_timelocked_tx() {
 
 	let previous_header = BlockHeader::default();
 
-	let b = new_block(
-		&[tx1],
-		&keychain,
-		&builder,
-		&previous_header,
-		&key_id3.clone(),
-	);
+	let b = new_block(&[tx1], &keychain, &builder, &previous_header, &key_id3);
 	b.validate(&BlindingFactor::zero()).unwrap();
 
 	// now try adding a timelocked tx where lock height is greater than current

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -244,7 +244,6 @@ fn transaction_cut_through() {
 	let tx1 = tx1i2o();
 	let tx2 = tx2i1o();
 
-
 	assert!(tx1.validate(Weighting::AsTransaction).is_ok());
 	assert!(tx2.validate(Weighting::AsTransaction).is_ok());
 
@@ -277,17 +276,12 @@ fn multi_kernel_transaction_deaggregation() {
 	assert!(tx34.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx34 = deaggregate(tx1234.clone(), &[tx12.clone()]).unwrap();
-	assert!(deaggregated_tx34
-		.validate(Weighting::AsTransaction)
-
-		.is_ok());
+	assert!(deaggregated_tx34.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx34, deaggregated_tx34);
 
 	let deaggregated_tx12 = deaggregate(tx1234, &[tx34]).unwrap();
 
-	assert!(deaggregated_tx12
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx12.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx12, deaggregated_tx12);
 }
 
@@ -309,9 +303,7 @@ fn multi_kernel_transaction_deaggregation_2() {
 	assert!(tx12.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx3 = deaggregate(tx123, &[tx12]).unwrap();
-	assert!(deaggregated_tx3
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx3.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx3, deaggregated_tx3);
 }
 
@@ -334,9 +326,7 @@ fn multi_kernel_transaction_deaggregation_3() {
 	assert!(tx2.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx13 = deaggregate(tx123, &[tx2]).unwrap();
-	assert!(deaggregated_tx13
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx13.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx13, deaggregated_tx13);
 }
 
@@ -366,9 +356,7 @@ fn multi_kernel_transaction_deaggregation_4() {
 	assert!(tx12345.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx5 = deaggregate(tx12345, &[tx1, tx2, tx3, tx4]).unwrap();
-	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx5.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
 
@@ -401,9 +389,7 @@ fn multi_kernel_transaction_deaggregation_5() {
 	assert!(tx12345.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx5 = deaggregate(tx12345, &[tx12, tx34]).unwrap();
-	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx5.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
 
@@ -424,16 +410,12 @@ fn basic_transaction_deaggregation() {
 
 	let deaggregated_tx1 = deaggregate(tx3.clone(), &[tx2.clone()]).unwrap();
 
-	assert!(deaggregated_tx1
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx1.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx1, deaggregated_tx1);
 
 	let deaggregated_tx2 = deaggregate(tx3, &[tx1]).unwrap();
 
-	assert!(deaggregated_tx2
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx2.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx2, deaggregated_tx2);
 }
 
@@ -558,8 +540,7 @@ fn reward_with_tx_block() {
 
 	let tx1 = tx2i1o();
 	let previous_header = BlockHeader::default();
-	tx1.validate(Weighting::AsTransaction)
-		.unwrap();
+	tx1.validate(Weighting::AsTransaction).unwrap();
 
 	let block = new_block(&[tx1], &keychain, &builder, &previous_header, &key_id);
 	block.validate(&BlindingFactor::zero()).unwrap();

--- a/core/tests/pmmr.rs
+++ b/core/tests/pmmr.rs
@@ -49,7 +49,7 @@ fn bench_peak_map() {
 		}
 		let fin = Utc::now().timestamp_nanos();
 		let dur_ms = (fin - start) as f64 * nano_to_millis;
-		println!("{:9?} peak_map_height() in {:9.3?}ms", v, dur_ms);
+		println!("{v:9?} peak_map_height() in {dur_ms:9.3?}ms");
 	}
 }
 

--- a/core/tests/segment.rs
+++ b/core/tests/segment.rs
@@ -38,8 +38,7 @@ fn test_unprunable_size(height: u8, n_leaves: u32) {
 		let id = SegmentIdentifier { height, idx };
 		let segment = Segment::from_pmmr(id, &mmr, false).unwrap();
 		println!(
-			"\n\n>>>>>>> N_LEAVES = {}, LAST_POS = {}, SEGMENT = {}:\n{:#?}",
-			n_leaves, last_pos, idx, segment
+			"\n\n>>>>>>> N_LEAVES = {n_leaves}, LAST_POS = {last_pos}, SEGMENT = {idx}:\n{segment:#?}"
 		);
 		if idx < n_segments - 1 || (n_leaves as u64) % size == 0 {
 			// Check if the reconstructed subtree root matches with the hash stored in the mmr

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -34,7 +34,7 @@ fn test_transaction_json_ser_deser() {
 	let tx1 = tx1i10_v2_compatible();
 
 	let value = serde_json::to_value(&tx1).unwrap();
-	println!("{:?}", value);
+	println!("{value:?}");
 
 	assert!(value["offset"].is_string());
 	assert_eq!(value["body"]["inputs"][0]["features"], "Plain");
@@ -52,7 +52,7 @@ fn test_transaction_json_ser_deser() {
 	assert_eq!(tx1, tx2);
 
 	let str = serde_json::to_string(&tx1).unwrap();
-	println!("{}", str);
+	println!("{str}");
 	let tx2: Transaction = serde_json::from_str(&str).unwrap();
 	assert_eq!(tx1, tx2);
 }
@@ -99,9 +99,9 @@ fn test_verify_cut_through_plain() -> Result<(), Error> {
 		&[
 			build::input(10, key_id1.clone()),
 			build::input(10, key_id2.clone()),
-			build::output(10, key_id1.clone()),
-			build::output(6, key_id2.clone()),
-			build::output(4, key_id3.clone()),
+			build::output(10, key_id1),
+			build::output(6, key_id2),
+			build::output(4, key_id3),
 		],
 		&keychain,
 		&builder,
@@ -158,9 +158,9 @@ fn test_verify_cut_through_coinbase() -> Result<(), Error> {
 		&[
 			build::coinbase_input(consensus::REWARD, key_id1.clone()),
 			build::coinbase_input(consensus::REWARD, key_id2.clone()),
-			build::output(60_000_000_000, key_id1.clone()),
-			build::output(50_000_000_000, key_id2.clone()),
-			build::output(10_000_000_000, key_id3.clone()),
+			build::output(60_000_000_000, key_id1),
+			build::output(50_000_000_000, key_id2),
+			build::output(10_000_000_000, key_id3),
 		],
 		&keychain,
 		&builder,
@@ -213,14 +213,14 @@ fn test_fee_fields() -> Result<(), Error> {
 		},
 		&[
 			build::coinbase_input(consensus::REWARD, key_id1.clone()),
-			build::output(60_000_000_000 - 84 - 42 - 21, key_id1.clone()),
+			build::output(60_000_000_000 - 84 - 42 - 21, key_id1),
 		],
 		&keychain,
 		&builder,
 	)
 	.expect("valid tx");
 
-	assert_eq!(tx.accept_fee(), (1 * 1 + 1 * 21 + 1 * 3) * 500_000);
+	assert_eq!(tx.accept_fee(), (1 + 21 + 3) * 500_000);
 	assert_eq!(tx.fee(), 42);
 	assert_eq!(tx.shifted_fee(), 21);
 

--- a/keychain/src/base58.rs
+++ b/keychain/src/base58.rs
@@ -41,7 +41,7 @@ fn sha256d_hash(data: &[u8]) -> [u8; 32] {
 	sha2.update(data);
 	ret.copy_from_slice(sha2.finalize().as_slice());
 	sha2 = Sha256::new();
-	sha2.update(&ret);
+	sha2.update(ret);
 	ret.copy_from_slice(sha2.finalize().as_slice());
 	ret
 }
@@ -73,15 +73,14 @@ pub enum Error {
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
-			Error::BadByte(b) => write!(f, "invalid base58 character 0x{:x}", b),
+			Error::BadByte(b) => write!(f, "invalid base58 character 0x{b:x}"),
 			Error::BadChecksum(exp, actual) => write!(
 				f,
-				"base58ck checksum 0x{:x} does not match expected 0x{:x}",
-				actual, exp
+				"base58ck checksum 0x{actual:x} does not match expected 0x{exp:x}"
 			),
-			Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
+			Error::InvalidLength(ell) => write!(f, "length {ell} invalid for this base58 type"),
 			Error::InvalidVersion(ref v) => {
-				write!(f, "version {:?} invalid for this base58 type", v)
+				write!(f, "version {v:?} invalid for this base58 type")
 			}
 			Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
 			Error::Other(ref s) => f.write_str(s),
@@ -358,14 +357,14 @@ pub fn _encode_slice(data: &[u8]) -> String {
 /// Obtain a string with the base58check encoding of a slice
 /// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
 pub fn check_encode_slice(data: &[u8]) -> String {
-	let checksum = sha256d_hash(&data);
+	let checksum = sha256d_hash(data);
 	encode_iter(data.iter().cloned().chain(checksum[0..4].iter().cloned()))
 }
 
 /// Obtain a string with the base58check encoding of a slice
 /// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
 pub fn _check_encode_slice_to_fmt(fmt: &mut fmt::Formatter<'_>, data: &[u8]) -> fmt::Result {
-	let checksum = sha256d_hash(&data);
+	let checksum = sha256d_hash(data);
 	let iter = data.iter().cloned().chain(checksum[0..4].iter().cloned());
 	_encode_iter_to_fmt(fmt, iter)
 }

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -50,8 +50,8 @@ impl Keychain for ExtKeychain {
 		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 		let master = ExtendedPrivKey::new_master(&secp, &mut h, seed)?;
 		let keychain = ExtKeychain {
-			secp: secp,
-			master: master,
+			secp,
+			master,
 			hasher: h,
 		};
 		Ok(keychain)
@@ -62,8 +62,8 @@ impl Keychain for ExtKeychain {
 		let h = BIP32GrinHasher::new(is_test);
 		let master = ExtendedPrivKey::from_mnemonic(&secp, word_list, extension_word, is_test)?;
 		let keychain = ExtKeychain {
-			secp: secp,
-			master: master,
+			secp,
+			master,
 			hasher: h,
 		};
 		Ok(keychain)
@@ -191,7 +191,7 @@ impl Keychain for ExtKeychain {
 		blinding: &BlindingFactor,
 	) -> Result<Signature, Error> {
 		let skey = &blinding.secret_key(&self.secp)?;
-		let sig = self.secp.sign(msg, &skey)?;
+		let sig = self.secp.sign(msg, skey)?;
 		Ok(sig)
 	}
 

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -138,11 +138,7 @@ impl Keychain for ExtKeychain {
 					&Identifier::from_path(&k.ext_keychain_path),
 					k.switch,
 				);
-				if let Ok(s) = res {
-					Some(s)
-				} else {
-					None
-				}
+				res.ok()
 			})
 			.collect();
 
@@ -155,11 +151,7 @@ impl Keychain for ExtKeychain {
 					&Identifier::from_path(&k.ext_keychain_path),
 					k.switch,
 				);
-				if let Ok(s) = res {
-					Some(s)
-				} else {
-					None
-				}
+				res.ok()
 			})
 			.collect();
 

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -42,13 +42,11 @@ pub enum Error {
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
-			Error::BadWord(ref b) => write!(f, "invalid bip39 word {}", b),
-			Error::BadChecksum(exp, actual) => write!(
-				f,
-				"checksum 0x{:x} does not match expected 0x{:x}",
-				actual, exp
-			),
-			Error::InvalidLength(ell) => write!(f, "invalid mnemonic/entropy length {}", ell),
+			Error::BadWord(ref b) => write!(f, "invalid bip39 word {b}"),
+			Error::BadChecksum(exp, actual) => {
+				write!(f, "checksum 0x{actual:x} does not match expected 0x{exp:x}")
+			}
+			Error::InvalidLength(ell) => write!(f, "invalid mnemonic/entropy length {ell}"),
 		}
 	}
 }
@@ -127,7 +125,7 @@ pub fn from_entropy(entropy: &[u8]) -> Result<String, Error> {
 	sha2sum.update(entropy);
 	hash.copy_from_slice(sha2sum.finalize().as_slice());
 
-	let checksum = (hash[0] >> 8 - checksum_bits) & mask;
+	let checksum = (hash[0] >> (8 - checksum_bits)) & mask;
 
 	let nwords = (length * 8 + checksum_bits) / 11;
 	let mut indexes: Vec<u16> = vec![0; nwords];
@@ -352,8 +350,8 @@ mod tests {
 		assert!(to_entropy("abandon abandon badword abandon abandon abandon abandon abandon abandon abandon abandon abandon").is_err());
 		// Invalid length
 		assert!(to_entropy("abandon abandon abandon abandon abandon abandon").is_err());
-		assert!(from_entropy(&vec![1, 2, 3, 4, 5]).is_err());
-		assert!(from_entropy(&vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]).is_err());
+		assert!(from_entropy(&[1, 2, 3, 4, 5]).is_err());
+		assert!(from_entropy(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]).is_err());
 		// Invalid checksum
 		assert!(to_entropy("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon").is_err());
 		assert!(to_entropy("zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo").is_err());

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -62,17 +62,13 @@ impl From<extkey_bip32::Error> for Error {
 
 impl error::Error for Error {
 	fn description(&self) -> &str {
-		match *self {
-			_ => "some kind of keychain error",
-		}
+		"some kind of keychain error"
 	}
 }
 
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match *self {
-			_ => write!(f, "some kind of keychain error"),
-		}
+		write!(f, "some kind of keychain error")
 	}
 }
 
@@ -125,7 +121,7 @@ impl Identifier {
 	}
 
 	pub fn to_path(&self) -> ExtKeychainPath {
-		ExtKeychainPath::from_identifier(&self)
+		ExtKeychainPath::from_identifier(self)
 	}
 
 	pub fn to_value_path(&self, value: u64) -> ValueExtKeychainPath {
@@ -157,7 +153,7 @@ impl Identifier {
 
 	/// Return the parent path
 	pub fn parent_path(&self) -> Identifier {
-		let mut p = ExtKeychainPath::from_identifier(&self);
+		let mut p = ExtKeychainPath::from_identifier(self);
 		if p.depth > 0 {
 			p.path[p.depth as usize - 1] = ChildNumber::from(0);
 			p.depth -= 1;
@@ -178,7 +174,7 @@ impl Identifier {
 	pub fn from_pubkey(secp: &Secp256k1, pubkey: &PublicKey) -> Identifier {
 		let bytes = pubkey.serialize_vec(secp, true);
 		let identifier = blake2b(IDENTIFIER_SIZE, &[], &bytes[..]);
-		Identifier::from_bytes(&identifier.as_bytes())
+		Identifier::from_bytes(identifier.as_bytes())
 	}
 
 	/// Return the identifier of the secret key
@@ -195,7 +191,7 @@ impl Identifier {
 	}
 
 	pub fn to_bip_32_string(&self) -> String {
-		let p = ExtKeychainPath::from_identifier(&self);
+		let p = ExtKeychainPath::from_identifier(self);
 		let mut retval = String::from("m");
 		for i in 0..p.depth {
 			retval.push_str(&format!("/{}", <u32>::from(p.path[i as usize])));
@@ -206,7 +202,7 @@ impl Identifier {
 
 impl AsRef<[u8]> for Identifier {
 	fn as_ref(&self) -> &[u8] {
-		&self.0.as_ref()
+		self.0.as_ref()
 	}
 }
 
@@ -243,7 +239,7 @@ impl AsRef<[u8]> for BlindingFactor {
 
 impl BlindingFactor {
 	pub fn from_secret_key(skey: SecretKey) -> BlindingFactor {
-		BlindingFactor::from_slice(&skey.as_ref())
+		BlindingFactor::from_slice(skey.as_ref())
 	}
 
 	pub fn from_slice(data: &[u8]) -> BlindingFactor {
@@ -286,7 +282,7 @@ impl BlindingFactor {
 		let keys = vec![self, other]
 			.into_iter()
 			.filter(|x| !x.is_zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
+			.filter_map(|x| x.secret_key(secp).ok())
 			.collect::<Vec<_>>();
 		if keys.is_empty() {
 			Ok(BlindingFactor::zero())
@@ -374,7 +370,7 @@ impl ExtKeychainPath {
 	/// Return a new chain path with given derivation and depth
 	pub fn new(depth: u8, d0: u32, d1: u32, d2: u32, d3: u32) -> ExtKeychainPath {
 		ExtKeychainPath {
-			depth: depth,
+			depth,
 			path: [
 				ChildNumber::from(d0),
 				ChildNumber::from(d1),
@@ -594,8 +590,8 @@ mod test {
 		let ret_path = id.to_path();
 		assert_eq!(path, ret_path);
 
-		println!("id: {:?}", id);
-		println!("ret_path {:?}", ret_path);
+		println!("id: {id:?}");
+		println!("ret_path {ret_path:?}");
 
 		let path = ExtKeychainPath::new(3, 0, 0, 10, 0);
 		let id = Identifier::from_path(&path);

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -187,7 +187,7 @@ impl Handshake {
 		} else {
 			// check the nonce to see if we are trying to connect to ourselves
 			let nonces = self.nonces.read();
-			let addr = resolve_peer_addr(hand.sender_addr, &conn);
+			let addr = resolve_peer_addr(hand.sender_addr, conn);
 			if nonces.contains(&hand.nonce) {
 				// save ip addresses of ourselves
 				let mut addrs = self.addrs.write();
@@ -205,7 +205,7 @@ impl Handshake {
 		let peer_info = PeerInfo {
 			capabilities: hand.capabilities,
 			user_agent: hand.user_agent,
-			addr: resolve_peer_addr(hand.sender_addr, &conn),
+			addr: resolve_peer_addr(hand.sender_addr, conn),
 			version: negotiated_version,
 			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(hand.total_difficulty))),
 			direction: Direction::Inbound,
@@ -224,7 +224,7 @@ impl Handshake {
 			version: self.protocol_version,
 			capabilities: capab,
 			genesis: self.genesis,
-			total_difficulty: total_difficulty,
+			total_difficulty,
 			user_agent: USER_AGENT.to_string(),
 		};
 

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -334,7 +334,7 @@ impl Peer {
 			"Requesting tx (kernel hash) {} from peer {}.",
 			h, self.info.addr
 		);
-		self.send(&h, msg::Type::GetTransaction)
+		self.send(h, msg::Type::GetTransaction)
 	}
 
 	/// Sends a request for a specific block by hash.
@@ -342,13 +342,13 @@ impl Peer {
 	pub fn send_block_request(&self, h: Hash, opts: chain::Options) -> Result<(), Error> {
 		debug!("Requesting block {} from peer {}.", h, self.info.addr);
 		self.tracking_adapter.push_req(h, opts);
-		self.send(&h, msg::Type::GetBlock)
+		self.send(h, msg::Type::GetBlock)
 	}
 
 	/// Sends a request for a specific compact block by hash
 	pub fn send_compact_block_request(&self, h: Hash) -> Result<(), Error> {
 		debug!("Requesting compact block {} from {}", h, self.info.addr);
-		self.send(&h, msg::Type::GetCompactBlock)
+		self.send(h, msg::Type::GetCompactBlock)
 	}
 
 	pub fn send_peer_request(&self, capab: Capabilities) -> Result<(), Error> {
@@ -461,7 +461,7 @@ struct TrackingAdapter {
 impl TrackingAdapter {
 	fn new(adapter: Arc<dyn NetAdapter>) -> TrackingAdapter {
 		TrackingAdapter {
-			adapter: adapter,
+			adapter,
 			received: Arc::new(RwLock::new(LruCache::new(MAX_TRACK_SIZE))),
 			requested: Arc::new(RwLock::new(LruCache::new(MAX_TRACK_SIZE))),
 		}

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -332,13 +332,13 @@ impl Peers {
 		// build a list of peers to be cleaned up
 		{
 			for peer in self.iter() {
-				let ref peer: &Peer = peer.as_ref();
+				let peer: &Peer = peer.as_ref();
 				if peer.is_banned() {
 					debug!("clean_peers {:?}, peer banned", peer.info.addr);
-					rm.push(peer.info.addr.clone());
+					rm.push(peer.info.addr);
 				} else if !peer.is_connected() {
 					debug!("clean_peers {:?}, not connected", peer.info.addr);
-					rm.push(peer.info.addr.clone());
+					rm.push(peer.info.addr);
 				} else if peer.is_abusive() {
 					let received = peer.tracker().received_bytes.read().count_per_min();
 					let sent = peer.tracker().sent_bytes.read().count_per_min();
@@ -347,7 +347,7 @@ impl Peers {
 						peer.info.addr, sent, received,
 					);
 					let _ = self.update_state(peer.info.addr, State::Banned);
-					rm.push(peer.info.addr.clone());
+					rm.push(peer.info.addr);
 				} else {
 					let (stuck, diff) = peer.is_stuck();
 					match self.adapter.total_difficulty() {
@@ -355,7 +355,7 @@ impl Peers {
 							if stuck && diff < total_difficulty {
 								debug!("clean_peers {:?}, stuck peer", peer.info.addr);
 								let _ = self.update_state(peer.info.addr, State::Defunct);
-								rm.push(peer.info.addr.clone());
+								rm.push(peer.info.addr);
 							}
 						}
 						Err(e) => error!("failed to get total difficulty: {:?}", e),
@@ -501,7 +501,7 @@ impl ChainAdapter for Peers {
 				hash, peer_info.addr,
 			);
 			self.ban_peer(peer_info.addr, ReasonForBan::BadBlock)
-				.map_err(|e| chain::Error::Other(format!("ban peer error: {:?}", e)))?;
+				.map_err(|e| chain::Error::Other(format!("ban peer error: {e:?}")))?;
 			Ok(false)
 		} else {
 			Ok(true)
@@ -522,7 +522,7 @@ impl ChainAdapter for Peers {
 				hash, peer_info.addr
 			);
 			self.ban_peer(peer_info.addr, ReasonForBan::BadCompactBlock)
-				.map_err(|e| chain::Error::Other(format!("ban peer error: {:?}", e)))?;
+				.map_err(|e| chain::Error::Other(format!("ban peer error: {e:?}")))?;
 			Ok(false)
 		} else {
 			Ok(true)
@@ -538,7 +538,7 @@ impl ChainAdapter for Peers {
 			// if the peer sent us a block header that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
 			self.ban_peer(peer_info.addr, ReasonForBan::BadBlockHeader)
-				.map_err(|e| chain::Error::Other(format!("ban peer error: {:?}", e)))?;
+				.map_err(|e| chain::Error::Other(format!("ban peer error: {e:?}")))?;
 			Ok(false)
 		} else {
 			Ok(true)
@@ -554,7 +554,7 @@ impl ChainAdapter for Peers {
 			// if the peer sent us a block header that's intrinsically bad
 			// they are either mistaken or malevolent, both of which require a ban
 			self.ban_peer(peer_info.addr, ReasonForBan::BadBlockHeader)
-				.map_err(|e| chain::Error::Other(format!("ban peer error: {:?}", e)))?;
+				.map_err(|e| chain::Error::Other(format!("ban peer error: {e:?}")))?;
 			Ok(false)
 		} else {
 			Ok(true)
@@ -593,7 +593,7 @@ impl ChainAdapter for Peers {
 				peer_info.addr
 			);
 			self.ban_peer(peer_info.addr, ReasonForBan::BadTxHashSet)
-				.map_err(|e| chain::Error::Other(format!("ban peer error: {:?}", e)))?;
+				.map_err(|e| chain::Error::Other(format!("ban peer error: {e:?}")))?;
 			Ok(true)
 		} else {
 			Ok(false)
@@ -746,7 +746,7 @@ impl<I: Iterator> IntoIterator for PeersIter<I> {
 	type IntoIter = I;
 
 	fn into_iter(self) -> Self::IntoIter {
-		self.iter.into_iter()
+		self.iter
 	}
 }
 

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -78,9 +78,9 @@ impl MessageHandler for Protocol {
 					);
 
 					let zip = File::open(meta.path.clone())?;
-					let res =
-						self.adapter
-							.txhashset_write(meta.hash.clone(), zip, &self.peer_info)?;
+					let res = self
+						.adapter
+						.txhashset_write(meta.hash, zip, &self.peer_info)?;
 
 					debug!(
 						"handle_payload: txhashset archive for {} at {}, DONE. Data Ok: {}",
@@ -233,7 +233,7 @@ impl MessageHandler for Protocol {
 					let mut resp = Msg::new(
 						Type::TxHashSetArchive,
 						&TxHashSetArchive {
-							height: txhashset_header.height as u64,
+							height: txhashset_header.height,
 							hash: txhashset_header_hash,
 							bytes: file_sz,
 						},
@@ -398,7 +398,7 @@ impl MessageHandler for Protocol {
 				adapter.receive_output_segment(
 					response.block_hash,
 					output_bitmap_root,
-					response.segment.into(),
+					response.segment,
 				)?;
 				Consumed::None
 			}
@@ -408,7 +408,7 @@ impl MessageHandler for Protocol {
 					segment,
 				} = req;
 				trace!("Received Rangeproof Segment: bh: {}", block_hash);
-				adapter.receive_rangeproof_segment(block_hash, segment.into())?;
+				adapter.receive_rangeproof_segment(block_hash, segment)?;
 				Consumed::None
 			}
 			Message::KernelSegment(req) => {
@@ -417,7 +417,7 @@ impl MessageHandler for Protocol {
 					segment,
 				} = req;
 				trace!("Received Kernel Segment: bh: {}", block_hash);
-				adapter.receive_kernel_segment(block_hash, segment.into())?;
+				adapter.receive_kernel_segment(block_hash, segment)?;
 				Consumed::None
 			}
 			Message::Unknown(_) => Consumed::None,

--- a/p2p/src/store.rs
+++ b/p2p/src/store.rs
@@ -97,7 +97,7 @@ impl Readable for PeerData {
 				addr,
 				capabilities,
 				user_agent,
-				flags: flags,
+				flags,
 				last_banned: lb,
 				ban_reason,
 				last_connected,
@@ -116,7 +116,7 @@ impl PeerStore {
 	/// Instantiates a new peer store under the provided root path.
 	pub fn new(db_root: &str) -> Result<PeerStore, Error> {
 		let db = grin_store::Store::new(db_root, Some(DB_NAME), Some(STORE_SUBPATH), None)?;
-		Ok(PeerStore { db: db })
+		Ok(PeerStore { db })
 	}
 
 	pub fn save_peer(&self, p: &PeerData) -> Result<(), Error> {
@@ -138,7 +138,7 @@ impl PeerStore {
 
 	pub fn get_peer(&self, peer_addr: PeerAddr) -> Result<PeerData, Error> {
 		option_to_not_found(self.db.get_ser(&peer_key(peer_addr)[..], None), || {
-			format!("Peer at address: {}", peer_addr)
+			format!("Peer at address: {peer_addr}")
 		})
 	}
 
@@ -192,7 +192,7 @@ impl PeerStore {
 
 		let mut peer = option_to_not_found(
 			batch.get_ser::<PeerData>(&peer_key(peer_addr)[..], None),
-			|| format!("Peer at address: {}", peer_addr),
+			|| format!("Peer at address: {peer_addr}"),
 		)?;
 		peer.flags = new_state;
 		if new_state == State::Banned {
@@ -233,5 +233,5 @@ impl PeerStore {
 
 // Ignore the port unless ip is loopback address.
 fn peer_key(peer_addr: PeerAddr) -> Vec<u8> {
-	to_key(PEER_PREFIX, &peer_addr.as_key())
+	to_key(PEER_PREFIX, peer_addr.as_key())
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -123,7 +123,7 @@ impl Writeable for PeerAddr {
 				ser_multiwrite!(
 					writer,
 					[write_u8, 0],
-					[write_fixed_bytes, &sav4.ip().octets().to_vec()],
+					[write_fixed_bytes, sav4.ip().octets()],
 					[write_u16, sav4.port()]
 				);
 			}
@@ -184,7 +184,7 @@ impl<'de> Visitor<'de> for PeerAddrs {
 				// If that fails it's probably a DNS record
 				Err(_) => {
 					let socket_addrs = entry.to_socket_addrs().map_err(|_| {
-						serde::de::Error::custom(format!("Unable to resolve DNS: {}", entry))
+						serde::de::Error::custom(format!("Unable to resolve DNS: {entry}"))
 					})?;
 					peers.append(&mut socket_addrs.map(PeerAddr).collect());
 				}

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -63,7 +63,7 @@ fn peer_handshake() {
 			p2p::Capabilities::UNKNOWN,
 			p2p_config.clone(),
 			net_adapter.clone(),
-			Hash::from_vec(&vec![]),
+			Hash::from_vec(&[]),
 			Arc::new(StopState::new()),
 		)
 		.unwrap(),
@@ -83,7 +83,7 @@ fn peer_handshake() {
 		p2p::Capabilities::UNKNOWN,
 		Difficulty::min_dma(),
 		my_addr,
-		&p2p::handshake::Handshake::new(Hash::from_vec(&vec![]), p2p_config.clone()),
+		&p2p::handshake::Handshake::new(Hash::from_vec(&[]), p2p_config),
 		net_adapter,
 	)
 	.unwrap();

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -45,28 +45,26 @@ fn test_capabilities() {
 	let expected = p2p::types::Capabilities::default();
 
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b00000000 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b00000000_u32),
 		p2p::types::Capabilities::UNKNOWN
 	);
 	assert_eq!(
-		p2p::types::Capabilities::from_bits_truncate(0b10000000 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b10000000_u32),
 		p2p::types::Capabilities::UNKNOWN
 	);
 
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b1011111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b1011111_u32),
 	);
 
 	assert_eq!(
 		expected,
-		p2p::types::Capabilities::from_bits_truncate(0b01011111 as u32),
+		p2p::types::Capabilities::from_bits_truncate(0b01011111_u32),
 	);
 
-	assert!(p2p::types::Capabilities::from_bits_truncate(0b01011111 as u32).contains(expected));
+	assert!(p2p::types::Capabilities::from_bits_truncate(0b01011111_u32).contains(expected));
 
-	assert!(
-		p2p::types::Capabilities::from_bits_truncate(0b00101111 as u32)
-			.contains(p2p::types::Capabilities::TX_KERNEL_HASH)
-	);
+	assert!(p2p::types::Capabilities::from_bits_truncate(0b00101111_u32)
+		.contains(p2p::types::Capabilities::TX_KERNEL_HASH));
 }

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -522,7 +522,7 @@ impl Bucket {
 		agg_tx.validate(weighting)?;
 		Ok(Bucket {
 			fee_rate: agg_tx.fee_rate(),
-			raw_txs: raw_txs,
+			raw_txs,
 			age_idx: self.age_idx,
 		})
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -402,9 +402,7 @@ where
 					// Otherwise discard and let the next block pick this tx up.
 					let bucket = &tx_buckets[pos];
 
-					if let Ok(new_bucket) =
-						bucket.aggregate_with_tx(entry.tx.clone(), weighting)
-					{
+					if let Ok(new_bucket) = bucket.aggregate_with_tx(entry.tx.clone(), weighting) {
 						if new_bucket.fee_rate >= bucket.fee_rate {
 							// Only aggregate if it would not reduce the fee_rate ratio.
 							tx_buckets[pos] = new_bucket;

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -162,7 +162,7 @@ where
 		} else {
 			self.deaggregate_tx(PoolEntry::new(tx, src))?
 		};
-		let ref tx = entry.tx;
+		let tx = &entry.tx;
 
 		// Check this tx is valid based on current header version.
 		// NRD kernels only valid post HF3 and if NRD feature enabled.
@@ -209,7 +209,7 @@ where
 			.verify_coinbase_maturity(&coinbase_inputs.as_slice().into())?;
 
 		// Convert the tx to "v2" compatibility with "features and commit" inputs.
-		let ref entry = self.convert_tx_v2(entry, &spent_pool, &spent_utxo)?;
+		let entry = &(self.convert_tx_v2(entry, &spent_pool, &spent_utxo)?);
 
 		// If this is a stem tx then attempt to add it to stempool.
 		// If the adapter fails to accept the new stem tx then fallback to fluff via txpool.

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -258,7 +258,7 @@ impl From<transaction::Error> for PoolError {
 	fn from(e: transaction::Error) -> PoolError {
 		match e {
 			transaction::Error::InvalidNRDRelativeHeight => PoolError::NRDKernelRelativeHeight,
-			e @ _ => PoolError::InvalidTx(e),
+			e => PoolError::InvalidTx(e),
 		}
 	}
 }

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -73,7 +73,7 @@ fn test_transaction_pool_block_building() -> Result<(), PoolError> {
 
 		// Now add the two child txs to the pool.
 		pool.add_to_pool(test_source(), child_tx_1.clone(), false, &header)?;
-		pool.add_to_pool(test_source(), child_tx_2.clone(), false, &header)?;
+		pool.add_to_pool(test_source(), child_tx_2, false, &header)?;
 
 		assert_eq!(pool.total_size(), 5);
 	}

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -100,7 +100,7 @@ fn test_transaction_pool_block_reconciliation() {
 		pool_child.clone(),
 		conflict_child,
 		conflict_valid_child.clone(),
-		valid_child_conflict.clone(),
+		valid_child_conflict,
 		valid_child_valid.clone(),
 		mixed_child,
 	];

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -60,10 +60,7 @@ fn test_coinbase_maturity() {
 	// Add 2 more blocks. Original coinbase output is now matured and can be spent.
 	add_some_blocks(&chain, 2, &keychain);
 	let header = chain.head_header().unwrap();
-	assert_eq!(
-		pool.add_to_pool(test_source(), tx.clone(), true, &header),
-		Ok(())
-	);
+	assert_eq!(pool.add_to_pool(test_source(), tx, true, &header), Ok(()));
 
 	clean_output_dir(db_root.into());
 }

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -80,7 +80,7 @@ where
 	let reward =
 		reward::output(keychain, &ProofBuilder::new(keychain), &key_id, fee, false).unwrap();
 
-	let mut block = Block::new(&prev, txs, next_header_info.clone().difficulty, reward).unwrap();
+	let mut block = Block::new(&prev, txs, next_header_info.difficulty, reward).unwrap();
 
 	block.header.timestamp = prev.timestamp + Duration::seconds(60);
 	block.header.pow.secondary_scaling = next_header_info.secondary_scaling;
@@ -164,7 +164,7 @@ where
 			max_stempool_size: 50,
 			mineable_max_weight: 10_000,
 		},
-		chain.clone(),
+		chain,
 		Arc::new(NoopPoolAdapter {}),
 	)
 }
@@ -299,6 +299,6 @@ pub fn test_source() -> TxSource {
 
 pub fn clean_output_dir(db_root: String) {
 	if let Err(e) = fs::remove_dir_all(db_root) {
-		println!("cleaning output dir failed - {:?}", e)
+		println!("cleaning output dir failed - {e:?}")
 	}
 }

--- a/pool/tests/nrd_kernels_disabled.rs
+++ b/pool/tests/nrd_kernels_disabled.rs
@@ -80,7 +80,7 @@ fn test_nrd_kernels_disabled() {
 
 	// NRD kernel support not enabled via feature flag, so not valid.
 	assert_eq!(
-		pool.add_to_pool(test_source(), tx_1.clone(), false, &header),
+		pool.add_to_pool(test_source(), tx_1, false, &header),
 		Err(PoolError::NRDKernelNotEnabled)
 	);
 

--- a/pool/tests/nrd_kernels_enabled.rs
+++ b/pool/tests/nrd_kernels_enabled.rs
@@ -85,7 +85,7 @@ fn test_nrd_kernels_enabled() {
 
 	// NRD kernel support enabled via feature flag, so valid.
 	assert_eq!(
-		pool.add_to_pool(test_source(), tx_1.clone(), false, &header),
+		pool.add_to_pool(test_source(), tx_1, false, &header),
 		Ok(())
 	);
 

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -169,8 +169,7 @@ fn test_the_transaction_pool() {
 		assert_eq!(pool.stempool.size(), 1);
 
 		// Duplicate stem tx so fluff, adding it to txpool and removing it from stempool.
-		pool.add_to_pool(test_source(), tx.clone(), true, &header)
-			.unwrap();
+		pool.add_to_pool(test_source(), tx, true, &header).unwrap();
 		assert_eq!(pool.total_size(), 5);
 		assert_eq!(pool.txpool.size(), 5);
 		assert!(pool.stempool.is_empty());
@@ -185,7 +184,7 @@ fn test_the_transaction_pool() {
 
 		// tx1 and tx2 are already in the txpool (in aggregated form)
 		// tx4 is the "new" part of this aggregated tx that we care about
-		let agg_tx = transaction::aggregate(&[tx1.clone(), tx2.clone(), tx4]).unwrap();
+		let agg_tx = transaction::aggregate(&[tx1, tx2, tx4]).unwrap();
 
 		agg_tx.validate(Weighting::AsTransaction).unwrap();
 
@@ -209,7 +208,7 @@ fn test_the_transaction_pool() {
 
 		// check we cannot add a double spend to the txpool
 		assert!(pool
-			.add_to_pool(test_source(), double_spend_tx.clone(), false, &header)
+			.add_to_pool(test_source(), double_spend_tx, false, &header)
 			.is_err());
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -196,7 +196,7 @@ where
 				}
 				Err(e) => {
 					debug!("Invalid hydrated block {}: {:?}", cb_hash, e);
-					return Ok(false);
+					Ok(false)
 				}
 			}
 		} else {
@@ -405,10 +405,10 @@ where
 	/// the required indexes for a consumer to rewind to a consistent state
 	/// at the provided block hash.
 	fn txhashset_read(&self, h: Hash) -> Option<p2p::TxHashSetRead> {
-		match self.chain().txhashset_read(h.clone()) {
+		match self.chain().txhashset_read(h) {
 			Ok((out_index, kernel_index, read)) => Some(p2p::TxHashSetRead {
 				output_index: out_index,
-				kernel_index: kernel_index,
+				kernel_index,
 				reader: read,
 			}),
 			Err(e) => {
@@ -576,7 +576,7 @@ where
 		// TODO: Entire process needs to be restarted if the horizon block
 		// has changed (perhaps not here, NB this has to go somewhere)
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let identifier = segment.identifier().clone();
+		let identifier = segment.identifier();
 		let mut retval = Ok(true);
 		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_bitmap_segment(segment, output_root);
@@ -609,7 +609,7 @@ where
 			bitmap_root,
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let identifier = segment.identifier().clone();
+		let identifier = segment.identifier();
 		let mut retval = Ok(true);
 		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_output_segment(segment, Some(bitmap_root));
@@ -640,7 +640,7 @@ where
 			block_hash,
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let identifier = segment.identifier().clone();
+		let identifier = segment.identifier();
 		let mut retval = Ok(true);
 		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_rangeproof_segment(segment);
@@ -671,7 +671,7 @@ where
 			block_hash,
 		);
 		let archive_header = self.chain().txhashset_archive_header_header_only()?;
-		let identifier = segment.identifier().clone();
+		let identifier = segment.identifier();
 		let mut retval = Ok(true);
 		if let Some(d) = self.chain().desegmenter(&archive_header)?.write().as_mut() {
 			let res = d.add_kernel_segment(segment);
@@ -740,7 +740,7 @@ where
 		let header_pmmr = header_pmmr.read();
 
 		for hash in locator {
-			if let Ok(header) = self.chain().get_block_header(&hash) {
+			if let Ok(header) = self.chain().get_block_header(hash) {
 				if let Ok(hash_at_height) = header_pmmr.get_header_hash_by_height(header.height) {
 					if let Ok(header_at_height) = self.chain().get_block_header(&hash_at_height) {
 						if header.hash() == header_at_height.hash() {
@@ -989,7 +989,7 @@ where
 		ChainToPoolAndNetAdapter {
 			tx_pool,
 			peers: OneTime::new(),
-			hooks: hooks,
+			hooks,
 		}
 	}
 

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -237,7 +237,7 @@ impl PeerStats {
 		};
 		PeerStats {
 			state: state.to_string(),
-			addr: addr,
+			addr,
 			version: peer.info.version,
 			user_agent: peer.info.user_agent.clone(),
 			total_difficulty: peer.info.total_difficulty().to_num(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -127,7 +127,7 @@ impl Server {
 	// This uses fs2 and should be safe cross-platform unless somebody abuses the file itself.
 	fn one_grin_at_a_time(config: &ServerConfig) -> Result<Arc<File>, Error> {
 		let path = Path::new(&config.db_root);
-		fs::create_dir_all(&path)?;
+		fs::create_dir_all(path)?;
 		let path = path.join("grin.lock");
 		let lock_file = fs::OpenOptions::new()
 			.read(true)
@@ -138,8 +138,7 @@ impl Server {
 			let mut stderr = std::io::stderr();
 			writeln!(
 				&mut stderr,
-				"Failed to lock {:?} (grin server already running?)",
-				path
+				"Failed to lock {path:?} (grin server already running?)"
 			)
 			.expect("Could not write to stderr");
 			e
@@ -158,10 +157,7 @@ impl Server {
 
 		// Defaults to None (optional) in config file.
 		// This translates to false here.
-		let archive_mode = match config.archive_mode {
-			None => false,
-			Some(b) => b,
-		};
+		let archive_mode = config.archive_mode.unwrap_or(false);
 
 		let stop_state = if stop_state.is_some() {
 			stop_state.unwrap()
@@ -453,7 +449,7 @@ impl Server {
 					.collect();
 
 			let tip_height = self.head()?.height as i64;
-			let mut height = tip_height as i64 - last_blocks.len() as i64 + 1;
+			let mut height = tip_height - last_blocks.len() as i64 + 1;
 
 			let diff_entries: Vec<DiffBlock> = last_blocks
 				.windows(2)
@@ -539,13 +535,13 @@ impl Server {
 		Ok(ServerStats {
 			peer_count: self.peer_count(),
 			chain_stats: head_stats,
-			header_stats: header_stats,
+			header_stats,
 			sync_status: self.sync_state.status(),
-			disk_usage_gb: disk_usage_gb,
-			stratum_stats: stratum_stats,
-			peer_stats: peer_stats,
-			diff_stats: diff_stats,
-			tx_stats: tx_stats,
+			disk_usage_gb,
+			stratum_stats,
+			peer_stats,
+			diff_stats,
+			tx_stats,
 		})
 	}
 

--- a/servers/src/grin/sync/body_sync.rs
+++ b/servers/src/grin/sync/body_sync.rs
@@ -66,7 +66,7 @@ impl BodySync {
 
 			self.sync_state.update(SyncStatus::BodySync {
 				current_height: head.height,
-				highest_height: highest_height,
+				highest_height,
 			});
 		}
 		Ok(false)
@@ -160,7 +160,7 @@ impl BodySync {
 				}
 			}
 		}
-		return Ok(false);
+		Ok(false)
 	}
 
 	fn block_hashes_to_sync(

--- a/servers/src/grin/sync/header_sync.rs
+++ b/servers/src/grin/sync/header_sync.rs
@@ -88,7 +88,7 @@ impl HeaderSync {
 			});
 
 			self.header_sync(sync_head, sync_peer.clone());
-			self.syncing_peer = Some(sync_peer.clone());
+			self.syncing_peer = Some(sync_peer);
 		}
 		Ok(true)
 	}

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -92,15 +92,14 @@ impl SyncRunner {
 			// * we have more than MIN_PEERS more_or_same_work peers
 			// * we are synced already, e.g. grin was quickly restarted
 			// * timeout
-			if wp > MIN_PEERS
+			if (wp > MIN_PEERS
 				|| (wp == 0
 					&& self.peers.enough_outbound_peers()
 					&& head.total_difficulty > Difficulty::zero())
-				|| n > wait_secs
+				|| n > wait_secs)
+				&& (wp > 0 || !global::is_production_mode())
 			{
-				if wp > 0 || !global::is_production_mode() {
-					break;
-				}
+				break;
 			}
 			thread::sleep(time::Duration::from_secs(1));
 			n += 1;
@@ -189,7 +188,7 @@ impl SyncRunner {
 
 			// if syncing is needed
 			let head = unwrap_or_restart_loop!(self.chain.head());
-			let tail = self.chain.tail().unwrap_or_else(|_| head.clone());
+			let tail = self.chain.tail().unwrap_or(head);
 			let header_head = unwrap_or_restart_loop!(self.chain.header_head());
 
 			// "sync_head" allows us to sync against a large fork on the header chain

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -544,11 +544,8 @@ impl Handler {
 				{
 					debug!("resend updated block");
 					let mut state = self.current_state.write();
-					let wallet_listener_url = if !config.burn_reward {
-						Some(config.wallet_listener_url.clone())
-					} else {
-						None
-					};
+					let wallet_listener_url =
+						(!config.burn_reward).then(|| config.wallet_listener_url.clone());
 					// If this is a new block we will clear the current_block version history
 					let clear_blocks = current_hash != latest_hash;
 

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -27,12 +27,12 @@ fn main() {
 
 	if cfg!(target_os = "windows") {
 		Command::new("cmd")
-			.args(&["/C", &git_hooks])
+			.args(["/C", &git_hooks])
 			.output()
 			.expect("failed to execute git config for hooks");
 	} else {
 		Command::new("sh")
-			.args(&["-c", &git_hooks])
+			.args(["-c", &git_hooks])
 			.output()
 			.expect("failed to execute git config for hooks");
 	}

--- a/store/src/leaf_set.rs
+++ b/store/src/leaf_set.rs
@@ -42,7 +42,7 @@ impl LeafSet {
 	pub fn open<P: AsRef<Path>>(path: P) -> io::Result<LeafSet> {
 		let file_path = path.as_ref();
 		let bitmap = if file_path.exists() {
-			read_bitmap(&file_path)?
+			read_bitmap(file_path)?
 		} else {
 			Bitmap::create()
 		};
@@ -74,7 +74,7 @@ impl LeafSet {
 			return Ok(());
 		}
 
-		let bitmap = read_bitmap(&cp_file_path)?;
+		let bitmap = read_bitmap(cp_file_path)?;
 		debug!(
 			"leaf_set: copying rewound file {} to {}",
 			cp_file_path.display(),
@@ -119,7 +119,7 @@ impl LeafSet {
 
 		// Then add back output pos to the leaf_set
 		// that were removed.
-		bitmap.or_inplace(&rewind_rm_pos);
+		bitmap.or_inplace(rewind_rm_pos);
 
 		// Invert bitmap for the leaf pos and return the resulting bitmap.
 		bitmap
@@ -138,7 +138,7 @@ impl LeafSet {
 
 		// Then add back output pos to the leaf_set
 		// that were removed.
-		self.bitmap.or_inplace(&rewind_rm_pos);
+		self.bitmap.or_inplace(rewind_rm_pos);
 	}
 
 	/// Append a new position to the leaf_set.

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -94,10 +94,10 @@ where
 	// Write temporary file
 	let temp_path = Path::new(&_original);
 	if temp_path.exists() {
-		remove_file(&temp_path)?;
+		remove_file(temp_path)?;
 	}
 
-	let mut temp_file = File::create(&temp_path)?;
+	let mut temp_file = File::create(temp_path)?;
 
 	// write the new data to the temp file
 	writer(&mut temp_file)?;
@@ -105,7 +105,7 @@ where
 	// force an fsync on the temp file to ensure bytes are on disk
 	temp_file.sync_all()?;
 
-	rename(&temp_path, &original)?;
+	rename(temp_path, original)?;
 
 	Ok(())
 }

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -420,10 +420,7 @@ impl<'a> Batch<'a> {
 			_ => DeserializationMode::default(),
 		};
 		self.get_with(key, |_, mut data| {
-			match ser::deserialize(&mut data, self.protocol_version(), d) {
-				Ok(res) => Ok(res),
-				Err(e) => Err(From::from(e)),
-			}
+			ser::deserialize(&mut data, self.protocol_version(), d).map_err(|e| From::from(e))
 		})
 	}
 
@@ -483,11 +480,7 @@ where
 		};
 		kv.ok()
 			.filter(|(k, _)| k.starts_with(self.prefix.as_slice()))
-			.map(|(k, v)| match (self.deserialize)(k, v) {
-				Ok(v) => Some(v),
-				Err(_) => None,
-			})
-			.flatten()
+			.and_then(|(k, v)| (self.deserialize)(k, v).ok())
 	}
 }
 

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -112,8 +112,7 @@ impl Store {
 		let full_path = [root_path.to_owned(), name].join("/");
 		fs::create_dir_all(&full_path).map_err(|e| {
 			Error::FileErr(format!(
-				"Unable to create directory 'db_root' to store chain_data: {:?}",
-				e
+				"Unable to create directory 'db_root' to store chain_data: {e:?}"
 			))
 		})?;
 
@@ -286,7 +285,7 @@ impl Store {
 			Some(d) => d,
 			_ => DeserializationMode::default(),
 		};
-		self.get_with(key, &access, &db, |_, mut data| {
+		self.get_with(key, &access, db, |_, mut data| {
 			ser::deserialize(&mut data, self.protocol_version(), d).map_err(From::from)
 		})
 	}
@@ -386,7 +385,7 @@ impl<'a> Batch<'a> {
 			.as_ref()
 			.ok_or_else(|| Error::NotFoundErr("chain db is None".to_string()))?;
 
-		self.store.get_with(key, &access, &db, deserialize)
+		self.store.get_with(key, &access, db, deserialize)
 	}
 
 	/// Whether the provided key exists.
@@ -420,7 +419,7 @@ impl<'a> Batch<'a> {
 			_ => DeserializationMode::default(),
 		};
 		self.get_with(key, |_, mut data| {
-			ser::deserialize(&mut data, self.protocol_version(), d).map_err(|e| From::from(e))
+			ser::deserialize(&mut data, self.protocol_version(), d).map_err(From::from)
 		})
 	}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -69,11 +69,11 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 		let size = self
 			.data_file
 			.append(&data.as_elmt())
-			.map_err(|e| format!("Failed to append data to file. {}", e))?;
+			.map_err(|e| format!("Failed to append data to file. {e}"))?;
 
 		self.hash_file
 			.extend_from_slice(hashes)
-			.map_err(|e| format!("Failed to append hash to file. {}", e))?;
+			.map_err(|e| format!("Failed to append hash to file. {e}"))?;
 
 		if self.prunable {
 			// (Re)calculate the latest pos given updated size of data file
@@ -95,7 +95,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 
 		self.hash_file
 			.append(&hash)
-			.map_err(|e| format!("Failed to append subtree hash to file. {}", e))?;
+			.map_err(|e| format!("Failed to append subtree hash to file. {e}"))?;
 
 		self.prune_list.append(pos0);
 
@@ -105,7 +105,7 @@ impl<T: PMMRable> Backend<T> for PMMRBackend<T> {
 	fn append_hash(&mut self, hash: Hash) -> Result<(), String> {
 		self.hash_file
 			.append(&hash)
-			.map_err(|e| format!("Failed to append hash to file. {}", e))?;
+			.map_err(|e| format!("Failed to append hash to file. {e}"))?;
 		Ok(())
 	}
 
@@ -296,7 +296,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		} else {
 			SizeInfo::VariableSize(Box::new(AppendOnlyFile::open(
 				data_dir.join(PMMR_SIZE_FILE),
-				SizeInfo::FixedSize(SizeEntry::LEN as u16),
+				SizeInfo::FixedSize(SizeEntry::LEN),
 				version,
 			)?))
 		};
@@ -304,8 +304,8 @@ impl<T: PMMRable> PMMRBackend<T> {
 		// Hash file is always "fixed size" and we use 32 bytes per hash.
 		let hash_size_info = SizeInfo::FixedSize(Hash::LEN.try_into().unwrap());
 
-		let hash_file = DataFile::open(&data_dir.join(PMMR_HASH_FILE), hash_size_info, version)?;
-		let data_file = DataFile::open(&data_dir.join(PMMR_DATA_FILE), size_info, version)?;
+		let hash_file = DataFile::open(data_dir.join(PMMR_HASH_FILE), hash_size_info, version)?;
+		let data_file = DataFile::open(data_dir.join(PMMR_DATA_FILE), size_info, version)?;
 
 		let leaf_set_path = data_dir.join(PMMR_LEAF_FILE);
 
@@ -321,7 +321,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 		}
 
 		let leaf_set = LeafSet::open(&leaf_set_path)?;
-		let prune_list = PruneList::open(&data_dir.join(PMMR_PRUN_FILE))?;
+		let prune_list = PruneList::open(data_dir.join(PMMR_PRUN_FILE))?;
 
 		Ok(PMMRBackend {
 			data_dir: data_dir.to_path_buf(),
@@ -381,7 +381,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 			.map_err(|e| {
 				io::Error::new(
 					io::ErrorKind::Interrupted,
-					format!("Could not sync pmmr to disk: {:?}", e),
+					format!("Could not sync pmmr to disk: {e:?}"),
 				)
 			})
 	}
@@ -472,7 +472,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 
 	fn clean_rewind_files(&self) -> io::Result<u32> {
 		let data_dir = self.data_dir.clone();
-		let pattern = format!("{}.", PMMR_LEAF_FILE);
+		let pattern = format!("{PMMR_LEAF_FILE}.");
 		clean_files_by_prefix(data_dir, &pattern, REWIND_FILE_CLEANUP_DURATION_SECONDS)
 	}
 

--- a/store/src/prune_list.rs
+++ b/store/src/prune_list.rs
@@ -293,9 +293,8 @@ impl PruneList {
 		let max = self.bitmap.maximum().unwrap_or(0) as u64;
 		assert!(
 			pos0 >= max,
-			"prune list append only - pos={} bitmap.maximum={}",
-			pos0,
-			max
+			"{}",
+			"prune list append only - pos={pos0} bitmap.maximum={max}"
 		);
 
 		let (parent0, sibling0) = family(pos0);

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -20,7 +20,7 @@ use crate::core::ser::{
 };
 use std::fmt::Debug;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufReader, BufWriter, Seek, SeekFrom, Write};
+use std::io::{self, BufReader, BufWriter, Seek, Write};
 use std::marker;
 use std::path::{Path, PathBuf};
 
@@ -263,7 +263,7 @@ where
 		if self.size()? == 0 {
 			self.buffer_start_pos = 0;
 		} else {
-			self.mmap = Some(unsafe { memmap::Mmap::map(&self.file.as_ref().unwrap())? });
+			self.mmap = Some(unsafe { memmap::Mmap::map(self.file.as_ref().unwrap())? });
 			self.buffer_start_pos = self.size_in_elmts()?;
 		}
 
@@ -401,7 +401,7 @@ where
 		if self.file.as_ref().unwrap().metadata()?.len() == 0 {
 			self.mmap = None;
 		} else {
-			self.mmap = Some(unsafe { memmap::Mmap::map(&self.file.as_ref().unwrap())? });
+			self.mmap = Some(unsafe { memmap::Mmap::map(self.file.as_ref().unwrap())? });
 		}
 
 		Ok(())
@@ -484,7 +484,7 @@ where
 
 		// Remember to seek back to start of the file as the caller is likely
 		// to read this file directly without reopening it.
-		writer.seek(SeekFrom::Start(0))?;
+		writer.rewind()?;
 
 		let file = writer.into_inner()?;
 		Ok(file)

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -141,9 +141,9 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
 
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
-			println!("Allocating chunk: {}", i);
+			println!("Allocating chunk: {i}");
 			let chunk = PhatChunkStruct::new();
-			let key_val = format!("phat_chunk_set_1_{}", i);
+			let key_val = format!("phat_chunk_set_1_{i}");
 			let batch = store.batch()?;
 			let key = store::to_key(b'P', &key_val);
 			batch.put_ser(&key, &chunk)?;
@@ -157,9 +157,9 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 	{
 		let store = store::Store::new(test_dir, Some("test1"), None, None)?;
 		for i in 0..WRITE_CHUNK_SIZE * 2 {
-			println!("Allocating chunk: {}", i);
+			println!("Allocating chunk: {i}");
 			let chunk = PhatChunkStruct::new();
-			let key_val = format!("phat_chunk_set_2_{}", i);
+			let key_val = format!("phat_chunk_set_2_{i}");
 			let batch = store.batch()?;
 			let key = store::to_key(b'P', &key_val);
 			batch.put_ser(&key, &chunk)?;

--- a/store/tests/test_bitmap.rs
+++ b/store/tests/test_bitmap.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand;
-
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 use rand::Rng;
@@ -136,7 +134,7 @@ fn bench_fast_or() {
 
 	let bitmaps = init_bitmaps();
 	let start = Utc::now().timestamp_nanos();
-	let bitmap = Bitmap::fast_or(&bitmaps.iter().map(|x| x).collect::<Vec<&Bitmap>>());
+	let bitmap = Bitmap::fast_or(&bitmaps.iter().collect::<Vec<&Bitmap>>());
 	let fin = Utc::now().timestamp_nanos();
 	let dur_ms = (fin - start) as f64 * nano_to_millis;
 	println!(
@@ -147,7 +145,7 @@ fn bench_fast_or() {
 
 	let bitmaps = init_bitmaps();
 	let start = Utc::now().timestamp_nanos();
-	let bitmap = Bitmap::fast_or_heap(&bitmaps.iter().map(|x| x).collect::<Vec<&Bitmap>>());
+	let bitmap = Bitmap::fast_or_heap(&bitmaps.iter().collect::<Vec<&Bitmap>>());
 	let fin = Utc::now().timestamp_nanos();
 	let dur_ms = (fin - start) as f64 * nano_to_millis;
 	println!(

--- a/store/tests/utxo_set_perf.rs
+++ b/store/tests/utxo_set_perf.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env_logger;
-
 use grin_store as store;
 
 use chrono::prelude::Utc;
@@ -25,7 +23,7 @@ use croaring::Bitmap;
 use crate::store::leaf_set::LeafSet;
 
 pub fn as_millis(d: Duration) -> u128 {
-	d.as_secs() as u128 * 1_000 as u128 + (d.subsec_nanos() / (1_000 * 1_000)) as u128
+	d.as_secs() as u128 * 1_000_u128 + d.subsec_millis() as u128
 }
 
 #[test]
@@ -96,10 +94,10 @@ fn test_leaf_set_performance() {
 }
 
 fn setup(test_name: &str) -> (LeafSet, String) {
-	let _ = env_logger::init();
+	env_logger::init();
 	let data_dir = format!("./target/{}-{}", test_name, Utc::now().timestamp());
 	fs::create_dir_all(data_dir.clone()).unwrap();
-	let leaf_set = LeafSet::open(&format!("{}/{}", data_dir, "utxo.bin")).unwrap();
+	let leaf_set = LeafSet::open(format!("{}/{}", data_dir, "utxo.bin")).unwrap();
 	(leaf_set, data_dir)
 }
 

--- a/util/src/hex.rs
+++ b/util/src/hex.rs
@@ -22,7 +22,7 @@ use std::fmt::Write;
 fn to_hex(bytes: &[u8]) -> String {
 	let mut s = String::with_capacity(bytes.len() * 2);
 	for byte in bytes {
-		write!(&mut s, "{:02x}", byte).expect("Unable to write hex");
+		write!(&mut s, "{byte:02x}").expect("Unable to write hex");
 	}
 	s
 }

--- a/util/src/logger.rs
+++ b/util/src/logger.rs
@@ -49,7 +49,7 @@ lazy_static! {
 const LOGGING_PATTERN: &str = "{d(%Y%m%d %H:%M:%S%.3f)} {h({l})} {M} - {m}{n}";
 
 /// 32 log files to rotate over by default
-const DEFAULT_ROTATE_LOG_FILES: u32 = 32 as u32;
+const DEFAULT_ROTATE_LOG_FILES: u32 = 32_u32;
 
 /// Log Entry
 #[derive(Clone, Serialize, Debug)]
@@ -167,7 +167,7 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 
 		// Start logger
 		let stdout = ConsoleAppender::builder()
-			.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
+			.encoder(Box::new(PatternEncoder::new(LOGGING_PATTERN)))
 			.build();
 
 		let mut root = Root::builder();
@@ -176,7 +176,7 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 
 		if tui_running {
 			let channel_appender = ChannelAppender {
-				encoder: Box::new(PatternEncoder::new(&LOGGING_PATTERN)),
+				encoder: Box::new(PatternEncoder::new(LOGGING_PATTERN)),
 				output: Mutex::new(logs_tx.unwrap()),
 			};
 
@@ -203,7 +203,7 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 			let filter = Box::new(ThresholdFilter::new(level_file));
 			let file: Box<dyn Append> = {
 				if let Some(size) = c.log_max_size {
-					let count = c.log_max_files.unwrap_or_else(|| DEFAULT_ROTATE_LOG_FILES);
+					let count = c.log_max_files.unwrap_or(DEFAULT_ROTATE_LOG_FILES);
 					let roller = FixedWindowRoller::builder()
 						.build(&format!("{}.{{}}.gz", c.log_file_path), count)
 						.unwrap();
@@ -214,7 +214,7 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 					Box::new(
 						RollingFileAppender::builder()
 							.append(c.log_file_append)
-							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
+							.encoder(Box::new(PatternEncoder::new(LOGGING_PATTERN)))
 							.build(c.log_file_path, Box::new(policy))
 							.expect("Failed to create logfile"),
 					)
@@ -222,7 +222,7 @@ pub fn init_logger(config: Option<LoggingConfig>, logs_tx: Option<mpsc::SyncSend
 					Box::new(
 						FileAppender::builder()
 							.append(c.log_file_append)
-							.encoder(Box::new(PatternEncoder::new(&LOGGING_PATTERN)))
+							.encoder(Box::new(PatternEncoder::new(LOGGING_PATTERN)))
 							.build(c.log_file_path)
 							.expect("Failed to create logfile"),
 					)
@@ -276,7 +276,7 @@ pub fn init_test_logger() {
 
 	// Start logger
 	let stdout = ConsoleAppender::builder()
-		.encoder(Box::new(PatternEncoder::default()))
+		.encoder(Box::<log4rs::encode::pattern::PatternEncoder>::default())
 		.build();
 
 	let mut root = Root::builder();

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -30,7 +30,7 @@ fn path_to_string(path: &std::path::Path) -> String {
 			if !path_str.is_empty() {
 				path_str.push('/');
 			}
-			path_str.push_str(&*os_str.to_string_lossy());
+			path_str.push_str(&os_str.to_string_lossy());
 		}
 	}
 	path_str
@@ -74,7 +74,7 @@ pub fn extract_files(from_archive: File, dest: &Path, files: Vec<PathBuf>) -> io
 			if let Ok(file) = archive.by_name(x.to_str().expect("valid path")) {
 				let path = dest.join(file.mangled_name());
 				let parent_dir = path.parent().expect("valid parent dir");
-				fs::create_dir_all(&parent_dir).expect("create parent dir");
+				fs::create_dir_all(parent_dir).expect("create parent dir");
 				let outfile = fs::File::create(&path).expect("file created");
 				io::copy(&mut BufReader::new(file), &mut BufWriter::new(outfile))
 					.expect("write to file");

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -24,16 +24,16 @@ use zip as zip_rs;
 // Sanitize file path for normal components, excluding '/', '..', and '.'
 // From private function in zip crate
 fn path_to_string(path: &std::path::Path) -> String {
-    let mut path_str = String::new();
-    for component in path.components() {
-        if let std::path::Component::Normal(os_str) = component {
-            if !path_str.is_empty() {
-                path_str.push('/');
-            }
-            path_str.push_str(&*os_str.to_string_lossy());
-        }
-    }
-    path_str
+	let mut path_str = String::new();
+	for component in path.components() {
+		if let std::path::Component::Normal(os_str) = component {
+			if !path_str.is_empty() {
+				path_str.push('/');
+			}
+			path_str.push_str(&*os_str.to_string_lossy());
+		}
+	}
+	path_str
 }
 
 /// Create a zip archive from source dir and list of relative file paths.

--- a/util/tests/file.rs
+++ b/util/tests/file.rs
@@ -24,12 +24,12 @@ fn copy_dir() {
 	let root = Path::new("./target/tmp2");
 	fs::create_dir_all(root.join("./original/sub")).unwrap();
 	fs::create_dir_all(root.join("./original/sub2")).unwrap();
-	write_files("original".to_string(), &root).unwrap();
+	write_files("original".to_string(), root).unwrap();
 	let original_path = Path::new("./target/tmp2/original");
 	let copy_path = Path::new("./target/tmp2/copy");
 	file::copy_dir_to(original_path, copy_path).unwrap();
-	let original_files = file::list_files(&Path::new("./target/tmp2/original"));
-	let copied_files = file::list_files(&Path::new("./target/tmp2/copy"));
+	let original_files = file::list_files(Path::new("./target/tmp2/original"));
+	let copied_files = file::list_files(Path::new("./target/tmp2/copy"));
 	assert_eq!(original_files, copied_files);
 	fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
This replaces some pattern-matches that are exact reimplementation of stdlib combinators.

This, as well as running clippy on the last commit involved changes that assume a more recent version of Rust, e.g.:
- captured identifiers (Rust 1.58)
- boolean combinators (`then`, ` then_some`, since Rust 1.62)

Opinions on this loosely held, feel free to suggest changes.
First commit tool-aided by [comby-rust](https://github.com/huitseeker/comby-rust)