### PR TITLE
[WIP] Update build process to produce dual MacOS builds

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -27,14 +27,14 @@ jobs:
                     target/release/grin-${{  github.ref_name }}-linux-x86_64.tar.gz
                     target/release/grin-${{  github.ref_name }}-linux-x86_64-sha256sum.txt
 
-    macos-release:
-        name: macOS Release
+    macos-release-x86:
+        name: macOS Release - x86_64
         runs-on: macos-latest
         steps:
           - name: Checkout
             uses: actions/checkout@v3
           - name: Build
-            run: cargo build --release
+            run: cargo build --release --target x86_64-apple-darwin
           - name: Archive
             working-directory: target/release
             run: tar -czvf grin-${{  github.ref_name }}-macos-x86_64.tar.gz grin
@@ -47,7 +47,28 @@ jobs:
                 files: |
                     target/release/grin-${{  github.ref_name }}-macos-x86_64.tar.gz
                     target/release/grin-${{  github.ref_name }}-macos-x86_64-sha256sum.txt
-    
+
+    macos-release-arm64:
+        name: macOS Release - arm64
+        runs-on: macos-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+          - name: Build
+            run: cargo build --release
+          - name: Archive
+            working-directory: target/release
+            run: tar -czvf grin-${{  github.ref_name }}-macos-arm64.tar.gz grin
+          - name: Create Checksum
+            working-directory: target/release
+            run: openssl sha256 grin-${{  github.ref_name }}-macos-arm64.tar.gz > grin-${{  github.ref_name }}-macos-arm64-sha256sum.txt
+          - name: Release
+            uses: softprops/action-gh-release@v1
+            with:
+                files: |
+                    target/release/grin-${{  github.ref_name }}-macos-arm64.tar.gz
+                    target/release/grin-${{  github.ref_name }}-macos-arm64-sha256sum.txt
+     
     windows-release:
         name: Windows Release
         runs-on: windows-2019


### PR DESCRIPTION
Update CD build to output separate sets of binaries for Mac x86_64 and arm64. (May require a few manual commits afterwards to test and tweak)