### PR TITLE
fix: clearer readiness while node is still syncing

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -21,6 +21,7 @@ use crate::handlers::blocks_api::{BlockHandler, HeaderHandler};
 use crate::handlers::chain_api::{ChainHandler, KernelHandler, OutputHandler};
 use crate::handlers::pool_api::PoolHandler;
 use crate::handlers::transactions_api::TxHashSetHandler;
+use crate::handlers::utils::ensure_not_syncing;
 use crate::handlers::version_api::VersionHandler;
 use crate::pool::{self, BlockChain, PoolAdapter, PoolEntry};
 use crate::types::{
@@ -236,6 +237,7 @@ where
 		include_proof: Option<bool>,
 		_include_merkle_proof: Option<bool>,
 	) -> Result<Vec<OutputPrintable>, Error> {
+		ensure_not_syncing(&self.sync_state)?;
 		let output_handler = OutputHandler {
 			chain: self.chain.clone(),
 		};
@@ -267,6 +269,7 @@ where
 		max: u64,
 		include_proof: Option<bool>,
 	) -> Result<OutputListing, Error> {
+		ensure_not_syncing(&self.sync_state)?;
 		let output_handler = OutputHandler {
 			chain: self.chain.clone(),
 		};
@@ -288,6 +291,8 @@ where
 		start_block_height: u64,
 		end_block_height: Option<u64>,
 	) -> Result<OutputListing, Error> {
+		// Wallet scan/info hits this early; return a clear signal while syncing (#3546).
+		ensure_not_syncing(&self.sync_state)?;
 		let txhashset_handler = TxHashSetHandler {
 			chain: self.chain.clone(),
 		};

--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -106,7 +106,13 @@ impl TxHashSetHandler {
 		let chain = w(&self.chain)?;
 		let range = chain
 			.block_height_range_to_pmmr_indices(start_block_height, end_block_height)
-			.map_err(|_| Error::NotFound)?;
+			.map_err(|e| {
+				// Prefer a descriptive error over empty NotFound (wallet misreports null).
+				Error::Argument(format!(
+					"cannot map block heights {}..{:?} to PMMR indices: {}",
+					start_block_height, end_block_height, e
+				))
+			})?;
 		let out = OutputListing {
 			last_retrieved_index: range.0,
 			highest_index: range.1,

--- a/api/src/handlers/utils.rs
+++ b/api/src/handlers/utils.rs
@@ -14,6 +14,7 @@
 
 use crate::chain;
 use crate::chain::types::CommitPos;
+use crate::chain::SyncState;
 use crate::core::core::OutputIdentifier;
 use crate::rest::*;
 use crate::types::*;
@@ -27,6 +28,18 @@ use std::sync::{Arc, Weak};
 pub fn w<T>(weak: &Weak<T>) -> Result<Arc<T>, Error> {
 	weak.upgrade()
 		.ok_or_else(|| Error::Internal("failed to upgrade weak reference".to_owned()))
+}
+
+/// Fail wallet-oriented queries while the node is still syncing so clients get a
+/// clear "try again later" signal instead of a misleading NotFound (#3546).
+pub fn ensure_not_syncing(sync_state: &Weak<SyncState>) -> Result<(), Error> {
+	let sync = w(sync_state)?;
+	if sync.is_syncing() {
+		return Err(Error::Unavailable(
+			"node is still syncing; wait until sync completes and retry".into(),
+		));
+	}
+	Ok(())
 }
 
 /// Internal function to retrieves an output by a given commitment
@@ -87,4 +100,32 @@ pub fn get_output_v2(
 	)?;
 
 	Ok(Some((output_printable, out)))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::chain::types::SyncStatus;
+	use crate::chain::SyncState;
+	use std::sync::Arc;
+
+	#[test]
+	fn ensure_not_syncing_ok_when_no_sync() {
+		let sync = Arc::new(SyncState::new());
+		sync.update(SyncStatus::NoSync);
+		let weak = Arc::downgrade(&sync);
+		assert!(ensure_not_syncing(&weak).is_ok());
+	}
+
+	#[test]
+	fn ensure_not_syncing_unavailable_while_syncing() {
+		let sync = Arc::new(SyncState::new());
+		// Default SyncState is Initial → is_syncing() true
+		let weak = Arc::downgrade(&sync);
+		let err = ensure_not_syncing(&weak).unwrap_err();
+		match err {
+			Error::Unavailable(msg) => assert!(msg.contains("syncing")),
+			other => panic!("expected Unavailable, got {:?}", other),
+		}
+	}
 }

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -49,6 +49,10 @@ pub enum Error {
 	Argument(String),
 	#[error("Not found.")]
 	NotFound,
+	/// Node is not ready yet (e.g. still syncing). Prefer this over [`NotFound`]
+	/// so clients can distinguish "missing data" from "try again later" (#3546).
+	#[error("Service unavailable: {0}")]
+	Unavailable(String),
 	#[error("Request error: {0}")]
 	RequestError(String),
 	#[error("ResponseError error: {0}")]

--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -52,6 +52,7 @@ where
 			Error::Argument(msg) => response(StatusCode::BAD_REQUEST, msg),
 			Error::RequestError(msg) => response(StatusCode::BAD_REQUEST, msg),
 			Error::NotFound => response(StatusCode::NOT_FOUND, "".into()),
+			Error::Unavailable(msg) => response(StatusCode::SERVICE_UNAVAILABLE, msg),
 			Error::Internal(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg),
 			Error::ResponseError(msg) => response(StatusCode::INTERNAL_SERVER_ERROR, msg),
 			Error::Router { .. } => response(StatusCode::INTERNAL_SERVER_ERROR, "".into()),

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -878,11 +878,23 @@ impl StratumServer {
 		let handler = Arc::new(Handler::from_stratum(&self));
 		let h = handler.clone();
 
+		// Wait until the node has finished syncing before accepting miner connections
+		// (#3546). Previously we listened early and returned confusing "syncing" /
+		// failed job responses while the chain was still catching up.
+		info!(
+			"(Server ID: {}) Stratum waiting for node sync before listening on {}",
+			self.id,
+			self.config.stratum_server_addr.clone().unwrap()
+		);
+		while self.sync_state.is_syncing() {
+			thread::sleep(Duration::from_millis(50));
+		}
+
 		let _listener_th = thread::spawn(move || {
 			accept_connections(listen_addr, h);
 		});
 
-		// We have started
+		// We have started (only after sync so is_running matches actual readiness).
 		{
 			let mut stratum_stats = self.stratum_stats.write();
 			stratum_stats.is_running = true;
@@ -894,11 +906,6 @@ impl StratumServer {
 			"Stratum server started on {}",
 			self.config.stratum_server_addr.clone().unwrap()
 		);
-
-		// Initial Loop. Waiting node complete syncing
-		while self.sync_state.is_syncing() {
-			thread::sleep(Duration::from_millis(50));
-		}
 
 		handler.run(&self.config, &self.tx_pool);
 	} // fn run_loop()


### PR DESCRIPTION
## Summary

Fixes [#3546](https://github.com/mimblewimble/grin/issues/3546).

API and stratum used to accept connections immediately while the chain was still initialising/syncing. Wallets then saw opaque `NotFound` / null decode errors (e.g. on `get_pmmr_indices`); miners connected only to get “node is syncing” job failures.

### Changes

| Area | Behaviour |
|------|-----------|
| **Stratum** | Do not bind/listen until `!sync_state.is_syncing()`; set `is_running` only then |
| **Foreign API** | `get_pmmr_indices` / `get_outputs` / `get_unspent_outputs` return `Error::Unavailable` (“node is still syncing…”) while syncing |
| **REST** | Map `Unavailable` → **HTTP 503** |
| **Status / tip / version** | Unchanged so monitoring still works during sync |
| **PMMR map errors** | Surface the real chain error instead of empty NotFound |

## Test plan

- [x] `cargo test -p grin_api --lib -- --test-threads=1` (includes `ensure_not_syncing_*`)
- [x] `cargo test -p grin_servers --lib mining::stratumserver -- --test-threads=1`
- [ ] Start node mid-sync: wallet `get_pmmr_indices` should report syncing / 503, not null NotFound
- [ ] Stratum port should not accept until sync completes