### PR TITLE
Create API secrets at configured paths

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -63,6 +63,7 @@ fn comments() -> HashMap<String, String> {
 		"api_secret_path".to_string(),
 		"
 #path of the secret token used by the Rest API and v2 Owner API to authenticate the calls
+#relative paths are resolved relative to the chain-specific grin home directory
 #comment the it to disable basic auth
 "
 		.to_string(),
@@ -72,6 +73,7 @@ fn comments() -> HashMap<String, String> {
 		"foreign_api_secret_path".to_string(),
 		"
 #path of the secret token used by the Foreign API to authenticate the calls
+#relative paths are resolved relative to the chain-specific grin home directory
 #comment the it to disable basic auth
 "
 		.to_string(),

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -94,28 +94,39 @@ pub fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	Ok(())
 }
 
-/// Check that the api secret files exist and are valid
-fn check_api_secret_files(
-	chain_type: &global::ChainTypes,
-	secret_file_name: &str,
-) -> Result<(), ConfigError> {
-	let grin_path = get_grin_path(chain_type)?;
-	let mut api_secret_path = grin_path;
-	api_secret_path.push(secret_file_name);
+/// Check that the api secret file exists and is valid
+fn check_api_secret_file(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	if !api_secret_path.exists() {
-		init_api_secret(&api_secret_path)
+		init_api_secret(api_secret_path)
 	} else {
-		check_api_secret(&api_secret_path)
+		check_api_secret(api_secret_path)
 	}
+}
+
+/// Check that the configured api secret files exist and are valid
+fn check_api_secret_files(config: &GlobalConfig) -> Result<(), ConfigError> {
+	let server_config = &config.members.as_ref().unwrap().server;
+	if let Some(ref api_secret_path) = server_config.api_secret_path {
+		check_api_secret_file(&PathBuf::from(api_secret_path))?;
+	}
+	if let Some(ref foreign_api_secret_path) = server_config.foreign_api_secret_path {
+		check_api_secret_file(&PathBuf::from(foreign_api_secret_path))?;
+	}
+	Ok(())
+}
+
+/// Load server config and ensure the configured api secret files exist
+pub fn load_server_config(file_path: &str) -> Result<GlobalConfig, ConfigError> {
+	let config = GlobalConfig::new(file_path)?;
+	check_api_secret_files(&config)?;
+	Ok(config)
 }
 
 /// Handles setup and detection of paths for node
 pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalConfig, ConfigError> {
-	check_api_secret_files(chain_type, API_SECRET_FILE_NAME)?;
-	check_api_secret_files(chain_type, FOREIGN_API_SECRET_FILE_NAME)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(SERVER_CONFIG_FILE_NAME) {
-		GlobalConfig::new(p.to_str().unwrap())
+		load_server_config(p.to_str().unwrap())
 	} else {
 		// Check if grin dir exists
 		let grin_path = get_grin_path(chain_type)?;
@@ -132,7 +143,7 @@ pub fn initial_setup_server(chain_type: &global::ChainTypes) -> Result<GlobalCon
 			default_config.write_to_file(config_path.to_str().unwrap())?;
 		}
 
-		GlobalConfig::new(config_path.to_str().unwrap())
+		load_server_config(config_path.to_str().unwrap())
 	}
 }
 
@@ -400,4 +411,103 @@ fn test_bad_config() {
 		}
 		_ => panic!("expected config parse error, got {:?}", res),
 	}
