### PR TITLE
fix: abort chain compaction cleanly on node shutdown

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -85,6 +85,7 @@ where
 		Arc::downgrade(&chain),
 		Arc::downgrade(&peers),
 		Arc::downgrade(&sync_state),
+		Arc::downgrade(&stop_state),
 	);
 	router.add_route("/v2/owner", Arc::new(api_handler))?;
 
@@ -142,15 +143,22 @@ pub struct OwnerAPIHandlerV2 {
 	pub chain: Weak<Chain>,
 	pub peers: Weak<p2p::Peers>,
 	pub sync_state: Weak<SyncState>,
+	pub stop_state: Weak<StopState>,
 }
 
 impl OwnerAPIHandlerV2 {
 	/// Create a new owner API handler for GET methods
-	pub fn new(chain: Weak<Chain>, peers: Weak<p2p::Peers>, sync_state: Weak<SyncState>) -> Self {
+	pub fn new(
+		chain: Weak<Chain>,
+		peers: Weak<p2p::Peers>,
+		sync_state: Weak<SyncState>,
+		stop_state: Weak<StopState>,
+	) -> Self {
 		OwnerAPIHandlerV2 {
 			chain,
 			peers,
 			sync_state,
+			stop_state,
 		}
 	}
 }
@@ -161,6 +169,7 @@ impl crate::router::Handler for OwnerAPIHandlerV2 {
 			self.chain.clone(),
 			self.peers.clone(),
 			self.sync_state.clone(),
+			self.stop_state.clone(),
 		);
 
 		Box::pin(async move {

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -100,19 +100,23 @@ impl ChainResetHandler {
 /// POST /v1/chain/compact
 pub struct ChainCompactHandler {
 	pub chain: Weak<chain::Chain>,
+	/// Optional shutdown flag so API-triggered compact can abort on stop.
+	pub stop_state: Weak<crate::util::StopState>,
 }
 
 impl ChainCompactHandler {
 	pub fn compact_chain(&self) -> Result<(), Error> {
 		let chain = w(&self.chain)?;
-		chain.compact()?;
+		let stop = self.stop_state.upgrade();
+		chain.compact_with_stop(stop)?;
 		Ok(())
 	}
 }
 
 impl Handler for ChainCompactHandler {
 	fn post(&self, _req: Request<Incoming>) -> ResponseFuture {
-		match w_fut!(&self.chain).compact() {
+		let stop = self.stop_state.upgrade();
+		match w_fut!(&self.chain).compact_with_stop(stop) {
 			Ok(_) => response(StatusCode::OK, "{}".into()),
 			Err(e) => response(
 				StatusCode::INTERNAL_SERVER_ERROR,

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -23,6 +23,7 @@ use crate::p2p::types::PeerInfoDisplay;
 use crate::p2p::{self, PeerData};
 use crate::rest::*;
 use crate::types::Status;
+use crate::util::StopState;
 use std::net::SocketAddr;
 use std::sync::Weak;
 
@@ -37,6 +38,7 @@ pub struct Owner {
 	pub chain: Weak<Chain>,
 	pub peers: Weak<p2p::Peers>,
 	pub sync_state: Weak<SyncState>,
+	pub stop_state: Weak<StopState>,
 }
 
 impl Owner {
@@ -48,16 +50,23 @@ impl Owner {
 	/// * `tx_pool` - A non-owning reference of the transaction pool.
 	/// * `peers` - A non-owning reference of the peers.
 	/// * `sync_state` - A non-owning reference of the `sync_state`.
+	/// * `stop_state` - A non-owning reference of the node stop flag (for cancellable compact).
 	///
 	/// # Returns
 	/// * An instance of the Node holding references to the current chain, transaction pool, peers and sync_state.
 	///
 
-	pub fn new(chain: Weak<Chain>, peers: Weak<p2p::Peers>, sync_state: Weak<SyncState>) -> Self {
+	pub fn new(
+		chain: Weak<Chain>,
+		peers: Weak<p2p::Peers>,
+		sync_state: Weak<SyncState>,
+		stop_state: Weak<StopState>,
+	) -> Self {
 		Owner {
 			chain,
 			peers,
 			sync_state,
+			stop_state,
 		}
 	}
 
@@ -107,6 +116,7 @@ impl Owner {
 	pub fn compact_chain(&self) -> Result<(), Error> {
 		let chain_compact_handler = ChainCompactHandler {
 			chain: self.chain.clone(),
+			stop_state: self.stop_state.clone(),
 		};
 		chain_compact_handler.compact_chain()
 	}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1329,6 +1329,23 @@ impl Chain {
 	/// * removes historical blocks and associated data from the db (unless archive mode)
 	///
 	pub fn compact(&self) -> Result<(), Error> {
+		self.compact_with_stop(None)
+	}
+
+	/// Compact the chain, optionally aborting if `stop_state` is stopped.
+	/// Used on shutdown so long compaction does not keep rewriting files after
+	/// the node was asked to stop (#3842).
+	pub fn compact_with_stop(
+		&self,
+		stop_state: Option<Arc<crate::util::StopState>>,
+	) -> Result<(), Error> {
+		let should_abort = || stop_state.as_ref().map(|s| s.is_stopped()).unwrap_or(false);
+
+		if should_abort() {
+			info!("compact: not starting, node is stopping");
+			return Ok(());
+		}
+
 		// A node may be restarted multiple times in a short period of time.
 		// We compact at most once per 60 blocks in this situation by comparing
 		// current "head" and "tail" height to our cut-through horizon and
@@ -1364,7 +1381,13 @@ impl Chain {
 			let horizon_hash = header_pmmr.get_header_hash_by_height(horizon_height)?;
 			let horizon_header = batch.get_block_header(&horizon_hash)?;
 
-			txhashset.compact(&horizon_header, &batch)?;
+			txhashset.compact_until(&horizon_header, &batch, should_abort)?;
+		}
+
+		if should_abort() {
+			info!("compact: aborted after txhashset compact (node stopping)");
+			// Do not commit further DB changes if we aborted mid-flight.
+			return Ok(());
 		}
 
 		// If we are not in archival mode remove historical blocks from the db.

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1334,7 +1334,7 @@ impl Chain {
 
 	/// Compact the chain, optionally aborting if `stop_state` is stopped.
 	/// Used on shutdown so long compaction does not keep rewriting files after
-	/// the node was asked to stop (#3842).
+	/// the node was asked to stop.
 	pub fn compact_with_stop(
 		&self,
 		stop_state: Option<Arc<crate::util::StopState>>,
@@ -1381,7 +1381,7 @@ impl Chain {
 			let horizon_hash = header_pmmr.get_header_hash_by_height(horizon_height)?;
 			let horizon_header = batch.get_block_header(&horizon_hash)?;
 
-			txhashset.compact_until(&horizon_header, &batch, should_abort)?;
+			txhashset.compact_with_abort(&horizon_header, &batch, should_abort)?;
 		}
 
 		if should_abort() {

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -528,12 +528,12 @@ impl TxHashSet {
 		horizon_header: &BlockHeader,
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {
-		self.compact_until(horizon_header, batch, || false)
+		self.compact_with_abort(horizon_header, batch, || false)
 	}
 
 	/// Compact MMR data files, honouring an abort callback so shutdown can
-	/// cancel before live files are replaced (see #3842).
-	pub fn compact_until<F>(
+	/// cancel before live files are replaced.
+	pub fn compact_with_abort<F>(
 		&mut self,
 		horizon_header: &BlockHeader,
 		batch: &Batch<'_>,
@@ -554,7 +554,7 @@ impl TxHashSet {
 		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, batch)?;
 
 		debug!("txhashset: check_compact output mmr backend...");
-		let output_done = self.output_pmmr_h.backend.check_compact_until(
+		let output_done = self.output_pmmr_h.backend.check_compact_with_abort(
 			horizon_header.output_mmr_size,
 			&rewind_rm_pos,
 			should_abort,
@@ -570,7 +570,7 @@ impl TxHashSet {
 		}
 
 		debug!("txhashset: check_compact rangeproof mmr backend...");
-		let rproof_done = self.rproof_pmmr_h.backend.check_compact_until(
+		let rproof_done = self.rproof_pmmr_h.backend.check_compact_with_abort(
 			horizon_header.output_mmr_size,
 			&rewind_rm_pos,
 			should_abort,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -528,21 +528,57 @@ impl TxHashSet {
 		horizon_header: &BlockHeader,
 		batch: &Batch<'_>,
 	) -> Result<(), Error> {
+		self.compact_until(horizon_header, batch, || false)
+	}
+
+	/// Compact MMR data files, honouring an abort callback so shutdown can
+	/// cancel before live files are replaced (see #3842).
+	pub fn compact_until<F>(
+		&mut self,
+		horizon_header: &BlockHeader,
+		batch: &Batch<'_>,
+		should_abort: F,
+	) -> Result<(), Error>
+	where
+		F: Fn() -> bool + Copy,
+	{
 		debug!("txhashset: starting compaction...");
+
+		if should_abort() {
+			info!("txhashset: compaction aborted (node stopping)");
+			return Ok(());
+		}
 
 		let head_header = batch.head_header()?;
 
 		let rewind_rm_pos = input_pos_to_rewind(&horizon_header, &head_header, batch)?;
 
 		debug!("txhashset: check_compact output mmr backend...");
-		self.output_pmmr_h
-			.backend
-			.check_compact(horizon_header.output_mmr_size, &rewind_rm_pos)?;
+		let output_done = self.output_pmmr_h.backend.check_compact_until(
+			horizon_header.output_mmr_size,
+			&rewind_rm_pos,
+			should_abort,
+		)?;
+		if !output_done {
+			info!("txhashset: compaction aborted during output mmr compact");
+			return Ok(());
+		}
+
+		if should_abort() {
+			info!("txhashset: compaction aborted before rangeproof mmr compact");
+			return Ok(());
+		}
 
 		debug!("txhashset: check_compact rangeproof mmr backend...");
-		self.rproof_pmmr_h
-			.backend
-			.check_compact(horizon_header.output_mmr_size, &rewind_rm_pos)?;
+		let rproof_done = self.rproof_pmmr_h.backend.check_compact_until(
+			horizon_header.output_mmr_size,
+			&rewind_rm_pos,
+			should_abort,
+		)?;
+		if !rproof_done {
+			info!("txhashset: compaction aborted during rangeproof mmr compact");
+			return Ok(());
+		}
 
 		debug!("txhashset: ... compaction finished");
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -15,14 +15,14 @@
 //! Adapters connecting new block, new transaction, and accepted transaction
 //! events to consumers of those events.
 
-use crate::util::{RwLock, StopState};
+use crate::util::{Mutex, RwLock, StopState};
 use std::collections::HashMap;
 use std::fs::File;
 use std::net::SocketAddr;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Weak};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
 use crate::chain::txhashset::BitmapChunk;
@@ -61,6 +61,49 @@ const WORKER_CHANNEL_BUFFER_SIZE: usize = 64;
 const HEADER_SEGMENT_REQUEST_WINDOW_SECS: i64 = 60;
 const MAX_HEADER_SEGMENT_REQUESTS_PER_WINDOW: usize = 120;
 
+/// Tracks the background compactor thread so shutdown can join it and let any
+/// in-progress replace phase finish before the process exits.
+#[derive(Default)]
+pub struct CompactorTracker {
+	thread: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl CompactorTracker {
+	/// Create an empty tracker.
+	pub fn new() -> Arc<Self> {
+		Arc::new(Self::default())
+	}
+
+	/// Block until any running (or finished) compactor thread has exited.
+	pub fn join(&self) {
+		if let Some(h) = self.thread.lock().take() {
+			if let Err(e) = h.join() {
+				error!("compactor thread panicked: {:?}", e);
+			}
+		}
+	}
+
+	/// True if no compact is running; reaps a finished handle if present.
+	fn ready(&self) -> bool {
+		let mut slot = self.thread.lock();
+		match slot.take() {
+			None => true,
+			Some(h) if h.is_finished() => {
+				let _ = h.join();
+				true
+			}
+			Some(h) => {
+				*slot = Some(h);
+				false
+			}
+		}
+	}
+
+	fn store(&self, h: JoinHandle<()>) {
+		*self.thread.lock() = Some(h);
+	}
+}
+
 /// Implementation of the NetAdapter for the . Gets notified when new
 /// blocks and transactions are received and forwards to the chain and pool
 /// implementations.
@@ -76,8 +119,10 @@ where
 	config: ServerConfig,
 	hooks: Vec<Box<dyn NetEvents + Send + Sync>>,
 	header_segment_requests: RwLock<HashMap<SocketAddr, (DateTime<Utc>, usize)>>,
-	/// Shared shutdown flag so compaction can abort cleanly (#3842).
+	/// Shared shutdown flag so compaction can abort cleanly.
 	stop_state: Arc<StopState>,
+	/// Join handle for the last spawned compactor (joined on server stop).
+	compactor: Arc<CompactorTracker>,
 	tx: mpsc::SyncSender<NetAdapterWorkerMessage>,
 }
 
@@ -701,6 +746,7 @@ where
 		config: ServerConfig,
 		hooks: Vec<Box<dyn NetEvents + Send + Sync>>,
 		stop_state: Arc<StopState>,
+		compactor: Arc<CompactorTracker>,
 	) -> Self {
 		let (tx, rx) = mpsc::sync_channel(WORKER_CHANNEL_BUFFER_SIZE);
 		let adapter = NetToChainAdapter {
@@ -712,6 +758,7 @@ where
 			hooks,
 			header_segment_requests: RwLock::new(HashMap::new()),
 			stop_state,
+			compactor,
 			tx,
 		};
 		adapter.spawn_net_adapter_worker(Arc::downgrade(&chain), rx);
@@ -974,6 +1021,10 @@ where
 		if self.stop_state.is_stopped() {
 			return;
 		}
+		// Only one background compact at a time; reap finished handles.
+		if !self.compactor.ready() {
+			return;
+		}
 
 		// Roll the dice to trigger compaction at 1/COMPACTION_CHECK chance per block,
 		// uses a different thread to avoid blocking the caller thread (likely a peer)
@@ -981,7 +1032,7 @@ where
 		if 0 == rng.gen_range(0, global::COMPACTION_CHECK) {
 			let chain = self.chain();
 			let stop_state = self.stop_state.clone();
-			let _ = thread::Builder::new()
+			match thread::Builder::new()
 				.name("compactor".to_string())
 				.spawn(move || {
 					if stop_state.is_stopped() {
@@ -991,7 +1042,10 @@ where
 					if let Err(e) = chain.compact_with_stop(Some(stop_state)) {
 						error!("Could not compact chain: {:?}", e);
 					}
-				});
+				}) {
+				Ok(h) => self.compactor.store(h),
+				Err(e) => error!("Could not spawn compactor thread: {:?}", e),
+			}
 		}
 	}
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -15,7 +15,7 @@
 //! Adapters connecting new block, new transaction, and accepted transaction
 //! events to consumers of those events.
 
-use crate::util::RwLock;
+use crate::util::{RwLock, StopState};
 use std::collections::HashMap;
 use std::fs::File;
 use std::net::SocketAddr;
@@ -76,6 +76,8 @@ where
 	config: ServerConfig,
 	hooks: Vec<Box<dyn NetEvents + Send + Sync>>,
 	header_segment_requests: RwLock<HashMap<SocketAddr, (DateTime<Utc>, usize)>>,
+	/// Shared shutdown flag so compaction can abort cleanly (#3842).
+	stop_state: Arc<StopState>,
 	tx: mpsc::SyncSender<NetAdapterWorkerMessage>,
 }
 
@@ -698,6 +700,7 @@ where
 		tx_pool: Arc<RwLock<pool::TransactionPool<B, P>>>,
 		config: ServerConfig,
 		hooks: Vec<Box<dyn NetEvents + Send + Sync>>,
+		stop_state: Arc<StopState>,
 	) -> Self {
 		let (tx, rx) = mpsc::sync_channel(WORKER_CHANNEL_BUFFER_SIZE);
 		let adapter = NetToChainAdapter {
@@ -708,6 +711,7 @@ where
 			config,
 			hooks,
 			header_segment_requests: RwLock::new(HashMap::new()),
+			stop_state,
 			tx,
 		};
 		adapter.spawn_net_adapter_worker(Arc::downgrade(&chain), rx);
@@ -966,15 +970,25 @@ where
 	}
 
 	fn check_compact(&self) {
+		// Do not start long-running compaction while the node is shutting down.
+		if self.stop_state.is_stopped() {
+			return;
+		}
+
 		// Roll the dice to trigger compaction at 1/COMPACTION_CHECK chance per block,
 		// uses a different thread to avoid blocking the caller thread (likely a peer)
 		let mut rng = thread_rng();
 		if 0 == rng.gen_range(0, global::COMPACTION_CHECK) {
 			let chain = self.chain();
+			let stop_state = self.stop_state.clone();
 			let _ = thread::Builder::new()
 				.name("compactor".to_string())
 				.spawn(move || {
-					if let Err(e) = chain.compact() {
+					if stop_state.is_stopped() {
+						debug!("compactor: not starting, node is stopping");
+						return;
+					}
+					if let Err(e) = chain.compact_with_stop(Some(stop_state)) {
 						error!("Could not compact chain: {:?}", e);
 					}
 				});

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -223,6 +223,7 @@ impl Server {
 			tx_pool.clone(),
 			config.clone(),
 			init_net_hooks(&config)?,
+			stop_state.clone(),
 		));
 
 		// Initialize our capabilities.

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -32,7 +32,8 @@ use crate::api;
 use crate::api::TLSConfig;
 use crate::chain::{self, SyncState, SyncStatus};
 use crate::common::adapters::{
-	ChainToPoolAndNetAdapter, NetToChainAdapter, PoolToChainAdapter, PoolToNetAdapter,
+	ChainToPoolAndNetAdapter, CompactorTracker, NetToChainAdapter, PoolToChainAdapter,
+	PoolToNetAdapter,
 };
 use crate::common::hooks::{init_chain_hooks, init_net_hooks};
 use crate::common::stats::{
@@ -76,6 +77,8 @@ pub struct Server {
 	connect_thread: Option<JoinHandle<()>>,
 	sync_thread: JoinHandle<()>,
 	dandelion_thread: JoinHandle<()>,
+	/// Background chain-compaction thread (joined on stop so replace finishes).
+	compactor: Arc<CompactorTracker>,
 }
 
 impl Server {
@@ -217,6 +220,7 @@ impl Server {
 
 		pool_adapter.set_chain(shared_chain.clone());
 
+		let compactor = CompactorTracker::new();
 		let net_adapter = Arc::new(NetToChainAdapter::new(
 			sync_state.clone(),
 			shared_chain.clone(),
@@ -224,6 +228,7 @@ impl Server {
 			config.clone(),
 			init_net_hooks(&config)?,
 			stop_state.clone(),
+			compactor.clone(),
 		));
 
 		// Initialize our capabilities.
@@ -341,6 +346,7 @@ impl Server {
 			connect_thread,
 			sync_thread,
 			dandelion_thread,
+			compactor,
 		})
 	}
 
@@ -578,6 +584,11 @@ impl Server {
 				Err(e) => error!("failed to join to dandelion_monitor thread: {:?}", e),
 				Ok(_) => info!("dandelion_monitor thread stopped"),
 			}
+
+			// Wait for any in-flight compaction so the replace phase can finish
+			// (or abort cleanly and discard tmp) before we exit.
+			self.compactor.join();
+			info!("compactor thread stopped");
 		}
 		// this call is blocking and makes sure all peers stop, however
 		// we can't be sure that we stopped a listener blocked on accept, so we don't join the p2p thread

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -174,7 +174,9 @@ impl SyncRunner {
 					// This triggers a chain compaction to keep out local node tidy.
 					// Note: Chain compaction runs with an internal threshold
 					// so can be safely run even if the node is restarted frequently.
-					unwrap_or_restart_loop!(self.chain.compact());
+					unwrap_or_restart_loop!(self
+						.chain
+						.compact_with_stop(Some(self.stop_state.clone())));
 				}
 
 				// sleep for 10 secs but check stop signal every second

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -414,13 +414,17 @@ impl<T: PMMRable> PMMRBackend<T> {
 	/// will have a suitable output_pos. This is used to enforce a horizon
 	/// after which the local node should have all the data to allow rewinding.
 	pub fn check_compact(&mut self, cutoff_pos: u64, rewind_rm_pos: &Bitmap) -> io::Result<bool> {
-		self.check_compact_until(cutoff_pos, rewind_rm_pos, || false)
+		self.check_compact_with_abort(cutoff_pos, rewind_rm_pos, || false)
 	}
 
 	/// Compact backend files, optionally aborting before live files are replaced
-	/// when `should_abort` returns true (e.g. node shutdown). Aborted compaction
-	/// discards `.tmp` files and leaves the live PMMR files untouched (#3842).
-	pub fn check_compact_until<F>(
+	/// when `should_abort` returns true (e.g. node shutdown).
+	///
+	/// If aborting after tmp files were written: discard them and leave live
+	/// PMMR files untouched. Once this check decides to proceed, the replace of
+	/// hash then data is not interrupted by further abort polls — callers that
+	/// shut down must join the compacting thread so that section can finish.
+	pub fn check_compact_with_abort<F>(
 		&mut self,
 		cutoff_pos: u64,
 		rewind_rm_pos: &Bitmap,
@@ -467,12 +471,12 @@ impl<T: PMMRable> PMMRBackend<T> {
 			self.data_file.write_tmp_pruned(&pos_to_rm)?;
 		}
 
-		// Critical section: do not replace live files if we are shutting down.
-		// Leaving a half-applied replace causes Invalid Root on next start (#3842).
+		// Decision point: after this, replace always runs to completion (no
+		// further should_abort checks) so hash/data stay consistent.
 		if should_abort() {
 			info!("compact: aborted before replace; discarding tmp files");
-			self.hash_file.discard_tmp();
-			self.data_file.discard_tmp();
+			self.hash_file.discard_tmp()?;
+			self.data_file.discard_tmp()?;
 			return Ok(false);
 		}
 

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -414,7 +414,27 @@ impl<T: PMMRable> PMMRBackend<T> {
 	/// will have a suitable output_pos. This is used to enforce a horizon
 	/// after which the local node should have all the data to allow rewinding.
 	pub fn check_compact(&mut self, cutoff_pos: u64, rewind_rm_pos: &Bitmap) -> io::Result<bool> {
+		self.check_compact_until(cutoff_pos, rewind_rm_pos, || false)
+	}
+
+	/// Compact backend files, optionally aborting before live files are replaced
+	/// when `should_abort` returns true (e.g. node shutdown). Aborted compaction
+	/// discards `.tmp` files and leaves the live PMMR files untouched (#3842).
+	pub fn check_compact_until<F>(
+		&mut self,
+		cutoff_pos: u64,
+		rewind_rm_pos: &Bitmap,
+		should_abort: F,
+	) -> io::Result<bool>
+	where
+		F: Fn() -> bool,
+	{
 		assert!(self.prunable, "Trying to compact a non-prunable PMMR");
+
+		if should_abort() {
+			debug!("compact: aborted before writing tmp files");
+			return Ok(false);
+		}
 
 		// Calculate the sets of leaf positions and node positions to remove based
 		// on the cutoff_pos provided.
@@ -445,6 +465,15 @@ impl<T: PMMRable> PMMRBackend<T> {
 			});
 
 			self.data_file.write_tmp_pruned(&pos_to_rm)?;
+		}
+
+		// Critical section: do not replace live files if we are shutting down.
+		// Leaving a half-applied replace causes Invalid Root on next start (#3842).
+		if should_abort() {
+			info!("compact: aborted before replace; discarding tmp files");
+			self.hash_file.discard_tmp();
+			self.data_file.discard_tmp();
+			return Ok(false);
 		}
 
 		// Replace hash and data files with compact copies.

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -18,7 +18,6 @@ use crate::grin_core::ser::{
 	self, BinWriter, DeserializationMode, ProtocolVersion, Readable, Reader, StreamingReader,
 	Writeable, Writer,
 };
-use log::warn;
 use std::fmt::Debug;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Seek, SeekFrom, Write};
@@ -162,7 +161,7 @@ where
 	}
 
 	/// Discard any temporary pruned file without applying it.
-	pub fn discard_tmp(&self) {
+	pub fn discard_tmp(&self) -> io::Result<()> {
 		self.file.discard_tmp()
 	}
 
@@ -528,13 +527,12 @@ where
 	}
 
 	/// Drop any `.tmp` companion file without replacing the live file.
-	pub fn discard_tmp(&self) {
+	pub fn discard_tmp(&self) -> io::Result<()> {
 		let tmp = self.tmp_path();
 		if tmp.exists() {
-			if let Err(e) = fs::remove_file(&tmp) {
-				warn!("discard_tmp: failed to remove {:?}: {}", tmp, e);
-			}
+			fs::remove_file(&tmp)?;
 		}
+		Ok(())
 	}
 
 	/// Replace the underlying file with the file at tmp path.

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -18,6 +18,7 @@ use crate::grin_core::ser::{
 	self, BinWriter, DeserializationMode, ProtocolVersion, Readable, Reader, StreamingReader,
 	Writeable, Writer,
 };
+use log::warn;
 use std::fmt::Debug;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Seek, SeekFrom, Write};
@@ -158,6 +159,11 @@ where
 		// Need to convert from 1-index to 0-index (don't ask).
 		let prune_idx: Vec<_> = prune_pos.iter().map(|x| x - 1).collect();
 		self.file.write_tmp_pruned(prune_idx.as_slice())
+	}
+
+	/// Discard any temporary pruned file without applying it.
+	pub fn discard_tmp(&self) {
+		self.file.discard_tmp()
 	}
 
 	/// Replace with file at tmp path.
@@ -519,6 +525,16 @@ where
 		}
 		buf_writer.flush()?;
 		Ok(())
+	}
+
+	/// Drop any `.tmp` companion file without replacing the live file.
+	pub fn discard_tmp(&self) {
+		let tmp = self.tmp_path();
+		if tmp.exists() {
+			if let Err(e) = fs::remove_file(&tmp) {
+				warn!("discard_tmp: failed to remove {:?}: {}", tmp, e);
+			}
+		}
 	}
 
 	/// Replace the underlying file with the file at tmp path.

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -214,6 +214,36 @@ fn pmmr_compact_leaf_sibling() {
 	teardown(data_dir);
 }
 
+/// Aborting compaction before replace must leave live files intact (#3842).
+#[test]
+fn pmmr_compact_abort_before_replace() {
+	let (data_dir, elems) = setup("compact_abort");
+	{
+		let mut backend =
+			store::pmmr::PMMRBackend::new(data_dir.to_string(), true, ProtocolVersion(1), None)
+				.unwrap();
+		let mmr_size = load(0, &elems[..], &mut backend);
+		backend.sync().unwrap();
+		let root_before = {
+			let pmmr = PMMR::at(&mut backend, mmr_size);
+			pmmr.root().unwrap()
+		};
+
+		// Always abort: should not replace live files.
+		let done = backend
+			.check_compact_until(2, &Bitmap::new(), || true)
+			.unwrap();
+		assert!(!done);
+
+		let root_after = {
+			let pmmr = PMMR::at(&mut backend, mmr_size);
+			pmmr.root().unwrap()
+		};
+		assert_eq!(root_before, root_after);
+	}
+	teardown(data_dir);
+}
+
 #[test]
 fn pmmr_prune_compact() {
 	let (data_dir, elems) = setup("prune_compact");

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -214,9 +214,11 @@ fn pmmr_compact_leaf_sibling() {
 	teardown(data_dir);
 }
 
-/// Aborting compaction before replace must leave live files intact (#3842).
+/// Abort after tmp write must discard tmp files and leave live roots intact.
 #[test]
 fn pmmr_compact_abort_before_replace() {
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
 	let (data_dir, elems) = setup("compact_abort");
 	{
 		let mut backend =
@@ -229,17 +231,38 @@ fn pmmr_compact_abort_before_replace() {
 			pmmr.root().unwrap()
 		};
 
-		// Always abort: should not replace live files.
+		// First should_abort is before tmp write (allow it); second is after
+		// tmp write and before replace (abort so discard_tmp runs).
+		let calls = AtomicUsize::new(0);
 		let done = backend
-			.check_compact_until(2, &Bitmap::new(), || true)
+			.check_compact_with_abort(2, &Bitmap::new(), || {
+				calls.fetch_add(1, Ordering::SeqCst) >= 1
+			})
 			.unwrap();
 		assert!(!done);
+		assert!(
+			calls.load(Ordering::SeqCst) >= 2,
+			"expected abort check after tmp write"
+		);
 
 		let root_after = {
 			let pmmr = PMMR::at(&mut backend, mmr_size);
 			pmmr.root().unwrap()
 		};
 		assert_eq!(root_before, root_after);
+
+		// No leftover .tmp companions under the data dir.
+		let tmp_left: Vec<_> = fs::read_dir(&data_dir)
+			.unwrap()
+			.filter_map(|e| e.ok())
+			.map(|e| e.path())
+			.filter(|p| p.extension().and_then(|s| s.to_str()) == Some("tmp"))
+			.collect();
+		assert!(
+			tmp_left.is_empty(),
+			"tmp files should be discarded on abort: {:?}",
+			tmp_left
+		);
 	}
 	teardown(data_dir);
 }


### PR DESCRIPTION
## Summary

Fixes [#3842](https://github.com/mimblewimble/grin/issues/3842).

Long compaction runs (especially on low-RAM machines / startup) continued after the node was asked to stop. Killing the process while live PMMR files were being replaced left the chain with **Invalid Root** on the next launch.

### Changes

| Layer | Behaviour |
|-------|-----------|
| `NetToChainAdapter` | Holds `StopState`; does not spawn compactors when stopped; passes stop into compact |
| `Syncer` | Uses `compact_with_stop` on transition to NoSync |
| `Chain::compact_with_stop` | Aborts early when stop is set |
| `PMMRBackend::check_compact_until` | After writing `.tmp` files, if aborting: **discard tmp**, do **not** replace live files |
| `AppendOnlyFile::discard_tmp` | Removes leftover `.tmp` companions |

`Chain::compact()` remains for API/tests (no stop handle).

## Test plan

- [x] `cargo test -p grin_store --test pmmr pmmr_compact_abort_before_replace`
- [x] `cargo test -p grin_store --test pmmr -- --test-threads=1`
- [x] `cargo test -p grin_chain --test mine_simple_chain compact -- --test-threads=1`
- [x] `cargo test -p grin_servers --lib -- --test-threads=1`
- [ ] Manual: trigger compact, stop node mid-run, confirm no Invalid Root on restart