### PR TITLE
Ignore grin++ peers

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -60,6 +60,17 @@ impl Peers {
 	/// Adds the peer to our internal peer mapping. Note that the peer is still
 	/// returned so the server can run it.
 	pub fn add_connected(&self, peer: Arc<Peer>) -> Result<(), Error> {
+		// ---hard filter: ignore Grin++ nodes
+		let ua_lc = peer.info.user_agent.to_lowercase();
+		if ua_lc.contains("grin++") || ua_lc.contains("grinplusplus") {
+			warn!(
+				"Ignore Grin++ peer {} [{}]",
+				peer.info.addr, peer.info.user_agent
+			);
+			peer.stop();
+			return Err(Error::PeerException);
+		}
+
 		let peer_data: PeerData;
 		{
 			// Scope for peers vector lock - dont hold the peers lock while adding to lmdb


### PR DESCRIPTION
Title

	Ignore grin++ peers

Description

This PR adds a minimal filter that ignores inbound or outbound connections from grin++ nodes based on their reported user agent.
The goal is to reduce incompatibility issues with grin++ peers while maintaining stability with standard Rust Grin nodes.

	•	✅ Logs a WARN when a grin++ node is detected and ignored
	•	✅ Keeps logic minimal — no config flag, hardcoded for now
	•	✅ Non-invasive; only skips peer addition, no ban or disconnect logic changed
	•	⚙️ Intended as a proof of concept just incase the need arises to move away from grin++, can later be made configurable

Example log line when a grin++ peer is ignored:

WARN grin_p2p::peers - Ignore grin++ peer [Grin++ 1.2.8]

Notes

This patch is mainly exploratory — Future iterations could make this configurable (e.g. p2p.ignore_grinpp = true) or extend to selective banning if necessary.