### PR TITLE
'Turn on' PIBD on main-net, in advance of 5.2.0 release

### DIFF
--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -100,13 +100,7 @@ impl StateSync {
 			} else if self.pibd_aborted {
 				false
 			} else {
-				// Only on testing chains for now
-				if global::get_chain_type() != global::ChainTypes::Mainnet {
-					true
-				//false
-				} else {
-					false
-				}
+				true
 			};
 
 		// Check whether we've errored and should restart pibd


### PR DESCRIPTION
Removes the check that restricts PIBD requests to testnet only.