### PR TITLE
Do not use workspace for submodules

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,6 @@ description = "APIs for grin, a simple, private and scalable cryptocurrency impl
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -6,7 +6,6 @@ description = "Chain implementation for grin, a simple, private and scalable cry
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -6,7 +6,6 @@ description = "Configuration for grin, a simple, private and scalable cryptocurr
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,6 @@ description = "Chain implementation for grin, a simple, private and scalable cry
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -6,7 +6,6 @@ description = "Chain implementation for grin, a simple, private and scalable cry
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = '..'
 edition = "2021"
 
 [dependencies]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -6,7 +6,6 @@ description = "Chain implementation for grin, a simple, private and scalable cry
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 build = "src/build/build.rs"
 

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -6,7 +6,6 @@ description = "Chain implementation for grin, a simple, private and scalable cry
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = '..'
 edition = "2021"
 
 [dependencies]

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -6,7 +6,6 @@ description = "Simple, private and scalable cryptocurrency implementation based 
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -6,7 +6,6 @@ description = "Simple, private and scalable cryptocurrency implementation based 
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,7 +6,6 @@ description = "Simple, private and scalable cryptocurrency implementation based 
 license = "Apache-2.0"
 repository = "https://github.com/mimblewimble/grin"
 keywords = [ "crypto", "grin", "mimblewimble" ]
-workspace = ".."
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Remove hardcoded workspace from Cargo modules to allow usage of them at external workspace (e.g. as git submodule for `grin-wallet`). It has no effect on build, cause all modules already specified at head `Cargo.toml` file.