### PR TITLE
Update rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [ "crypto", "grin", "mimblewimble" ]
 readme = "README.md"
 exclude = ["**/*.grin", "**/*.grin2"]
 build = "src/build/build.rs"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = ["api", "chain", "config", "core", "keychain", "p2p", "servers", "store", "util", "pool"]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 easy-jsonrpc-mw = "0.5.4"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bit-vec = "0.6"

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1439,7 +1439,8 @@ impl Chain {
 			0
 		} else {
 			self.get_header_by_height(start_block_height - 1)?
-				.output_mmr_size + 1
+				.output_mmr_size
+				+ 1
 		};
 		let end_mmr_size = self.get_header_by_height(end_block_height)?.output_mmr_size;
 		Ok((start_mmr_size, end_mmr_size))

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rand = "0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 blake2 = { package = "blake2-rfc", version = "0.2"}

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "grin_core-fuzz"
 version = "0.0.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libfuzzer-sys = "0.4.0"

--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -71,7 +71,7 @@ impl PoWContext for CuckarooContext {
 		let mut xor0: u64 = 0;
 		let mut xor1: u64 = 0;
 		let mask = u64::MAX >> (size as u64).leading_zeros(); // round size up to 2-power - 1
-													  // the next three arrays form a linked list of nodes with matching bits 6..1
+														// the next three arrays form a linked list of nodes with matching bits 6..1
 		let mut headu = vec![2 * size; 1 + mask as usize];
 		let mut headv = vec![2 * size; 1 + mask as usize];
 		let mut prev = vec![0usize; 2 * size];

--- a/core/src/pow/cuckarood.rs
+++ b/core/src/pow/cuckarood.rs
@@ -66,7 +66,7 @@ impl PoWContext for CuckaroodContext {
 		let mut xor0: u64 = 0;
 		let mut xor1: u64 = 0;
 		let mask = u64::MAX >> (size as u64).leading_zeros(); // round size up to 2-power - 1
-													  // the next two arrays form a linked list of nodes with matching bits 4..0|dir
+														// the next two arrays form a linked list of nodes with matching bits 4..0|dir
 		let mut headu = vec![2 * size; 1 + mask as usize];
 		let mut headv = vec![2 * size; 1 + mask as usize];
 		let mut prev = vec![0usize; 2 * size];

--- a/core/src/pow/cuckaroom.rs
+++ b/core/src/pow/cuckaroom.rs
@@ -65,7 +65,7 @@ impl PoWContext for CuckaroomContext {
 		let mut xor_from: u64 = 0;
 		let mut xor_to: u64 = 0;
 		let mask = u64::MAX >> (size as u64).leading_zeros(); // round size up to 2-power - 1
-													  // the next two arrays form a linked list of nodes with matching bits 6..1
+														// the next two arrays form a linked list of nodes with matching bits 6..1
 		let mut head = vec![size; 1 + mask as usize];
 		let mut prev = vec![0usize; size];
 

--- a/core/src/pow/cuckarooz.rs
+++ b/core/src/pow/cuckarooz.rs
@@ -64,7 +64,7 @@ impl PoWContext for CuckaroozContext {
 		let mut uvs = vec![0u64; 2 * size];
 		let mut xoruv: u64 = 0;
 		let mask = u64::MAX >> (size as u64).leading_zeros(); // round size up to 2-power - 1
-													  // the next two arrays form a linked list of nodes with matching bits 6..1
+														// the next two arrays form a linked list of nodes with matching bits 6..1
 		let mut head = vec![2 * size; 1 + mask as usize];
 		let mut prev = vec![0usize; 2 * size];
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -244,7 +244,6 @@ fn transaction_cut_through() {
 	let tx1 = tx1i2o();
 	let tx2 = tx2i1o();
 
-
 	assert!(tx1.validate(Weighting::AsTransaction).is_ok());
 	assert!(tx2.validate(Weighting::AsTransaction).is_ok());
 
@@ -277,17 +276,12 @@ fn multi_kernel_transaction_deaggregation() {
 	assert!(tx34.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx34 = deaggregate(tx1234.clone(), &[tx12.clone()]).unwrap();
-	assert!(deaggregated_tx34
-		.validate(Weighting::AsTransaction)
-
-		.is_ok());
+	assert!(deaggregated_tx34.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx34, deaggregated_tx34);
 
 	let deaggregated_tx12 = deaggregate(tx1234, &[tx34]).unwrap();
 
-	assert!(deaggregated_tx12
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx12.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx12, deaggregated_tx12);
 }
 
@@ -309,9 +303,7 @@ fn multi_kernel_transaction_deaggregation_2() {
 	assert!(tx12.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx3 = deaggregate(tx123, &[tx12]).unwrap();
-	assert!(deaggregated_tx3
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx3.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx3, deaggregated_tx3);
 }
 
@@ -334,9 +326,7 @@ fn multi_kernel_transaction_deaggregation_3() {
 	assert!(tx2.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx13 = deaggregate(tx123, &[tx2]).unwrap();
-	assert!(deaggregated_tx13
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx13.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx13, deaggregated_tx13);
 }
 
@@ -366,9 +356,7 @@ fn multi_kernel_transaction_deaggregation_4() {
 	assert!(tx12345.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx5 = deaggregate(tx12345, &[tx1, tx2, tx3, tx4]).unwrap();
-	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx5.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
 
@@ -401,9 +389,7 @@ fn multi_kernel_transaction_deaggregation_5() {
 	assert!(tx12345.validate(Weighting::AsTransaction).is_ok());
 
 	let deaggregated_tx5 = deaggregate(tx12345, &[tx12, tx34]).unwrap();
-	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx5.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
 
@@ -424,16 +410,12 @@ fn basic_transaction_deaggregation() {
 
 	let deaggregated_tx1 = deaggregate(tx3.clone(), &[tx2.clone()]).unwrap();
 
-	assert!(deaggregated_tx1
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx1.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx1, deaggregated_tx1);
 
 	let deaggregated_tx2 = deaggregate(tx3, &[tx1]).unwrap();
 
-	assert!(deaggregated_tx2
-		.validate(Weighting::AsTransaction)
-		.is_ok());
+	assert!(deaggregated_tx2.validate(Weighting::AsTransaction).is_ok());
 	assert_eq!(tx2, deaggregated_tx2);
 }
 
@@ -558,8 +540,7 @@ fn reward_with_tx_block() {
 
 	let tx1 = tx2i1o();
 	let previous_header = BlockHeader::default();
-	tx1.validate(Weighting::AsTransaction)
-		.unwrap();
+	tx1.validate(Weighting::AsTransaction).unwrap();
 
 	let block = new_block(&[tx1], &keychain, &builder, &previous_header, &key_id);
 	block.validate(&BlindingFactor::zero()).unwrap();

--- a/etc/gen_gen/_Cargo.toml
+++ b/etc/gen_gen/_Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grin_gen_gen"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Utility to automate the generation of Grin's genesis block"
 license = "Apache-2.0"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = '..'
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 byteorder = "1"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bitflags = "1"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
 edition = "2021"
+build = "src/build/build.rs"
 
 [dependencies]
 bitflags = "1"

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = '..'
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 blake2-rfc = "0.2"

--- a/pool/fuzz/Cargo.toml
+++ b/pool/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "grin_pool_fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 chrono = "0.4.11"

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -402,9 +402,7 @@ where
 					// Otherwise discard and let the next block pick this tx up.
 					let bucket = &tx_buckets[pos];
 
-					if let Ok(new_bucket) =
-						bucket.aggregate_with_tx(entry.tx.clone(), weighting)
-					{
+					if let Ok(new_bucket) = bucket.aggregate_with_tx(entry.tx.clone(), weighting) {
 						if new_bucket.fee_rate >= bucket.fee_rate {
 							// Only aggregate if it would not reduce the fee_rate ratio.
 							tx_buckets[pos] = new_bucket;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 hard_tabs = true
-edition = "2018"
+edition = "2021"

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 byteorder = "1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/util/src/zip.rs
+++ b/util/src/zip.rs
@@ -24,16 +24,16 @@ use zip as zip_rs;
 // Sanitize file path for normal components, excluding '/', '..', and '.'
 // From private function in zip crate
 fn path_to_string(path: &std::path::Path) -> String {
-    let mut path_str = String::new();
-    for component in path.components() {
-        if let std::path::Component::Normal(os_str) = component {
-            if !path_str.is_empty() {
-                path_str.push('/');
-            }
-            path_str.push_str(&*os_str.to_string_lossy());
-        }
-    }
-    path_str
+	let mut path_str = String::new();
+	for component in path.components() {
+		if let std::path::Component::Normal(os_str) = component {
+			if !path_str.is_empty() {
+				path_str.push('/');
+			}
+			path_str.push_str(&*os_str.to_string_lossy());
+		}
+	}
+	path_str
 }
 
 /// Create a zip archive from source dir and list of relative file paths.


### PR DESCRIPTION
- Update Rust to more modern actual edition, also to avoid problems in last IDE RustRover where it can not load macros on every change at code.
https://rust-lang.github.io/book/appendix-05-editions.html
- Format all code using `cargo fmt --all`