### PR TITLE
Change default IP address for P2PConfig to IPv6

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -262,8 +262,11 @@ fn comments() -> HashMap<String, String> {
 		"host".to_string(),
 		"
 #The interface on which to listen.
-#0.0.0.0 will listen on all interfaces, allowing others to interact
-#127.0.0.1 will listen on the local machine only
+#:: will listen on all IPv6 interfaces and may also accept IPv4 depending on OS socket settings
+#0.0.0.0 will listen on all IPv4 interfaces, allowing others to interact
+#Set host to 0.0.0.0 if only IPv4 listening is desired
+#127.0.0.1 will listen on the local machine only over IPv4
+#::1 will listen on the local machine only over IPv6
 "
 		.to_string(),
 	);

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -293,7 +293,7 @@ pub struct P2PConfig {
 /// Default address for peer-to-peer connections.
 impl Default for P2PConfig {
 	fn default() -> P2PConfig {
-		let ipaddr = "0.0.0.0".parse().unwrap();
+		let ipaddr = "::".parse().unwrap();
 		P2PConfig {
 			host: ipaddr,
 			port: 3414,


### PR DESCRIPTION
Feature request: Change default P2P listen host from 0.0.0.0 to :: for dual-stack IPv4+IPv6 support. As tested on several windows/linux machines and not found issue. Worked with ipv4 or ipv6 or dual ipv4+ipv6.