### PR TITLE
Fix TUI server startup shutdown handling

### DIFF
--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -79,9 +79,8 @@ pub struct Server {
 }
 
 impl Server {
-	/// Instantiates and starts a new server. Optionally takes a callback
-	/// for the server to send an ARC copy of itself, to allow another process
-	/// to poll info about the server status
+	/// Instantiates and starts a new server, optionally sending initialization
+	/// status updates through the provided channel.
 	pub fn start(
 		config: ServerConfig,
 		stop_state: Option<Arc<StopState>>,

--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -50,7 +50,7 @@ pub fn start_server(
 		let serv_tx_clone = serv_tx.clone();
 		let stop_state = Arc::new(StopState::new());
 		let stop_state_clone = stop_state.clone();
-		thread::spawn(move || {
+		let server_thread = thread::spawn(move || {
 			match Server::start(
 				config,
 				Some(stop_state_clone.clone()),
@@ -71,6 +71,10 @@ pub fn start_server(
 		});
 		let exit_code = controller.run();
 		stop_state.stop();
+		if let Err(e) = server_thread.join() {
+			error!("Failed to join server startup thread: {:?}", e);
+		}
+		controller.stop_server();
 		exit_code
 	} else {
 		warn!("Starting GRIN w/o UI...");

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -209,7 +209,7 @@ impl Controller {
 	/// Server initialization status.
 	pub fn init_status(&mut self, text: &str, pop: bool) {
 		if pop {
-			self.ui.cursive.pop_layer();
+			self.pop_dialog();
 		}
 		let content = StyledString::styled(text, Color::Light(BaseColor::Green));
 		self.ui
@@ -220,6 +220,7 @@ impl Controller {
 
 	/// Server initialization error.
 	pub fn init_error(&mut self, e: Error) {
+		self.pop_dialog();
 		let content = StyledString::styled(format!("{:?}", e), Color::Light(BaseColor::Red));
 		self.ui.cursive.add_layer(
 			CircularFocus::new(Dialog::around(TextView::new(content)).button("Exit", |s| {
@@ -228,6 +229,24 @@ impl Controller {
 			.wrap_tab(),
 		);
 		self.ui.show_dialog.store(true, Ordering::Relaxed);
+	}
+
+	fn pop_dialog(&mut self) {
+		if self.ui.show_dialog.swap(false, Ordering::Relaxed) {
+			self.ui.cursive.pop_layer();
+		}
+	}
+
+	/// Stop a fully initialized server, including one queued by the startup thread.
+	pub fn stop_server(&mut self) {
+		if let Some(s) = self.server.take() {
+			s.stop();
+		}
+		while let Ok(message) = self.serv_rx.try_recv() {
+			if let ServerInitStatus::FinishedLoading(s) = message {
+				s.stop();
+			}
+		}
 	}
 
 	/// Server UI after initialization.
@@ -251,9 +270,7 @@ impl Controller {
 					ControllerMessage::Shutdown => {
 						warn!("Shutdown in progress, please wait");
 						self.ui.stop();
-						if let Some(s) = self.server.take() {
-							s.stop();
-						}
+						self.stop_server();
 						exit_code
 					}
 				};
@@ -265,8 +282,7 @@ impl Controller {
 					ServerInitStatus::StartSync => self.init_status("Start syncing...", true),
 					ServerInitStatus::StartAPI => self.init_status("Starting API...", true),
 					ServerInitStatus::FinishedLoading(s) => {
-						self.ui.cursive.pop_layer();
-						self.ui.show_dialog.store(false, Ordering::Relaxed);
+						self.pop_dialog();
 						self.server = Some(s)
 					}
 					ServerInitStatus::ErrorLoading(e) => {
@@ -290,6 +306,7 @@ impl Controller {
 			}
 			thread::sleep(delay);
 		}
+		self.stop_server();
 		exit_code
 	}
 }

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -252,7 +252,7 @@ impl Controller {
 	/// Server UI after initialization.
 	pub fn server(&mut self, server: &Server) {
 		if let Ok(stats) = server.get_server_stats() {
-			self.ui.ui_tx.send(UIMessage::UpdateStatus(stats)).unwrap();
+			let _ = self.ui.ui_tx.send(UIMessage::UpdateStatus(stats));
 		}
 	}
 
@@ -300,7 +300,7 @@ impl Controller {
 				next_stat_update = Utc::now().timestamp() + stat_update_interval;
 				if let Some(server) = &self.server {
 					if let Ok(stats) = server.get_server_stats() {
-						self.ui.ui_tx.send(UIMessage::UpdateStatus(stats)).unwrap();
+						let _ = self.ui.ui_tx.send(UIMessage::UpdateStatus(stats));
 					}
 				}
 			}


### PR DESCRIPTION
- stop the server when the TUI exits through non-`q` paths
- join the async startup thread and drain any queued initialized server before exiting
- replace active startup dialogs on error/status changes instead of stacking them
- update stale `Server::start` documentation