### PR TITLE
[PIBD] Fix to restart of PIBD download on corrupted data or mismatched roots

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -122,6 +122,7 @@ pub fn process_block(
 	let txhashset = &mut ctx.txhashset;
 	let batch = &mut ctx.batch;
 	let ctx_specific_validation = &ctx.header_allowed;
+	error!("PROCESSING BLOCK?");
 	let fork_point = txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
 		let fork_point = rewind_and_apply_fork(&prev, ext, batch, ctx_specific_validation)?;
 
@@ -630,6 +631,7 @@ pub fn rewind_and_apply_fork(
 	while current.height > 0 && !header_extension.is_on_current_chain(&current, batch)? {
 		current = batch.get_previous_header(&current)?;
 	}
+	error!("REWIND AND APPLY FORK!");
 	let fork_point = current;
 	extension.rewind(&fork_point, batch)?;
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -122,7 +122,6 @@ pub fn process_block(
 	let txhashset = &mut ctx.txhashset;
 	let batch = &mut ctx.batch;
 	let ctx_specific_validation = &ctx.header_allowed;
-	error!("PROCESSING BLOCK?");
 	let fork_point = txhashset::extending(header_pmmr, txhashset, batch, |ext, batch| {
 		let fork_point = rewind_and_apply_fork(&prev, ext, batch, ctx_specific_validation)?;
 
@@ -631,7 +630,6 @@ pub fn rewind_and_apply_fork(
 	while current.height > 0 && !header_extension.is_on_current_chain(&current, batch)? {
 		current = batch.get_previous_header(&current)?;
 	}
-	error!("REWIND AND APPLY FORK!");
 	let fork_point = current;
 	extension.rewind(&fork_point, batch)?;
 

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -237,7 +237,7 @@ impl Desegmenter {
 		// Quick root check first:
 		{
 			let txhashset = self.txhashset.read();
-			txhashset.roots().validate(&self.archive_header)?;
+			txhashset.roots()?.validate(&self.archive_header)?;
 		}
 
 		// TODO: Possibly Keep track of this in the DB so we can pick up where we left off if needed

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1606,7 +1606,6 @@ impl<'a> Extension<'a> {
 		} else {
 			let mut affected_pos = vec![];
 			let mut current = head_header;
-			error!("REWINDING TWO");
 			while header.height < current.height {
 				let block = batch.get_block(&current.hash())?;
 				let mut affected_pos_single_block = self.rewind_single_block(&block, batch)?;

--- a/chain/tests/test_pibd_copy.rs
+++ b/chain/tests/test_pibd_copy.rs
@@ -238,7 +238,7 @@ impl DesegmenterRequestor {
 	}
 
 	pub fn check_roots(&self) {
-		let roots = self.chain.txhashset().read().roots();
+		let roots = self.chain.txhashset().read().roots().unwrap();
 		let archive_header = self.chain.txhashset_archive_header_header_only().unwrap();
 		debug!("Archive Header is {:?}", archive_header);
 		debug!("TXHashset output root is {:?}", roots);

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -111,11 +111,11 @@ impl StateSync {
 				if let Some(d) = desegmenter.write().as_mut() {
 					d.reset();
 				};
-				if let Err(e) = self.chain.reset_chain_head(self.chain.genesis(), false) {
-					error!("pibd_sync restart: chain reset error = {}", e);
-				}
 				if let Err(e) = self.chain.reset_pibd_head() {
 					error!("pibd_sync restart: reset pibd_head error = {}", e);
+				}
+				if let Err(e) = self.chain.reset_chain_head_to_genesis() {
+					error!("pibd_sync restart: chain reset to genesis error = {}", e);
 				}
 				if let Err(e) = self.chain.reset_prune_lists() {
 					error!("pibd_sync restart: reset prune lists error = {}", e);


### PR DESCRIPTION
In tandem with, #3774 this fixes a case where PIBD fails to restart properly if the downloads txhashset state does not match with expected roots.

The previous logic attempted to manually roll back the output PMMR states to genesis, which could not work given rollback relies on blocks data existing in the DB (which is not guaranteed beyond the horizon block). This adds a `reset_chain_head_to_genesis` function to `chain.rs`, which re-initializes the body PMMRs to the genesis block while leaving the header MMR intact, allowing PIBD to start again from the genesis block.

Once we've tested this, I'll merge #3774  first and then merge into this one to maintain @ardocrat's credit where credit is due.