### PR TITLE
Update versioning for 5.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "grin"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "blake2-rfc",
  "built",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "bytes 0.5.6",
  "easy-jsonrpc-mw",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "dirs",
  "grin_core",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "bitflags 1.3.2",
  "bytes 0.5.6",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1056,15 +1056,14 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04798e32404c0af082b6a209ad4df1ab1d9ec3a5a5056f284cfa32f74e59ce6"
+checksum = "447e2e66d2f6cc14d49afdad59a5b26f47654c845483dbb3f3403ace0dbb94b4"
 dependencies = [
  "arrayvec 0.3.25",
  "cc",
  "libc",
  "rand 0.5.6",
- "rustc-serialize",
  "serde",
  "serde_json",
  "zeroize",
@@ -1072,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1101,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1123,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -2285,12 +2284,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -32,14 +32,14 @@ serde_json = "1"
 log = "0.4"
 term = "0.6"
 
-grin_api = { path = "./api", version = "5.3.0-alpha.1" }
-grin_config = { path = "./config", version = "5.3.0-alpha.1" }
-grin_chain = { path = "./chain", version = "5.3.0-alpha.1" }
-grin_core = { path = "./core", version = "5.3.0-alpha.1" }
-grin_keychain = { path = "./keychain", version = "5.3.0-alpha.1" }
-grin_p2p = { path = "./p2p", version = "5.3.0-alpha.1" }
-grin_servers = { path = "./servers", version = "5.3.0-alpha.1" }
-grin_util = { path = "./util", version = "5.3.0-alpha.1" }
+grin_api = { path = "./api", version = "5.3.0" }
+grin_config = { path = "./config", version = "5.3.0" }
+grin_chain = { path = "./chain", version = "5.3.0" }
+grin_core = { path = "./core", version = "5.3.0" }
+grin_keychain = { path = "./keychain", version = "5.3.0" }
+grin_p2p = { path = "./p2p", version = "5.3.0" }
+grin_servers = { path = "./servers", version = "5.3.0" }
+grin_util = { path = "./util", version = "5.3.0" }
 
 [dependencies.cursive]
 version = "0.20"
@@ -50,5 +50,5 @@ features = ["pancurses-backend"]
 built = { version = "0.4", features = ["git2"]}
 
 [dev-dependencies]
-grin_chain = { path = "./chain", version = "5.3.0-alpha.1" }
-grin_store = { path = "./store", version = "5.3.0-alpha.1" }
+grin_chain = { path = "./chain", version = "5.3.0" }
+grin_store = { path = "./store", version = "5.3.0" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_api"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "APIs for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ rustls = "0.17"
 url = "2.1"
 bytes = "0.5"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_chain = { path = "../chain", version = "5.3.0-alpha.1" }
-grin_p2p = { path = "../p2p", version = "5.3.0-alpha.1" }
-grin_pool = { path = "../pool", version = "5.3.0-alpha.1" }
-grin_store = { path = "../store", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_chain = { path = "../chain", version = "5.3.0" }
+grin_p2p = { path = "../p2p", version = "5.3.0" }
+grin_pool = { path = "../pool", version = "5.3.0" }
+grin_store = { path = "../store", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_chain"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ chrono = "0.4.11"
 lru-cache = "0.1"
 lazy_static = "1"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_keychain = { path = "../keychain", version = "5.3.0-alpha.1" }
-grin_store = { path = "../store", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_keychain = { path = "../keychain", version = "5.3.0" }
+grin_store = { path = "../store", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_config"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.5"
 dirs = "2.0"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_servers = { path = "../servers", version = "5.3.0-alpha.1" }
-grin_p2p = { path = "../p2p", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_servers = { path = "../servers", version = "5.3.0" }
+grin_p2p = { path = "../p2p", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_core"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -28,8 +28,8 @@ chrono = { version = "0.4.11", features = ["serde"] }
 zeroize = { version = "1.1", features =["zeroize_derive"] }
 bytes = "0.5"
 
-keychain = { package = "grin_keychain", path = "../keychain", version = "5.3.0-alpha.1" }
-util = { package = "grin_util", path = "../util", version = "5.3.0-alpha.1" }
+keychain = { package = "grin_keychain", path = "../keychain", version = "5.3.0" }
+util = { package = "grin_util", path = "../util", version = "5.3.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_keychain"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -26,4 +26,4 @@ ripemd160 = "0.9"
 sha2 = "0.9"
 pbkdf2 = "0.8"
 
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_util = { path = "../util", version = "5.3.0" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_p2p"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ log = "0.4"
 chrono = { version = "0.4.11", features = ["serde"] }
 bytes = "0.5"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_store = { path = "../store", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
-grin_chain = { path = "../chain", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_store = { path = "../store", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }
+grin_chain = { path = "../chain", version = "5.3.0" }
 
 [dev-dependencies]
-grin_pool = { path = "../pool", version = "5.3.0-alpha.1" }
+grin_pool = { path = "../pool", version = "5.3.0" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_pool"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Chain implementation for grin, a simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -18,9 +18,9 @@ thiserror = "1"
 log = "0.4"
 chrono = "0.4.11"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_keychain = { path = "../keychain", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_keychain = { path = "../keychain", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }
 
 [dev-dependencies]
-grin_chain = { path = "../chain", version = "5.3.0-alpha.1" }
+grin_chain = { path = "../chain", version = "5.3.0" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_servers"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ tokio = {version = "0.2", features = ["full"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 walkdir = "2.3.1"
 
-grin_api = { path = "../api", version = "5.3.0-alpha.1" }
-grin_chain = { path = "../chain", version = "5.3.0-alpha.1" }
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_keychain = { path = "../keychain", version = "5.3.0-alpha.1" }
-grin_p2p = { path = "../p2p", version = "5.3.0-alpha.1" }
-grin_pool = { path = "../pool", version = "5.3.0-alpha.1" }
-grin_store = { path = "../store", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_api = { path = "../api", version = "5.3.0" }
+grin_chain = { path = "../chain", version = "5.3.0" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_keychain = { path = "../keychain", version = "5.3.0" }
+grin_p2p = { path = "../p2p", version = "5.3.0" }
+grin_pool = { path = "../pool", version = "5.3.0" }
+grin_store = { path = "../store", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_store"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -21,8 +21,8 @@ serde_derive = "1"
 thiserror = "1"
 log = "0.4"
 
-grin_core = { path = "../core", version = "5.3.0-alpha.1" }
-grin_util = { path = "../util", version = "5.3.0-alpha.1" }
+grin_core = { path = "../core", version = "5.3.0" }
+grin_util = { path = "../util", version = "5.3.0" }
 
 [dev-dependencies]
 chrono = "0.4.11"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_util"
-version = "5.3.0-alpha.1"
+version = "5.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the Mimblewimble chain format."
 license = "Apache-2.0"
@@ -28,5 +28,5 @@ zeroize = { version = "1.1", features =["zeroize_derive"] }
 #git = "https://github.com/mimblewimble/rust-secp256k1-zkp"
 #tag = "grin_integration_29"
 #path = "../../rust-secp256k1-zkp"
-version = "0.7.12"
+version = "0.7.13"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
* Update version to 5.3.0. Full minor update since a major underlying library (croaring) was updated.
* Update version of grin_secp256k1zkp dependency, see https://github.com/mimblewimble/rust-secp256k1-zkp/pull/83 for details