### PR TITLE
feat: expose stratum mining stats via Owner API

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -62,6 +62,39 @@ pub fn node_apis<B, P>(
 	tls_config: Option<TLSConfig>,
 	api_chan: (mpsc::Sender<()>, mpsc::Receiver<()>),
 	stop_state: Arc<StopState>,
+) -> Result<(), Error>
+where
+	B: BlockChain + 'static,
+	P: PoolAdapter + 'static,
+{
+	node_apis_with_mining_stats(
+		addr,
+		chain,
+		tx_pool,
+		peers,
+		sync_state,
+		api_secret,
+		foreign_api_secret,
+		tls_config,
+		api_chan,
+		stop_state,
+		None,
+	)
+}
+
+/// Same as [`node_apis`] but additionally wires a provider of live stratum
+/// mining stats into the Owner API `get_mining_status` method.
+pub fn node_apis_with_mining_stats<B, P>(
+	addr: &str,
+	chain: Arc<Chain>,
+	tx_pool: Arc<RwLock<pool::TransactionPool<B, P>>>,
+	peers: Arc<p2p::Peers>,
+	sync_state: Arc<SyncState>,
+	api_secret: Option<String>,
+	foreign_api_secret: Option<String>,
+	tls_config: Option<TLSConfig>,
+	api_chan: (mpsc::Sender<()>, mpsc::Receiver<()>),
+	stop_state: Arc<StopState>,
 	mining_stats: Option<MiningStatsProvider>,
 ) -> Result<(), Error>
 where

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -27,7 +27,7 @@ use crate::auth::{
 use crate::chain::{Chain, SyncState};
 use crate::foreign::Foreign;
 use crate::foreign_rpc::ForeignRpc;
-use crate::owner::Owner;
+use crate::owner::{MiningStatsProvider, Owner};
 use crate::owner_rpc::OwnerRpc;
 use crate::pool;
 use crate::pool::{BlockChain, PoolAdapter};
@@ -62,6 +62,7 @@ pub fn node_apis<B, P>(
 	tls_config: Option<TLSConfig>,
 	api_chan: (mpsc::Sender<()>, mpsc::Receiver<()>),
 	stop_state: Arc<StopState>,
+	mining_stats: Option<MiningStatsProvider>,
 ) -> Result<(), Error>
 where
 	B: BlockChain + 'static,
@@ -85,6 +86,7 @@ where
 		Arc::downgrade(&chain),
 		Arc::downgrade(&peers),
 		Arc::downgrade(&sync_state),
+		mining_stats,
 	);
 	router.add_route("/v2/owner", Arc::new(api_handler))?;
 
