### PR TITLE
fix: keep Node API responsive during txhashset zip

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -858,25 +858,36 @@ impl Chain {
 	/// Provides a reading view into the current txhashset state as well as
 	/// the required indexes for a consumer to rewind to a consistent state
 	/// at the provided block hash.
+	///
+	/// Write locks are only held while rewinding/snapshotting. Packaging the
+	/// multi-GB zip is done under *read* locks so the Node API and other
+	/// readers remain responsive while a peer is served a txhashset archive
+	/// (see #3550). Compaction and other writers wait until the zip finishes.
 	pub fn txhashset_read(&self, h: Hash) -> Result<(u64, u64, File), Error> {
-		// now we want to rewind the txhashset extension and
-		// sync a "rewound" copy of the leaf_set files to disk
-		// so we can send these across as part of the zip file.
-		// The fast sync client does *not* have the necessary data
-		// to rewind after receiving the txhashset zip.
+		// Rewind the txhashset extension and sync a "rewound" copy of the
+		// leaf_set files to disk so we can send these across as part of the zip.
+		// The fast sync client does *not* have the necessary data to rewind
+		// after receiving the txhashset zip.
 		let header = self.get_block_header(&h)?;
 
-		let mut header_pmmr = self.header_pmmr.write();
-		let mut txhashset = self.txhashset.write();
+		{
+			let mut header_pmmr = self.header_pmmr.write();
+			let mut txhashset = self.txhashset.write();
 
-		txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
-			self.rewind_and_apply_fork(&header, ext, batch)?;
-			ext.extension.snapshot(batch)?;
+			txhashset::extending_readonly(&mut header_pmmr, &mut txhashset, |ext, batch| {
+				self.rewind_and_apply_fork(&header, ext, batch)?;
+				ext.extension.snapshot(batch)?;
+				Ok(())
+			})?;
+		}
 
-			// prepare the zip
-			txhashset::zip_read(self.db_root.clone(), &header)
-				.map(|file| (header.output_mmr_size, header.kernel_mmr_size, file))
-		})
+		// Shared locks: allow concurrent chain reads (API, header queries) while
+		// still preventing compaction from rewriting backend files mid-zip.
+		let _header_pmmr = self.header_pmmr.read();
+		let _txhashset = self.txhashset.read();
+
+		let file = txhashset::zip_read(self.db_root.clone(), &header)?;
+		Ok((header.output_mmr_size, header.kernel_mmr_size, file))
 	}
 
 	/// The segmenter is responsible for generation PIBD segments.


### PR DESCRIPTION
## Summary

Fixes [#3550](https://github.com/mimblewimble/grin/issues/3550): Node API becomes unresponsive while packaging a `txhashset` zip for a syncing peer.

### Cause

`Chain::txhashset_read` held **write** locks on `header_pmmr` and `txhashset` for the entire rewind + snapshot + multi-GB zip path. API handlers that need any chain access blocked for the whole packaging duration.

### Fix

1. **Write locks** only for rewind + snapshot (short, consistency-critical).
2. **Read locks** for `zip_read` (copy + package). Concurrent readers (Node API, headers, etc.) can proceed. Compaction/writers still wait until the zip finishes so backend files are not rewritten mid-package.

## Test plan

- [x] `cargo test -p grin_chain --test test_txhashset -- --test-threads=1`
- [ ] Manual: request txhashset from a peer while polling foreign API (chain height) every second — requests should continue to succeed during zip packaging