### PR TITLE
`get_blocks` API call - set tail height to include genesis

### DIFF
--- a/api/src/handlers/blocks_api.rs
+++ b/api/src/handlers/blocks_api.rs
@@ -152,9 +152,16 @@ impl BlockHandler {
 			max = BLOCK_TRANSFER_LIMIT;
 		}
 		let tail_height = self.get_tail_height()?;
+		let orig_start_height = start_height;
 
 		if start_height < tail_height {
 			start_height = tail_height;
+		}
+
+		// In full archive node, tail will be set to 1, so include genesis block as well
+		// for consistency
+		if start_height == 1 && orig_start_height == 0 {
+			start_height = 0;
 		}
 
 		let mut result_set = BlockListing {


### PR DESCRIPTION
When calling the `get_blocks` function with a start height of 0, the start height is adjusted to the 'tail', or the earliest stored block. The tail function appears to be returning 1 in the case of an archive node, causing the call to skip block 0. This adjusts the start height in that single case to make the API more consistent.