### PR TITLE
Show node runtime in status view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "log",
+ "millisecond",
  "rand 0.6.5",
  "serde",
  "serde_derive",
@@ -1903,6 +1904,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "millisecond"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63befb9f9db85caa92fe71eb3e7a42d76b90b38914f0356983d726442825770"
 
 [[package]]
 name = "miniz_oxide"

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -25,6 +25,7 @@ async-stream = "0.3"
 walkdir = "2.3.1"
 hyper-util = { version = "0.1.20", features = ["client-legacy"] }
 http-body-util = "0.1.3"
+millisecond = "0.15"
 
 grin_api = { path = "../api", version = "5.5.1-alpha.0" }
 grin_chain = { path = "../chain", version = "5.5.1-alpha.0" }

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -15,19 +15,18 @@
 //! Server stat collection types, to be used by tests, logging or GUI/TUI
 //! to collect information about server status
 
-use crate::util::RwLock;
+use chrono::prelude::*;
+use grin_core::pow::Difficulty;
+use millisecond::MillisecondFormatter;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use crate::chain::SyncStatus;
 use crate::core::core::hash::Hash;
 use crate::core::ser::ProtocolVersion;
-
-use chrono::prelude::*;
-
-use crate::chain::SyncStatus;
 use crate::p2p;
 use crate::p2p::Capabilities;
-use grin_core::pow::Difficulty;
+use crate::util::RwLock;
 
 /// Server state info collection struct, to be passed around into internals
 /// and populated when required
@@ -68,6 +67,14 @@ pub struct ServerStats {
 	pub tx_stats: Option<TxStats>,
 	/// Disk usage in GB
 	pub disk_usage_gb: String,
+}
+
+impl ServerStats {
+	/// Formatted uptime (i.e.: 1y 17d 5h 10m 48s).
+	pub fn uptime_format(&self) -> String {
+		let time = millisecond::Millisecond::from_millis(self.uptime_seconds * 1000);
+		time.pretty()
+	}
 }
 
 /// Chain Statistics

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -48,6 +48,8 @@ impl Default for ServerStateInfo {
 /// consumers might be interested in, such as test results or UI
 #[derive(Debug, Clone)]
 pub struct ServerStats {
+	/// Server runtime in seconds
+	pub uptime_seconds: u64,
 	/// Number of peers
 	pub peer_count: u32,
 	/// Chain head

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -47,7 +47,7 @@ impl Default for ServerStateInfo {
 /// consumers might be interested in, such as test results or UI
 #[derive(Debug, Clone)]
 pub struct ServerStats {
-	/// Server runtime in seconds
+	/// Server uptime in seconds
 	pub uptime_seconds: u64,
 	/// Number of peers
 	pub peer_count: u32,
@@ -72,7 +72,7 @@ pub struct ServerStats {
 impl ServerStats {
 	/// Formatted uptime (i.e.: 1y 17d 5h 10m 48s).
 	pub fn uptime_format(&self) -> String {
-		let time = millisecond::Millisecond::from_millis(self.uptime_seconds * 1000);
+		let time = millisecond::Millisecond::from_secs(self.uptime_seconds);
 		time.pretty()
 	}
 }

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -72,6 +72,7 @@ pub struct Server {
 	pub stop_state: Arc<StopState>,
 	/// Maintain a lock_file so we do not run multiple Grin nodes from same dir.
 	lock_file: Arc<File>,
+	start_time: time::Instant,
 	connect_thread: Option<JoinHandle<()>>,
 	sync_thread: JoinHandle<()>,
 	dandelion_thread: JoinHandle<()>,
@@ -153,6 +154,7 @@ impl Server {
 	) -> Result<Server, Error> {
 		// Obtain our lock_file or fail immediately with an error.
 		let lock_file = Server::one_grin_at_a_time(&config)?;
+		let start_time = time::Instant::now();
 
 		// Defaults to None (optional) in config file.
 		// This translates to false here.
@@ -339,6 +341,7 @@ impl Server {
 			},
 			stop_state,
 			lock_file,
+			start_time,
 			connect_thread,
 			sync_thread,
 			dandelion_thread,
@@ -542,6 +545,7 @@ impl Server {
 		let disk_usage_gb = format!("{:.*}", 3, (disk_usage_bytes as f64 / 1_000_000_000_f64));
 
 		Ok(ServerStats {
+			uptime_seconds: self.start_time.elapsed().as_secs(),
 			peer_count: self.peer_count(),
 			chain_stats: head_stats,
 			header_stats,

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -182,7 +182,7 @@ impl TUIStatusView {
 			LinearLayout::new(Orientation::Vertical)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
-						.child(TextView::new("Runtime (s):                  "))
+						.child(TextView::new("Uptime:                       "))
 						.child(TextView::new("0").with_name("basic_runtime_seconds")),
 				)
 				.child(
@@ -298,7 +298,7 @@ impl TUIStatusListener for TUIStatusView {
 		let basic_status = TUIStatusView::update_sync_status(stats.sync_status);
 
 		c.call_on_name("basic_runtime_seconds", |t: &mut TextView| {
-			t.set_content(stats.uptime_seconds.to_string());
+			t.set_content(stats.uptime_format());
 		});
 		c.call_on_name("basic_current_status", |t: &mut TextView| {
 			t.set_content(basic_status);

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -182,6 +182,11 @@ impl TUIStatusView {
 			LinearLayout::new(Orientation::Vertical)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
+						.child(TextView::new("Runtime (s):                  "))
+						.child(TextView::new("0").with_name("basic_runtime_seconds")),
+				)
+				.child(
+					LinearLayout::new(Orientation::Horizontal)
 						.child(TextView::new("Current Status:               "))
 						.child(TextView::new("Starting").with_name("basic_current_status")),
 				)
@@ -292,6 +297,9 @@ impl TUIStatusListener for TUIStatusView {
 	fn update(c: &mut Cursive, stats: &ServerStats) {
 		let basic_status = TUIStatusView::update_sync_status(stats.sync_status);
 
+		c.call_on_name("basic_runtime_seconds", |t: &mut TextView| {
+			t.set_content(stats.uptime_seconds.to_string());
+		});
 		c.call_on_name("basic_current_status", |t: &mut TextView| {
 			t.set_content(basic_status);
 		});

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -183,7 +183,7 @@ impl TUIStatusView {
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
 						.child(TextView::new("Uptime:                       "))
-						.child(TextView::new("0").with_name("basic_runtime_seconds")),
+						.child(TextView::new("0").with_name("basic_uptime")),
 				)
 				.child(
 					LinearLayout::new(Orientation::Horizontal)
@@ -297,7 +297,7 @@ impl TUIStatusListener for TUIStatusView {
 	fn update(c: &mut Cursive, stats: &ServerStats) {
 		let basic_status = TUIStatusView::update_sync_status(stats.sync_status);
 
-		c.call_on_name("basic_runtime_seconds", |t: &mut TextView| {
+		c.call_on_name("basic_uptime", |t: &mut TextView| {
 			t.set_content(stats.uptime_format());
 		});
 		c.call_on_name("basic_current_status", |t: &mut TextView| {


### PR DESCRIPTION
4/4: PIBD PR #3835 

Adds the node runtime in seconds to the TUI status view.