### PR TITLE
Better init of global variables

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -178,13 +178,13 @@ thread_local! {
 
 /// One time initialization of the global chain_type.
 /// Will panic if we attempt to re-initialize this (via OneTime).
-pub fn init_global_chain_type(new_type: ChainTypes) {
-	GLOBAL_CHAIN_TYPE.init(new_type)
+pub fn init_global_chain_type(new_type: ChainTypes) -> bool {
+	GLOBAL_CHAIN_TYPE.init_if_unset(new_type)
 }
 
 /// Set the global chain_type using an override
 pub fn set_global_chain_type(new_type: ChainTypes) {
-	GLOBAL_CHAIN_TYPE.set(new_type, true);
+	GLOBAL_CHAIN_TYPE.set(new_type);
 }
 
 /// Set the chain type on a per-thread basis via thread_local storage.
@@ -194,16 +194,15 @@ pub fn set_local_chain_type(new_type: ChainTypes) {
 
 /// Get the chain type via thread_local, fallback to global chain_type.
 pub fn get_chain_type() -> ChainTypes {
-	CHAIN_TYPE.with(|chain_type| match chain_type.get() {
-		None => {
+	CHAIN_TYPE.with(|chain_type| {
+		chain_type.get().unwrap_or_else(|| {
 			if !GLOBAL_CHAIN_TYPE.is_init() {
 				panic!("GLOBAL_CHAIN_TYPE and CHAIN_TYPE unset. Consider set_local_chain_type() in tests.");
 			}
 			let chain_type = GLOBAL_CHAIN_TYPE.borrow();
 			set_local_chain_type(chain_type);
 			chain_type
-		}
-		Some(chain_type) => chain_type,
+		})
 	})
 }
 
@@ -218,37 +217,37 @@ pub fn get_genesis_block() -> Block {
 
 /// One time initialization of the global future time limit
 /// Will panic if we attempt to re-initialize this (via OneTime).
-pub fn init_global_future_time_limit(new_ftl: u64) {
-	GLOBAL_FUTURE_TIME_LIMIT.init(new_ftl)
+pub fn init_global_future_time_limit(new_ftl: u64) -> bool {
+	GLOBAL_FUTURE_TIME_LIMIT.init_if_unset(new_ftl)
 }
 
 /// The global future time limit may be reset again using the override
 pub fn set_global_future_time_limit(new_ftl: u64) {
-	GLOBAL_FUTURE_TIME_LIMIT.set(new_ftl, true)
+	GLOBAL_FUTURE_TIME_LIMIT.set(new_ftl)
 }
 
 /// One time initialization of the global accept fee base
 /// Will panic if we attempt to re-initialize this (via OneTime).
-pub fn init_global_accept_fee_base(new_base: u64) {
-	GLOBAL_ACCEPT_FEE_BASE.init(new_base)
+pub fn init_global_accept_fee_base(new_base: u64) -> bool {
+	GLOBAL_ACCEPT_FEE_BASE.init_if_unset(new_base)
 }
 
 /// The global accept fee base may be reset using override.
 pub fn set_global_accept_fee_base(new_base: u64) {
-	GLOBAL_ACCEPT_FEE_BASE.set(new_base, true)
+	GLOBAL_ACCEPT_FEE_BASE.set(new_base)
 }
 
 /// Set the accept fee base on a per-thread basis via thread_local storage.
 pub fn set_local_accept_fee_base(new_base: u64) {
-	ACCEPT_FEE_BASE.with(|base| base.set(Some(new_base)))
+	ACCEPT_FEE_BASE.set(Some(new_base))
 }
 
 /// Accept Fee Base
 /// Look at thread local config first. If not set fallback to global config.
 /// Default to grin-cent/20 if global config unset.
 pub fn get_accept_fee_base() -> u64 {
-	ACCEPT_FEE_BASE.with(|base| match base.get() {
-		None => {
+	ACCEPT_FEE_BASE.with(|base| {
+		base.get().unwrap_or_else(|| {
 			let base = if GLOBAL_ACCEPT_FEE_BASE.is_init() {
 				GLOBAL_ACCEPT_FEE_BASE.borrow()
 			} else {
@@ -256,22 +255,21 @@ pub fn get_accept_fee_base() -> u64 {
 			};
 			set_local_accept_fee_base(base);
 			base
-		}
-		Some(base) => base,
+		})
 	})
 }
 
 /// Set the future time limit on a per-thread basis via thread_local storage.
 pub fn set_local_future_time_limit(new_ftl: u64) {
-	FUTURE_TIME_LIMIT.with(|ftl| ftl.set(Some(new_ftl)))
+	FUTURE_TIME_LIMIT.set(Some(new_ftl))
 }
 
 /// Future Time Limit (FTL)
 /// Look at thread local config first. If not set fallback to global config.
 /// Default to false if global config unset.
 pub fn get_future_time_limit() -> u64 {
-	FUTURE_TIME_LIMIT.with(|ftl| match ftl.get() {
-		None => {
+	FUTURE_TIME_LIMIT.with(|ftl| {
+		ftl.get().unwrap_or_else(|| {
 			let ftl = if GLOBAL_FUTURE_TIME_LIMIT.is_init() {
 				GLOBAL_FUTURE_TIME_LIMIT.borrow()
 			} else {
@@ -279,25 +277,24 @@ pub fn get_future_time_limit() -> u64 {
 			};
 			set_local_future_time_limit(ftl);
 			ftl
-		}
-		Some(ftl) => ftl,
+		})
 	})
 }
 
 /// One time initialization of the global NRD feature flag.
 /// Will panic if we attempt to re-initialize this (via OneTime).
-pub fn init_global_nrd_enabled(enabled: bool) {
-	GLOBAL_NRD_FEATURE_ENABLED.init(enabled)
+pub fn init_global_nrd_enabled(enabled: bool) -> bool {
+	GLOBAL_NRD_FEATURE_ENABLED.init_if_unset(enabled)
 }
 
 /// Set the global NRD feature flag using override.
 pub fn set_global_nrd_enabled(enabled: bool) {
-	GLOBAL_NRD_FEATURE_ENABLED.set(enabled, true)
+	GLOBAL_NRD_FEATURE_ENABLED.set(enabled)
 }
 
 /// Explicitly enable the local NRD feature flag.
 pub fn set_local_nrd_enabled(enabled: bool) {
-	NRD_FEATURE_ENABLED.with(|flag| flag.set(Some(enabled)))
+	NRD_FEATURE_ENABLED.set(Some(enabled))
 }
 
 /// Is the NRD feature flag enabled?

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -177,7 +177,7 @@ thread_local! {
 }
 
 /// One time initialization of the global chain_type.
-/// Will panic if we attempt to re-initialize this (via OneTime).
+/// Returns `false` if already was initialized.
 pub fn init_global_chain_type(new_type: ChainTypes) -> bool {
 	GLOBAL_CHAIN_TYPE.init_if_unset(new_type)
 }

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -184,7 +184,7 @@ pub fn init_global_chain_type(new_type: ChainTypes) -> bool {
 
 /// Set the global chain_type using an override
 pub fn set_global_chain_type(new_type: ChainTypes) {
-	GLOBAL_CHAIN_TYPE.set(new_type);
+	GLOBAL_CHAIN_TYPE.set(new_type, true);
 }
 
 /// Set the chain type on a per-thread basis via thread_local storage.
@@ -216,25 +216,25 @@ pub fn get_genesis_block() -> Block {
 }
 
 /// One time initialization of the global future time limit
-/// Will panic if we attempt to re-initialize this (via OneTime).
+/// Returns `false` if already was initialized.
 pub fn init_global_future_time_limit(new_ftl: u64) -> bool {
 	GLOBAL_FUTURE_TIME_LIMIT.init_if_unset(new_ftl)
 }
 
 /// The global future time limit may be reset again using the override
 pub fn set_global_future_time_limit(new_ftl: u64) {
-	GLOBAL_FUTURE_TIME_LIMIT.set(new_ftl)
+	GLOBAL_FUTURE_TIME_LIMIT.set(new_ftl, true)
 }
 
 /// One time initialization of the global accept fee base
-/// Will panic if we attempt to re-initialize this (via OneTime).
+/// Returns `false` if already was initialized.
 pub fn init_global_accept_fee_base(new_base: u64) -> bool {
 	GLOBAL_ACCEPT_FEE_BASE.init_if_unset(new_base)
 }
 
 /// The global accept fee base may be reset using override.
 pub fn set_global_accept_fee_base(new_base: u64) {
-	GLOBAL_ACCEPT_FEE_BASE.set(new_base)
+	GLOBAL_ACCEPT_FEE_BASE.set(new_base, true)
 }
 
 /// Set the accept fee base on a per-thread basis via thread_local storage.
@@ -282,14 +282,14 @@ pub fn get_future_time_limit() -> u64 {
 }
 
 /// One time initialization of the global NRD feature flag.
-/// Will panic if we attempt to re-initialize this (via OneTime).
+/// Returns `false` if already was initialized.
 pub fn init_global_nrd_enabled(enabled: bool) -> bool {
 	GLOBAL_NRD_FEATURE_ENABLED.init_if_unset(enabled)
 }
 
 /// Set the global NRD feature flag using override.
 pub fn set_global_nrd_enabled(enabled: bool) {
-	GLOBAL_NRD_FEATURE_ENABLED.set(enabled)
+	GLOBAL_NRD_FEATURE_ENABLED.set(enabled, true)
 }
 
 /// Explicitly enable the local NRD feature flag.

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -111,11 +111,7 @@ where
 		Ok(self.chain().head()?.height)
 	}
 
-	fn transaction_received(
-		&self,
-		tx: core::Transaction,
-		stem: bool,
-	) -> Result<bool, chain::Error> {
+	fn transaction_received(&self, tx: Transaction, stem: bool) -> Result<bool, chain::Error> {
 		// nothing much we can do with a new transaction while syncing
 		if self.sync_state.is_syncing() {
 			return Ok(true);
@@ -141,7 +137,7 @@ where
 		}
 	}
 
-	fn get_transaction(&self, kernel_hash: Hash) -> Option<core::Transaction> {
+	fn get_transaction(&self, kernel_hash: Hash) -> Option<Transaction> {
 		self.tx_pool.read().retrieve_tx_by_kernel_hash(kernel_hash)
 	}
 
@@ -167,7 +163,7 @@ where
 		&self,
 		b: core::Block,
 		peer_info: &PeerInfo,
-		opts: chain::Options,
+		opts: Options,
 	) -> Result<bool, chain::Error> {
 		if self.chain().is_known(&b.header).is_err() {
 			return Ok(true);
@@ -187,7 +183,7 @@ where
 
 	fn compact_block_received(
 		&self,
-		cb: core::CompactBlock,
+		cb: CompactBlock,
 		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		// No need to process this compact block if we have previously accepted the _full block_.
@@ -222,7 +218,7 @@ where
 							hook.on_block_received(&block, &peer_info.addr);
 						}
 					}
-					self.process_block(block, peer_info, chain::Options::NONE)
+					self.process_block(block, peer_info, Options::NONE)
 				}
 				Err(e) => {
 					debug!("Invalid hydrated block {}: {:?}", cb_hash, e);
@@ -231,10 +227,7 @@ where
 			}
 		} else {
 			// check at least the header is valid before hydrating
-			if let Err(e) = self
-				.chain()
-				.process_block_header(&cb.header, chain::Options::NONE)
-			{
+			if let Err(e) = self.chain().process_block_header(&cb.header, Options::NONE) {
 				debug!("Invalid compact block header {}: {:?}", cb_hash, e);
 				return Ok(!e.is_bad_data());
 			}
@@ -253,7 +246,7 @@ where
 
 			// If we have missing kernels then we know we cannot hydrate this compact block.
 			if !missing_short_ids.is_empty() {
-				self.request_block(&cb.header, peer_info, chain::Options::NONE);
+				self.request_block(&cb.header, peer_info, Options::NONE);
 				return Ok(true);
 			}
 
@@ -280,10 +273,10 @@ where
 						block.header.height,
 						block.inputs().version_str(),
 					);
-					self.process_block(block, peer_info, chain::Options::NONE)
+					self.process_block(block, peer_info, Options::NONE)
 				} else if self.sync_state.status() == SyncStatus::NoSync {
 					debug!("adapter: block invalid after hydration, requesting full block");
-					self.request_block(&cb.header, peer_info, chain::Options::NONE);
+					self.request_block(&cb.header, peer_info, Options::NONE);
 					Ok(true)
 				} else {
 					debug!("block invalid after hydration, ignoring it, cause still syncing");
@@ -296,11 +289,7 @@ where
 		}
 	}
 
-	fn header_received(
-		&self,
-		bh: core::BlockHeader,
-		peer_info: &PeerInfo,
-	) -> Result<bool, chain::Error> {
+	fn header_received(&self, bh: BlockHeader, peer_info: &PeerInfo) -> Result<bool, chain::Error> {
 		// No need to process this header if we have previously accepted the _full block_.
 		if self.chain().block_exists(bh.hash())? {
 			return Ok(true);
@@ -313,7 +302,7 @@ where
 
 		// pushing the new block header through the header chain pipeline
 		// we will go ask for the block if this is a new header
-		let res = self.chain().process_block_header(&bh, chain::Options::NONE);
+		let res = self.chain().process_block_header(&bh, Options::NONE);
 
 		if let Err(e) = res {
 			debug!("Block header {} refused by chain: {:?}", bh.hash(), e);
@@ -336,7 +325,7 @@ where
 
 	fn headers_received(
 		&self,
-		bhs: &[core::BlockHeader],
+		bhs: &[BlockHeader],
 		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		info!(
@@ -362,7 +351,7 @@ where
 		self.process_header_batch(bhs, sync_head)
 	}
 
-	fn locate_headers(&self, locator: &[Hash]) -> Result<Vec<core::BlockHeader>, chain::Error> {
+	fn locate_headers(&self, locator: &[Hash]) -> Result<Vec<BlockHeader>, chain::Error> {
 		debug!("locator: {:?}", locator);
 
 		let header = match self.find_common_header(locator) {
@@ -401,7 +390,7 @@ where
 		&self,
 		id: SegmentIdentifier,
 		peer_info: &PeerInfo,
-	) -> Result<Option<Vec<core::BlockHeader>>, chain::Error> {
+	) -> Result<Option<Vec<BlockHeader>>, chain::Error> {
 		if !peer_info
 			.capabilities
 			.contains(p2p::Capabilities::PIHD_HIST)
@@ -482,7 +471,7 @@ where
 		}
 	}
 
-	fn txhashset_archive_header(&self) -> Result<core::BlockHeader, chain::Error> {
+	fn txhashset_archive_header(&self) -> Result<BlockHeader, chain::Error> {
 		self.chain().txhashset_archive_header()
 	}
 
@@ -672,7 +661,7 @@ where
 	fn receive_header_segment(
 		&self,
 		id: SegmentIdentifier,
-		headers: &[core::BlockHeader],
+		headers: &[BlockHeader],
 		peer_info: &PeerInfo,
 	) -> Result<HeaderSegmentAcceptance, chain::Error> {
 		if id.height != p2p::PIHD_HEADER_SEGMENT_HEIGHT {
@@ -841,8 +830,8 @@ where
 
 	/// Initialize a NetToChainAdaptor with reference to a Peers object.
 	/// Should only be called once.
-	pub fn init(&self, peers: Arc<p2p::Peers>) {
-		self.peers.init(Arc::downgrade(&peers));
+	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
+		self.peers.init_if_unset(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1171,7 +1160,7 @@ where
 		&self,
 		b: core::Block,
 		peer_info: &PeerInfo,
-		opts: chain::Options,
+		opts: Options,
 	) -> Result<bool, chain::Error> {
 		// We cannot process blocks earlier than the horizon so check for this here.
 		{
@@ -1206,7 +1195,7 @@ where
 								&& !self.sync_state.is_syncing()
 							{
 								debug!("process_block: received an orphan block, checking the parent: {:}", previous.hash());
-								self.request_block(&previous, peer_info, chain::Options::NONE)
+								self.request_block(&previous, peer_info, Options::NONE)
 							}
 						}
 						Ok(true)
@@ -1354,7 +1343,7 @@ where
 		}
 
 		// Suppress broadcast of new blocks received during sync.
-		if !opts.contains(chain::Options::SYNC) {
+		if !opts.contains(Options::SYNC) {
 			// If we mined the block then we want to broadcast the compact block.
 			// If we received the block from another node then broadcast "header first"
 			// to minimize network traffic.
@@ -1369,7 +1358,7 @@ where
 		}
 
 		// Reconcile the txpool against the new block *after* we have broadcast it too our peers.
-		// This may be slow and we do not want to delay block propagation.
+		// This may be slow, and we do not want to delay block propagation.
 		// We only want to reconcile the txpool against the new block *if* total work has increased.
 
 		if status.is_next() || status.is_reorg() {
@@ -1401,14 +1390,14 @@ where
 		ChainToPoolAndNetAdapter {
 			tx_pool,
 			peers: OneTime::new(),
-			hooks: hooks,
+			hooks,
 		}
 	}
 
 	/// Initialize a ChainToPoolAndNetAdapter instance with handle to a Peers
 	/// object. Should only be called once.
-	pub fn init(&self, peers: Arc<p2p::Peers>) {
-		self.peers.init(Arc::downgrade(&peers));
+	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
+		self.peers.init_if_unset(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1499,8 +1488,8 @@ impl PoolToNetAdapter {
 	}
 
 	/// Setup the p2p server on the adapter
-	pub fn init(&self, peers: Arc<p2p::Peers>) {
-		self.peers.init(Arc::downgrade(&peers));
+	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
+		self.peers.init_if_unset(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1528,8 +1517,8 @@ impl PoolToChainAdapter {
 	}
 
 	/// Set the pool adapter's chain. Should only be called once.
-	pub fn set_chain(&self, chain_ref: Arc<chain::Chain>) {
-		self.chain.init(Arc::downgrade(&chain_ref));
+	pub fn set_chain(&self, chain_ref: Arc<chain::Chain>) -> bool {
+		self.chain.init_if_unset(Arc::downgrade(&chain_ref))
 	}
 
 	fn chain(&self) -> Arc<chain::Chain> {
@@ -1540,7 +1529,32 @@ impl PoolToChainAdapter {
 	}
 }
 
-impl pool::BlockChain for PoolToChainAdapter {
+impl BlockChain for PoolToChainAdapter {
+	fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), pool::PoolError> {
+		self.chain()
+			.verify_coinbase_maturity(inputs)
+			.map_err(|_| pool::PoolError::ImmatureCoinbase)
+	}
+
+	fn verify_tx_lock_height(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
+		self.chain()
+			.verify_tx_lock_height(tx)
+			.map_err(|_| pool::PoolError::ImmatureTransaction)
+	}
+
+	fn validate_tx(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
+		self.chain()
+			.validate_tx(tx)
+			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
+	}
+
+	fn validate_inputs(&self, inputs: &Inputs) -> Result<Vec<OutputIdentifier>, pool::PoolError> {
+		self.chain()
+			.validate_inputs(inputs)
+			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
+			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
+	}
+
 	fn chain_head(&self) -> Result<BlockHeader, pool::PoolError> {
 		self.chain()
 			.head_header()
@@ -1557,30 +1571,5 @@ impl pool::BlockChain for PoolToChainAdapter {
 		self.chain()
 			.get_block_sums(hash)
 			.map_err(|_| pool::PoolError::Other("failed to get block_sums".to_string()))
-	}
-
-	fn validate_tx(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		self.chain()
-			.validate_tx(tx)
-			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
-	}
-
-	fn validate_inputs(&self, inputs: &Inputs) -> Result<Vec<OutputIdentifier>, pool::PoolError> {
-		self.chain()
-			.validate_inputs(inputs)
-			.map(|outputs| outputs.into_iter().map(|(out, _)| out).collect::<Vec<_>>())
-			.map_err(|_| pool::PoolError::Other("failed to validate tx".to_string()))
-	}
-
-	fn verify_coinbase_maturity(&self, inputs: &Inputs) -> Result<(), pool::PoolError> {
-		self.chain()
-			.verify_coinbase_maturity(inputs)
-			.map_err(|_| pool::PoolError::ImmatureCoinbase)
-	}
-
-	fn verify_tx_lock_height(&self, tx: &Transaction) -> Result<(), pool::PoolError> {
-		self.chain()
-			.verify_tx_lock_height(tx)
-			.map_err(|_| pool::PoolError::ImmatureTransaction)
 	}
 }

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -830,8 +830,8 @@ where
 
 	/// Initialize a NetToChainAdaptor with reference to a Peers object.
 	/// Should only be called once.
-	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
-		self.peers.init_if_unset(Arc::downgrade(&peers))
+	pub fn init(&self, peers: Arc<p2p::Peers>) {
+		self.peers.init(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1396,8 +1396,8 @@ where
 
 	/// Initialize a ChainToPoolAndNetAdapter instance with handle to a Peers
 	/// object. Should only be called once.
-	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
-		self.peers.init_if_unset(Arc::downgrade(&peers))
+	pub fn init(&self, peers: Arc<p2p::Peers>) {
+		self.peers.init(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1488,8 +1488,8 @@ impl PoolToNetAdapter {
 	}
 
 	/// Setup the p2p server on the adapter
-	pub fn init(&self, peers: Arc<p2p::Peers>) -> bool {
-		self.peers.init_if_unset(Arc::downgrade(&peers))
+	pub fn init(&self, peers: Arc<p2p::Peers>) {
+		self.peers.init(Arc::downgrade(&peers))
 	}
 
 	fn peers(&self) -> Arc<p2p::Peers> {
@@ -1517,8 +1517,8 @@ impl PoolToChainAdapter {
 	}
 
 	/// Set the pool adapter's chain. Should only be called once.
-	pub fn set_chain(&self, chain_ref: Arc<chain::Chain>) -> bool {
-		self.chain.init_if_unset(Arc::downgrade(&chain_ref))
+	pub fn set_chain(&self, chain_ref: Arc<chain::Chain>) {
+		self.chain.init(Arc::downgrade(&chain_ref))
 	}
 
 	fn chain(&self) -> Arc<chain::Chain> {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -51,6 +51,7 @@ pub mod macros;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
 mod hex;
 pub use crate::hex::*;
 
@@ -172,4 +173,23 @@ impl StopState {
 	pub fn resume(&self) {
 		self.paused.store(false, Ordering::Relaxed)
 	}
+}
+
+#[test]
+fn one_time() {
+	use std::thread;
+
+	let one_time: OneTime<u8> = OneTime::new();
+	one_time.init(1);
+	assert!(!one_time.init_if_unset(2));
+
+	let one_time_parallel: OneTime<u8> = OneTime::new();
+	let one_time_parallel_clone1 = one_time_parallel.clone();
+	thread::spawn(move || {
+		assert!(one_time_parallel_clone1.init_if_unset(2));
+	});
+	let one_time_parallel_clone2 = one_time_parallel.clone();
+	thread::spawn(move || {
+		assert!(!one_time_parallel_clone2.init_if_unset(2));
+	});
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -185,11 +185,23 @@ fn one_time() {
 
 	let one_time_parallel: OneTime<u8> = OneTime::new();
 	let one_time_parallel_clone1 = one_time_parallel.clone();
-	thread::spawn(move || {
-		assert!(one_time_parallel_clone1.init_if_unset(2));
-	});
+	let mut handles = vec![];
+	handles.push(thread::spawn(move || {
+		one_time_parallel_clone1.init_if_unset(1)
+	}));
 	let one_time_parallel_clone2 = one_time_parallel.clone();
-	thread::spawn(move || {
-		assert!(!one_time_parallel_clone2.init_if_unset(2));
-	});
+	handles.push(thread::spawn(move || {
+		one_time_parallel_clone2.init_if_unset(2)
+	}));
+	let mut counter = 0;
+	for handle in handles {
+		let value = handle.join().unwrap();
+		if counter == 0 {
+			assert!(value);
+		} else {
+			assert!(!value);
+		}
+		counter += 1;
+	}
+	assert_eq!(one_time_parallel.borrow(), 1);
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -94,9 +94,18 @@ where
 		false
 	}
 
+	/// Initializes the OneTime, should only be called once after construction.
+	/// Will panic (via assert) if called more than once.
+	pub fn init(&self, value: T) {
+		self.set(value, false);
+	}
+
 	/// Allows the one time to be set again with an override.
-	pub fn set(&self, value: T) {
+	pub fn set(&self, value: T, is_override: bool) {
 		let mut inner = self.inner.write();
+		if !is_override {
+			assert!(inner.is_none());
+		}
 		*inner = Some(value);
 	}
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -187,21 +187,17 @@ fn one_time() {
 	let one_time_parallel_clone1 = one_time_parallel.clone();
 	let mut handles = vec![];
 	handles.push(thread::spawn(move || {
-		one_time_parallel_clone1.init_if_unset(1)
+		(1, one_time_parallel_clone1.init_if_unset(1))
 	}));
 	let one_time_parallel_clone2 = one_time_parallel.clone();
 	handles.push(thread::spawn(move || {
-		one_time_parallel_clone2.init_if_unset(2)
+		(2, one_time_parallel_clone2.init_if_unset(2))
 	}));
-	let mut counter = 0;
-	for handle in handles {
-		let value = handle.join().unwrap();
-		if counter == 0 {
-			assert!(value);
-		} else {
-			assert!(!value);
-		}
-		counter += 1;
-	}
-	assert_eq!(one_time_parallel.borrow(), 1);
+	let results: Vec<_> = handles
+		.into_iter()
+		.map(|handle| handle.join().unwrap())
+		.collect();
+	assert_ne!(results[0].1, results[1].1);
+	let winner = results.iter().find(|result| result.1).unwrap().0;
+	assert_eq!(one_time_parallel.borrow(), winner);
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -84,17 +84,19 @@ where
 	}
 
 	/// Initializes the OneTime, should only be called once after construction.
-	/// Will panic (via assert) if called more than once.
-	pub fn init(&self, value: T) {
-		self.set(value, false);
+	/// Returns `false` if already was initialized.
+	pub fn init_if_unset(&self, value: T) -> bool {
+		let mut inner = self.inner.write();
+		if inner.is_none() {
+			*inner = Some(value);
+			return true;
+		}
+		false
 	}
 
 	/// Allows the one time to be set again with an override.
-	pub fn set(&self, value: T, is_override: bool) {
+	pub fn set(&self, value: T) {
 		let mut inner = self.inner.write();
-		if !is_override {
-			assert!(inner.is_none());
-		}
 		*inner = Some(value);
 	}
 


### PR DESCRIPTION
Change from OneTime's `init` to `init_if_unset` to do not check if it was already set to do not panic and avoid data races in multi-threading (at tests).