### PR TITLE
Include git info into docker build, show git ref at version

### DIFF
--- a/.github/workflows/publish-ghcr.yaml.yml
+++ b/.github/workflows/publish-ghcr.yaml.yml
@@ -41,13 +41,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           provenance: false # Disable provenance to avoid unknown/unknown
           sbom: false       # Disable sbom to avoid unknown/unknown
           platforms: ${{ matrix.platform }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ name = "grin_p2p"
 version = "5.4.0"
 dependencies = [
  "bitflags 1.3.2",
+ "built",
  "bytes 0.5.6",
  "chrono",
  "enum_primitive",

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -95,7 +95,7 @@ impl Status {
 		Status {
 			chain: global::get_chain_type().shortname(),
 			protocol_version: ser::ProtocolVersion::local().into(),
-			user_agent: p2p::msg::USER_AGENT.to_string(),
+			user_agent: p2p::msg::user_agent().to_string(),
 			connections: connections,
 			tip: Tip::from_tip(current_tip),
 			sync_status,
@@ -465,7 +465,8 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 				}
 
 				if output_type.is_none()
-					|| commit.is_none() || spent.is_none()
+					|| commit.is_none()
+					|| spent.is_none()
 					|| proof_hash.is_none()
 					|| mmr_index.is_none()
 				{

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 edition = "2018"
+build = "src/build/build.rs"
 
 [dependencies]
 bitflags = "1"
@@ -29,3 +30,6 @@ grin_chain = { path = "../chain", version = "5.4.0" }
 
 [dev-dependencies]
 grin_pool = { path = "../pool", version = "5.4.0" }
+
+[build-dependencies]
+built = { version = "0.8.0", features = ["git2"]}

--- a/p2p/src/build/build.rs
+++ b/p2p/src/build/build.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Build hooks to spit out version info
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+	// build and versioning information
+	let out_dir_path = format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs");
+	// don't fail the build if something's missing, may just be cargo release
+	let _ = built::write_built_file_with_opts(
+		Some(Path::new(env!("CARGO_MANIFEST_DIR"))),
+		Path::new(&out_dir_path),
+	);
+}

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -16,7 +16,7 @@ use crate::conn::Tracker;
 use crate::core::core::hash::Hash;
 use crate::core::pow::Difficulty;
 use crate::core::ser::ProtocolVersion;
-use crate::msg::{read_message, write_message, Hand, Msg, Shake, Type, USER_AGENT};
+use crate::msg::{read_message, user_agent, write_message, Hand, Msg, Shake, Type};
 use crate::peer::Peer;
 use crate::types::{Capabilities, Direction, Error, P2PConfig, PeerAddr, PeerInfo, PeerLiveInfo};
 use crate::util::RwLock;
@@ -120,7 +120,7 @@ impl Handshake {
 			total_difficulty,
 			sender_addr: self_addr,
 			receiver_addr: peer_addr,
-			user_agent: USER_AGENT.to_string(),
+			user_agent: user_agent().to_string(),
 		};
 
 		// write and read the handshake response
@@ -225,7 +225,7 @@ impl Handshake {
 			capabilities: capab,
 			genesis: self.genesis,
 			total_difficulty: total_difficulty,
-			user_agent: USER_AGENT.to_string(),
+			user_agent: user_agent().to_string(),
 		};
 
 		let msg = Msg::new(Type::Shake, shake, negotiated_version)?;

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -40,8 +40,19 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::{fmt, thread, time::Duration};
 
+// include build information
+pub mod built_info {
+	include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 /// Grin's user agent with current version
-pub const USER_AGENT: &str = concat!("MW/Grin ", env!("CARGO_PKG_VERSION"));
+pub fn user_agent() -> String {
+	format!(
+		"MW/Grim {}{}",
+		env!("CARGO_PKG_VERSION"),
+		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "+".to_owned(), |v| ".".to_owned() + v)
+	)
+}
 
 /// Magic numbers expected in the header of every message
 const OTHER_MAGIC: [u8; 2] = [73, 43];

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -50,7 +50,7 @@ pub fn user_agent() -> String {
 	format!(
 		"MW/Grim {}{}",
 		env!("CARGO_PKG_VERSION"),
-		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "+".to_owned(), |v| ".".to_owned() + v)
+		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "".to_owned(), |v| ".".to_owned() + v)
 	)
 }
 

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -48,7 +48,7 @@ pub mod built_info {
 /// Grin's user agent with current version
 pub fn user_agent() -> String {
 	format!(
-		"MW/Grim {}{}",
+		"MW/Grin {}{}",
 		env!("CARGO_PKG_VERSION"),
 		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "".to_owned(), |v| ".".to_owned() + v)
 	)

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -25,6 +25,7 @@ use std::{thread, time};
 use crate::core::core::hash::Hash;
 use crate::core::global;
 use crate::core::pow::Difficulty;
+use crate::p2p::msg::built_info;
 use crate::p2p::types::PeerAddr;
 use crate::p2p::Peer;
 
@@ -88,7 +89,12 @@ fn peer_handshake() {
 	)
 	.unwrap();
 
-	assert!(peer.info.user_agent.ends_with(env!("CARGO_PKG_VERSION")));
+	let git_hash =
+		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "+".to_owned(), |v| ".".to_owned() + v);
+	assert!(peer
+		.info
+		.user_agent
+		.ends_with(format!("{}{}", env!("CARGO_PKG_VERSION"), git_hash).as_str()));
 
 	thread::sleep(time::Duration::from_secs(1));
 

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -90,7 +90,7 @@ fn peer_handshake() {
 	.unwrap();
 
 	let git_hash =
-		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "+".to_owned(), |v| ".".to_owned() + v);
+		built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "".to_owned(), |v| ".".to_owned() + v);
 	assert!(peer
 		.info
 		.user_agent

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -55,7 +55,7 @@ pub fn info_strings() -> (String, String) {
 		format!(
 			"This is Grin version {}{}, built for {} by {}.",
 			built_info::PKG_VERSION,
-			built_info::GIT_VERSION.map_or_else(|| "".to_owned(), |v| format!(" (git {})", v)),
+			built_info::GIT_COMMIT_HASH.map_or_else(|| "".to_owned(), |v| format!(" (git {})", v)),
 			built_info::TARGET,
 			built_info::RUSTC_VERSION,
 		),


### PR DESCRIPTION
- Include .git directory into Docker build to show git ref into build info: https://github.com/mimblewimble/grin/blob/90dab5fcc68381ce39526c56c7dd25f8bdd33fb7/src/bin/grin.rs#L58
- Remove `actions/checkout` action from CI, since `docker/build-push-action` uses its own git context.
- Show git ref at version and full commit hash at logs instead of last tag to differentiate running docker builds from master branch.