### PR TITLE
Optimize desegmenter check progress

### DIFF
--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -171,7 +171,7 @@ impl StateSync {
 				if self.continue_pibd() {
 					let desegmenter = self.chain.desegmenter(&archive_header).unwrap();
 					// All segments in, validate
-					if let Some(d) = desegmenter.read().as_ref() {
+					if let Some(d) = desegmenter.write().as_mut() {
 						if let Ok(true) = d.check_progress(self.sync_state.clone()) {
 							if let Err(e) = d.check_update_leaf_set_state() {
 								error!("error updating PIBD leaf set: {}", e);


### PR DESCRIPTION
Save `latest_block_height` at `Desegmenter::check_progress` to request less data from db at `PMMRHandle<BlockHeader>::get_first_header_with` (`from_height` parameter) with each iteration.