### PR TITLE
test: add unit tests for stratumserver module

### DIFF
--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -928,6 +928,8 @@ mod tests {
 	// ----------------------------------------
 	// Helpers
 
+	const TEST_MINIMUM_SHARE_DIFFICULTY: u64 = 1;
+
 	fn dummy_tx() -> Tx {
 		let (tx, _rx) = mpsc::unbounded();
 		tx
@@ -960,7 +962,7 @@ mod tests {
 	}
 
 	/// Build a Handler backed by the shared test chain for RPC routing tests.
-	fn setup_handler(minimum_share_difficulty: u64) -> Handler {
+	fn setup_handler() -> Handler {
 		global::set_local_chain_type(ChainTypes::AutomatedTesting);
 		let chain = shared_test_chain();
 		let stratum_stats = Arc::new(RwLock::new(StratumStats::default()));
@@ -971,7 +973,7 @@ mod tests {
 			String::from("test"),
 			stratum_stats,
 			sync_state,
-			minimum_share_difficulty,
+			TEST_MINIMUM_SHARE_DIFFICULTY,
 			chain,
 		)
 	}
@@ -1314,7 +1316,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_keepalive() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1327,7 +1329,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_method_not_found() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1341,7 +1343,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_login_ok() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let params = serde_json::json!({
@@ -1363,7 +1365,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_login_invalid_params() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp =
@@ -1375,7 +1377,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_getjobtemplate_while_syncing() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		// Force syncing state
 		handler.sync_state.update(SyncStatus::HeaderSync {
 			sync_head: handler.chain.head().unwrap(),
@@ -1396,7 +1398,10 @@ mod tests {
 
 	#[test]
 	fn test_handle_getjobtemplate_ok() {
-		let handler = setup_handler(7);
+		let handler = setup_handler();
+		// Non-default difficulty so the template path is not only asserting the const.
+		let job_difficulty = 7;
+		handler.current_state.write().minimum_share_difficulty = job_difficulty;
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1406,7 +1411,7 @@ mod tests {
 		let result = resp.result.unwrap();
 		assert_eq!(result["height"], 0);
 		assert_eq!(result["job_id"], 0);
-		assert_eq!(result["difficulty"], 7);
+		assert_eq!(result["difficulty"], job_difficulty);
 		// pre_pow is hex-encoded header bytes.
 		let pre_pow = result["pre_pow"].as_str().unwrap();
 		assert!(!pre_pow.is_empty());
@@ -1415,7 +1420,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_status() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 		handler.workers.update_stats(worker_id, |ws| {
 			ws.num_accepted = 10;
@@ -1439,7 +1444,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_submit_too_late() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// Wrong height vs current block version (height 0) => stale share
@@ -1463,7 +1468,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_submit_invalid_job_id() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// job_id out of range of current_block_versions
@@ -1484,7 +1489,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_submit_missing_params() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1496,7 +1501,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_submit_invalid_edge_bits() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// edge_bits below the AutomatedTesting minimum (10) and not the
@@ -1522,7 +1527,7 @@ mod tests {
 
 	#[test]
 	fn test_last_seen_updates() {
-		let handler = setup_handler(1);
+		let handler = setup_handler();
 		let worker_id = handler.workers.add_worker(dummy_tx());
 		// Force a known baseline instead of racing a real clock read against
 		// the update below.

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -918,7 +918,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::chain::types::{NoopAdapter, SyncStatus};
+	use crate::chain::types::{HeaderSyncMode, NoopAdapter, SyncStatus};
 	use crate::core::genesis;
 	use crate::core::global::{self, ChainTypes};
 	use crate::core::pow::Difficulty;
@@ -1405,6 +1405,7 @@ mod tests {
 		// Force syncing state
 		handler.sync_state.update(SyncStatus::HeaderSync {
 			sync_head: handler.chain.head().unwrap(),
+			sync_mode: HeaderSyncMode::Legacy,
 			highest_height: 100,
 			highest_diff: Difficulty::from_num(1000),
 		});

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -1137,32 +1137,6 @@ mod tests {
 
 	#[test]
 	fn test_rpc_error_constructors() {
-		let cases = vec![
-			(RpcError::internal_error(), -32603, "Internal error"),
-			(
-				RpcError::node_is_syncing(),
-				-32000,
-				"Node is syncing - Please wait",
-			),
-			(RpcError::method_not_found(), -32601, "Method not found"),
-			(RpcError::too_late(), -32503, "Solution submitted too late"),
-			(
-				RpcError::cannot_validate(),
-				-32502,
-				"Failed to validate solution",
-			),
-			(
-				RpcError::too_low_difficulty(),
-				-32501,
-				"Share rejected due to low difficulty",
-			),
-			(RpcError::invalid_request(), -32600, "Invalid Request"),
-		];
-		for (err, code, message) in cases {
-			assert_eq!(err.code, code);
-			assert_eq!(err.message, message);
-		}
-
 		// Regression: internal_error() must serialize with the negative
 		// JSON-RPC 2.0 code, matching api/src/json_rpc.rs.
 		let value: Value = RpcError::internal_error().into();

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -928,37 +928,24 @@ mod tests {
 	// ----------------------------------------
 	// Helpers
 
-	fn clean_output_dir(dir_name: &str) {
-		let _ = fs::remove_dir_all(dir_name);
-	}
-
-	/// Path under `target/tmp/` so interrupted tests do not leave dirs in the repo root.
-	fn test_chain_dir(name: &str) -> String {
-		format!("target/tmp/{}", name)
-	}
-
 	fn dummy_tx() -> Tx {
 		let (tx, _rx) = mpsc::unbounded();
 		tx
 	}
 
-	/// A single chain instance shared by every RPC routing test below.
-	///
-	/// None of these tests submit a full solution (that would call
-	/// `chain::Chain::process_block`), so the chain is only ever read from and
-	/// is safe to reuse. Initializing one LMDB env instead of one per test
-	/// avoids intermittent "Invalid argument" failures seen when many envs are
-	/// opened concurrently under the default test-runner parallelism.
+	/// Read-only chain shared by the RPC routing tests below, so the suite
+	/// opens a single LMDB env. Tests that write to the chain need their own.
 	fn shared_test_chain() -> Arc<chain::Chain> {
 		static CHAIN: OnceLock<Arc<chain::Chain>> = OnceLock::new();
 		CHAIN
 			.get_or_init(|| {
 				global::set_local_chain_type(ChainTypes::AutomatedTesting);
-				let dir = test_chain_dir("grin_stratum_test_shared_chain");
-				clean_output_dir(&dir);
+				// Under target/ so interrupted tests do not litter the repo root.
+				let dir = "target/tmp/grin_stratum_test_shared_chain";
+				let _ = fs::remove_dir_all(dir);
 				Arc::new(
 					chain::Chain::init(
-						dir,
+						dir.to_string(),
 						Arc::new(NoopAdapter {}),
 						genesis::genesis_dev(),
 						pow::verify_size,
@@ -1002,7 +989,7 @@ mod tests {
 	}
 
 	// ----------------------------------------
-	// RpcRequest / RpcResponse serde (existing)
+	// RpcRequest / RpcResponse serde
 
 	/// Tests deserializing an `RpcRequest` given a String as the id.
 	#[test]
@@ -1233,29 +1220,6 @@ mod tests {
 	}
 
 	// ----------------------------------------
-	// State / Worker
-
-	#[test]
-	fn test_state_new() {
-		global::set_local_chain_type(ChainTypes::AutomatedTesting);
-		let state = State::new(42);
-		assert_eq!(state.minimum_share_difficulty, 42);
-		assert_eq!(state.current_difficulty, u64::max_value());
-		assert!(state.current_key_id.is_none());
-		assert_eq!(state.current_block_versions.len(), 1);
-		assert_eq!(state.current_block_versions[0].header.height, 0);
-	}
-
-	#[test]
-	fn test_worker_new() {
-		let worker = Worker::new(7, dummy_tx());
-		assert_eq!(worker.id, 7);
-		assert!(worker.login.is_none());
-		assert!(!worker.authenticated);
-		assert_eq!(worker.agent, "");
-	}
-
-	// ----------------------------------------
 	// WorkersList
 
 	#[test]
@@ -1300,7 +1264,7 @@ mod tests {
 		workers
 			.login(id0, "alice".to_string(), "agent-a".to_string())
 			.unwrap();
-		// Logging in again (e.g. after a reconnect) replaces the previous
+		// A second login for the same worker replaces the previous
 		// login and agent rather than being rejected.
 		workers
 			.login(id0, "bob".to_string(), "agent-b".to_string())

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -84,7 +84,7 @@ struct RpcError {
 impl RpcError {
 	pub fn internal_error() -> Self {
 		RpcError {
-			code: 32603,
+			code: -32603,
 			message: "Internal error".to_owned(),
 		}
 	}
@@ -931,6 +931,11 @@ mod tests {
 		let _ = fs::remove_dir_all(dir_name);
 	}
 
+	/// Path under `target/tmp/` so interrupted tests do not leave dirs in the repo root.
+	fn test_chain_dir(name: &str) -> String {
+		format!("target/tmp/{}", name)
+	}
+
 	fn dummy_tx() -> Tx {
 		let (tx, _rx) = mpsc::unbounded();
 		tx
@@ -1126,7 +1131,7 @@ mod tests {
 	#[test]
 	fn test_rpc_error_constructors() {
 		let cases = vec![
-			(RpcError::internal_error(), 32603, "Internal error"),
+			(RpcError::internal_error(), -32603, "Internal error"),
 			(
 				RpcError::node_is_syncing(),
 				-32000,
@@ -1346,8 +1351,8 @@ mod tests {
 
 	#[test]
 	fn test_handle_keepalive() {
-		let dir = ".grin_stratum_test_keepalive";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_keepalive");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1357,13 +1362,13 @@ mod tests {
 		assert_eq!(resp.result, Some(Value::String("ok".to_string())));
 		assert_eq!(resp.method, "keepalive");
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_method_not_found() {
-		let dir = ".grin_stratum_test_method_not_found";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_method_not_found");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1374,13 +1379,13 @@ mod tests {
 		assert_eq!(err["code"], -32601);
 		assert_eq!(err["message"], "Method not found");
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_login_ok() {
-		let dir = ".grin_stratum_test_login_ok";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_login_ok");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let params = serde_json::json!({
@@ -1399,29 +1404,28 @@ mod tests {
 		assert_eq!(worker.agent, "test-agent");
 		assert!(worker.authenticated);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_login_invalid_params() {
-		let dir = ".grin_stratum_test_login_bad";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_login_bad");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
-		let resp = parse_rpc_response(
-			&handler.handle_rpc_requests(rpc_request("login", None), worker_id),
-		);
+		let resp =
+			parse_rpc_response(&handler.handle_rpc_requests(rpc_request("login", None), worker_id));
 		assert!(resp.result.is_none());
 		let err = resp.error.unwrap();
 		assert_eq!(err["code"], -32600);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_getjobtemplate_while_syncing() {
-		let dir = ".grin_stratum_test_job_syncing";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_job_syncing");
+		let handler = setup_handler(&dir, 1);
 		// Force syncing state
 		handler.sync_state.update(SyncStatus::HeaderSync {
 			sync_head: handler.chain.head().unwrap(),
@@ -1438,13 +1442,13 @@ mod tests {
 		assert_eq!(err["code"], -32000);
 		assert_eq!(err["message"], "Node is syncing - Please wait");
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_getjobtemplate_ok() {
-		let dir = ".grin_stratum_test_job_ok";
-		let handler = setup_handler(dir, 7);
+		let dir = test_chain_dir("grin_stratum_test_job_ok");
+		let handler = setup_handler(&dir, 7);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1457,13 +1461,13 @@ mod tests {
 		assert_eq!(result["difficulty"], 7);
 		assert!(result["pre_pow"].as_str().unwrap().len() > 0);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_status() {
-		let dir = ".grin_stratum_test_status";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_status");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 		handler.workers.update_stats(worker_id, |ws| {
 			ws.num_accepted = 10;
@@ -1484,13 +1488,13 @@ mod tests {
 		assert_eq!(result["rejected"], 2);
 		assert_eq!(result["stale"], 1);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_submit_too_late() {
-		let dir = ".grin_stratum_test_submit_late";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_submit_late");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// Wrong height vs current block version (height 0) => stale share
@@ -1511,13 +1515,13 @@ mod tests {
 		let ws = handler.workers.get_stats(worker_id).unwrap();
 		assert_eq!(ws.num_stale, 1);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_submit_invalid_job_id() {
-		let dir = ".grin_stratum_test_submit_bad_job";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_submit_bad_job");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// job_id out of range of current_block_versions
@@ -1535,13 +1539,13 @@ mod tests {
 		assert_eq!(resp.error.unwrap()["code"], -32503);
 		assert_eq!(handler.workers.get_stats(worker_id).unwrap().num_stale, 1);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_build_block_template() {
-		let dir = ".grin_stratum_test_template";
-		let handler = setup_handler(dir, 11);
+		let dir = test_chain_dir("grin_stratum_test_template");
+		let handler = setup_handler(&dir, 11);
 		let template = handler.build_block_template();
 		assert_eq!(template.height, 0);
 		assert_eq!(template.job_id, 0);
@@ -1550,13 +1554,13 @@ mod tests {
 		// pre_pow is hex-encoded header bytes
 		assert!(template.pre_pow.chars().all(|c| c.is_ascii_hexdigit()));
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_last_seen_updates() {
-		let dir = ".grin_stratum_test_last_seen";
-		let handler = setup_handler(dir, 1);
+		let dir = test_chain_dir("grin_stratum_test_last_seen");
+		let handler = setup_handler(&dir, 1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 		let before = handler.workers.get_stats(worker_id).unwrap().last_seen;
 
@@ -1566,6 +1570,6 @@ mod tests {
 		let after = handler.workers.get_stats(worker_id).unwrap().last_seen;
 		assert!(after >= before);
 
-		clean_output_dir(dir);
+		clean_output_dir(&dir);
 	}
 }

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -940,7 +940,8 @@ mod tests {
 		CHAIN
 			.get_or_init(|| {
 				global::set_local_chain_type(ChainTypes::AutomatedTesting);
-				// Under target/ so interrupted tests do not litter the repo root.
+				// Under the crate-local target directory (servers/target/tmp), not
+				// the workspace target/, so interrupted tests do not litter the repo root.
 				let dir = "target/tmp/grin_stratum_test_shared_chain";
 				let _ = fs::remove_dir_all(dir);
 				Arc::new(
@@ -1161,46 +1162,35 @@ mod tests {
 			assert_eq!(err.code, code);
 			assert_eq!(err.message, message);
 		}
-	}
 
-	#[test]
-	fn test_rpc_error_into_value() {
-		let err = RpcError::method_not_found();
-		let value: Value = err.into();
-		assert_eq!(value["code"], -32601);
-		assert_eq!(value["message"], "Method not found");
+		// Regression: internal_error() must serialize with the negative
+		// JSON-RPC 2.0 code, matching api/src/json_rpc.rs.
+		let value: Value = RpcError::internal_error().into();
+		assert_eq!(value["code"], -32603);
 	}
 
 	// ----------------------------------------
 	// parse_params
 
 	#[test]
-	fn test_parse_params_login_ok() {
-		let params = serde_json::json!({
+	fn test_parse_params_ok() {
+		let login: LoginParams = parse_params(Some(serde_json::json!({
 			"login": "miner1",
 			"pass": "x",
 			"agent": "grin-miner"
-		});
-		let login: LoginParams = parse_params(Some(params)).unwrap();
+		})))
+		.unwrap();
 		assert_eq!(login.login, "miner1");
-		assert_eq!(login.pass, "x");
-		assert_eq!(login.agent, "grin-miner");
-	}
 
-	#[test]
-	fn test_parse_params_submit_ok() {
-		let params = serde_json::json!({
+		let submit: SubmitParams = parse_params(Some(serde_json::json!({
 			"height": 42,
 			"job_id": 0,
 			"nonce": 12345,
 			"edge_bits": 29,
 			"pow": [1, 2, 3, 4]
-		});
-		let submit: SubmitParams = parse_params(Some(params)).unwrap();
+		})))
+		.unwrap();
 		assert_eq!(submit.height, 42);
-		assert_eq!(submit.job_id, 0);
-		assert_eq!(submit.nonce, 12345);
-		assert_eq!(submit.edge_bits, 29);
 		assert_eq!(submit.pow, vec![1, 2, 3, 4]);
 	}
 
@@ -1296,23 +1286,6 @@ mod tests {
 		// clean RpcError rather than panicking.
 		let err = workers.get_stats(99).unwrap_err();
 		assert_eq!(err.code, RpcError::internal_error().code);
-	}
-
-	#[test]
-	fn test_workers_list_update_stats() {
-		let stats = Arc::new(RwLock::new(StratumStats::default()));
-		let workers = WorkersList::new(stats);
-		let id = workers.add_worker(dummy_tx());
-
-		workers.update_stats(id, |ws| {
-			ws.num_accepted += 3;
-			ws.num_rejected += 1;
-			ws.num_stale += 2;
-		});
-		let ws = workers.get_stats(id).unwrap();
-		assert_eq!(ws.num_accepted, 3);
-		assert_eq!(ws.num_rejected, 1);
-		assert_eq!(ws.num_stale, 2);
 	}
 
 	#[test]
@@ -1459,7 +1432,10 @@ mod tests {
 		assert_eq!(result["height"], 0);
 		assert_eq!(result["job_id"], 0);
 		assert_eq!(result["difficulty"], 7);
-		assert!(result["pre_pow"].as_str().unwrap().len() > 0);
+		// pre_pow is hex-encoded header bytes.
+		let pre_pow = result["pre_pow"].as_str().unwrap();
+		assert!(!pre_pow.is_empty());
+		assert!(pre_pow.chars().all(|c| c.is_ascii_hexdigit()));
 	}
 
 	#[test]
@@ -1567,18 +1543,6 @@ mod tests {
 			handler.workers.get_stats(worker_id).unwrap().num_rejected,
 			1
 		);
-	}
-
-	#[test]
-	fn test_build_block_template() {
-		let handler = setup_handler(11);
-		let template = handler.build_block_template();
-		assert_eq!(template.height, 0);
-		assert_eq!(template.job_id, 0);
-		assert_eq!(template.difficulty, 11);
-		assert!(!template.pre_pow.is_empty());
-		// pre_pow is hex-encoded header bytes
-		assert!(template.pre_pow.chars().all(|c| c.is_ascii_hexdigit()));
 	}
 
 	#[test]

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -918,6 +918,67 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::chain::types::{NoopAdapter, SyncStatus};
+	use crate::core::genesis;
+	use crate::core::global::{self, ChainTypes};
+	use crate::core::pow::Difficulty;
+	use std::fs;
+
+	// ----------------------------------------
+	// Helpers
+
+	fn clean_output_dir(dir_name: &str) {
+		let _ = fs::remove_dir_all(dir_name);
+	}
+
+	fn dummy_tx() -> Tx {
+		let (tx, _rx) = mpsc::unbounded();
+		tx
+	}
+
+	/// Build a Handler backed by a temporary chain for RPC routing tests.
+	fn setup_handler(dir_name: &str, minimum_share_difficulty: u64) -> Handler {
+		global::set_local_chain_type(ChainTypes::AutomatedTesting);
+		clean_output_dir(dir_name);
+		let chain = Arc::new(
+			chain::Chain::init(
+				dir_name.to_string(),
+				Arc::new(NoopAdapter {}),
+				genesis::genesis_dev(),
+				pow::verify_size,
+				false,
+				None,
+			)
+			.unwrap(),
+		);
+		let stratum_stats = Arc::new(RwLock::new(StratumStats::default()));
+		let sync_state = Arc::new(SyncState::new());
+		// Default SyncState is Initial (syncing); mark as fully synced for most tests.
+		sync_state.update(SyncStatus::NoSync);
+		Handler::new(
+			String::from("test"),
+			stratum_stats,
+			sync_state,
+			minimum_share_difficulty,
+			chain,
+		)
+	}
+
+	fn rpc_request(method: &str, params: Option<Value>) -> RpcRequest {
+		RpcRequest {
+			id: JsonId::IntId(1),
+			jsonrpc: String::from("2.0"),
+			method: method.to_string(),
+			params,
+		}
+	}
+
+	fn parse_rpc_response(json: &str) -> RpcResponse {
+		serde_json::from_str(json).unwrap()
+	}
+
+	// ----------------------------------------
+	// RpcRequest / RpcResponse serde (existing)
 
 	/// Tests deserializing an `RpcRequest` given a String as the id.
 	#[test]
@@ -1057,5 +1118,454 @@ mod tests {
 		let actual_deserialized: RpcResponse = serde_json::from_str(&json_actual).unwrap();
 
 		assert_eq!(expected_deserialized, actual_deserialized);
+	}
+
+	// ----------------------------------------
+	// RpcError
+
+	#[test]
+	fn test_rpc_error_constructors() {
+		let cases = vec![
+			(RpcError::internal_error(), 32603, "Internal error"),
+			(
+				RpcError::node_is_syncing(),
+				-32000,
+				"Node is syncing - Please wait",
+			),
+			(RpcError::method_not_found(), -32601, "Method not found"),
+			(RpcError::too_late(), -32503, "Solution submitted too late"),
+			(
+				RpcError::cannot_validate(),
+				-32502,
+				"Failed to validate solution",
+			),
+			(
+				RpcError::too_low_difficulty(),
+				-32501,
+				"Share rejected due to low difficulty",
+			),
+			(RpcError::invalid_request(), -32600, "Invalid Request"),
+		];
+		for (err, code, message) in cases {
+			assert_eq!(err.code, code);
+			assert_eq!(err.message, message);
+		}
+	}
+
+	#[test]
+	fn test_rpc_error_into_value() {
+		let err = RpcError::method_not_found();
+		let value: Value = err.into();
+		assert_eq!(value["code"], -32601);
+		assert_eq!(value["message"], "Method not found");
+	}
+
+	// ----------------------------------------
+	// parse_params
+
+	#[test]
+	fn test_parse_params_login_ok() {
+		let params = serde_json::json!({
+			"login": "miner1",
+			"pass": "x",
+			"agent": "grin-miner"
+		});
+		let login: LoginParams = parse_params(Some(params)).unwrap();
+		assert_eq!(login.login, "miner1");
+		assert_eq!(login.pass, "x");
+		assert_eq!(login.agent, "grin-miner");
+	}
+
+	#[test]
+	fn test_parse_params_submit_ok() {
+		let params = serde_json::json!({
+			"height": 42,
+			"job_id": 0,
+			"nonce": 12345,
+			"edge_bits": 29,
+			"pow": [1, 2, 3, 4]
+		});
+		let submit: SubmitParams = parse_params(Some(params)).unwrap();
+		assert_eq!(submit.height, 42);
+		assert_eq!(submit.job_id, 0);
+		assert_eq!(submit.nonce, 12345);
+		assert_eq!(submit.edge_bits, 29);
+		assert_eq!(submit.pow, vec![1, 2, 3, 4]);
+	}
+
+	#[test]
+	fn test_parse_params_none() {
+		let res: Result<LoginParams, _> = parse_params(None);
+		let err = res.unwrap_err();
+		assert_eq!(err.code, RpcError::invalid_request().code);
+	}
+
+	#[test]
+	fn test_parse_params_wrong_shape() {
+		let params = serde_json::json!({"foo": "bar"});
+		let res: Result<LoginParams, _> = parse_params(Some(params));
+		let err = res.unwrap_err();
+		assert_eq!(err.code, RpcError::invalid_request().code);
+	}
+
+	// ----------------------------------------
+	// State / Worker
+
+	#[test]
+	fn test_state_new() {
+		global::set_local_chain_type(ChainTypes::AutomatedTesting);
+		let state = State::new(42);
+		assert_eq!(state.minimum_share_difficulty, 42);
+		assert_eq!(state.current_difficulty, u64::max_value());
+		assert!(state.current_key_id.is_none());
+		assert_eq!(state.current_block_versions.len(), 1);
+		assert_eq!(state.current_block_versions[0].header.height, 0);
+	}
+
+	#[test]
+	fn test_worker_new() {
+		let worker = Worker::new(7, dummy_tx());
+		assert_eq!(worker.id, 7);
+		assert!(worker.login.is_none());
+		assert!(!worker.authenticated);
+		assert_eq!(worker.agent, "");
+	}
+
+	// ----------------------------------------
+	// WorkersList
+
+	#[test]
+	fn test_workers_list_add_login_remove() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats.clone());
+
+		assert_eq!(workers.count(), 0);
+
+		let id0 = workers.add_worker(dummy_tx());
+		let id1 = workers.add_worker(dummy_tx());
+		assert_eq!(id0, 0);
+		assert_eq!(id1, 1);
+		assert_eq!(workers.count(), 2);
+		assert_eq!(stats.read().num_workers, 2);
+
+		workers
+			.login(id0, "alice".to_string(), "agent-a".to_string())
+			.unwrap();
+		let w = workers.get_worker(id0).unwrap();
+		assert_eq!(w.login.as_deref(), Some("alice"));
+		assert_eq!(w.agent, "agent-a");
+		assert!(w.authenticated);
+
+		let ws = workers.get_stats(id0).unwrap();
+		assert_eq!(ws.id, "0");
+		assert!(ws.is_connected);
+
+		workers.remove_worker(id0);
+		assert_eq!(workers.count(), 1);
+		assert_eq!(stats.read().num_workers, 1);
+		assert!(!workers.get_stats(id0).unwrap().is_connected);
+		assert!(workers.get_worker(id0).is_err());
+	}
+
+	#[test]
+	fn test_workers_list_login_missing_worker() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats);
+		let err = workers
+			.login(99, "x".to_string(), "y".to_string())
+			.unwrap_err();
+		assert_eq!(err.code, RpcError::internal_error().code);
+	}
+
+	#[test]
+	fn test_workers_list_update_stats() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats);
+		let id = workers.add_worker(dummy_tx());
+
+		workers.update_stats(id, |ws| {
+			ws.num_accepted += 3;
+			ws.num_rejected += 1;
+			ws.num_stale += 2;
+		});
+		let ws = workers.get_stats(id).unwrap();
+		assert_eq!(ws.num_accepted, 3);
+		assert_eq!(ws.num_rejected, 1);
+		assert_eq!(ws.num_stale, 2);
+	}
+
+	#[test]
+	fn test_workers_list_broadcast_and_send_to() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats);
+
+		let (tx0, mut rx0) = mpsc::unbounded();
+		let (tx1, mut rx1) = mpsc::unbounded();
+		let id0 = workers.add_worker(tx0);
+		let _id1 = workers.add_worker(tx1);
+
+		workers.broadcast("hello-all".to_string());
+		assert_eq!(
+			futures::executor::block_on(rx0.next()).unwrap(),
+			"hello-all"
+		);
+		assert_eq!(
+			futures::executor::block_on(rx1.next()).unwrap(),
+			"hello-all"
+		);
+
+		workers.send_to(id0, "hello-one".to_string());
+		assert_eq!(
+			futures::executor::block_on(rx0.next()).unwrap(),
+			"hello-one"
+		);
+		// Unicast must not deliver to the other worker (channel open but empty).
+		assert!(rx1.try_recv().is_err());
+	}
+
+	#[test]
+	fn test_workers_list_network_stats() {
+		global::set_local_chain_type(ChainTypes::AutomatedTesting);
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats.clone());
+
+		workers.update_block_height(100);
+		workers.update_network_difficulty(1000);
+		workers.update_edge_bits(29);
+
+		let s = stats.read();
+		assert_eq!(s.block_height, 100);
+		assert_eq!(s.network_difficulty, 1000);
+		assert_eq!(s.edge_bits, 29);
+		// hashrate is recomputed from difficulty / graph_weight
+		assert!(s.network_hashrate > 0.0);
+	}
+
+	// ----------------------------------------
+	// Handler RPC routing
+
+	#[test]
+	fn test_handle_keepalive() {
+		let dir = ".grin_stratum_test_keepalive";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("keepalive", None), worker_id),
+		);
+		assert!(resp.error.is_none());
+		assert_eq!(resp.result, Some(Value::String("ok".to_string())));
+		assert_eq!(resp.method, "keepalive");
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_method_not_found() {
+		let dir = ".grin_stratum_test_method_not_found";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("does_not_exist", None), worker_id),
+		);
+		assert!(resp.result.is_none());
+		let err = resp.error.unwrap();
+		assert_eq!(err["code"], -32601);
+		assert_eq!(err["message"], "Method not found");
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_login_ok() {
+		let dir = ".grin_stratum_test_login_ok";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let params = serde_json::json!({
+			"login": "bob",
+			"pass": "secret",
+			"agent": "test-agent"
+		});
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("login", Some(params)), worker_id),
+		);
+		assert!(resp.error.is_none());
+		assert_eq!(resp.result, Some(Value::String("ok".to_string())));
+
+		let worker = handler.workers.get_worker(worker_id).unwrap();
+		assert_eq!(worker.login.as_deref(), Some("bob"));
+		assert_eq!(worker.agent, "test-agent");
+		assert!(worker.authenticated);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_login_invalid_params() {
+		let dir = ".grin_stratum_test_login_bad";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("login", None), worker_id),
+		);
+		assert!(resp.result.is_none());
+		let err = resp.error.unwrap();
+		assert_eq!(err["code"], -32600);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_getjobtemplate_while_syncing() {
+		let dir = ".grin_stratum_test_job_syncing";
+		let handler = setup_handler(dir, 1);
+		// Force syncing state
+		handler.sync_state.update(SyncStatus::HeaderSync {
+			sync_head: handler.chain.head().unwrap(),
+			highest_height: 100,
+			highest_diff: Difficulty::from_num(1000),
+		});
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("getjobtemplate", None), worker_id),
+		);
+		assert!(resp.result.is_none());
+		let err = resp.error.unwrap();
+		assert_eq!(err["code"], -32000);
+		assert_eq!(err["message"], "Node is syncing - Please wait");
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_getjobtemplate_ok() {
+		let dir = ".grin_stratum_test_job_ok";
+		let handler = setup_handler(dir, 7);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("getjobtemplate", None), worker_id),
+		);
+		assert!(resp.error.is_none());
+		let result = resp.result.unwrap();
+		assert_eq!(result["height"], 0);
+		assert_eq!(result["job_id"], 0);
+		assert_eq!(result["difficulty"], 7);
+		assert!(result["pre_pow"].as_str().unwrap().len() > 0);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_status() {
+		let dir = ".grin_stratum_test_status";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+		handler.workers.update_stats(worker_id, |ws| {
+			ws.num_accepted = 10;
+			ws.num_rejected = 2;
+			ws.num_stale = 1;
+			ws.pow_difficulty = 5;
+		});
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("status", None), worker_id),
+		);
+		assert!(resp.error.is_none());
+		let result = resp.result.unwrap();
+		assert_eq!(result["id"], "0");
+		assert_eq!(result["height"], 0);
+		assert_eq!(result["difficulty"], 5);
+		assert_eq!(result["accepted"], 10);
+		assert_eq!(result["rejected"], 2);
+		assert_eq!(result["stale"], 1);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_submit_too_late() {
+		let dir = ".grin_stratum_test_submit_late";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		// Wrong height vs current block version (height 0) => stale share
+		let params = serde_json::json!({
+			"height": 99,
+			"job_id": 0,
+			"nonce": 1,
+			"edge_bits": 29,
+			"pow": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41]
+		});
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("submit", Some(params)), worker_id),
+		);
+		assert!(resp.result.is_none());
+		let err = resp.error.unwrap();
+		assert_eq!(err["code"], -32503);
+
+		let ws = handler.workers.get_stats(worker_id).unwrap();
+		assert_eq!(ws.num_stale, 1);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_handle_submit_invalid_job_id() {
+		let dir = ".grin_stratum_test_submit_bad_job";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		// job_id out of range of current_block_versions
+		let params = serde_json::json!({
+			"height": 0,
+			"job_id": 99,
+			"nonce": 1,
+			"edge_bits": 29,
+			"pow": [0, 1, 2, 3]
+		});
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("submit", Some(params)), worker_id),
+		);
+		assert!(resp.result.is_none());
+		assert_eq!(resp.error.unwrap()["code"], -32503);
+		assert_eq!(handler.workers.get_stats(worker_id).unwrap().num_stale, 1);
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_build_block_template() {
+		let dir = ".grin_stratum_test_template";
+		let handler = setup_handler(dir, 11);
+		let template = handler.build_block_template();
+		assert_eq!(template.height, 0);
+		assert_eq!(template.job_id, 0);
+		assert_eq!(template.difficulty, 11);
+		assert!(!template.pre_pow.is_empty());
+		// pre_pow is hex-encoded header bytes
+		assert!(template.pre_pow.chars().all(|c| c.is_ascii_hexdigit()));
+
+		clean_output_dir(dir);
+	}
+
+	#[test]
+	fn test_last_seen_updates() {
+		let dir = ".grin_stratum_test_last_seen";
+		let handler = setup_handler(dir, 1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+		let before = handler.workers.get_stats(worker_id).unwrap().last_seen;
+
+		// Any RPC call updates last_seen via handle_rpc_requests
+		thread::sleep(Duration::from_millis(5));
+		let _ = handler.handle_rpc_requests(rpc_request("keepalive", None), worker_id);
+		let after = handler.workers.get_stats(worker_id).unwrap().last_seen;
+		assert!(after >= before);
+
+		clean_output_dir(dir);
 	}
 }

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -923,6 +923,7 @@ mod tests {
 	use crate::core::global::{self, ChainTypes};
 	use crate::core::pow::Difficulty;
 	use std::fs;
+	use std::sync::OnceLock;
 
 	// ----------------------------------------
 	// Helpers
@@ -941,21 +942,39 @@ mod tests {
 		tx
 	}
 
-	/// Build a Handler backed by a temporary chain for RPC routing tests.
-	fn setup_handler(dir_name: &str, minimum_share_difficulty: u64) -> Handler {
+	/// A single chain instance shared by every RPC routing test below.
+	///
+	/// None of these tests submit a full solution (that would call
+	/// `chain::Chain::process_block`), so the chain is only ever read from and
+	/// is safe to reuse. Initializing one LMDB env instead of one per test
+	/// avoids intermittent "Invalid argument" failures seen when many envs are
+	/// opened concurrently under the default test-runner parallelism.
+	fn shared_test_chain() -> Arc<chain::Chain> {
+		static CHAIN: OnceLock<Arc<chain::Chain>> = OnceLock::new();
+		CHAIN
+			.get_or_init(|| {
+				global::set_local_chain_type(ChainTypes::AutomatedTesting);
+				let dir = test_chain_dir("grin_stratum_test_shared_chain");
+				clean_output_dir(&dir);
+				Arc::new(
+					chain::Chain::init(
+						dir,
+						Arc::new(NoopAdapter {}),
+						genesis::genesis_dev(),
+						pow::verify_size,
+						false,
+						None,
+					)
+					.unwrap(),
+				)
+			})
+			.clone()
+	}
+
+	/// Build a Handler backed by the shared test chain for RPC routing tests.
+	fn setup_handler(minimum_share_difficulty: u64) -> Handler {
 		global::set_local_chain_type(ChainTypes::AutomatedTesting);
-		clean_output_dir(dir_name);
-		let chain = Arc::new(
-			chain::Chain::init(
-				dir_name.to_string(),
-				Arc::new(NoopAdapter {}),
-				genesis::genesis_dev(),
-				pow::verify_size,
-				false,
-				None,
-			)
-			.unwrap(),
-		);
+		let chain = shared_test_chain();
 		let stratum_stats = Arc::new(RwLock::new(StratumStats::default()));
 		let sync_state = Arc::new(SyncState::new());
 		// Default SyncState is Initial (syncing); mark as fully synced for most tests.
@@ -1273,12 +1292,45 @@ mod tests {
 	}
 
 	#[test]
+	fn test_workers_list_relogin_replaces_login_and_agent() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats);
+		let id0 = workers.add_worker(dummy_tx());
+
+		workers
+			.login(id0, "alice".to_string(), "agent-a".to_string())
+			.unwrap();
+		// Logging in again (e.g. after a reconnect) replaces the previous
+		// login and agent rather than being rejected.
+		workers
+			.login(id0, "bob".to_string(), "agent-b".to_string())
+			.unwrap();
+
+		let w = workers.get_worker(id0).unwrap();
+		assert_eq!(w.login.as_deref(), Some("bob"));
+		assert_eq!(w.agent, "agent-b");
+		assert!(w.authenticated);
+	}
+
+	#[test]
 	fn test_workers_list_login_missing_worker() {
 		let stats = Arc::new(RwLock::new(StratumStats::default()));
 		let workers = WorkersList::new(stats);
 		let err = workers
 			.login(99, "x".to_string(), "y".to_string())
 			.unwrap_err();
+		assert_eq!(err.code, RpcError::internal_error().code);
+	}
+
+	#[test]
+	fn test_workers_list_get_stats_missing_worker() {
+		let stats = Arc::new(RwLock::new(StratumStats::default()));
+		let workers = WorkersList::new(stats);
+		let _ = workers.add_worker(dummy_tx());
+
+		// Index past the end of the stats vec: `get_stats` reports it as a
+		// clean RpcError rather than panicking.
+		let err = workers.get_stats(99).unwrap_err();
 		assert_eq!(err.code, RpcError::internal_error().code);
 	}
 
@@ -1351,8 +1403,7 @@ mod tests {
 
 	#[test]
 	fn test_handle_keepalive() {
-		let dir = test_chain_dir("grin_stratum_test_keepalive");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1361,14 +1412,11 @@ mod tests {
 		assert!(resp.error.is_none());
 		assert_eq!(resp.result, Some(Value::String("ok".to_string())));
 		assert_eq!(resp.method, "keepalive");
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_method_not_found() {
-		let dir = test_chain_dir("grin_stratum_test_method_not_found");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1378,14 +1426,11 @@ mod tests {
 		let err = resp.error.unwrap();
 		assert_eq!(err["code"], -32601);
 		assert_eq!(err["message"], "Method not found");
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_login_ok() {
-		let dir = test_chain_dir("grin_stratum_test_login_ok");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let params = serde_json::json!({
@@ -1403,14 +1448,11 @@ mod tests {
 		assert_eq!(worker.login.as_deref(), Some("bob"));
 		assert_eq!(worker.agent, "test-agent");
 		assert!(worker.authenticated);
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_login_invalid_params() {
-		let dir = test_chain_dir("grin_stratum_test_login_bad");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp =
@@ -1418,14 +1460,11 @@ mod tests {
 		assert!(resp.result.is_none());
 		let err = resp.error.unwrap();
 		assert_eq!(err["code"], -32600);
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_getjobtemplate_while_syncing() {
-		let dir = test_chain_dir("grin_stratum_test_job_syncing");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		// Force syncing state
 		handler.sync_state.update(SyncStatus::HeaderSync {
 			sync_head: handler.chain.head().unwrap(),
@@ -1441,14 +1480,11 @@ mod tests {
 		let err = resp.error.unwrap();
 		assert_eq!(err["code"], -32000);
 		assert_eq!(err["message"], "Node is syncing - Please wait");
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_getjobtemplate_ok() {
-		let dir = test_chain_dir("grin_stratum_test_job_ok");
-		let handler = setup_handler(&dir, 7);
+		let handler = setup_handler(7);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		let resp = parse_rpc_response(
@@ -1460,14 +1496,11 @@ mod tests {
 		assert_eq!(result["job_id"], 0);
 		assert_eq!(result["difficulty"], 7);
 		assert!(result["pre_pow"].as_str().unwrap().len() > 0);
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_status() {
-		let dir = test_chain_dir("grin_stratum_test_status");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 		handler.workers.update_stats(worker_id, |ws| {
 			ws.num_accepted = 10;
@@ -1487,14 +1520,11 @@ mod tests {
 		assert_eq!(result["accepted"], 10);
 		assert_eq!(result["rejected"], 2);
 		assert_eq!(result["stale"], 1);
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_submit_too_late() {
-		let dir = test_chain_dir("grin_stratum_test_submit_late");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// Wrong height vs current block version (height 0) => stale share
@@ -1514,14 +1544,11 @@ mod tests {
 
 		let ws = handler.workers.get_stats(worker_id).unwrap();
 		assert_eq!(ws.num_stale, 1);
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_handle_submit_invalid_job_id() {
-		let dir = test_chain_dir("grin_stratum_test_submit_bad_job");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
 
 		// job_id out of range of current_block_versions
@@ -1538,14 +1565,49 @@ mod tests {
 		assert!(resp.result.is_none());
 		assert_eq!(resp.error.unwrap()["code"], -32503);
 		assert_eq!(handler.workers.get_stats(worker_id).unwrap().num_stale, 1);
+	}
 
-		clean_output_dir(&dir);
+	#[test]
+	fn test_handle_submit_missing_params() {
+		let handler = setup_handler(1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("submit", None), worker_id),
+		);
+		assert!(resp.result.is_none());
+		assert_eq!(resp.error.unwrap()["code"], -32600);
+	}
+
+	#[test]
+	fn test_handle_submit_invalid_edge_bits() {
+		let handler = setup_handler(1);
+		let worker_id = handler.workers.add_worker(dummy_tx());
+
+		// edge_bits below the AutomatedTesting minimum (10) and not the
+		// secondary size (29): the proof is neither primary nor secondary, so
+		// it is rejected before any cuckoo verification is attempted.
+		let params = serde_json::json!({
+			"height": 0,
+			"job_id": 0,
+			"nonce": 1,
+			"edge_bits": 5,
+			"pow": [0, 1, 2, 3]
+		});
+		let resp = parse_rpc_response(
+			&handler.handle_rpc_requests(rpc_request("submit", Some(params)), worker_id),
+		);
+		assert!(resp.result.is_none());
+		assert_eq!(resp.error.unwrap()["code"], -32502);
+		assert_eq!(
+			handler.workers.get_stats(worker_id).unwrap().num_rejected,
+			1
+		);
 	}
 
 	#[test]
 	fn test_build_block_template() {
-		let dir = test_chain_dir("grin_stratum_test_template");
-		let handler = setup_handler(&dir, 11);
+		let handler = setup_handler(11);
 		let template = handler.build_block_template();
 		assert_eq!(template.height, 0);
 		assert_eq!(template.job_id, 0);
@@ -1553,23 +1615,20 @@ mod tests {
 		assert!(!template.pre_pow.is_empty());
 		// pre_pow is hex-encoded header bytes
 		assert!(template.pre_pow.chars().all(|c| c.is_ascii_hexdigit()));
-
-		clean_output_dir(&dir);
 	}
 
 	#[test]
 	fn test_last_seen_updates() {
-		let dir = test_chain_dir("grin_stratum_test_last_seen");
-		let handler = setup_handler(&dir, 1);
+		let handler = setup_handler(1);
 		let worker_id = handler.workers.add_worker(dummy_tx());
-		let before = handler.workers.get_stats(worker_id).unwrap().last_seen;
+		// Force a known baseline instead of racing a real clock read against
+		// the update below.
+		handler
+			.workers
+			.update_stats(worker_id, |ws| ws.last_seen = SystemTime::UNIX_EPOCH);
 
-		// Any RPC call updates last_seen via handle_rpc_requests
-		thread::sleep(Duration::from_millis(5));
 		let _ = handler.handle_rpc_requests(rpc_request("keepalive", None), worker_id);
 		let after = handler.workers.get_stats(worker_id).unwrap().last_seen;
-		assert!(after >= before);
-
-		clean_output_dir(&dir);
+		assert!(after > SystemTime::UNIX_EPOCH);
 	}
 }


### PR DESCRIPTION
## Summary

- Expand `stratumserver` unit tests from 8 (RPC serde only) to 30, covering the main testable units without consensus or full PoW mining.
- Adds coverage for:
  - `RpcError` constructors and JSON conversion
  - `parse_params` success/failure paths (`LoginParams`, `SubmitParams`)
  - `WorkersList` add/login/remove/re-login, stats updates, broadcast vs unicast, network stats, unknown-worker error paths
  - `Handler` RPC routing: `keepalive`, unknown method, login, `status`, `getjobtemplate` (synced + syncing), stale/invalid/missing-params/invalid-edge_bits `submit`, `build_block_template`, `last_seen`

Addresses #3210.

**Behavior fix (found via these tests, not just a test change):** `RpcError::internal_error()` used a positive JSON-RPC error code (`32603`). Per the JSON-RPC 2.0 spec (and `api/src/json_rpc.rs`, which already uses the correct value), this is now `-32603`. This changes the wire response a stratum client receives on an internal error from `{"code": 32603, ...}` to `{"code": -32603, ...}`.

RPC routing tests share a single lazily-initialized test chain (via `OnceLock`) instead of opening one LMDB env per test, to avoid intermittent `Invalid argument` failures under default test-runner parallelism.

## Test plan

- [x] `cargo test -p grin_servers --lib mining::stratumserver::tests` (30 passed, default parallelism; also verified with `--test-threads=16`)
- [x] CI on this PR

Not covered in this PR (possible follow-ups): valid share/block submit with real PoW, TCP accept-loop integration tests. See also the review comment about a pre-existing panic on out-of-range `worker_id` in `handle_rpc_requests`.