### PR TITLE
Optimize desegmenter check progress

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -328,7 +328,7 @@ impl GlobalConfig {
 	) -> Result<String, ConfigError> {
 		// Parse existing config and return unchanged if not eligible for migration
 
-		let mut config_members: Result<ConfigMembers, toml::de::Error> =
+		let config_members: Result<ConfigMembers, toml::de::Error> =
 			toml::from_str(&GlobalConfig::fix_warning_level(config_str.clone()));
 		let mut config: ConfigMembers = match config_members {
 			Ok(p) => p,

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -171,7 +171,7 @@ impl StateSync {
 				if self.continue_pibd() {
 					let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
 					// All segments in, validate
-					if let Some(d) = desegmenter.read().as_ref() {
+					if let Some(d) = desegmenter.write().as_mut() {
 						if let Ok(true) = d.check_progress(self.sync_state.clone()) {
 							if let Err(e) = d.check_update_leaf_set_state() {
 								error!("error updating PIBD leaf set: {}", e);


### PR DESCRIPTION
Save `latest_block_height` at `Desegmenter::check_progress` to request less data from db at `PMMRHandle<BlockHeader>::get_first_header_with` (`from_height` parameter) with each iteration.