### PR TITLE
chrono deprecations warning cleanup 

### DIFF
--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -34,7 +34,7 @@ use util::secp::Signature;
 pub fn genesis_dev() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		height: 0,
-		timestamp: Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
+		timestamp: Utc.with_ymd_and_hms(1997, 8, 4, 0, 0, 0).unwrap(),
 		pow: ProofOfWork {
 			nonce: 0,
 			..Default::default()
@@ -48,7 +48,7 @@ pub fn genesis_dev() -> core::Block {
 pub fn genesis_test() -> core::Block {
 	let gen = core::Block::with_header(core::BlockHeader {
 		height: 0,
-		timestamp: Utc.ymd(2018, 12, 28).and_hms(20, 48, 4),
+		timestamp: Utc.with_ymd_and_hms(2018, 12, 28, 20, 48, 4).unwrap(),
 		prev_root: Hash::from_hex(
 			"00000000000000000017ff4903ef366c8f62e3151ba74e41b8332a126542f538",
 		)
@@ -161,7 +161,7 @@ pub fn genesis_test() -> core::Block {
 pub fn genesis_main() -> core::Block {
 	let gen = core::Block::with_header(core::BlockHeader {
 		height: 0,
-		timestamp: Utc.ymd(2019, 1, 15).and_hms(16, 1, 26),
+		timestamp: Utc.with_ymd_and_hms(2019, 1, 15, 16, 1, 26).unwrap(),
 		prev_root: Hash::from_hex(
 			"0000000000000000002a8bc32f43277fe9c063b9c99ea252b483941dcd06e217",
 		)

--- a/core/src/pow.rs
+++ b/core/src/pow.rs
@@ -115,7 +115,8 @@ pub fn pow_size(
 		// and if we're back where we started, update the time (changes the hash as
 		// well)
 		if bh.pow.nonce == start_nonce {
-			bh.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+			bh.timestamp =
+				DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc);
 		}
 	}
 }

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -437,7 +437,7 @@ impl Peers {
 
 		// Delete defunct peers from storage
 		let _ = self.store.delete_peers(|peer| {
-			let diff = now - Utc.timestamp(peer.last_connected, 0);
+			let diff = now - Utc.timestamp_opt(peer.last_connected, 0).unwrap();
 
 			let should_remove = peer.flags == State::Defunct
 				&& diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME);

--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -69,8 +69,9 @@ pub fn connect_and_monitor(
 			// check seeds first
 			connect_to_seeds_and_peers(peers.clone(), tx.clone(), seed_list, config);
 
-			let mut prev = chrono::Date::<Utc>::MIN_UTC.and_hms(0, 0, 0);
-			let mut prev_expire_check = chrono::Date::<Utc>::MIN_UTC.and_hms(0, 0, 0);
+			let mut prev = DateTime::<Utc>::MIN_UTC;
+			let mut prev_expire_check = DateTime::<Utc>::MIN_UTC;
+
 			let mut prev_ping = Utc::now();
 			let mut start_attempt = 0;
 			let mut connecting_history: HashMap<PeerAddr, DateTime<Utc>> = HashMap::new();

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -168,7 +168,11 @@ fn build_block(
 
 	b.header.pow.nonce = thread_rng().gen();
 	b.header.pow.secondary_scaling = difficulty.secondary_scaling;
-	b.header.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now_sec, 0), Utc);
+	let ts = NaiveDateTime::from_timestamp_opt(now_sec, 0);
+	if ts.is_none() {
+		return Err(Error::General("Utc::now into timestamp".into()));
+	}
+	b.header.timestamp = DateTime::<Utc>::from_utc(ts.unwrap(), Utc);
 
 	debug!(
 		"Built new block with {} inputs and {} outputs, block difficulty: {}, cumulative difficulty {}",

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -64,13 +64,14 @@ impl StratumWorkerColumn {
 
 impl TableViewItem<StratumWorkerColumn> for WorkerStats {
 	fn to_column(&self, column: StratumWorkerColumn) -> String {
-		let naive_datetime = NaiveDateTime::from_timestamp(
+		let naive_datetime = NaiveDateTime::from_timestamp_opt(
 			self.last_seen
 				.duration_since(time::UNIX_EPOCH)
 				.unwrap()
 				.as_secs() as i64,
 			0,
-		);
+		)
+		.unwrap_or_default();
 		let datetime: DateTime<Utc> = DateTime::from_utc(naive_datetime, Utc);
 
 		match column {
@@ -126,7 +127,8 @@ impl DiffColumn {
 
 impl TableViewItem<DiffColumn> for DiffBlock {
 	fn to_column(&self, column: DiffColumn) -> String {
-		let naive_datetime = NaiveDateTime::from_timestamp(self.time as i64, 0);
+		let naive_datetime =
+			NaiveDateTime::from_timestamp_opt(self.time as i64, 0).unwrap_or_default();
 		let datetime: DateTime<Utc> = DateTime::from_utc(naive_datetime, Utc);
 
 		match column {


### PR DESCRIPTION
Cleans up warnings related to specific errors, mostly `from_timestamp` moving to a `from_timestamp_opt` function that returns an options.

Note `from_timestamp_opt` returns `None` in the following circumstances:

```
Returns None on the out-of-range number of seconds (more than 262 000 years away from common era) and/or invalid nanosecond (2 seconds or more).
```

* Where timestamps are hardcoded on initialization (such as being hardcoded with 0s), I've just called unwrap as there's no reason for the function to return `None`
* Where timestamps are initialized dynamically in critical code check for `None` and return appropriate error
* where timestamps are less crucial, (tui, mining) just `unwrap_or_default`