### PR TITLE
fix: claim state_sync_requested with compare_exchange

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -289,12 +289,17 @@ impl MessageHandler for Protocol {
 					);
 					return Err(Error::BadMessage);
 				}
-				if !self.state_sync_requested.load(Ordering::Relaxed) {
+				// Atomically claim the outstanding state-sync request so two
+				// concurrent archive messages cannot both observe "requested"
+				// and proceed (load+store race; see #3588).
+				if self
+					.state_sync_requested
+					.compare_exchange(true, false, Ordering::SeqCst, Ordering::Relaxed)
+					.is_err()
+				{
 					error!("handle_payload: txhashset archive received but from the wrong peer",);
 					return Err(Error::BadMessage);
 				}
-				// Update the sync state requested status
-				self.state_sync_requested.store(false, Ordering::Relaxed);
 
 				let start_time = Utc::now();
 				self.adapter


### PR DESCRIPTION
## Summary

Fixes [#3588](https://github.com/mimblewimble/grin/issues/3588).

When handling `TxHashSetArchive`, the code used a non-atomic check-then-clear:

```rust
if !state_sync_requested.load(...) { return Err(...) }
state_sync_requested.store(false, ...)
```

Two concurrent archive messages could both observe `true` and proceed.

### Change

Use `compare_exchange(true → false)` so only one handler claims the outstanding state-sync request.

## Test plan

- [x] `cargo test -p grin_p2p --lib -- --test-threads=1`