### PR TITLE
rest: use tokio channel for shutdown signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,19 +1022,16 @@ dependencies = [
 name = "grin"
 version = "5.5.1-alpha.0"
 dependencies = [
- "blake2-rfc",
  "built",
  "chrono",
  "clap",
  "ctrlc",
  "cursive",
  "cursive_table_view",
- "futures 0.3.32",
  "grin_api",
  "grin_chain",
  "grin_config",
  "grin_core",
- "grin_keychain",
  "grin_p2p",
  "grin_servers",
  "grin_store",
@@ -1046,6 +1043,7 @@ dependencies = [
  "serde_json",
  "term",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ name = "grin"
 path = "src/bin/grin.rs"
 
 [dependencies]
-blake2-rfc = "0.2"
 chrono = "0.4.11"
 thiserror = "1"
 clap = { version = "2.33", features = ["yaml"] }
@@ -29,16 +28,15 @@ cursive_table_view = "0.15.0"
 humansize = "1.1.0"
 serde = "1"
 serde_derive = "1"
-futures = "0.3.19"
 serde_json = "1"
 log = "0.4"
 term = "0.6"
+tokio = { version = "1", features = ["full"] }
 
 grin_api = { path = "./api", version = "5.5.1-alpha.0" }
 grin_config = { path = "./config", version = "5.5.1-alpha.0" }
 grin_chain = { path = "./chain", version = "5.5.1-alpha.0" }
 grin_core = { path = "./core", version = "5.5.1-alpha.0" }
-grin_keychain = { path = "./keychain", version = "5.5.1-alpha.0" }
 grin_p2p = { path = "./p2p", version = "5.5.1-alpha.0" }
 grin_servers = { path = "./servers", version = "5.5.1-alpha.0" }
 grin_util = { path = "./util", version = "5.5.1-alpha.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_derive = "1"
 serde_json = "1"
 log = "0.4"
 term = "0.6"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["sync"] }
 
 grin_api = { path = "./api", version = "5.5.1-alpha.0" }
 grin_config = { path = "./config", version = "5.5.1-alpha.0" }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -40,7 +40,6 @@ use crate::util::StopState;
 use crate::web::*;
 use crate::{p2p, ApiBody};
 use easy_jsonrpc_mw::{Handler, MaybeReply};
-use futures::channel::oneshot;
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
@@ -48,6 +47,7 @@ use serde::Serialize;
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
 use std::thread;
+use tokio::sync::mpsc;
 
 /// Listener version, providing same API but listening for requests on a
 /// port and wrapping the calls
@@ -60,7 +60,7 @@ pub fn node_apis<B, P>(
 	api_secret: Option<String>,
 	foreign_api_secret: Option<String>,
 	tls_config: Option<TLSConfig>,
-	api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+	api_chan: (mpsc::Sender<()>, mpsc::Receiver<()>),
 	stop_state: Arc<StopState>,
 ) -> Result<(), Error>
 where

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -121,7 +121,7 @@ where
 			loop {
 				thread::sleep(std::time::Duration::from_millis(100));
 				if stop_state.is_stopped() {
-					apis.stop();
+					let _ = apis.stop();
 					break;
 				}
 			}

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -163,9 +163,9 @@ impl ApiServer {
 	}
 
 	/// Stops the API server.
-	pub async fn stop(&mut self) -> bool {
+	pub fn stop(&mut self) -> bool {
 		if let Some(tx) = self.shutdown_sender.take() {
-			match tx.send(()).await {
+			match tx.try_send(()) {
 				Ok(_) => {
 					info!("API server has been stopped");
 					true

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -147,7 +147,7 @@ impl ApiServer {
 
 		if self.shutdown_sender.is_some() {
 			return Err(Error::Internal(
-				"Can't start HTTPS API server, it's running already".to_string(),
+				"Can't start API server, it's running already".to_string(),
 			));
 		}
 		self.shutdown_sender = Some(api_chan.0);

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -20,7 +20,6 @@
 
 use crate::router::{Handler, HandlerObj, ResponseFuture, Router, RouterError};
 use crate::web::response;
-use futures::channel::oneshot;
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::{Request, StatusCode};
@@ -34,6 +33,7 @@ use std::sync::Arc;
 use std::{io, thread};
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout, Duration};
 use tokio_rustls::TlsAcceptor;
 
@@ -123,7 +123,7 @@ impl TLSConfig {
 
 /// HTTP server allowing the registration of ApiEndpoint implementations.
 pub struct ApiServer {
-	shutdown_sender: Option<oneshot::Sender<()>>,
+	shutdown_sender: Option<mpsc::Sender<()>>,
 }
 
 impl ApiServer {
@@ -141,77 +141,31 @@ impl ApiServer {
 		addr: SocketAddr,
 		router: Router,
 		conf: Option<TLSConfig>,
-		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
-	) -> Result<thread::JoinHandle<()>, Error> {
-		match conf {
-			Some(conf) => self.start_tls(addr, router, conf, api_chan),
-			None => self.start_no_tls(addr, router, api_chan),
-		}
-	}
-
-	/// Starts the ApiServer at the provided address.
-	fn start_no_tls(
-		&mut self,
-		addr: SocketAddr,
-		router: Router,
-		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
-	) -> Result<thread::JoinHandle<()>, Error> {
-		if self.shutdown_sender.is_some() {
-			return Err(Error::Internal(
-				"Can't start HTTP API server, it's running already".to_string(),
-			));
-		}
-		let rx = &mut api_chan.1;
-		let tx = &mut api_chan.0;
-
-		// Jones's trick to update memory
-		let m = oneshot::channel::<()>();
-		let tx = std::mem::replace(tx, m.0);
-		self.shutdown_sender = Some(tx);
-
-		thread::Builder::new()
-			.name("apis".to_string())
-			.spawn(move || start_server(addr, router, rx, None))
-			.map_err(|_| Error::Internal("failed to spawn API thread".to_string()))
-	}
-
-	/// Starts the TLS ApiServer at the provided address.
-	fn start_tls(
-		&mut self,
-		addr: SocketAddr,
-		router: Router,
-		conf: TLSConfig,
-		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+		api_chan: (mpsc::Sender<()>, mpsc::Receiver<()>),
 	) -> Result<thread::JoinHandle<()>, Error> {
 		if self.shutdown_sender.is_some() {
 			return Err(Error::Internal(
 				"Can't start HTTPS API server, it's running already".to_string(),
 			));
 		}
+		self.shutdown_sender = Some(api_chan.0);
 
-		let rx = &mut api_chan.1;
-		let tx = &mut api_chan.0;
-
-		// Jones's trick to update memory
-		let m = oneshot::channel::<()>();
-		let tx = std::mem::replace(tx, m.0);
-		self.shutdown_sender = Some(tx);
-
-		let tls_acceptor = TlsAcceptor::from(conf.build_server_config()?);
-
+		let tls = match conf {
+			Some(conf) => Some(TlsAcceptor::from(conf.build_server_config()?)),
+			None => None,
+		};
 		thread::Builder::new()
 			.name("apis".to_string())
-			.spawn(move || start_server(addr, router, rx, Some(tls_acceptor)))
+			.spawn(move || start_server(addr, router, api_chan.1, tls))
 			.map_err(|_| Error::Internal("failed to spawn API thread".to_string()))
 	}
 
 	/// Stops the API server.
 	pub fn stop(&mut self) -> bool {
-		if self.shutdown_sender.is_some() {
-			let tx = self.shutdown_sender.as_mut().unwrap();
-			let m = oneshot::channel::<()>();
-			let tx = std::mem::replace(tx, m.0);
-			match tx.send(()) {
+		if let Some(tx) = self.shutdown_sender.take() {
+			let rt = Runtime::new().unwrap();
+			let res = rt.block_on(tx.send(()));
+			match res {
 				Ok(_) => {
 					info!("API server has been stopped");
 					true
@@ -222,7 +176,7 @@ impl ApiServer {
 				}
 			}
 		} else {
-			error!("Can't stop API server, it's not running or doesn't support stop operation");
+			error!("Can't stop API server, it's not running or already stopped");
 			false
 		}
 	}
@@ -232,7 +186,7 @@ impl ApiServer {
 fn start_server(
 	addr: SocketAddr,
 	router: Router,
-	rx: &mut oneshot::Receiver<()>,
+	rx: mpsc::Receiver<()>,
 	tls: Option<TlsAcceptor>,
 ) {
 	let server = async move {
@@ -322,8 +276,8 @@ fn start_server(
 }
 
 /// Signal for graceful API server shutdown.
-async fn shutdown_signal(rx: &mut oneshot::Receiver<()>) {
-	rx.await.ok();
+async fn shutdown_signal(mut rx: mpsc::Receiver<()>) {
+	let _ = rx.recv().await;
 }
 
 pub struct LoggingMiddleware {}

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -163,11 +163,9 @@ impl ApiServer {
 	}
 
 	/// Stops the API server.
-	pub fn stop(&mut self) -> bool {
+	pub async fn stop(&mut self) -> bool {
 		if let Some(tx) = self.shutdown_sender.take() {
-			let rt = Runtime::new().unwrap();
-			let res = rt.block_on(tx.send(()));
-			match res {
+			match tx.send(()).await {
 				Ok(_) => {
 					info!("API server has been stopped");
 					true

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -387,6 +387,6 @@ mod tests {
 		assert_eq!(call_handler("/v1/zzz/1"), 104);
 		assert_eq!(call_handler("/v1/zzz/2"), 104);
 		assert_eq!(call_handler("/v1/zzz/2/zzz"), 105);
-		server.stop();
+		let _ = server.stop();
 	}
 }

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -301,9 +301,9 @@ mod tests {
 
 	use super::*;
 	use crate::{client, ApiServer};
-	use futures::channel::oneshot;
 	use http_body_util::Full;
 	use std::net::{SocketAddr, TcpListener};
+	use tokio::sync::mpsc;
 
 	struct HandlerImpl(u16);
 
@@ -370,8 +370,7 @@ mod tests {
 		let server_port = open_port();
 		let server_addr = format!("127.0.0.1:{}", server_port);
 		let addr: SocketAddr = server_addr.parse().expect("unable to parse server address");
-		let api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>) =
-			Box::leak(Box::new(oneshot::channel::<()>()));
+		let api_chan = mpsc::channel::<()>(1);
 		server.start(addr, routes.clone(), None, api_chan).unwrap();
 
 		let call_handler = |url| {

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use grin_api as api;
 use grin_util as util;
 
@@ -89,10 +103,7 @@ fn test_start_api() {
 	let index = request_with_retry(url.as_str()).unwrap();
 	assert_eq!(index.len(), 2);
 	assert_eq!(counter.value(), 1);
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
-		assert!(server.stop().await);
-	});
+	assert!(server.stop());
 	thread::sleep(time::Duration::from_millis(1_000));
 }
 
@@ -118,10 +129,7 @@ fn test_start_api_tls() {
 	assert!(server.start(addr, router, Some(tls_conf), api_chan).is_ok());
 	let index = request_with_retry("https://yourdomain.com:14444/v1/").unwrap();
 	assert_eq!(index.len(), 2);
-	let rt = tokio::runtime::Runtime::new().unwrap();
-	rt.block_on(async {
-		assert!(server.stop().await);
-	});
+	assert!(server.stop())
 }
 
 fn request_with_retry(url: &str) -> Result<Vec<String>, Error> {

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -89,7 +89,10 @@ fn test_start_api() {
 	let index = request_with_retry(url.as_str()).unwrap();
 	assert_eq!(index.len(), 2);
 	assert_eq!(counter.value(), 1);
-	assert!(server.stop());
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		assert!(server.stop().await);
+	});
 	thread::sleep(time::Duration::from_millis(1_000));
 }
 
@@ -115,7 +118,10 @@ fn test_start_api_tls() {
 	assert!(server.start(addr, router, Some(tls_conf), api_chan).is_ok());
 	let index = request_with_retry("https://yourdomain.com:14444/v1/").unwrap();
 	assert_eq!(index.len(), 2);
-	assert!(!server.stop());
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		assert!(server.stop().await);
+	});
 }
 
 fn request_with_retry(url: &str) -> Result<Vec<String>, Error> {

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -2,13 +2,13 @@ use grin_api as api;
 use grin_util as util;
 
 use crate::api::*;
-use futures::channel::oneshot;
 use hyper::body::Incoming;
 use hyper::{Request, StatusCode};
 use std::net::{SocketAddr, TcpListener};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::{thread, time};
+use tokio::sync::mpsc;
 
 struct IndexHandler {
 	list: Vec<String>,
@@ -83,8 +83,7 @@ fn test_start_api() {
 	let server_port = open_port(server_host);
 	let server_addr = format!("{}:{}", server_host, server_port);
 	let addr: SocketAddr = server_addr.parse().expect("unable to parse server address");
-	let api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>) =
-		Box::leak(Box::new(oneshot::channel::<()>()));
+	let api_chan = mpsc::channel::<()>(1);
 	assert!(server.start(addr, router, None, api_chan).is_ok());
 	let url = format!("http://{}/v1/", server_addr);
 	let index = request_with_retry(url.as_str()).unwrap();
@@ -112,8 +111,7 @@ fn test_start_api_tls() {
 	let server_port = open_port(server_host);
 	let server_addr = format!("{}:{}", server_host, server_port);
 	let addr: SocketAddr = server_addr.parse().expect("unable to parse server address");
-	let api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>) =
-		Box::leak(Box::new(oneshot::channel::<()>()));
+	let api_chan = mpsc::channel::<()>(1);
 	assert!(server.start(addr, router, Some(tls_conf), api_chan).is_ok());
 	let index = request_with_retry("https://yourdomain.com:14444/v1/").unwrap();
 	assert_eq!(index.len(), 2);

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -50,9 +50,8 @@ use crate::p2p::types::{Capabilities, PeerAddr};
 use crate::pool;
 use crate::util::file::get_first_line;
 use crate::util::{RwLock, StopState};
-use futures::channel::oneshot;
 
-/// Arcified  thread-safe TransactionPool with type parameters used by server components
+/// Thread-safe TransactionPool with type parameters used by server components
 pub type ServerTxPool = Arc<RwLock<pool::TransactionPool<PoolToChainAdapter, PoolToNetAdapter>>>;
 
 /// Grin server holding internal structures.
@@ -85,7 +84,10 @@ impl Server {
 		config: ServerConfig,
 		stop_state: Option<Arc<StopState>>,
 		server_tx: Option<mpsc::Sender<ServerInitStatus>>,
-		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+		api_chan: (
+			tokio::sync::mpsc::Sender<()>,
+			tokio::sync::mpsc::Receiver<()>,
+		),
 	) -> Result<Server, Error> {
 		let mining_config = config.stratum_mining_config.clone();
 		let enable_test_miner = config.run_test_miner;
@@ -144,17 +146,17 @@ impl Server {
 		config: ServerConfig,
 		stop_state: Option<Arc<StopState>>,
 		server_tx: Option<mpsc::Sender<ServerInitStatus>>,
-		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+		api_chan: (
+			tokio::sync::mpsc::Sender<()>,
+			tokio::sync::mpsc::Receiver<()>,
+		),
 	) -> Result<Server, Error> {
 		// Obtain our lock_file or fail immediately with an error.
 		let lock_file = Server::one_grin_at_a_time(&config)?;
 
 		// Defaults to None (optional) in config file.
 		// This translates to false here.
-		let archive_mode = match config.archive_mode {
-			None => false,
-			Some(b) => b,
-		};
+		let archive_mode = config.archive_mode.unwrap_or_else(|| false);
 
 		let stop_state = if stop_state.is_some() {
 			stop_state.unwrap()
@@ -190,7 +192,7 @@ impl Server {
 			let _ = server_tx.send(ServerInitStatus::LoadDatabase);
 		}
 
-		let (db_migration_prog_tx, db_migration_prog_rx) = mpsc::channel::<i8>();
+		let (db_migration_prog_tx, db_migration_prog_rx) = std::sync::mpsc::channel::<i8>();
 		if let Some(ref server_tx) = server_tx {
 			let server_tx = server_tx.clone();
 			thread::spawn(move || loop {
@@ -226,7 +228,7 @@ impl Server {
 		));
 
 		// Initialize our capabilities.
-		// Currently either "default" or with optional "archive_mode" (block history) support enabled.
+		// Currently, either "default" or with optional "archive_mode" (block history) support enabled.
 		let capabilities = if let Some(true) = config.archive_mode {
 			Capabilities::default() | Capabilities::BLOCK_HIST
 		} else {
@@ -396,10 +398,9 @@ impl Server {
 	) {
 		info!("start_test_miner - start",);
 		let sync_state = self.sync_state.clone();
-		let config_wallet_url = match wallet_listener_url.clone() {
-			Some(u) => u,
-			None => String::from("http://127.0.0.1:13415"),
-		};
+		let config_wallet_url = wallet_listener_url
+			.clone()
+			.unwrap_or_else(|| String::from("http://127.0.0.1:13415"));
 
 		let config = StratumServerConfig {
 			attempt_time_per_block: 60,
@@ -543,13 +544,13 @@ impl Server {
 		Ok(ServerStats {
 			peer_count: self.peer_count(),
 			chain_stats: head_stats,
-			header_stats: header_stats,
+			header_stats,
 			sync_status: self.sync_state.status(),
-			disk_usage_gb: disk_usage_gb,
-			stratum_stats: stratum_stats,
-			peer_stats: peer_stats,
-			diff_stats: diff_stats,
-			tx_stats: tx_stats,
+			disk_usage_gb,
+			stratum_stats,
+			peer_stats,
+			diff_stats,
+			tx_stats,
 		})
 	}
 

--- a/src/bin/cmd/server.rs
+++ b/src/bin/cmd/server.rs
@@ -13,32 +13,32 @@
 // limitations under the License.
 
 /// Grin server commands processing
+use clap::ArgMatches;
 use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
-
-use clap::ArgMatches;
 
 use crate::config::GlobalConfig;
 use crate::p2p::Seeding;
 use crate::servers;
 use crate::tui::ui;
-use futures::channel::oneshot;
 use grin_p2p::msg::PeerAddrs;
 use grin_p2p::PeerAddr;
 use grin_servers::common::types::ServerInitStatus;
 use grin_servers::Server;
 use grin_util::logger::LogEntry;
 use grin_util::StopState;
-use std::sync::mpsc;
 
 /// Start node server at TUI or non-TUI mode.
 pub fn start_server(
 	config: servers::ServerConfig,
 	logs_rx: Option<mpsc::Receiver<LogEntry>>,
-	api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+	api_chan: (
+		tokio::sync::mpsc::Sender<()>,
+		tokio::sync::mpsc::Receiver<()>,
+	),
 ) {
 	let exit_code = if config.run_tui.unwrap_or(false) {
 		warn!("Starting GRIN in UI mode...");
@@ -110,7 +110,10 @@ pub fn server_command(
 	server_args: Option<&ArgMatches<'_>>,
 	global_config: GlobalConfig,
 	logs_rx: Option<mpsc::Receiver<LogEntry>>,
-	api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
+	api_chan: (
+		tokio::sync::mpsc::Sender<()>,
+		tokio::sync::mpsc::Receiver<()>,
+	),
 ) -> i32 {
 	// just get defaults from the global config
 	let mut server_config = global_config.members.as_ref().unwrap().server.clone();

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -24,7 +24,6 @@ use crate::core::global;
 use crate::tools::check_seeds;
 use crate::util::init_logger;
 use clap::App;
-use futures::channel::oneshot;
 use grin_api as api;
 use grin_chain as chain;
 use grin_config as config;
@@ -182,8 +181,7 @@ fn real_main() -> i32 {
 		}
 	}
 
-	let api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>) =
-		Box::leak(Box::new(oneshot::channel::<()>()));
+	let api_chan = tokio::sync::mpsc::channel::<()>(1);
 
 	let (logs_tx, logs_rx) = if logging_config.tui_running.unwrap() {
 		let (logs_tx, logs_rx) = mpsc::sync_channel::<LogEntry>(200);


### PR DESCRIPTION
- use `tokio` channel for shutdown signal, so it can be called remotely from another thread