+}
+
+#[cfg(test)]
+fn temp_config_dir(name: &str) -> PathBuf {
+	let mut test_dir = env::temp_dir();
+	test_dir.push(format!(
+		"{}_{}_{}",
+		name,
+		std::process::id(),
+		std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.unwrap()
+			.as_nanos()
+	));
+	fs::create_dir_all(&test_dir).unwrap();
+	test_dir
+}
+
+#[cfg(test)]
+fn write_test_config(test_dir: &PathBuf) -> (PathBuf, PathBuf, PathBuf) {
+	let mut config = GlobalConfig::for_chain(&global::ChainTypes::Mainnet);
+	config.update_paths(test_dir);
+
+	let mut config_path = test_dir.clone();
+	config_path.push(SERVER_CONFIG_FILE_NAME);
+	config.write_to_file(config_path.to_str().unwrap()).unwrap();
+
+	let mut api_secret_path = test_dir.clone();
+	api_secret_path.push(API_SECRET_FILE_NAME);
+	let mut foreign_api_secret_path = test_dir.clone();
+	foreign_api_secret_path.push(FOREIGN_API_SECRET_FILE_NAME);
+
+	(config_path, api_secret_path, foreign_api_secret_path)
+}
+
+#[cfg(test)]
+fn check_test_secrets(
+	server_config: ServerConfig,
+	api_secret_path: &PathBuf,
+	foreign_api_secret_path: &PathBuf,
+	api_secret_exists: bool,
+	foreign_api_secret_exists: bool,
+) {
+	assert_eq!(
+		server_config.api_secret_path,
+		Some(api_secret_path.to_str().unwrap().to_owned())
+	);
+	assert_eq!(
+		server_config.foreign_api_secret_path,
+		Some(foreign_api_secret_path.to_str().unwrap().to_owned())
+	);
+	assert!(api_secret_exists);
+	assert!(foreign_api_secret_exists);
+}
+
+#[test]
+fn test_api_secret_paths() {
+	let current_dir = env::current_dir().unwrap();
+	let test_dir = temp_config_dir("grin_config");
+	let (_config_path, api_secret_path, foreign_api_secret_path) = write_test_config(&test_dir);
+
+	env::set_current_dir(&test_dir).unwrap();
+	let res = initial_setup_server(&global::ChainTypes::Mainnet);
+	env::set_current_dir(current_dir).unwrap();
+
+	let server_config = res.map(|config| config.members.unwrap().server);
+	let api_secret_exists = api_secret_path.exists();
+	let foreign_api_secret_exists = foreign_api_secret_path.exists();
+
+	fs::remove_dir_all(&test_dir).unwrap();
+
+	check_test_secrets(
+		server_config.unwrap(),
+		&api_secret_path,
+		&foreign_api_secret_path,
+		api_secret_exists,
+		foreign_api_secret_exists,
+	);
+}
+
+#[test]
+fn test_api_secret_paths_config_file() {
+	let test_dir = temp_config_dir("grin_config_file");
+	let (config_path, api_secret_path, foreign_api_secret_path) = write_test_config(&test_dir);
+
+	let res = load_server_config(config_path.to_str().unwrap());
+	let server_config = res.map(|config| config.members.unwrap().server);
+	let api_secret_exists = api_secret_path.exists();
+	let foreign_api_secret_exists = foreign_api_secret_path.exists();
+
+	fs::remove_dir_all(&test_dir).unwrap();
+
+	check_test_secrets(
+		server_config.unwrap(),
+		&api_secret_path,
+		&foreign_api_secret_path,
+		api_secret_exists,
+		foreign_api_secret_exists,
+	);
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -103,22 +103,53 @@ fn check_api_secret_file(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	}
 }
 
+fn resolve_api_secret_path(path: &str, grin_path: &PathBuf) -> PathBuf {
+	let path = PathBuf::from(path);
+	if path.is_absolute() {
+		path
+	} else {
+		let mut resolved = grin_path.clone();
+		resolved.push(path);
+		resolved
+	}
+}
+
+fn resolve_api_secret_path_for_chain(
+	path: &str,
+	chain_type: &global::ChainTypes,
+) -> Result<PathBuf, ConfigError> {
+	let path_buf = PathBuf::from(path);
+	if path_buf.is_absolute() {
+		Ok(path_buf)
+	} else {
+		Ok(resolve_api_secret_path(path, &get_grin_path(chain_type)?))
+	}
+}
+
 /// Check that the configured api secret files exist and are valid
