### PR TITLE
LMDB resize fixes

### DIFF
--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -99,7 +99,7 @@ static ENV_MAP: OnceLock<RwLock<HashMap<String, EnvState>>> = OnceLock::new();
 struct EnvState {
 	env: Env<WithoutTls>,
 	open_txs_count: AtomicU32,
-	resizing: AtomicBool,
+	resize_pending: AtomicBool,
 	resize_checking: AtomicBool,
 	stores_count: AtomicU32,
 }
@@ -202,7 +202,7 @@ impl Store {
 				EnvState {
 					env,
 					open_txs_count: AtomicU32::new(0),
-					resizing: AtomicBool::new(false),
+					resize_pending: AtomicBool::new(false),
 					resize_checking: AtomicBool::new(false),
 					stores_count: AtomicU32::new(1),
 				},
@@ -419,97 +419,48 @@ impl Store {
 			.store(resize_checking, Ordering::Relaxed);
 	}
 
-	/// Wait while database is resizing.
-	fn wait_for_resize(&self) {
-		loop {
-			if ENV_MAP
-				.get()
-				.unwrap()
-				.read()
-				.get(&self.env_path)
-				.unwrap()
-				.resizing
-				.load(Ordering::Relaxed)
-				&& self.open_txs_count() == 0
-			{
-				debug!("Wait on resizing DB {}", self.env_path);
-				thread::sleep(Duration::from_millis(100));
-				continue;
-			}
-			break;
-		}
+	/// Set flag if environment is waiting for resize.
+	fn set_resize_pending(&self, resize_pending: bool) {
+		ENV_MAP
+			.get()
+			.unwrap()
+			.write()
+			.get_mut(&self.env_path)
+			.unwrap()
+			.resize_pending
+			.store(resize_pending, Ordering::Relaxed);
 	}
 
 	/// Resize database environment if needed.
 	fn maybe_resize(&self) {
-		self.wait_for_resize();
-
-		// Check only one resize requirement per time to avoid multiple resizes.
 		if self.resize_checking() {
 			return;
-		} else {
-			self.set_resize_checking(true);
 		}
+		self.set_resize_checking(true);
 
 		let (resize, new_size) = needs_resize(&self.env, self.alloc_chunk_size);
-		if resize {
-			let env_path = self.env_path.clone();
-			let env = self.env.clone();
+		if !resize {
+			self.set_resize_checking(false);
+			return;
+		}
+		// Stop new top-level transactions first.
+		self.set_resize_pending(true);
+		while {
+			let count = self.open_txs_count();
+			debug!("Wait {} opened txs to resize", count);
+			count != 0
+		} {
+			thread::sleep(Duration::from_millis(10));
+		}
 
-			{
-				let mut w_env_map = ENV_MAP.get().unwrap().write();
-				let env_state = w_env_map.get_mut(&env_path).unwrap();
-				env_state.resizing.store(true, Ordering::Relaxed);
-			}
-
-			// Resize immediately or at another thread to not interrupt current
-			// transaction waiting all open transactions to be closed.
-			if self.open_txs_count() != 0 {
-				debug!("Waiting txs to be closed before DB {} resize", env_path);
-				thread::spawn(move || {
-					loop {
-						let txs_count = ENV_MAP
-							.get()
-							.unwrap()
-							.read()
-							.get(&env_path)
-							.unwrap()
-							.open_txs_count
-							.load(Ordering::Relaxed);
-						if txs_count == 0 {
-							debug!("Start resizing DB {}", env_path);
-							break;
-						}
-						thread::sleep(Duration::from_millis(100));
-					}
-
-					unsafe {
-						match env.resize(new_size) {
-							Ok(_) => debug!("End resizing DB {}", env_path),
-							Err(e) => error!("Resize DB {} error: {:?}", env_path, e),
-						}
-					}
-
-					let mut w_env_map = ENV_MAP.get().unwrap().write();
-					let env_state = w_env_map.get_mut(&env_path).unwrap();
-					env_state.resizing.store(false, Ordering::Relaxed);
-					env_state.resize_checking.store(false, Ordering::Relaxed);
-				});
-				return;
-			} else {
-				debug!("Start immediate resizing DB {}", env_path);
-				unsafe {
-					match env.resize(new_size) {
-						Ok(_) => debug!("End resizing DB {}", env_path),
-						Err(e) => error!("Resize DB {} error: {:?}", env_path, e),
-					}
-				}
-				let mut w_env_map = ENV_MAP.get().unwrap().write();
-				let env_state = w_env_map.get_mut(&env_path).unwrap();
-				env_state.resizing.store(false, Ordering::Relaxed);
+		unsafe {
+			match self.env.resize(new_size) {
+				Ok(_) => debug!("End resizing DB {}", self.env_path),
+				Err(e) => error!("Resize DB {} error: {:?}", self.env_path, e),
 			}
 		}
 
+		self.set_resize_pending(false);
 		self.set_resize_checking(false);
 	}
 
@@ -571,9 +522,8 @@ impl Store {
 		key: &[u8],
 		deser_mode: Option<DeserializationMode>,
 	) -> Result<Option<T>, Error> {
-		self.wait_for_resize();
+		let _ = self.enter_tx();
 
-		TxCounter::on_change_tx_count(&self.env_path, true);
 		let res = {
 			let d = match deser_mode {
 				Some(d) => d,
@@ -586,15 +536,13 @@ impl Store {
 				Err(e) => Err(Error::from(e)),
 			}
 		};
-		TxCounter::on_change_tx_count(&self.env_path, false);
 		res
 	}
 
 	/// Whether the key exists at the provided database key.
 	pub fn exists(&self, db_key: Option<u8>, key: &[u8]) -> Result<bool, Error> {
-		self.wait_for_resize();
+		let _ = self.enter_tx();
 
-		TxCounter::on_change_tx_count(&self.env_path, true);
 		let res = {
 			match self.env.read_txn() {
 				Ok(read) => {
@@ -613,7 +561,6 @@ impl Store {
 				Err(e) => Err(Error::from(e)),
 			}
 		};
-		TxCounter::on_change_tx_count(&self.env_path, false);
 		res
 	}
 
@@ -626,68 +573,66 @@ impl Store {
 	where
 		F: Fn(&[u8], &[u8]) -> Result<T, Error>,
 	{
-		self.wait_for_resize();
+		let tx_counter = self.enter_tx();
 
-		TxCounter::on_change_tx_count(&self.env_path, true);
 		let res = {
 			match self.env.clone().static_read_txn() {
 				Ok(read) => {
 					let db_res = self.get_db(db_key);
 					match db_res {
-						Ok(db) => {
-							DatabaseIterator::new(self, Arc::new(db.clone()), read, deserialize)
-						}
+						Ok(db) => DatabaseIterator::new(
+							Arc::new(db.clone()),
+							Some(tx_counter),
+							read,
+							deserialize,
+						),
 						Err(e) => Err(Error::from(e)),
 					}
 				}
 				Err(e) => Err(Error::from(e)),
 			}
 		};
-		if res.is_err() {
-			TxCounter::on_change_tx_count(&self.env_path, false);
-		}
 		res
 	}
 
 	/// Builds a new batch to be used with this store.
 	pub fn batch(&self) -> Result<Batch<'_>, Error> {
 		self.maybe_resize();
+		Batch::new(self)
+	}
 
-		TxCounter::on_change_tx_count(&self.env_path, true);
-		let res = { Batch::new(self) };
-		if res.is_err() {
-			TxCounter::on_change_tx_count(&self.env_path, false);
+	/// Creates tx counter incrementing if resize is not pending.
+	fn enter_tx(&self) -> TxCounter {
+		loop {
+			let mut map = ENV_MAP.get().unwrap().write();
+			let state = map.get_mut(&self.env_path).unwrap();
+			if state.open_txs_count.load(Ordering::Relaxed) > 0
+				|| !state.resize_pending.load(Ordering::Acquire)
+			{
+				state.open_txs_count.fetch_add(1, Ordering::Relaxed);
+				return TxCounter {
+					env_path: self.env_path.clone(),
+				};
+			}
+			drop(map);
+			thread::sleep(Duration::from_millis(10));
 		}
-		res
 	}
 }
 
 /// Environment transactions counter, allows to decrement value on drop.
-struct TxCounter {
+pub struct TxCounter {
 	env_path: String,
 }
 
 impl Drop for TxCounter {
 	fn drop(&mut self) {
-		Self::on_change_tx_count(&self.env_path, false);
-	}
-}
-
-impl TxCounter {
-	/// Increment or decrement active transactions count for current environment.
-	fn on_change_tx_count(env_path: &String, inc: bool) {
 		let mut w_env_map = ENV_MAP.get().unwrap().write();
-		let env_state = w_env_map.get_mut(env_path).unwrap();
+		let env_state = w_env_map.get_mut(&self.env_path).unwrap();
 		let open_txs_count = env_state.open_txs_count.load(Ordering::Relaxed);
-		if inc {
-			env_state
-				.open_txs_count
-				.store(open_txs_count + 1, Ordering::Relaxed);
-		} else {
-			env_state
-				.open_txs_count
-				.store(open_txs_count - 1, Ordering::Relaxed);
-		}
+		env_state
+			.open_txs_count
+			.store(open_txs_count - 1, Ordering::Relaxed);
 	}
 }
 
@@ -696,19 +641,18 @@ pub struct Batch<'a> {
 	store: &'a Store,
 	write: RwTxn<'a>,
 	#[allow(dead_code)]
-	tx_counter: TxCounter,
+	tx_counter: Option<TxCounter>,
 }
 
 impl<'a> Batch<'a> {
 	/// Creates a new batch for provided store.
 	pub fn new(store: &'a Store) -> Result<Batch<'a>, Error> {
+		let tx_counter = store.enter_tx();
 		let write = store.env.write_txn()?;
 		Ok(Batch {
 			store,
 			write,
-			tx_counter: TxCounter {
-				env_path: store.env_path.clone(),
-			},
+			tx_counter: Some(tx_counter),
 		})
 	}
 
@@ -785,29 +729,20 @@ impl<'a> Batch<'a> {
 	where
 		F: Fn(&[u8], &[u8]) -> Result<T, Error>,
 	{
-		self.store.wait_for_resize();
-
-		TxCounter::on_change_tx_count(&self.store.env_path, true);
 		let res = {
 			match self.write.nested_read_txn() {
 				Ok(read) => {
 					let db_res = self.store.get_db(db_key);
 					match db_res {
-						Ok(db) => DatabaseIterator::new(
-							self.store,
-							Arc::new(db.clone()),
-							read,
-							deserialize,
-						),
+						Ok(db) => {
+							DatabaseIterator::new(Arc::new(db.clone()), None, read, deserialize)
+						}
 						Err(e) => Err(Error::from(e)),
 					}
 				}
 				Err(e) => Err(Error::from(e)),
 			}
 		};
-		if res.is_err() {
-			TxCounter::on_change_tx_count(&self.store.env_path, false);
-		}
 		res
 	}
 
@@ -846,22 +781,16 @@ impl<'a> Batch<'a> {
 	/// Creates a child of this batch. It will be merged with its parent on
 	/// commit, abandoned otherwise.
 	pub fn child(&mut self) -> Result<Batch<'_>, Error> {
-		TxCounter::on_change_tx_count(&self.store.env_path, true);
 		let res = {
 			match self.store.env.nested_write_txn(&mut self.write) {
 				Ok(write) => Ok(Batch {
 					store: self.store,
 					write,
-					tx_counter: TxCounter {
-						env_path: self.store.env_path.clone(),
-					},
+					tx_counter: None,
 				}),
 				Err(e) => Err(Error::from(e)),
 			}
 		};
-		if res.is_err() {
-			TxCounter::on_change_tx_count(&self.store.env_path, false);
-		}
 		res
 	}
 }
@@ -880,7 +809,7 @@ where
 	done: bool,
 	deserialize: F,
 	#[allow(dead_code)]
-	tx_counter: TxCounter,
+	tx_counter: Option<TxCounter>,
 }
 
 impl<F, T> Iterator for DatabaseIterator<'_, F, T>
@@ -930,8 +859,8 @@ where
 {
 	/// Initialize a new prefix iterator.
 	pub fn new(
-		store: &Store,
 		db: Arc<Database<Bytes, Bytes>>,
+		tx_counter: Option<TxCounter>,
 		read: RoTxn<'a, WithoutTls>,
 		deserialize: F,
 	) -> Result<DatabaseIterator<'a, F, T>, Error> {
@@ -946,9 +875,7 @@ where
 			skip_total: 0,
 			done,
 			deserialize,
-			tx_counter: TxCounter {
-				env_path: store.env_path.clone(),
-			},
+			tx_counter,
 		})
 	}
 

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -189,18 +189,12 @@ impl Store {
 		if !has_env {
 			let env = unsafe {
 				let mut options = EnvOpenOptions::new().read_txn_without_tls();
-				let mut env_options = options.map_size(alloc_chunk_size).max_dbs(24);
+				let mut env_options = options.max_dbs(24);
 				if let Some(max_readers) = max_readers {
 					env_options = env_options.max_readers(max_readers);
 				}
 				env_options.open(&full_path)?
 			};
-			let (resize, new_size) = needs_resize(&env, alloc_chunk_size);
-			if resize {
-				unsafe {
-					env.resize(new_size)?;
-				};
-			}
 			debug!("DB Mapsize is {}", env.info().map_size);
 			let mut w_env_map = env_map.write();
 			w_env_map.insert(
@@ -328,15 +322,20 @@ impl Store {
 
 		let from_env = unsafe {
 			let mut options = EnvOpenOptions::new().read_txn_without_tls();
-			let env_options = options.map_size(self.alloc_chunk_size).max_dbs(24);
+			let env_options = options.max_dbs(24);
 			env_options.open(from_path)?
 		};
-		let (resize, new_size) = needs_resize(&from_env, self.alloc_chunk_size);
-		if resize {
-			// We are sure there are no active txs, cause migration is called on database creation.
+		let from_used = env_size(&from_env);
+		let to_used = env_size(&self.env);
+		let to_map_size = self.env.info().map_size;
+
+		// Leave headroom so the migrated env is not immediately above the resize threshold.
+		let required = ((to_used + from_used) as f32 / RESIZE_MIN_TARGET_PERCENT) as usize;
+		let required = round_size_to_chunk(required, self.alloc_chunk_size);
+
+		if required > to_map_size {
 			unsafe {
-				from_env.resize(new_size)?;
-				self.env.resize(new_size)?;
+				self.env.resize(required)?;
 			}
 		}
 		let db_from = {
@@ -974,11 +973,27 @@ where
 	}
 }
 
+/// Get environment size.
+fn env_size(env: &Env<WithoutTls>) -> usize {
+	let info = env.info();
+	let stat = env.stat();
+	stat.page_size as usize * info.last_page_number
+}
+
+/// Round size proportionally to chunk size.
+fn round_size_to_chunk(size: usize, chunk_size: usize) -> usize {
+	let rem = size % chunk_size;
+	if rem == 0 {
+		size
+	} else {
+		size + (chunk_size - rem)
+	}
+}
+
 /// Determines whether the environment needs a resize based on a simple percentage threshold.
 pub fn needs_resize(env: &Env<WithoutTls>, alloc_chunk_size: usize) -> (bool, usize) {
 	let env_info = env.info();
-	let stat = env.stat();
-	let size_used = stat.page_size as usize * env_info.last_page_number;
+	let size_used = env_size(env);
 	trace!("DB map size: {}", env_info.map_size);
 	trace!("Space used: {}", size_used);
 	trace!("Space remaining: {}", env_info.map_size - size_used);

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -16,8 +16,11 @@
 
 use heed::types::Bytes;
 use heed::{Database, Env, EnvOpenOptions, RoTxn, RwTxn, WithoutTls};
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::path::Path;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{mpsc, Arc, OnceLock};
 use std::time::Duration;
@@ -94,6 +97,10 @@ pub const PREFIX_KEY_SEPARATOR: u8 = b':';
 
 /// Mapping of database path to environment state.
 static ENV_MAP: OnceLock<RwLock<HashMap<String, EnvState>>> = OnceLock::new();
+
+thread_local! {
+	static THREAD_TX_COUNTS: RefCell<HashMap<String, u32>> = RefCell::new(HashMap::new());
+}
 
 /// State of active database environment.
 struct EnvState {
@@ -395,8 +402,8 @@ impl Store {
 			.load(Ordering::Relaxed)
 	}
 
-	/// Check if requirement for environment resize is checking.
-	fn resize_checking(&self) -> bool {
+	/// Try to acquire the resize check guard.
+	fn start_resize_checking(&self) -> bool {
 		ENV_MAP
 			.get()
 			.unwrap()
@@ -404,19 +411,20 @@ impl Store {
 			.get(&self.env_path)
 			.unwrap()
 			.resize_checking
-			.load(Ordering::Relaxed)
+			.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+			.is_ok()
 	}
 
-	/// Set flag if requirement for environment resize is checking.
-	fn set_resize_checking(&self, resize_checking: bool) {
+	/// Release the resize check guard.
+	fn finish_resize_checking(&self) {
 		ENV_MAP
 			.get()
 			.unwrap()
-			.write()
-			.get_mut(&self.env_path)
+			.read()
+			.get(&self.env_path)
 			.unwrap()
 			.resize_checking
-			.store(resize_checking, Ordering::Relaxed);
+			.store(false, Ordering::Release);
 	}
 
 	/// Set flag if environment is waiting for resize.
@@ -424,23 +432,22 @@ impl Store {
 		ENV_MAP
 			.get()
 			.unwrap()
-			.write()
-			.get_mut(&self.env_path)
+			.read()
+			.get(&self.env_path)
 			.unwrap()
 			.resizing
-			.store(resizing, Ordering::Relaxed);
+			.store(resizing, Ordering::Release);
 	}
 
 	/// Resize database environment if needed.
 	fn maybe_resize(&self) {
-		if self.resize_checking() {
+		if !self.start_resize_checking() {
 			return;
 		}
-		self.set_resize_checking(true);
 
 		let (resize, new_size) = needs_resize(&self.env, self.alloc_chunk_size);
 		if !resize {
-			self.set_resize_checking(false);
+			self.finish_resize_checking();
 			return;
 		}
 
@@ -479,8 +486,8 @@ impl Store {
 
 				let mut w_env_map = ENV_MAP.get().unwrap().write();
 				let env_state = w_env_map.get_mut(&env_path).unwrap();
-				env_state.resizing.store(false, Ordering::Relaxed);
-				env_state.resize_checking.store(false, Ordering::Relaxed);
+				env_state.resizing.store(false, Ordering::Release);
+				env_state.resize_checking.store(false, Ordering::Release);
 			});
 		} else {
 			debug!("Start immediate resizing DB {}", env_path);
@@ -491,7 +498,7 @@ impl Store {
 				}
 			}
 			self.set_resizing(false);
-			self.set_resize_checking(false);
+			self.finish_resize_checking();
 		}
 	}
 
@@ -632,17 +639,25 @@ impl Store {
 		Batch::new(self)
 	}
 
-	/// Creates tx counter incrementing if resize is not pending.
+	/// Increment the open-tx counter, blocking during resize unless this thread already holds a tx.
 	fn enter_tx(&self) -> TxCounter {
 		loop {
 			let mut map = ENV_MAP.get().unwrap().write();
 			let state = map.get_mut(&self.env_path).unwrap();
-			if !state.resizing.load(Ordering::Acquire)
-				|| state.open_txs_count.load(Ordering::Relaxed) > 0
-			{
+			let nested_tx = THREAD_TX_COUNTS.with(|txs| {
+				txs.borrow()
+					.get(&self.env_path)
+					.is_some_and(|count| *count > 0)
+			});
+			if !state.resizing.load(Ordering::Acquire) || nested_tx {
 				state.open_txs_count.fetch_add(1, Ordering::Relaxed);
+				THREAD_TX_COUNTS.with(|txs| {
+					let mut txs = txs.borrow_mut();
+					*txs.entry(self.env_path.clone()).or_insert(0) += 1;
+				});
 				return TxCounter {
 					env_path: self.env_path.clone(),
+					_not_send: PhantomData,
 				};
 			}
 			drop(map);
@@ -654,10 +669,20 @@ impl Store {
 /// Environment transactions counter, allows to decrement value on drop.
 pub struct TxCounter {
 	env_path: String,
+	_not_send: PhantomData<Rc<()>>,
 }
 
 impl Drop for TxCounter {
 	fn drop(&mut self) {
+		THREAD_TX_COUNTS.with(|txs| {
+			let mut txs = txs.borrow_mut();
+			if let Some(count) = txs.get_mut(&self.env_path) {
+				*count -= 1;
+				if *count == 0 {
+					txs.remove(&self.env_path);
+				}
+			}
+		});
 		let mut w_env_map = ENV_MAP.get().unwrap().write();
 		let env_state = w_env_map.get_mut(&self.env_path).unwrap();
 		let open_txs_count = env_state.open_txs_count.load(Ordering::Relaxed);

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -522,7 +522,7 @@ impl Store {
 		key: &[u8],
 		deser_mode: Option<DeserializationMode>,
 	) -> Result<Option<T>, Error> {
-		let _ = self.enter_tx();
+		let _tx_counter = self.enter_tx();
 
 		let res = {
 			let d = match deser_mode {
@@ -541,7 +541,7 @@ impl Store {
 
 	/// Whether the key exists at the provided database key.
 	pub fn exists(&self, db_key: Option<u8>, key: &[u8]) -> Result<bool, Error> {
-		let _ = self.enter_tx();
+		let _tx_counter = self.enter_tx();
 
 		let res = {
 			match self.env.read_txn() {

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -99,7 +99,7 @@ static ENV_MAP: OnceLock<RwLock<HashMap<String, EnvState>>> = OnceLock::new();
 struct EnvState {
 	env: Env<WithoutTls>,
 	open_txs_count: AtomicU32,
-	resize_pending: AtomicBool,
+	resizing: AtomicBool,
 	resize_checking: AtomicBool,
 	stores_count: AtomicU32,
 }
@@ -202,7 +202,7 @@ impl Store {
 				EnvState {
 					env,
 					open_txs_count: AtomicU32::new(0),
-					resize_pending: AtomicBool::new(false),
+					resizing: AtomicBool::new(false),
 					resize_checking: AtomicBool::new(false),
 					stores_count: AtomicU32::new(1),
 				},
@@ -420,15 +420,15 @@ impl Store {
 	}
 
 	/// Set flag if environment is waiting for resize.
-	fn set_resize_pending(&self, resize_pending: bool) {
+	fn set_resizing(&self, resizing: bool) {
 		ENV_MAP
 			.get()
 			.unwrap()
 			.write()
 			.get_mut(&self.env_path)
 			.unwrap()
-			.resize_pending
-			.store(resize_pending, Ordering::Relaxed);
+			.resizing
+			.store(resizing, Ordering::Relaxed);
 	}
 
 	/// Resize database environment if needed.
@@ -443,25 +443,56 @@ impl Store {
 			self.set_resize_checking(false);
 			return;
 		}
-		// Stop new top-level transactions first.
-		self.set_resize_pending(true);
-		while {
-			let count = self.open_txs_count();
-			debug!("Wait {} opened txs to resize", count);
-			count != 0
-		} {
-			thread::sleep(Duration::from_millis(10));
-		}
 
-		unsafe {
-			match self.env.resize(new_size) {
-				Ok(_) => debug!("End resizing DB {}", self.env_path),
-				Err(e) => error!("Resize DB {} error: {:?}", self.env_path, e),
+		let env_path = self.env_path.clone();
+		let env = self.env.clone();
+
+		self.set_resizing(true);
+
+		// Resize immediately or at another thread to not interrupt current
+		// transaction waiting all open transactions to be closed.
+		if self.open_txs_count() != 0 {
+			debug!("Waiting txs to be closed before DB {} resize", env_path);
+			thread::spawn(move || {
+				loop {
+					let txs_count = ENV_MAP
+						.get()
+						.unwrap()
+						.read()
+						.get(&env_path)
+						.unwrap()
+						.open_txs_count
+						.load(Ordering::Relaxed);
+					if txs_count == 0 {
+						debug!("Start resizing DB {}", env_path);
+						break;
+					}
+					thread::sleep(Duration::from_millis(100));
+				}
+
+				unsafe {
+					match env.resize(new_size) {
+						Ok(_) => debug!("End resizing DB {}", env_path),
+						Err(e) => error!("Resize DB {} error: {:?}", env_path, e),
+					}
+				}
+
+				let mut w_env_map = ENV_MAP.get().unwrap().write();
+				let env_state = w_env_map.get_mut(&env_path).unwrap();
+				env_state.resizing.store(false, Ordering::Relaxed);
+				env_state.resize_checking.store(false, Ordering::Relaxed);
+			});
+		} else {
+			debug!("Start immediate resizing DB {}", env_path);
+			unsafe {
+				match env.resize(new_size) {
+					Ok(_) => debug!("End resizing DB {}", env_path),
+					Err(e) => error!("Resize DB {} error: {:?}", env_path, e),
+				}
 			}
+			self.set_resizing(false);
+			self.set_resize_checking(false);
 		}
-
-		self.set_resize_pending(false);
-		self.set_resize_checking(false);
 	}
 
 	/// Clear all data from database environment.
@@ -606,8 +637,8 @@ impl Store {
 		loop {
 			let mut map = ENV_MAP.get().unwrap().write();
 			let state = map.get_mut(&self.env_path).unwrap();
-			if state.open_txs_count.load(Ordering::Relaxed) > 0
-				|| !state.resize_pending.load(Ordering::Acquire)
+			if !state.resizing.load(Ordering::Acquire)
+				|| state.open_txs_count.load(Ordering::Relaxed) > 0
 			{
 				state.open_txs_count.fetch_add(1, Ordering::Relaxed);
 				return TxCounter {

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -27,6 +27,9 @@ use heed::types::Bytes;
 use heed::{Database, Env, EnvOpenOptions, WithoutTls};
 use std::fs;
 use std::path::Path;
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
 
 const WRITE_CHUNK_SIZE: usize = 20;
 const TEST_ALLOC_SIZE: usize = store::lmdb::ALLOC_CHUNK_SIZE_DEFAULT / 8 / WRITE_CHUNK_SIZE;
@@ -306,6 +309,61 @@ fn test_migration() -> Result<(), store::Error> {
 		assert_eq!(data, Some(test_data_3.to_vec()));
 	}
 
+	clean_output_dir(test_dir);
+	Ok(())
+}
+
+#[test]
+fn resize_batch_waits_for_open_read_iterator() -> Result<(), store::Error> {
+	let test_dir = "target/open_read_iterator_resize";
+	global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+	util::init_test_logger();
+	clean_output_dir(test_dir);
+
+	let prefix = b'P';
+	let store = Arc::new(Store::new(
+		test_dir,
+		Some("test1"),
+		None,
+		vec![prefix],
+		None,
+		None,
+	)?);
+	let value = vec![1u8; 128 * 1024];
+	let mut saw_waiting_resize = false;
+
+	for i in 0..40u32 {
+		let mut batch = store.batch()?;
+		batch.put(Some(prefix), &i.to_be_bytes(), &value)?;
+		batch.commit()?;
+
+		let held_iter = store.iter(Some(prefix), |_, v| Ok(v.to_vec()))?;
+		let (tx, rx) = mpsc::channel();
+		let writer_store = store.clone();
+		let writer = thread::spawn(move || {
+			let res = writer_store.batch().map(|_| ());
+			tx.send(res).unwrap();
+		});
+
+		match rx.recv_timeout(Duration::from_millis(100)) {
+			Ok(writer_res) => writer_res?,
+			Err(mpsc::RecvTimeoutError::Timeout) => {
+				saw_waiting_resize = true;
+				drop(held_iter);
+				let writer_res = rx
+					.recv_timeout(Duration::from_secs(2))
+					.expect("batch did not continue after the read iterator was closed");
+				writer_res?;
+				writer.join().unwrap();
+				continue;
+			}
+			Err(e) => panic!("batch thread disconnected: {:?}", e),
+		}
+		drop(held_iter);
+		writer.join().unwrap();
+	}
+
+	assert!(saw_waiting_resize);
 	clean_output_dir(test_dir);
 	Ok(())
 }

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -329,10 +329,10 @@ fn resize_batch_waits_for_open_read_iterator() -> Result<(), store::Error> {
 		None,
 		None,
 	)?);
-	let value = vec![1u8; 128 * 1024];
+	let value = vec![1u8; 32 * 1024];
 	let mut saw_waiting_resize = false;
 
-	for i in 0..40u32 {
+	for i in 0..80u32 {
 		let mut batch = store.batch()?;
 		batch.put(Some(prefix), &i.to_be_bytes(), &value)?;
 		batch.commit()?;


### PR DESCRIPTION
- Do not resize source env before migration and on env initialization
- Optimize open txs counter before resize