### PR TITLE
Change default IP address for P2PConfig to '::'

### DIFF
--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -293,7 +293,7 @@ pub struct P2PConfig {
 /// Default address for peer-to-peer connections.
 impl Default for P2PConfig {
 	fn default() -> P2PConfig {
-		let ipaddr = "0.0.0.0".parse().unwrap();
+		let ipaddr = "::".parse().unwrap();
 		P2PConfig {
 			host: ipaddr,
 			port: 3414,


### PR DESCRIPTION
Feature request: Change default P2P listen host from 0.0.0.0 to :: for dual-stack IPv4+IPv6 support. As tested on several windows/linux machines and not found issue. Worked with ipv4 or ipv6 or dual ipv4+ipv6.