-fn check_api_secret_files(config: &GlobalConfig) -> Result<(), ConfigError> {
-	let server_config = &config.members.as_ref().unwrap().server;
-	if let Some(ref api_secret_path) = server_config.api_secret_path {
-		check_api_secret_file(&PathBuf::from(api_secret_path))?;
+fn check_api_secret_files(config: &mut GlobalConfig) -> Result<(), ConfigError> {
+	let server_config = &mut config.members.as_mut().unwrap().server;
+
+	if let Some(api_secret_path) = server_config.api_secret_path.clone() {
+		let resolved =
+			resolve_api_secret_path_for_chain(&api_secret_path, &server_config.chain_type)?;
+		check_api_secret_file(&resolved)?;
+		server_config.api_secret_path = Some(resolved.to_str().unwrap().to_owned());
 	}
-	if let Some(ref foreign_api_secret_path) = server_config.foreign_api_secret_path {
-		check_api_secret_file(&PathBuf::from(foreign_api_secret_path))?;
+	if let Some(foreign_api_secret_path) = server_config.foreign_api_secret_path.clone() {
+		let resolved =
+			resolve_api_secret_path_for_chain(&foreign_api_secret_path, &server_config.chain_type)?;
+		check_api_secret_file(&resolved)?;
+		server_config.foreign_api_secret_path = Some(resolved.to_str().unwrap().to_owned());
 	}
+
 	Ok(())
 }
 
 /// Load server config and ensure the configured api secret files exist
 pub fn load_server_config(file_path: &str) -> Result<GlobalConfig, ConfigError> {
-	let config = GlobalConfig::new(file_path)?;
-	check_api_secret_files(&config)?;
+	let mut config = GlobalConfig::new(file_path)?;
+	check_api_secret_files(&mut config)?;
 	Ok(config)
 }
 
@@ -464,6 +495,25 @@ fn check_test_secrets(
 	);
 	assert!(api_secret_exists);
 	assert!(foreign_api_secret_exists);
+}
+
+#[test]
+fn test_relative_api_secret_paths() {
+	let grin_path = temp_config_dir("grin_config_relative_home");
+	let mut expected_api_secret_path = grin_path.clone();
+	expected_api_secret_path.push(API_SECRET_FILE_NAME);
+	let mut absolute_api_secret_path = temp_config_dir("grin_config_absolute");
+	absolute_api_secret_path.push(API_SECRET_FILE_NAME);
+
+	let resolved_api_secret_path = resolve_api_secret_path(API_SECRET_FILE_NAME, &grin_path);
+	let resolved_absolute_api_secret_path =
+		resolve_api_secret_path(absolute_api_secret_path.to_str().unwrap(), &grin_path);
+
+	assert_eq!(resolved_api_secret_path, expected_api_secret_path);
+	assert_eq!(resolved_absolute_api_secret_path, absolute_api_secret_path);
+
+	fs::remove_dir_all(&grin_path).unwrap();
+	fs::remove_dir_all(absolute_api_secret_path.parent().unwrap()).unwrap();
 }
 
 #[test]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -32,5 +32,5 @@ mod comments;
 pub mod config;
 pub mod types;
 
-pub use crate::config::initial_setup_server;
+pub use crate::config::{initial_setup_server, load_server_config};
 pub use crate::types::{ConfigError, ConfigMembers, GlobalConfig};

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -111,7 +111,7 @@ fn real_main() -> i32 {
 		// When the subscommand is 'server' take into account the 'config_file' flag
 		("server", Some(server_args)) => {
 			if let Some(_path) = server_args.value_of("config_file") {
-				node_config = Some(config::GlobalConfig::new(_path).unwrap_or_else(|e| {
+				node_config = Some(config::load_server_config(_path).unwrap_or_else(|e| {
 					panic!("Error loading server configuration: {}", e);
 				}));
 			} else {


### PR DESCRIPTION
Fixes #3821.

API secret files are now created and checked using the paths from grin-server.toml, instead of defaulting to ~/.grin/"chain" before the config is loaded.
Also applies to explicit --config_file usage.

Test:
* cargo test -p grin_config

Tested on Mac:
./grin server config
rm -f .api_secret .foreign_api_secret
./grin server run
ls -la .api_secret .foreign_api_secret

Config-path:
rm -f .api_secret .foreign_api_secret
./grin server --config_file "$PWD/grin-server.toml" run
ls -la .api_secret .foreign_api_secret