### PR TITLE
Chain type field

### DIFF
--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -49,6 +49,7 @@ pub trait OwnerRpc: Sync + Send {
 		"jsonrpc": "2.0",
 		"result": {
 			"Ok": {
+						"chain": "main",
 			"protocol_version": "2",
 			"user_agent": "MW/Grin 2.x.x",
 			"connections": "8",

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -49,7 +49,7 @@ pub trait OwnerRpc: Sync + Send {
 		"jsonrpc": "2.0",
 		"result": {
 			"Ok": {
-						"chain": "main",
+			"chain": "main",
 			"protocol_version": "2",
 			"user_agent": "MW/Grin 2.x.x",
 			"connections": "8",

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -16,7 +16,7 @@ use crate::chain;
 use crate::core::core::hash::Hashed;
 use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::{FeeFields, KernelFeatures, TxKernel};
-use crate::core::{core, ser};
+use crate::core::{core, global, ser};
 use crate::p2p;
 use crate::util::secp::pedersen;
 use crate::util::{self, ToHex};
@@ -68,6 +68,8 @@ impl Tip {
 /// Status page containing different server information
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Status {
+	// The chain type
+	pub chain: String,
 	// The protocol version
 	pub protocol_version: u32,
 	// The user user agent
@@ -91,6 +93,7 @@ impl Status {
 		sync_info: Option<serde_json::Value>,
 	) -> Status {
 		Status {
+			chain: global::get_chain_type().shortname(),
 			protocol_version: ser::ProtocolVersion::local().into(),
 			user_agent: p2p::msg::USER_AGENT.to_string(),
 			connections: connections,

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -92,6 +92,7 @@ impl HTTPNodeClient {
 		t.reset().unwrap();
 		match self.send_json_request::<Status>("get_status", &serde_json::Value::Null) {
 			Ok(status) => {
+				writeln!(e, "Chain type: {}", status.chain).unwrap();
 				writeln!(e, "Protocol version: {:?}", status.protocol_version).unwrap();
 				writeln!(e, "User agent: {}", status.user_agent).unwrap();
 				writeln!(e, "Connections: {}", status.connections).unwrap();


### PR DESCRIPTION
Added chain type field into get_status rpc as following:

```
{
  "id": 1,
  "result": {
    "Ok": {
      "chain": "main",
      "connections": 8,
      "protocol_version": 1000,
      "sync_status": "no_sync",
      "tip": {
        "height": 2813226,
        "last_block_pushed": "0001664af94b6e9585ac10c3925f3ab601165aca833f794ed676b5ee25f50c5f",
        "prev_block_to_last": "0001cf87025e4e515063263caee56ad3d7c6cdaf2e08751fdb1f10b5fe95f619",
        "total_difficulty": 2175334614969923
      },
      "user_agent": "MW/Grin 5.4.0-alpha.0"
    }
  }
}
```

```
Chain type: main
Protocol version: 1000
User agent: MW/Grin 5.4.0-alpha.0
Connections: 8
Chain height: 2813226
Last block hash: 0001664af94b6e9585ac10c3925f3ab601165aca833f794ed676b5ee25f50c5f
Previous block hash: 0001cf87025e4e515063263caee56ad3d7c6cdaf2e08751fdb1f10b5fe95f619
Total difficulty: 2175334614969923
Sync status: no_sync
```

Related to https://github.com/mimblewimble/grin/issues/3777
