### PR TITLE
Refactor: Improve Inbound Capabilities Counting

### DIFF
--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -84,7 +84,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			PeerColumn::Direction => self.direction.clone(),
 			PeerColumn::Version => format!("{}", self.version),
 			PeerColumn::UserAgent => self.user_agent.clone(),
-			PeerColumn::Capabilities => format!("{}", self.capabilities.bits()),
+			PeerColumn::Capabilities => format!("{}", self.capabilities.bits() + 1),
 		}
 	}
 


### PR DESCRIPTION
Improve correctness by incrementing the inbound capabilities by one in the 'peers and sync' menu. With the default value for inbound set to 128, it was a bit misleading to see 127. Non-programmers start counting at 1, not 0.

Before :

```
Address [  ]  |  . . . .  |  Capab [  ]  |  User Agent [  ]
x.x.x.x:3414                 127            MW/Grin 5.4.0-Alpha
```

After :

```
Address [  ]  |  . . . .  |  Capab [  ]  |  User Agent [  ]
x.x.x.x:3414                 128            MW/Grin 5.4.0-Alpha
```