### PR TITLE
Fix tests using rustls

### DIFF
--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -347,9 +347,7 @@ mod tests {
 
 	#[test]
 	fn test_get() {
-		rustls::crypto::ring::default_provider()
-			.install_default()
-			.expect("Failed to install rustls crypto provider");
+		let _ = rustls::crypto::ring::default_provider().install_default();
 		util::init_test_logger();
 		let mut routes = Router::new();
 		routes

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -347,6 +347,9 @@ mod tests {
 
 	#[test]
 	fn test_get() {
+		rustls::crypto::ring::default_provider()
+			.install_default()
+			.expect("Failed to install rustls crypto provider");
 		util::init_test_logger();
 		let mut routes = Router::new();
 		routes

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -73,6 +73,9 @@ fn open_port(host: &str) -> u16 {
 
 #[test]
 fn test_start_api() {
+	rustls::crypto::ring::default_provider()
+		.install_default()
+		.expect("Failed to install rustls crypto provider");
 	util::init_test_logger();
 	let mut server = ApiServer::new();
 	let mut router = build_router();
@@ -101,6 +104,9 @@ fn test_start_api() {
 #[ignore]
 #[test]
 fn test_start_api_tls() {
+	rustls::crypto::ring::default_provider()
+		.install_default()
+		.expect("Failed to install rustls crypto provider");
 	util::init_test_logger();
 	let tls_conf = TLSConfig::new(
 		"tests/fullchain.pem".to_string(),

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -73,9 +73,7 @@ fn open_port(host: &str) -> u16 {
 
 #[test]
 fn test_start_api() {
-	rustls::crypto::ring::default_provider()
-		.install_default()
-		.expect("Failed to install rustls crypto provider");
+	let _ = rustls::crypto::ring::default_provider().install_default();
 	util::init_test_logger();
 	let mut server = ApiServer::new();
 	let mut router = build_router();
@@ -104,9 +102,7 @@ fn test_start_api() {
 #[ignore]
 #[test]
 fn test_start_api_tls() {
-	rustls::crypto::ring::default_provider()
-		.install_default()
-		.expect("Failed to install rustls crypto provider");
+	let _ = rustls::crypto::ring::default_provider().install_default();
 	util::init_test_logger();
 	let tls_conf = TLSConfig::new(
 		"tests/fullchain.pem".to_string(),


### PR DESCRIPTION
Initialize default rustls provider so external process tests will not fail (grin-wallet).