### PR TITLE
Add Telegram notifications for GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Tests
         run: cargo test --release --all
+
+  telegram-notify:
+    name: Telegram Notification
+    needs: [linux-tests, macos-tests, windows-tests]
+    if: always() && github.event_name == 'push'
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin CI
+      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
+      details: |
+        <b>Linux:</b> ${{ needs.linux-tests.result }}
+        <b>macOS:</b> ${{ needs.macos-tests.result }}
+        <b>Windows:</b> ${{ needs.windows-tests.result }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/publish-ghcr.yaml.yml
+++ b/.github/workflows/publish-ghcr.yaml.yml
@@ -125,3 +125,18 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  telegram-notify:
+    name: Telegram Notification
+    needs: [build, merge]
+    if: always()
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin Docker
+      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
+      details: |
+        <b>Images:</b> ${{ needs.build.result }}
+        <b>Manifest:</b> ${{ needs.merge.result }}
+      image_tag: ${{ github.ref_name == 'master' && 'latest' || 'staging' }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -43,3 +43,17 @@ jobs:
           name: grin-snap
           path: "*.snap"
           if-no-files-found: error
+
+  telegram-notify:
+    name: Telegram Notification
+    needs: [build-snap]
+    if: always()
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin Snap
+      status: ${{ needs.build-snap.result }}
+      details: |
+        <b>Package:</b> ${{ needs.build-snap.result }}
+      artifact_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/telegram.yaml
+++ b/.github/workflows/telegram.yaml
@@ -1,0 +1,157 @@
+name: Telegram Events
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        required: true
+        type: string
+      status:
+        required: true
+        type: string
+      details:
+        required: false
+        type: string
+        default: ""
+      image:
+        required: false
+        type: string
+        default: ""
+      image_tag:
+        required: false
+        type: string
+        default: ""
+      artifact_url:
+        required: false
+        type: string
+        default: ""
+      commit_message:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      TELEGRAM_BOT_TOKEN:
+        required: false
+      TELEGRAM_CHAT_ID:
+        required: false
+      TELEGRAM_MESSAGE_THREAD_ID:
+        required: false
+      GHCR_USERNAME:
+        required: false
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+    branches: [master, staging, telegram_bot]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  telegram-notify:
+    name: Telegram Notification
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      TELEGRAM_MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+    steps:
+      - name: Send Telegram message
+        if: ${{ env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION_NAME: ${{ github.event.action }}
+          REPOSITORY: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          NOTIFY_TITLE: ${{ inputs.title }}
+          NOTIFY_STATUS: ${{ inputs.status }}
+          NOTIFY_DETAILS: ${{ inputs.details }}
+          NOTIFY_IMAGE: ${{ inputs.image }}
+          NOTIFY_IMAGE_TAG: ${{ inputs.image_tag }}
+          NOTIFY_ARTIFACT_URL: ${{ inputs.artifact_url }}
+          NOTIFY_COMMIT_MESSAGE: ${{ inputs.commit_message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          html_escape() {
+            printf "%s" "$1" | sed \
+              -e "s/&/\&amp;/g" \
+              -e "s/</\&lt;/g" \
+              -e "s/>/\&gt;/g"
+          }
+
+          if [ -n "$NOTIFY_TITLE" ]; then
+            commit_message=$(html_escape "$NOTIFY_COMMIT_MESSAGE")
+            text=$(printf "<b>%s</b>\n<b>Build %s</b>" "$NOTIFY_TITLE" "$NOTIFY_STATUS")
+
+            if [ -n "$NOTIFY_DETAILS" ]; then
+              text=$(printf "%s\n\n%s" "$text" "$NOTIFY_DETAILS")
+            fi
+
+            text=$(printf "%s\n\n<b>Actor:</b> %s\n<b>Repository:</b> %s\n<b>Branch:</b> %s" \
+              "$text" \
+              "${{ github.actor }}" \
+              "$REPOSITORY" \
+              "${{ github.ref_name }}")
+
+            if [ -n "$NOTIFY_IMAGE" ]; then
+              text=$(printf "%s\n<b>Image:</b> %s" "$text" "$NOTIFY_IMAGE")
+            elif [ -n "$NOTIFY_IMAGE_TAG" ]; then
+              image_owner="${GHCR_USERNAME:-${REPOSITORY%%/*}}"
+              image_name="${REPOSITORY#*/}"
+              text=$(printf "%s\n<b>Image:</b> ghcr.io/%s/%s:%s" "$text" "$image_owner" "$image_name" "$NOTIFY_IMAGE_TAG")
+            fi
+
+            text=$(printf "%s\n<b>Commit:</b> <a href=\"%s\">%s</a>" \
+              "$text" \
+              "$COMMIT_URL" \
+              "${GITHUB_SHA::7}")
+
+            if [ -n "$commit_message" ]; then
+              text=$(printf "%s\n%s" "$text" "$commit_message")
+            fi
+
+            if [ -n "$NOTIFY_ARTIFACT_URL" ]; then
+              text=$(printf "%s\n\n<a href=\"%s\">Download artifacts</a>" "$text" "$NOTIFY_ARTIFACT_URL")
+            else
+              text=$(printf "%s\n\n<a href=\"%s\">View workflow run</a>" "$text" "$RUN_URL")
+            fi
+          elif [ "$EVENT_NAME" = "pull_request_target" ]; then
+            title=$(html_escape "$PR_TITLE")
+            text=$(printf "<b>Grin pull request</b>\n<b>Status:</b> %s\n\n<b>Repository:</b> %s\n<b>PR:</b> <a href=\"%s\">#%s %s</a>" \
+              "$ACTION_NAME" \
+              "$REPOSITORY" \
+              "$PR_URL" \
+              "$PR_NUMBER" \
+              "$title")
+          else
+            title=$(html_escape "$ISSUE_TITLE")
+            text=$(printf "<b>Grin issue</b>\n<b>Status:</b> %s\n\n<b>Repository:</b> %s\n<b>Issue:</b> <a href=\"%s\">#%s %s</a>" \
+              "$ACTION_NAME" \
+              "$REPOSITORY" \
+              "$ISSUE_URL" \
+              "$ISSUE_NUMBER" \
+              "$title")
+          fi
+
+          payload=$(jq -n \
+            --arg chat_id "$TELEGRAM_CHAT_ID" \
+            --arg text "$text" \
+            '{chat_id: $chat_id, text: $text, parse_mode: "HTML", disable_web_page_preview: true}')
+
+          if [ -n "$TELEGRAM_MESSAGE_THREAD_ID" ]; then
+            payload=$(jq --argjson message_thread_id "$TELEGRAM_MESSAGE_THREAD_ID" \
+              '. + {message_thread_id: $message_thread_id}' <<< "$payload")
+          fi
+
+          curl -sSf \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            > /dev/null

--- a/.github/workflows/telegram.yaml
+++ b/.github/workflows/telegram.yaml
@@ -79,6 +79,10 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
+          telegram_api_url="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"
+          echo "::add-mask::$TELEGRAM_BOT_TOKEN"
+          echo "::add-mask::$telegram_api_url"
+
           html_escape() {
             printf "%s" "$1" | sed \
               -e "s/&/\&amp;/g" \
@@ -153,5 +157,5 @@ jobs:
           curl -sSf \
             -H "Content-Type: application/json" \
             -d "$payload" \
-            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            "$telegram_api_url" \
             > /dev/null

--- a/.github/workflows/telegram.yaml
+++ b/.github/workflows/telegram.yaml
@@ -40,7 +40,7 @@ on:
         required: false
   pull_request_target:
     types: [opened, reopened, ready_for_review]
-    branches: [master, staging, telegram_bot]
+    branches: [master, staging]
   issues:
     types: [opened, reopened]
 


### PR DESCRIPTION
Adds Telegram notifications for GitHub workflow results and repository events.
This introduces a reusable Telegram workflow used by CI, GHCR, and Snap builds to send one summary message after each workflow completes. It also sends notifications for opened or reopened issues and pull requests.
