### PR TITLE
Add DNS Seeder fountainoffairfortune

### DIFF
--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -35,18 +35,20 @@ use crate::util::StopState;
 
 /// DNS Seeds with contacts associated - Mainnet
 pub const MAINNET_DNS_SEEDS: &[&str] = &[
-	"mainnet-seed.grinnode.live", // info@grinnode.live
-	"grincoin.org",               // xmpp:aglkm@conversations.im
-	"main.gri.mw",                // admin@gri.mw
-	"mainnet.grinffindor.org",    // support@grinffindor.org
-	"main-seed.grin.money",       // support@grinily.com
+	"mainnet-seed.grinnode.live",       // info@grinnode.live
+	"grincoin.org",                     // xmpp:aglkm@conversations.im
+	"main.gri.mw",                      // admin@gri.mw
+	"mainnet.grinffindor.org",          // support@grinffindor.org
+	"main-seed.grin.money",             // support@grinily.com
+	"mainnet.fountainoffairfortune.it", // support@fountainoffairfortune.it
 ];
 /// DNS Seeds with contacts associated - Testnet
 pub const TESTNET_DNS_SEEDS: &[&str] = &[
-	"testnet.grincoin.org",    // xmpp:aglkm@conversations.im
-	"test.gri.mw",             // admin@gri.mw
-	"testnet.grinffindor.org", // support@grinffindor.org
-	"test-seed.grin.money",    // support@grinily.com
+	"testnet.grincoin.org",             // xmpp:aglkm@conversations.im
+	"test.gri.mw",                      // admin@gri.mw
+	"testnet.grinffindor.org",          // support@grinffindor.org
+	"test-seed.grin.money",             // support@grinily.com
+	"testnet.fountainoffairfortune.it", // support@fountainoffairfortune.it
 ];
 
 pub fn connect_and_monitor(


### PR DESCRIPTION
This PR adds two (main/test) additional DNS seeders for the Grin network:

mainnet.fountainoffairfortune.it
testnet.fountainoffairfortune.it
