### PR TITLE
rest: install rustls provider at single place

### DIFF
--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -143,6 +143,7 @@ impl ApiServer {
 		conf: Option<TLSConfig>,
 		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
 	) -> Result<thread::JoinHandle<()>, Error> {
+		let _ = rustls::crypto::ring::default_provider().install_default();
 		match conf {
 			Some(conf) => self.start_tls(addr, router, conf, api_chan),
 			None => self.start_no_tls(addr, router, api_chan),

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -143,6 +143,7 @@ impl ApiServer {
 		conf: Option<TLSConfig>,
 		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
 	) -> Result<thread::JoinHandle<()>, Error> {
+		let _ = rustls::crypto::ring::default_provider().install_default();
 		match conf {
 			Some(conf) => self.start_tls(addr, router, conf, api_chan),
 			None => self.start_no_tls(addr, router, api_chan),
@@ -197,7 +198,6 @@ impl ApiServer {
 		let tx = std::mem::replace(tx, m.0);
 		self.shutdown_sender = Some(tx);
 
-		let _ = rustls::crypto::ring::default_provider().install_default();
 		let tls_acceptor = TlsAcceptor::from(conf.build_server_config()?);
 
 		thread::Builder::new()

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -143,7 +143,6 @@ impl ApiServer {
 		conf: Option<TLSConfig>,
 		api_chan: &'static mut (oneshot::Sender<()>, oneshot::Receiver<()>),
 	) -> Result<thread::JoinHandle<()>, Error> {
-		let _ = rustls::crypto::ring::default_provider().install_default();
 		match conf {
 			Some(conf) => self.start_tls(addr, router, conf, api_chan),
 			None => self.start_no_tls(addr, router, api_chan),
@@ -198,6 +197,9 @@ impl ApiServer {
 		let tx = std::mem::replace(tx, m.0);
 		self.shutdown_sender = Some(tx);
 
+		rustls::crypto::ring::default_provider()
+			.install_default()
+			.map_err(|e| Error::Internal(format!("{:?}", e)))?;
 		let tls_acceptor = TlsAcceptor::from(conf.build_server_config()?);
 
 		thread::Builder::new()

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -197,9 +197,7 @@ impl ApiServer {
 		let tx = std::mem::replace(tx, m.0);
 		self.shutdown_sender = Some(tx);
 
-		rustls::crypto::ring::default_provider()
-			.install_default()
-			.map_err(|e| Error::Internal(format!("{:?}", e)))?;
+		let _ = rustls::crypto::ring::default_provider().install_default();
 		let tls_acceptor = TlsAcceptor::from(conf.build_server_config()?);
 
 		thread::Builder::new()

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -347,7 +347,6 @@ mod tests {
 
 	#[test]
 	fn test_get() {
-		let _ = rustls::crypto::ring::default_provider().install_default();
 		util::init_test_logger();
 		let mut routes = Router::new();
 		routes

--- a/api/tests/rest.rs
+++ b/api/tests/rest.rs
@@ -73,7 +73,6 @@ fn open_port(host: &str) -> u16 {
 
 #[test]
 fn test_start_api() {
-	let _ = rustls::crypto::ring::default_provider().install_default();
 	util::init_test_logger();
 	let mut server = ApiServer::new();
 	let mut router = build_router();
@@ -102,7 +101,6 @@ fn test_start_api() {
 #[ignore]
 #[test]
 fn test_start_api_tls() {
-	let _ = rustls::crypto::ring::default_provider().install_default();
 	util::init_test_logger();
 	let tls_conf = TLSConfig::new(
 		"tests/fullchain.pem".to_string(),


### PR DESCRIPTION
To avoid installing at multiple places and manually when using this crate.