### PR TITLE
Clarifies the blinding factor range proof explanation and includes the remaining typo fixes

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -32,7 +32,7 @@ use crate::{rest::*, BlockListing};
 use std::sync::Weak;
 
 /// Main interface into all node API functions.
-/// Node APIs are split into two seperate blocks of functionality
+/// Node APIs are split into two separate blocks of functionality
 /// called the ['Owner'](struct.Owner.html) and ['Foreign'](struct.Foreign.html) APIs
 ///
 /// Methods in this API are intended to be 'single use'.

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -27,7 +27,7 @@ use std::net::SocketAddr;
 use std::sync::Weak;
 
 /// Main interface into all node API functions.
-/// Node APIs are split into two seperate blocks of functionality
+/// Node APIs are split into two separate blocks of functionality
 /// called the ['Owner'](struct.Owner.html) and ['Foreign'](struct.Foreign.html) APIs
 ///
 /// Methods in this API are intended to be 'single use'.

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -252,7 +252,9 @@ which can be signed by the attacker because Carol's blinding factor cancels out 
 
 This output (`(113 + 99)*G + 2*H`) requires that both the numbers 113 and 99 are known in order to be spent; the attacker
 would thus have successfully locked Carol's UTXO. The requirement for a range proof for the blinding factor prevents this
-because the attacker doesn't know the number 113 and thus neither (113 + 99). A more detailed description of range proofs is further detailed in the [range proof paper](https://eprint.iacr.org/2017/1066.pdf).
+because the attacker doesn't know the number 113 and thus neither (113 + 99). In other words, without knowing the private
+key (blinding factor), the attacker would not know the value in the output and would not be able to produce a valid range proof for it.
+A more detailed description of range proofs is further detailed in the [range proof paper](https://eprint.iacr.org/2017/1066.pdf).
 
 #### Putting It All Together
 

--- a/doc/pow/pow.md
+++ b/doc/pow/pow.md
@@ -113,10 +113,10 @@ Now, (hopefully) armed with a basic understanding of what the Cuckoo Cycle algor
 
 ## Mining in Grin
 
-The Cuckoo Cycle outlined above forms the basis of Grin's mining process, however Grin uses two variantion of Cuckoo Cycle in tandem with several other systems to create a Proof-of-Work.
+The Cuckoo Cycle outlined above forms the basis of Grin's mining process, however Grin uses two variations of Cuckoo Cycle in tandem with several other systems to create a Proof-of-Work.
 
 1. for GPUs: Cuckaroo on 2^29 edges
-    * Tweaked every 6 months to maitain ASIC resistance.
+    * Tweaked every 6 months to maintain ASIC resistance.
     * 90% of rewards at launch, linearly decreasing to 0% in 2 years.
     * Variant of Cuckoo that enforces so-called ``mean'' mining.
     * Takes 5.5GB of memory (perhaps 4GB with slowdown).


### PR DESCRIPTION
This PR replaces PR #3783 by applying the same clarification on top of the current `staging` branch.

It also includes @Anynomouss review suggestion to make the explanation of why the blinding factor range proof is needed clearer.

This PR replaces PR #3785