@@ -142,25 +144,33 @@ pub struct OwnerAPIHandlerV2 {
 	pub chain: Weak<Chain>,
 	pub peers: Weak<p2p::Peers>,
 	pub sync_state: Weak<SyncState>,
+	pub mining_stats: Option<MiningStatsProvider>,
 }
 
 impl OwnerAPIHandlerV2 {
 	/// Create a new owner API handler for GET methods
-	pub fn new(chain: Weak<Chain>, peers: Weak<p2p::Peers>, sync_state: Weak<SyncState>) -> Self {
+	pub fn new(
+		chain: Weak<Chain>,
+		peers: Weak<p2p::Peers>,
+		sync_state: Weak<SyncState>,
+		mining_stats: Option<MiningStatsProvider>,
+	) -> Self {
 		OwnerAPIHandlerV2 {
 			chain,
 			peers,
 			sync_state,
+			mining_stats,
 		}
 	}
 }
 
 impl crate::router::Handler for OwnerAPIHandlerV2 {
 	fn post(&self, req: Request<Incoming>) -> ResponseFuture {
-		let api = Owner::new(
+		let api = Owner::with_mining_stats(
 			self.chain.clone(),
 			self.peers.clone(),
 			self.sync_state.clone(),
+			self.mining_stats.clone(),
 		);
 
 		Box::pin(async move {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::auth::{
 };
 pub use crate::foreign::Foreign;
 pub use crate::foreign_rpc::ForeignRpc;
-pub use crate::handlers::node_apis;
+pub use crate::handlers::{node_apis, node_apis_with_mining_stats};
 pub use crate::owner::{MiningStatsProvider, Owner};
 pub use crate::owner_rpc::OwnerRpc;
 pub use crate::rest::*;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::auth::{
 pub use crate::foreign::Foreign;
 pub use crate::foreign_rpc::ForeignRpc;
 pub use crate::handlers::node_apis;
-pub use crate::owner::Owner;
+pub use crate::owner::{MiningStatsProvider, Owner};
 pub use crate::owner_rpc::OwnerRpc;
 pub use crate::rest::*;
 pub use crate::router::*;

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -22,9 +22,12 @@ use crate::handlers::server_api::StatusHandler;
 use crate::p2p::types::PeerInfoDisplay;
 use crate::p2p::{self, PeerData};
 use crate::rest::*;
-use crate::types::Status;
+use crate::types::{MiningStatus, Status};
 use std::net::SocketAddr;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
+
+/// Callback that returns a snapshot of stratum mining stats for the Owner API.
+pub type MiningStatsProvider = Arc<dyn Fn() -> MiningStatus + Send + Sync>;
 
 /// Main interface into all node API functions.
 /// Node APIs are split into two separate blocks of functionality
@@ -37,6 +40,8 @@ pub struct Owner {
 	pub chain: Weak<Chain>,
 	pub peers: Weak<p2p::Peers>,
 	pub sync_state: Weak<SyncState>,
+	/// Optional provider of live stratum mining stats (set by the server process).
+	pub mining_stats: Option<MiningStatsProvider>,
 }
 
 impl Owner {
@@ -58,6 +63,22 @@ impl Owner {
 			chain,
 			peers,
 			sync_state,
+			mining_stats: None,
+		}
+	}
+
+	/// Create a new Owner API instance with a mining stats provider.
+	pub fn with_mining_stats(
+		chain: Weak<Chain>,
+		peers: Weak<p2p::Peers>,
+		sync_state: Weak<SyncState>,
+		mining_stats: Option<MiningStatsProvider>,
+	) -> Self {
+		Owner {
+			chain,
+			peers,
+			sync_state,
+			mining_stats,
 		}
 	}
 
@@ -76,6 +97,25 @@ impl Owner {
 			sync_state: self.sync_state.clone(),
 		};
 		status_handler.get_status()
+	}
+
+	/// Returns current stratum mining statistics (enabled/running, workers, difficulty, etc.).
+	/// Useful when running headless without the TUI mining tab.
+	///
+	/// When stratum is disabled or no stats provider is wired up, returns a default
+	/// (disabled) [`MiningStatus`](types/struct.MiningStatus.html).
+	///
+	/// # Returns
+	/// * Result Containing:
+	/// * A [`MiningStatus`](types/struct.MiningStatus.html)
+	/// * or [`Error`](struct.Error.html) if an error is encountered.
+	///
+
+	pub fn get_mining_status(&self) -> Result<MiningStatus, Error> {
+		match &self.mining_stats {
+			Some(provider) => Ok(provider()),
+			None => Ok(MiningStatus::default()),
+		}
 	}
 
 	/// Trigger a validation of the chain state.
@@ -199,5 +239,49 @@ impl Owner {
 			peers: self.peers.clone(),
 		};
 		peer_handler.unban_peer(addr)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::types::{MiningStatus, WorkerInfo};
+	use std::sync::Arc;
+
+	#[test]
+	fn get_mining_status_without_provider_returns_default() {
+		let owner = Owner::new(Weak::new(), Weak::new(), Weak::new());
+		let status = owner.get_mining_status().unwrap();
+		assert_eq!(status, MiningStatus::default());
+	}
+
+	#[test]
+	fn get_mining_status_with_provider() {
+		let expected = MiningStatus {
+			is_enabled: true,
+			is_running: true,
+			num_workers: 2,
+			block_height: 50,
+			network_difficulty: 10,
+			edge_bits: 29,
+			blocks_found: 1,
+			network_hashrate: 0.5,
+			minimum_share_difficulty: 1,
+			worker_stats: vec![WorkerInfo {
+				id: "w0".into(),
+				is_connected: true,
+				last_seen: 100,
+				initial_block_height: 40,
+				pow_difficulty: 1,
+				num_accepted: 3,
+				num_rejected: 0,
+				num_stale: 0,
+				num_blocks_found: 0,
+			}],
+		};
+		let expected_clone = expected.clone();
+		let provider: MiningStatsProvider = Arc::new(move || expected_clone.clone());
+		let owner = Owner::with_mining_stats(Weak::new(), Weak::new(), Weak::new(), Some(provider));
+		assert_eq!(owner.get_mining_status().unwrap(), expected);
 	}
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -243,17 +243,43 @@ impl Owner {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::owner_rpc::OwnerRpc;
 	use crate::types::{MiningStatus, WorkerInfo};
+	use easy_jsonrpc_mw::{Handler, MaybeReply};
+	use serde_json::json;
 	use std::sync::Arc;
+
+	fn mining_status_request() -> serde_json::Value {
+		json!({
+			"jsonrpc": "2.0",
+			"method": "get_mining_status",
+			"params": [],
+			"id": 1
+		})
+	}
 
 	#[test]
 	fn get_mining_status_without_provider_returns_error() {
 		let owner = Owner::new(Weak::new(), Weak::new(), Weak::new());
 		assert!(owner.get_mining_status().is_err());
+
+		// Also cover the generated JSON-RPC wire path for the error case.
+		let owner_api = &owner as &dyn OwnerRpc;
+		let reply = match owner_api.handle_request(mining_status_request()) {
+			MaybeReply::Reply(r) => r,
+			MaybeReply::DontReply => panic!("expected JSON-RPC reply"),
+		};
+		assert_eq!(reply["id"], 1);
+		assert_eq!(reply["jsonrpc"], "2.0");
+		assert!(
+			reply["result"]["Err"].is_object(),
+			"expected Err result, got {}",
+			reply
+		);
 	}
 
 	#[test]
-	fn get_mining_status_with_provider() {
+	fn get_mining_status_jsonrpc_wire_response() {
 		let expected = MiningStatus {
 			is_enabled: true,
 			is_running: true,
@@ -278,6 +304,33 @@ mod test {
 		let expected_clone = expected.clone();
 		let provider: MiningStatsProvider = Arc::new(move || expected_clone.clone());
 		let owner = Owner::with_mining_stats(Weak::new(), Weak::new(), Weak::new(), Some(provider));
-		assert_eq!(owner.get_mining_status().unwrap(), expected);
+
+		let owner_api = &owner as &dyn OwnerRpc;
+		let reply = match owner_api.handle_request(mining_status_request()) {
+			MaybeReply::Reply(r) => r,
+			MaybeReply::DontReply => panic!("expected JSON-RPC reply"),
+		};
+
+		assert_eq!(reply["id"], 1);
+		assert_eq!(reply["jsonrpc"], "2.0");
+		let ok = &reply["result"]["Ok"];
+		assert_eq!(ok["is_enabled"], true);
+		assert_eq!(ok["is_running"], true);
+		assert_eq!(ok["num_workers"], 2);
+		assert_eq!(ok["block_height"], 50);
+		assert_eq!(ok["network_difficulty"], 10);
+		assert_eq!(ok["edge_bits"], 29);
+		assert_eq!(ok["blocks_found"], 1);
+		assert_eq!(ok["network_hashrate"], 0.5);
+		assert_eq!(ok["minimum_share_difficulty"], 1);
+		assert_eq!(ok["worker_stats"][0]["id"], "w0");
+		assert_eq!(ok["worker_stats"][0]["last_seen"], 100);
+		assert_eq!(ok["worker_stats"][0]["num_accepted"], 3);
+		// Field dropped from the public WorkerInfo shape.
+		assert!(ok["worker_stats"][0].get("is_connected").is_none());
+
+		// Round-trip the Ok payload into MiningStatus to lock the wire schema.
+		let status: MiningStatus = serde_json::from_value(ok.clone()).unwrap();
+		assert_eq!(status, expected);
 	}
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -99,22 +99,20 @@ impl Owner {
 		status_handler.get_status()
 	}
 
-	/// Returns current stratum mining statistics (enabled/running, workers, difficulty, etc.).
-	/// Useful when running headless without the TUI mining tab.
-	///
-	/// When stratum is disabled or no stats provider is wired up, returns a default
-	/// (disabled) [`MiningStatus`](types/struct.MiningStatus.html).
+	/// Returns current stratum mining statistics, mirroring the TUI mining tab.
 	///
 	/// # Returns
 	/// * Result Containing:
 	/// * A [`MiningStatus`](types/struct.MiningStatus.html)
-	/// * or [`Error`](struct.Error.html) if an error is encountered.
+	/// * or [`Error`](struct.Error.html) if no mining stats provider is configured.
 	///
 
 	pub fn get_mining_status(&self) -> Result<MiningStatus, Error> {
 		match &self.mining_stats {
 			Some(provider) => Ok(provider()),
-			None => Ok(MiningStatus::default()),
+			None => Err(Error::Internal(
+				"no mining stats provider configured".to_string(),
+			)),
 		}
 	}
 
@@ -249,10 +247,9 @@ mod test {
 	use std::sync::Arc;
 
 	#[test]
-	fn get_mining_status_without_provider_returns_default() {
+	fn get_mining_status_without_provider_returns_error() {
 		let owner = Owner::new(Weak::new(), Weak::new(), Weak::new());
-		let status = owner.get_mining_status().unwrap();
-		assert_eq!(status, MiningStatus::default());
+		assert!(owner.get_mining_status().is_err());
 	}
 
 	#[test]
@@ -269,7 +266,6 @@ mod test {
 			minimum_share_difficulty: 1,
 			worker_stats: vec![WorkerInfo {
 				id: "w0".into(),
-				is_connected: true,
 				last_seen: 100,
 				initial_block_height: 40,
 				pow_difficulty: 1,

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -110,7 +110,6 @@ pub trait OwnerRpc: Sync + Send {
 				"worker_stats": [
 					{
 						"id": "0",
-						"is_connected": true,
 						"last_seen": 1609459200,
 						"initial_block_height": 990,
 						"pow_difficulty": 1,

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -18,7 +18,7 @@ use crate::owner::Owner;
 use crate::p2p::types::PeerInfoDisplay;
 use crate::p2p::PeerData;
 use crate::rest::Error;
-use crate::types::Status;
+use crate::types::{MiningStatus, Status};
 use std::net::SocketAddr;
 
 /// Public definition used to generate Node jsonrpc api.
@@ -72,6 +72,62 @@ pub trait OwnerRpc: Sync + Send {
 	```
 	 */
 	fn get_status(&self) -> Result<Status, Error>;
+
+	/**
+	Networked version of [Owner::get_mining_status](struct.Owner.html#method.get_mining_status).
+
+	Returns the same mining / stratum information shown on the TUI mining tab so
+	headless operators can query connected workers and share stats.
+
+	# Json rpc example
+
+	```
+	# grin_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "get_mining_status",
+		"params": [],
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": {
+				"is_enabled": true,
+				"is_running": true,
+				"num_workers": 1,
+				"block_height": 1000,
+				"network_difficulty": 42,
+				"edge_bits": 29,
+				"blocks_found": 3,
+				"network_hashrate": 1.5,
+				"minimum_share_difficulty": 1,
+				"worker_stats": [
+					{
+						"id": "0",
+						"is_connected": true,
+						"last_seen": 1609459200,
+						"initial_block_height": 990,
+						"pow_difficulty": 1,
+						"num_accepted": 10,
+						"num_rejected": 0,
+						"num_stale": 0,
+						"num_blocks_found": 1
+					}
+				]
+			}
+		}
+	}
+	# "#
+	# );
+	```
+	 */
+	fn get_mining_status(&self) -> Result<MiningStatus, Error>;
 
 	/**
 	Networked version of [Owner::validate_chain](struct.Owner.html#method.validate_chain).
@@ -362,6 +418,10 @@ pub trait OwnerRpc: Sync + Send {
 impl OwnerRpc for Owner {
 	fn get_status(&self) -> Result<Status, Error> {
 		Owner::get_status(self)
+	}
+
+	fn get_mining_status(&self) -> Result<MiningStatus, Error> {
+		Owner::get_mining_status(self)
 	}
 
 	fn validate_chain(&self, assume_valid_rangeproofs_kernels: bool) -> Result<(), Error> {

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -152,23 +152,6 @@ pub struct MiningStatus {
 	pub worker_stats: Vec<WorkerInfo>,
 }
 
-impl Default for MiningStatus {
-	fn default() -> MiningStatus {
-		MiningStatus {
-			is_enabled: false,
-			is_running: false,
-			num_workers: 0,
-			block_height: 0,
-			network_difficulty: 0,
-			edge_bits: 32,
-			blocks_found: 0,
-			network_hashrate: 0.0,
-			minimum_share_difficulty: 1,
-			worker_stats: Vec::new(),
-		}
-	}
-}
-
 /// TxHashSet
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TxHashSet {
@@ -845,15 +828,6 @@ mod test {
 		let deserialized: Output = serde_json::from_str(&hex_commit).unwrap();
 		let serialized = serde_json::to_string(&deserialized).unwrap();
 		assert_eq!(serialized, hex_commit);
-	}
-
-	#[test]
-	fn mining_status_default_is_disabled() {
-		let status = MiningStatus::default();
-		assert!(!status.is_enabled);
-		assert!(!status.is_running);
-		assert_eq!(status.num_workers, 0);
-		assert!(status.worker_stats.is_empty());
 	}
 
 	#[test]

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -109,8 +109,6 @@ impl Status {
 pub struct WorkerInfo {
 	/// Unique ID for this worker
 	pub id: String,
-	/// Whether the stratum worker is currently connected
-	pub is_connected: bool,
 	/// Unix timestamp (seconds) of most recent communication with this worker
 	pub last_seen: u64,
 	/// Block height the worker started mining at
@@ -133,7 +131,8 @@ pub struct WorkerInfo {
 pub struct MiningStatus {
 	/// Whether the stratum server is enabled in config
 	pub is_enabled: bool,
-	/// Whether the stratum server is currently running
+	/// Whether the stratum server has been started. Set once at startup and
+	/// not cleared on listener failure or shutdown.
 	pub is_running: bool,
 	/// Number of currently connected workers
 	pub num_workers: usize,
@@ -149,7 +148,7 @@ pub struct MiningStatus {
 	pub network_hashrate: f64,
 	/// Minimum share difficulty requested from miners
 	pub minimum_share_difficulty: u64,
-	/// Per-worker status
+	/// Per-worker status for currently connected workers
 	pub worker_stats: Vec<WorkerInfo>,
 }
 
@@ -871,7 +870,6 @@ mod test {
 			minimum_share_difficulty: 1,
 			worker_stats: vec![WorkerInfo {
 				id: "0".into(),
-				is_connected: true,
 				last_seen: 1609459200,
 				initial_block_height: 990,
 				pow_difficulty: 1,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -104,6 +104,72 @@ impl Status {
 	}
 }
 
+/// Stratum worker statistics exposed via the Owner mining API.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct WorkerInfo {
+	/// Unique ID for this worker
+	pub id: String,
+	/// Whether the stratum worker is currently connected
+	pub is_connected: bool,
+	/// Unix timestamp (seconds) of most recent communication with this worker
+	pub last_seen: u64,
+	/// Block height the worker started mining at
+	pub initial_block_height: u64,
+	/// PoW difficulty this worker is using
+	pub pow_difficulty: u64,
+	/// Number of valid shares submitted
+	pub num_accepted: u64,
+	/// Number of invalid shares submitted
+	pub num_rejected: u64,
+	/// Number of shares submitted too late
+	pub num_stale: u64,
+	/// Number of valid blocks found by this worker
+	pub num_blocks_found: u64,
+}
+
+/// Mining / stratum status available via the Owner API (and `grin client miningstatus`).
+/// Mirrors the stats shown on the TUI mining tab so headless operators can query them.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct MiningStatus {
+	/// Whether the stratum server is enabled in config
+	pub is_enabled: bool,
+	/// Whether the stratum server is currently running
+	pub is_running: bool,
+	/// Number of currently connected workers
+	pub num_workers: usize,
+	/// Block height currently being mined
+	pub block_height: u64,
+	/// Current network difficulty
+	pub network_difficulty: u64,
+	/// Edge bits (cuckoo size) for the current network target
+	pub edge_bits: u16,
+	/// Total blocks found by all workers
+	pub blocks_found: u16,
+	/// Estimated network hashrate for the current edge_bits
+	pub network_hashrate: f64,
+	/// Minimum share difficulty requested from miners
+	pub minimum_share_difficulty: u64,
+	/// Per-worker status
+	pub worker_stats: Vec<WorkerInfo>,
+}
+
+impl Default for MiningStatus {
+	fn default() -> MiningStatus {
+		MiningStatus {
+			is_enabled: false,
+			is_running: false,
+			num_workers: 0,
+			block_height: 0,
+			network_difficulty: 0,
+			edge_bits: 32,
+			blocks_found: 0,
+			network_hashrate: 0.0,
+			minimum_share_difficulty: 1,
+			worker_stats: Vec::new(),
+		}
+	}
+}
+
 /// TxHashSet
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TxHashSet {
@@ -780,5 +846,46 @@ mod test {
 		let deserialized: Output = serde_json::from_str(&hex_commit).unwrap();
 		let serialized = serde_json::to_string(&deserialized).unwrap();
 		assert_eq!(serialized, hex_commit);
+	}
+
+	#[test]
+	fn mining_status_default_is_disabled() {
+		let status = MiningStatus::default();
+		assert!(!status.is_enabled);
+		assert!(!status.is_running);
+		assert_eq!(status.num_workers, 0);
+		assert!(status.worker_stats.is_empty());
+	}
+
+	#[test]
+	fn serialize_mining_status_roundtrip() {
+		let status = MiningStatus {
+			is_enabled: true,
+			is_running: true,
+			num_workers: 1,
+			block_height: 1000,
+			network_difficulty: 42,
+			edge_bits: 29,
+			blocks_found: 3,
+			network_hashrate: 1.5,
+			minimum_share_difficulty: 1,
+			worker_stats: vec![WorkerInfo {
+				id: "0".into(),
+				is_connected: true,
+				last_seen: 1609459200,
+				initial_block_height: 990,
+				pow_difficulty: 1,
+				num_accepted: 10,
+				num_rejected: 0,
+				num_stale: 0,
+				num_blocks_found: 1,
+			}],
+		};
+		let json = serde_json::to_string(&status).unwrap();
+		let back: MiningStatus = serde_json::from_str(&json).unwrap();
+		assert_eq!(back, status);
+		assert!(json.contains("\"is_enabled\":true"));
+		assert!(json.contains("\"num_workers\":1"));
+		assert!(json.contains("\"num_accepted\":10"));
 	}
 }

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -30,7 +30,7 @@ Or from the CLI:
 grin client miningstatus
 ```
 
-The response includes whether stratum is enabled/running, connected worker count, current block height and network difficulty, blocks found, network hashrate estimate, and per-worker share stats.
+The response includes whether stratum is enabled/running, connected worker count, current block height and network difficulty, blocks found, network hashrate estimate, and per-worker share stats for currently connected workers.
 
 ## Node API v1
 

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -11,6 +11,27 @@ This API version uses jsonrpc for its requests. It is split up in a foreign API 
 
 Basic auth passwords can be found in `.api_secret`/`.foreign_api_secret` files respectively.
 
+### Mining status (Owner API)
+
+Headless operators can query stratum mining statistics (the same data shown on the TUI mining tab) via:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "get_mining_status",
+  "params": [],
+  "id": 1
+}
+```
+
+Or from the CLI:
+
+```
+grin client miningstatus
+```
+
+The response includes whether stratum is enabled/running, connected worker count, current block height and network difficulty, blocks found, network hashrate estimate, and per-worker share stats.
+
 ## Node API v1
 
 **Note:** version 1 of the API will be deprecated in v4.0.0 and subsequently removed in v5.0.0. Users of this API are encouraged to upgrade to API v2.

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -19,7 +19,7 @@ use chrono::prelude::*;
 use grin_core::pow::Difficulty;
 use millisecond::MillisecondFormatter;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::chain::SyncStatus;
 use crate::core::core::hash::Hash;
@@ -27,6 +27,7 @@ use crate::core::ser::ProtocolVersion;
 use crate::p2p;
 use crate::p2p::Capabilities;
 use crate::util::RwLock;
+use grin_api::types::{MiningStatus, WorkerInfo};
 
 /// Server state info collection struct, to be passed around into internals
 /// and populated when required
@@ -290,5 +291,93 @@ impl Default for StratumStats {
 			minimum_share_difficulty: 1,
 			worker_stats: Vec::new(),
 		}
+	}
+}
+
+impl From<&WorkerStats> for WorkerInfo {
+	fn from(stats: &WorkerStats) -> WorkerInfo {
+		let last_seen = stats
+			.last_seen
+			.duration_since(UNIX_EPOCH)
+			.map(|d| d.as_secs())
+			.unwrap_or(0);
+		WorkerInfo {
+			id: stats.id.clone(),
+			is_connected: stats.is_connected,
+			last_seen,
+			initial_block_height: stats.initial_block_height,
+			pow_difficulty: stats.pow_difficulty,
+			num_accepted: stats.num_accepted,
+			num_rejected: stats.num_rejected,
+			num_stale: stats.num_stale,
+			num_blocks_found: stats.num_blocks_found,
+		}
+	}
+}
+
+impl From<&StratumStats> for MiningStatus {
+	fn from(stats: &StratumStats) -> MiningStatus {
+		MiningStatus {
+			is_enabled: stats.is_enabled,
+			is_running: stats.is_running,
+			num_workers: stats.num_workers,
+			block_height: stats.block_height,
+			network_difficulty: stats.network_difficulty,
+			edge_bits: stats.edge_bits,
+			blocks_found: stats.blocks_found,
+			network_hashrate: stats.network_hashrate,
+			minimum_share_difficulty: stats.minimum_share_difficulty,
+			worker_stats: stats.worker_stats.iter().map(WorkerInfo::from).collect(),
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use std::time::Duration;
+
+	#[test]
+	fn stratum_stats_to_mining_status() {
+		let mut worker = WorkerStats::default();
+		worker.id = "42".into();
+		worker.is_connected = true;
+		worker.last_seen = UNIX_EPOCH + Duration::from_secs(1_600_000_000);
+		worker.initial_block_height = 100;
+		worker.pow_difficulty = 7;
+		worker.num_accepted = 5;
+		worker.num_rejected = 1;
+		worker.num_stale = 2;
+		worker.num_blocks_found = 1;
+
+		let stats = StratumStats {
+			is_enabled: true,
+			is_running: true,
+			num_workers: 1,
+			block_height: 123,
+			network_difficulty: 999,
+			edge_bits: 29,
+			blocks_found: 4,
+			network_hashrate: 12.5,
+			minimum_share_difficulty: 3,
+			worker_stats: vec![worker],
+		};
+
+		let mining = MiningStatus::from(&stats);
+		assert!(mining.is_enabled);
+		assert!(mining.is_running);
+		assert_eq!(mining.num_workers, 1);
+		assert_eq!(mining.block_height, 123);
+		assert_eq!(mining.network_difficulty, 999);
+		assert_eq!(mining.edge_bits, 29);
+		assert_eq!(mining.blocks_found, 4);
+		assert!((mining.network_hashrate - 12.5).abs() < f64::EPSILON);
+		assert_eq!(mining.minimum_share_difficulty, 3);
+		assert_eq!(mining.worker_stats.len(), 1);
+		assert_eq!(mining.worker_stats[0].id, "42");
+		assert!(mining.worker_stats[0].is_connected);
+		assert_eq!(mining.worker_stats[0].last_seen, 1_600_000_000);
+		assert_eq!(mining.worker_stats[0].num_accepted, 5);
+		assert_eq!(mining.worker_stats[0].num_blocks_found, 1);
 	}
 }

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -303,7 +303,6 @@ impl From<&WorkerStats> for WorkerInfo {
 			.unwrap_or(0);
 		WorkerInfo {
 			id: stats.id.clone(),
-			is_connected: stats.is_connected,
 			last_seen,
 			initial_block_height: stats.initial_block_height,
 			pow_difficulty: stats.pow_difficulty,
@@ -327,7 +326,14 @@ impl From<&StratumStats> for MiningStatus {
 			blocks_found: stats.blocks_found,
 			network_hashrate: stats.network_hashrate,
 			minimum_share_difficulty: stats.minimum_share_difficulty,
-			worker_stats: stats.worker_stats.iter().map(WorkerInfo::from).collect(),
+			// worker_stats retains every worker that ever connected; only expose
+			// currently connected ones so the response does not grow unbounded.
+			worker_stats: stats
+				.worker_stats
+				.iter()
+				.filter(|w| w.is_connected)
+				.map(WorkerInfo::from)
+				.collect(),
 		}
 	}
 }
@@ -350,6 +356,10 @@ mod test {
 		worker.num_stale = 2;
 		worker.num_blocks_found = 1;
 
+		let mut disconnected = WorkerStats::default();
+		disconnected.id = "gone".into();
+		disconnected.is_connected = false;
+
 		let stats = StratumStats {
 			is_enabled: true,
 			is_running: true,
@@ -360,7 +370,7 @@ mod test {
 			blocks_found: 4,
 			network_hashrate: 12.5,
 			minimum_share_difficulty: 3,
-			worker_stats: vec![worker],
+			worker_stats: vec![worker, disconnected],
 		};
 
 		let mining = MiningStatus::from(&stats);
@@ -375,7 +385,6 @@ mod test {
 		assert_eq!(mining.minimum_share_difficulty, 3);
 		assert_eq!(mining.worker_stats.len(), 1);
 		assert_eq!(mining.worker_stats[0].id, "42");
-		assert!(mining.worker_stats[0].is_connected);
 		assert_eq!(mining.worker_stats[0].last_seen, 1_600_000_000);
 		assert_eq!(mining.worker_stats[0].num_accepted, 5);
 		assert_eq!(mining.worker_stats[0].num_blocks_found, 1);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -316,7 +316,7 @@ impl Server {
 			api::types::MiningStatus::from(&*stats)
 		});
 
-		api::node_apis(
+		api::node_apis_with_mining_stats(
 			&config.api_http_addr,
 			shared_chain.clone(),
 			tx_pool.clone(),

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -308,6 +308,14 @@ impl Server {
 			}
 		};
 
+		// Shared with stratum (started later) and Owner API `get_mining_status`.
+		let state_info = ServerStateInfo::default();
+		let stratum_stats = state_info.stratum_stats.clone();
+		let mining_stats: api::MiningStatsProvider = Arc::new(move || {
+			let stats = stratum_stats.read();
+			api::types::MiningStatus::from(&*stats)
+		});
+
 		api::node_apis(
 			&config.api_http_addr,
 			shared_chain.clone(),
@@ -319,6 +327,7 @@ impl Server {
 			tls_conf,
 			api_chan,
 			stop_state.clone(),
+			Some(mining_stats),
 		)?;
 
 		info!("Starting dandelion monitor: {}", &config.api_http_addr);
@@ -336,9 +345,7 @@ impl Server {
 			chain: shared_chain,
 			tx_pool,
 			sync_state,
-			state_info: ServerStateInfo {
-				..Default::default()
-			},
+			state_info,
 			stop_state,
 			lock_file,
 			start_time,

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -178,9 +178,6 @@ impl HTTPNodeClient {
 				if !status.worker_stats.is_empty() {
 					writeln!(e, "Workers:").unwrap();
 					for worker in status.worker_stats {
-						if !worker.is_connected {
-							continue;
-						}
 						writeln!(
 							e,
 							"  id={} accepted={} rejected={} stale={} blocks={} difficulty={}",

--- a/src/bin/cmd/client.rs
+++ b/src/bin/cmd/client.rs
@@ -19,7 +19,7 @@ use clap::ArgMatches;
 
 use crate::api::client;
 use crate::api::json_rpc::*;
-use crate::api::types::Status;
+use crate::api::types::{MiningStatus, Status};
 use crate::config::GlobalConfig;
 use crate::p2p::types::PeerInfoDisplay;
 use crate::util::file::get_first_line;
@@ -139,6 +139,72 @@ impl HTTPNodeClient {
 		e.reset().unwrap();
 	}
 
+	pub fn show_mining_status(&self) {
+		println!();
+		let title = "Grin Mining Status".to_string();
+		if term::stdout().is_none() {
+			println!("Could not open terminal");
+			return;
+		}
+		let mut t = term::stdout().unwrap();
+		let mut e = term::stdout().unwrap();
+		t.fg(term::color::MAGENTA).unwrap();
+		writeln!(t, "{}", title).unwrap();
+		writeln!(t, "--------------------------").unwrap();
+		t.reset().unwrap();
+		match self.send_json_request::<MiningStatus>("get_mining_status", &serde_json::Value::Null)
+		{
+			Ok(status) => {
+				writeln!(e, "Mining server enabled: {}", status.is_enabled).unwrap();
+				writeln!(e, "Mining server running: {}", status.is_running).unwrap();
+				writeln!(e, "Active workers:        {}", status.num_workers).unwrap();
+				writeln!(e, "Blocks found:          {}", status.blocks_found).unwrap();
+				if status.num_workers > 0 {
+					writeln!(e, "Solving block height:  {}", status.block_height).unwrap();
+					writeln!(e, "Network difficulty:    {}", status.network_difficulty).unwrap();
+					writeln!(
+						e,
+						"Network hashrate (C{}): {:.2}",
+						status.edge_bits, status.network_hashrate
+					)
+					.unwrap();
+				}
+				writeln!(
+					e,
+					"Minimum share difficulty: {}",
+					status.minimum_share_difficulty
+				)
+				.unwrap();
+				if !status.worker_stats.is_empty() {
+					writeln!(e, "Workers:").unwrap();
+					for worker in status.worker_stats {
+						if !worker.is_connected {
+							continue;
+						}
+						writeln!(
+							e,
+							"  id={} accepted={} rejected={} stale={} blocks={} difficulty={}",
+							worker.id,
+							worker.num_accepted,
+							worker.num_rejected,
+							worker.num_stale,
+							worker.num_blocks_found,
+							worker.pow_difficulty
+						)
+						.unwrap();
+					}
+				}
+			}
+			Err(_) => writeln!(
+				e,
+				"WARNING: Client failed to get mining data. Is your `grin server` offline or broken?"
+			)
+			.unwrap(),
+		};
+		e.reset().unwrap();
+		println!()
+	}
+
 	pub fn reset_chain_head(&self, hash: String) {
 		let mut e = term::stdout().unwrap();
 		let params = json!([hash]);
@@ -210,6 +276,9 @@ pub fn client_command(client_args: &ArgMatches<'_>, global_config: GlobalConfig)
 	match client_args.subcommand() {
 		("status", Some(_)) => {
 			node_client.show_status();
+		}
+		("miningstatus", Some(_)) => {
+			node_client.show_mining_status();
 		}
 		("listconnectedpeers", Some(_)) => {
 			node_client.list_connected_peers();

--- a/src/bin/grin.yml
+++ b/src/bin/grin.yml
@@ -56,6 +56,8 @@ subcommands:
       subcommands:
         - status:
             about: Current status of the Grin chain
+        - miningstatus:
+            about: Current stratum mining status and connected workers
         - listconnectedpeers:
             about: Print a list of currently connected peers
         - ban:


### PR DESCRIPTION
## Summary

Adds an Owner API endpoint for stratum mining statistics so operators running headless (no TUI) can inspect connected workers and share stats — the same data shown on the TUI mining tab.

Closes #3201

### Changes
- New `get_mining_status` method on Owner JSON-RPC (`/v2/owner`)
- New types: `MiningStatus` / `WorkerInfo` in the API crate
- Server wires live `StratumStats` into the Owner API via a provider callback
- CLI: `grin client miningstatus`
- Brief docs in `doc/api/api.md`

### Example

```json
{
  "jsonrpc": "2.0",
  "method": "get_mining_status",
  "params": [],
  "id": 1
}
```

Returns whether stratum is enabled/running, worker count, block height, network difficulty/hashrate, blocks found, and per-worker share stats for currently connected workers. When stratum is disabled, a provider still returns `is_enabled: false`. If no mining stats provider is wired into the Owner API, `get_mining_status` returns an internal error instead of masking the misconfiguration as disabled.

## Test plan
- [x] Unit tests: `MiningStatus` serde roundtrip
- [x] Unit tests: `Owner::get_mining_status` without provider (error) and with provider via generated OwnerRpc JSON-RPC handler (wire response)
- [x] Unit tests: `StratumStats` → `MiningStatus` conversion (filters disconnected workers)
- [x] `cargo check -p grin --bin grin`
- [ ] Manually: enable stratum, connect a miner, run `grin client miningstatus`