### PR TITLE
Add multi-OS builds

### DIFF
--- a/.github/scripts/smoke.sh
+++ b/.github/scripts/smoke.sh
@@ -20,6 +20,11 @@ trap 'exit 1' HUP INT TERM
 
 cd "$smoke_dir"
 "$binary" --usernet server config
+api_addr=$(grep '^api_http_addr = ' grin-server.toml | cut -d '"' -f 2)
+if [ -z "$api_addr" ]; then
+	cat grin-server.toml
+	exit 1
+fi
 "$binary" --usernet --no-tui server run >node.log 2>&1 &
 node_pid=$!
 
@@ -36,8 +41,8 @@ while [ "$attempt" -lt 60 ]; do
 			--user "grin:$secret" \
 			--header 'Content-Type: application/json' \
 			--data '{"jsonrpc":"2.0","method":"get_status","params":null,"id":1}' \
-			http://127.0.0.1:23413/v2/owner 2>/dev/null) || true
-		if printf '%s' "$response" | grep -q '"chain": "user"'; then
+			"http://$api_addr/v2/owner" 2>/dev/null) || true
+		if printf '%s' "$response" | tr -d '[:space:]' | grep -q '"chain":"user"'; then
 			printf '%s\n' "$response"
 			exit 0
 		fi

--- a/.github/scripts/smoke.sh
+++ b/.github/scripts/smoke.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -eu
+
+binary=$1
+smoke_dir=$(mktemp -d "${TMPDIR:-/tmp}/grin-smoke.XXXXXX")
+node_pid=
+
+# Stop the node and remove its temporary data.
+cleanup() {
+	if [ -n "$node_pid" ] && kill -0 "$node_pid" 2>/dev/null; then
+		kill "$node_pid" 2>/dev/null || true
+		wait "$node_pid" 2>/dev/null || true
+	fi
+	rm -rf "$smoke_dir"
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+cd "$smoke_dir"
+"$binary" --usernet server config
+"$binary" --usernet --no-tui server run >node.log 2>&1 &
+node_pid=$!
+
+# Wait up to one minute for the owner API.
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+	if ! kill -0 "$node_pid" 2>/dev/null; then
+		cat node.log
+		exit 1
+	fi
+	if [ -f .api_secret ]; then
+		secret=$(head -n 1 .api_secret)
+		response=$(curl --noproxy '*' -fsS \
+			--user "grin:$secret" \
+			--header 'Content-Type: application/json' \
+			--data '{"jsonrpc":"2.0","method":"get_status","params":null,"id":1}' \
+			http://127.0.0.1:23413/v2/owner 2>/dev/null) || true
+		if printf '%s' "$response" | grep -q '"chain": "user"'; then
+			printf '%s\n' "$response"
+			exit 0
+		fi
+	fi
+	attempt=$((attempt + 1))
+	sleep 1
+done
+
+cat node.log
+exit 1

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   linux-release:
     name: Linux Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'wiesche89/grin' && 'grin-linux' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -57,7 +57,7 @@ jobs:
 
   linux-musl:
     name: Linux musl ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'grin-build' || matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:
@@ -115,7 +115,7 @@ jobs:
 
   bsd:
     name: ${{ matrix.name }} x86_64
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     defaults:
       run:
@@ -127,15 +127,22 @@ jobs:
           - name: OpenBSD
             os: openbsd
             version: "7.9"
+            runner: ${{ github.repository == 'wiesche89/grin' && 'grin-openbsd' || 'ubuntu-24.04' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
+            host: 192.168.178.146
+            key: openbsd_ci
           - name: FreeBSD
             os: freebsd
             version: "14.4"
+            runner: ${{ github.repository == 'wiesche89/grin' && 'grin-freebsd' || 'ubuntu-24.04' }}
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
+            host: 192.168.178.147
+            key: freebsd_ci
     steps:
       - uses: actions/checkout@v6
 
       - name: Start ${{ matrix.name }}
+        if: github.repository != 'wiesche89/grin'
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ matrix.os }}
@@ -144,28 +151,65 @@ jobs:
           cpu_count: 4
 
       - name: Install dependencies
+        if: github.repository != 'wiesche89/grin'
         run: ${{ matrix.install }}
 
       - name: Build
+        if: github.repository != 'wiesche89/grin'
         run: cargo build --release --locked
 
       - name: Check binary
+        if: github.repository != 'wiesche89/grin'
         run: |
           file target/release/grin
           target/release/grin --version
 
       - name: Smoke test
+        if: github.repository != 'wiesche89/grin'
         run: sh .github/scripts/smoke.sh "$PWD/target/release/grin"
 
       - name: Archive
+        if: github.repository != 'wiesche89/grin'
         run: |
           cd target/release
           tar -czf grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz grin
 
       - name: Create checksum
+        if: github.repository != 'wiesche89/grin'
         run: |
           cd target/release
           openssl sha256 grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz > grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64-sha256sum.txt
+
+      - name: Build on ${{ matrix.name }} VM
+        if: github.repository == 'wiesche89/grin'
+        shell: bash
+        run: |
+          ssh -i ~/.ssh/${{ matrix.key }} runner@${{ matrix.host }} \
+            sh -s -- "$GITHUB_SHA" "$BUILD_LABEL" "${{ matrix.os }}" <<'EOF'
+          set -e
+          commit=$1
+          label=$2
+          os=$3
+          cd /home/runner/grin
+          git fetch --quiet origin "$commit"
+          git checkout --quiet --force --detach "$commit"
+          if [ "$os" = openbsd ]; then
+            ulimit -n 1024
+          fi
+          cargo build --release --locked
+          file target/release/grin
+          target/release/grin --version
+          sh .github/scripts/smoke.sh "$PWD/target/release/grin"
+          cd target/release
+          archive=grin-${label}-${os}-x86_64.tar.gz
+          tar -czf "$archive" grin
+          openssl sha256 "$archive" > "grin-${label}-${os}-x86_64-sha256sum.txt"
+          EOF
+          mkdir -p target/release
+          scp -i ~/.ssh/${{ matrix.key }} \
+            runner@${{ matrix.host }}:/home/runner/grin/target/release/grin-${BUILD_LABEL}-${{ matrix.os }}-x86_64.tar.gz \
+            runner@${{ matrix.host }}:/home/runner/grin/target/release/grin-${BUILD_LABEL}-${{ matrix.os }}-x86_64-sha256sum.txt \
+            target/release/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6
@@ -254,7 +298,7 @@ jobs:
 
   windows-release:
     name: Windows Release
-    runs-on: windows-2022
+    runs-on: ${{ github.repository == 'wiesche89/grin' && 'grin-windows' || 'windows-2022' }}
     env:
       ROARING_ARCH: x86-64-v2
     steps:
@@ -265,7 +309,7 @@ jobs:
         run: cargo build --release --locked
 
       - name: Check binary
-        shell: pwsh
+        shell: powershell
         run: |
           Get-Item target/release/grin.exe
           target/release/grin.exe --version
@@ -276,12 +320,12 @@ jobs:
 
       - name: Archive
         working-directory: target/release
-        shell: pwsh
+        shell: powershell
         run: Compress-Archive -Path grin.exe -DestinationPath grin-${{ env.BUILD_LABEL }}-win-x86_64.zip
 
       - name: Create checksum
         working-directory: target/release
-        shell: pwsh
+        shell: powershell
         run: Get-FileHash -Algorithm SHA256 grin-${{ env.BUILD_LABEL }}-win-x86_64.zip | Format-List | Out-String | ForEach-Object { $_.Trim() } > grin-${{ env.BUILD_LABEL }}-win-x86_64-sha256sum.txt
 
       - name: Upload artifact

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -295,13 +295,6 @@ jobs:
 
   docker:
     name: Docker
-    needs:
-      - linux-release
-      - linux-musl
-      - bsd
-      - macos-release-x86
-      - macos-release-arm64
-      - windows-release
     uses: ./.github/workflows/publish-ghcr.yaml
     permissions:
       contents: read
@@ -309,13 +302,6 @@ jobs:
 
   snap:
     name: Snap
-    needs:
-      - linux-release
-      - linux-musl
-      - bsd
-      - macos-release-x86
-      - macos-release-arm64
-      - windows-release
     uses: ./.github/workflows/snap.yaml
     secrets: inherit
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   linux-release:
     name: Linux Release
-    runs-on: ${{ github.repository == 'wiesche89/grin' && 'grin-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && 'linux-gnu-x64' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -57,7 +57,7 @@ jobs:
 
   linux-musl:
     name: Linux musl ${{ matrix.arch }}
-    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'grin-build' || matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'linux-musl-x64' || matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:
@@ -127,14 +127,14 @@ jobs:
           - name: OpenBSD
             os: openbsd
             version: "7.9"
-            runner: ${{ github.repository == 'wiesche89/grin' && 'grin-openbsd' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && 'openbsd-x64' || 'ubuntu-24.04' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
             host: 192.168.178.146
             key: openbsd_ci
           - name: FreeBSD
             os: freebsd
             version: "14.4"
-            runner: ${{ github.repository == 'wiesche89/grin' && 'grin-freebsd' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && 'freebsd-x64' || 'ubuntu-24.04' }}
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
             host: 192.168.178.147
             key: freebsd_ci
@@ -298,7 +298,7 @@ jobs:
 
   windows-release:
     name: Windows Release
-    runs-on: ${{ github.repository == 'wiesche89/grin' && 'grin-windows' || 'windows-2022' }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && 'windows-x64' || 'windows-2022' }}
     env:
       ROARING_ARCH: x86-64-v2
     steps:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -141,7 +141,6 @@ jobs:
           operating_system: ${{ matrix.os }}
           architecture: x86-64
           version: ${{ matrix.version }}
-          memory: 6G
           cpu_count: 4
 
       - name: Install dependencies
@@ -365,5 +364,7 @@ jobs:
         <b>Windows:</b> ${{ needs['windows-release'].result }}
         <b>Docker:</b> ${{ needs.docker.result }}
         <b>Snap:</b> ${{ needs.snap.result }}
+        <b>Release:</b> ${{ needs.release.result }}
+      image_tag: ${{ needs.docker.outputs.image_tag }}
       artifact_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Check binary
         run: |
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        run: cargo build --release --target x86_64-apple-darwin
+        run: cargo build --release --locked --target x86_64-apple-darwin
 
       - name: Check binary
         run: |
@@ -225,7 +225,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Check binary
         run: |
@@ -263,7 +263,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Check binary
         shell: pwsh

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -52,6 +52,7 @@ jobs:
           path: |
             target/release/grin-${{ env.BUILD_LABEL }}-linux-x86_64.tar.gz
             target/release/grin-${{ env.BUILD_LABEL }}-linux-x86_64-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   linux-musl:
@@ -109,6 +110,7 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl.tar.gz
             target/${{ matrix.target }}/release/grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   bsd:
@@ -177,6 +179,7 @@ jobs:
           path: |
             target/release/grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz
             target/release/grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   macos-release-x86:
@@ -215,6 +218,7 @@ jobs:
           path: |
             target/x86_64-apple-darwin/release/grin-${{ env.BUILD_LABEL }}-macos-x86_64.tar.gz
             target/x86_64-apple-darwin/release/grin-${{ env.BUILD_LABEL }}-macos-x86_64-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   macos-release-arm64:
@@ -250,6 +254,7 @@ jobs:
           path: |
             target/release/grin-${{ env.BUILD_LABEL }}-macos-arm64.tar.gz
             target/release/grin-${{ env.BUILD_LABEL }}-macos-arm64-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   windows-release:
@@ -291,6 +296,7 @@ jobs:
           path: |
             target/release/grin-${{ env.BUILD_LABEL }}-win-x86_64.zip
             target/release/grin-${{ env.BUILD_LABEL }}-win-x86_64-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14
 
   docker:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,98 +1,349 @@
 name: Continuous Deployment
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - master
+      - staging
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
+env:
+  BUILD_LABEL: ${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'staging' && 'staging-latest' || github.ref_name }}
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
-    linux-release:
-        name: Linux Release
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v3
-          - name: Build
-            run: cargo build --release
-          - name: Archive
-            working-directory: target/release
-            run: tar -czvf grin-${{  github.ref_name }}-linux-x86_64.tar.gz grin
-          - name: Create Checksum
-            working-directory: target/release
-            run: openssl sha256 grin-${{  github.ref_name }}-linux-x86_64.tar.gz > grin-${{  github.ref_name }}-linux-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-                generate_release_notes: true
-                files: |
-                    target/release/grin-${{  github.ref_name }}-linux-x86_64.tar.gz
-                    target/release/grin-${{  github.ref_name }}-linux-x86_64-sha256sum.txt
+  linux-release:
+    name: Linux Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-    macos-release-x86:
-        name: macOS Release - x86_64
-        runs-on: macos-15-intel
-        steps:
-          - name: Install Rust Target
-            run: rustup target add x86_64-apple-darwin
-          - name: Checkout
-            uses: actions/checkout@v3
-          - name: Build
-            run: cargo build --release --target x86_64-apple-darwin
-          - name: Archive
-            working-directory: target/x86_64-apple-darwin/release
-            run: tar -czvf grin-${{  github.ref_name }}-macos-x86_64.tar.gz grin
-          - name: Create Checksum
-            working-directory: target/x86_64-apple-darwin/release
-            run: openssl sha256 grin-${{  github.ref_name }}-macos-x86_64.tar.gz > grin-${{  github.ref_name }}-macos-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-                files: |
-                    target/x86_64-apple-darwin/release/grin-${{  github.ref_name }}-macos-x86_64.tar.gz
-                    target/x86_64-apple-darwin/release/grin-${{  github.ref_name }}-macos-x86_64-sha256sum.txt
+      - name: Build
+        run: cargo build --release
 
-    macos-release-arm64:
-        name: macOS Release - arm64
-        runs-on: macos-latest
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v3
-          - name: Build
-            run: cargo build --release
-          - name: Archive
-            working-directory: target/release
-            run: tar -czvf grin-${{  github.ref_name }}-macos-arm64.tar.gz grin
-          - name: Create Checksum
-            working-directory: target/release
-            run: openssl sha256 grin-${{  github.ref_name }}-macos-arm64.tar.gz > grin-${{  github.ref_name }}-macos-arm64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-                files: |
-                    target/release/grin-${{  github.ref_name }}-macos-arm64.tar.gz
-                    target/release/grin-${{  github.ref_name }}-macos-arm64-sha256sum.txt
-     
-    windows-release:
-        name: Windows Release
-        runs-on: windows-2022
-        env:
-          ROARING_ARCH: x86-64-v2
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v3
-          - name: Build
-            run: cargo build --release
-          - name: Archive
-            uses: vimtor/action-zip@v1
-            with:
-                files: target/release/grin.exe
-                dest: target/release/grin-${{  github.ref_name }}-win-x86_64.zip
-          - name: Create Checksum
-            working-directory: target/release
-            shell: pwsh
-            run: get-filehash -algorithm sha256 grin-${{  github.ref_name }}-win-x86_64.zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > grin-${{  github.ref_name }}-win-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-              files: |
-                target/release/grin-${{  github.ref_name }}-win-x86_64.zip
-                target/release/grin-${{  github.ref_name }}-win-x86_64-sha256sum.txt
+      - name: Check binary
+        run: |
+          file target/release/grin
+          target/release/grin --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin"
+
+      - name: Archive
+        working-directory: target/release
+        run: tar -czf grin-${{ env.BUILD_LABEL }}-linux-x86_64.tar.gz grin
+
+      - name: Create checksum
+        working-directory: target/release
+        run: openssl sha256 grin-${{ env.BUILD_LABEL }}-linux-x86_64.tar.gz > grin-${{ env.BUILD_LABEL }}-linux-x86_64-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-x86_64
+          path: |
+            target/release/grin-${{ env.BUILD_LABEL }}-linux-x86_64.tar.gz
+            target/release/grin-${{ env.BUILD_LABEL }}-linux-x86_64-sha256sum.txt
+          retention-days: 14
+
+  linux-musl:
+    name: Linux musl ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            image: messense/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            image: messense/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Check binary
+        run: |
+          binary=target/${{ matrix.target }}/release/grin
+          file "$binary"
+          if readelf -l "$binary" | grep -q INTERP; then
+            exit 1
+          fi
+          if readelf -d "$binary" | grep -q NEEDED; then
+            exit 1
+          fi
+          "$binary" --version
+
+      - name: Smoke test
+        run: |
+          binary=target/${{ matrix.target }}/release/grin
+          sh .github/scripts/smoke.sh "$PWD/$binary"
+
+      - name: Archive
+        working-directory: target/${{ matrix.target }}/release
+        run: tar -czf grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl.tar.gz grin
+
+      - name: Create checksum
+        working-directory: target/${{ matrix.target }}/release
+        run: openssl sha256 grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl.tar.gz > grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-${{ matrix.arch }}-musl
+          path: |
+            target/${{ matrix.target }}/release/grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl.tar.gz
+            target/${{ matrix.target }}/release/grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl-sha256sum.txt
+          retention-days: 14
+
+  bsd:
+    name: ${{ matrix.name }} x86_64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: cpa.sh {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: OpenBSD
+            os: openbsd
+            version: "7.9"
+            install: sudo pkg_add rust git cmake pkgconf gmake curl
+          - name: FreeBSD
+            os: freebsd
+            version: "14.4"
+            install: sudo pkg install -y rust git cmake pkgconf gmake curl
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start ${{ matrix.name }}
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os }}
+          architecture: x86-64
+          version: ${{ matrix.version }}
+          memory: 6G
+          cpu_count: 4
+
+      - name: Install dependencies
+        run: ${{ matrix.install }}
+
+      - name: Store test
+        if: matrix.os == 'openbsd'
+        run: cargo test -p grin_store --lib flush_map
+
+      - name: Build
+        run: cargo build --release --locked
+
+      - name: Check binary
+        run: |
+          file target/release/grin
+          target/release/grin --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin"
+
+      - name: Archive
+        run: |
+          cd target/release
+          tar -czf grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz grin
+
+      - name: Create checksum
+        run: |
+          cd target/release
+          openssl sha256 grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz > grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.os }}-x86_64
+          path: |
+            target/release/grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz
+            target/release/grin-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64-sha256sum.txt
+          retention-days: 14
+
+  macos-release-x86:
+    name: macOS Release - x86_64
+    runs-on: macos-15-intel
+    steps:
+      - name: Install Rust target
+        run: rustup target add x86_64-apple-darwin
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: cargo build --release --target x86_64-apple-darwin
+
+      - name: Check binary
+        run: |
+          file target/x86_64-apple-darwin/release/grin
+          target/x86_64-apple-darwin/release/grin --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/x86_64-apple-darwin/release/grin"
+
+      - name: Archive
+        working-directory: target/x86_64-apple-darwin/release
+        run: tar -czf grin-${{ env.BUILD_LABEL }}-macos-x86_64.tar.gz grin
+
+      - name: Create checksum
+        working-directory: target/x86_64-apple-darwin/release
+        run: openssl sha256 grin-${{ env.BUILD_LABEL }}-macos-x86_64.tar.gz > grin-${{ env.BUILD_LABEL }}-macos-x86_64-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-x86_64
+          path: |
+            target/x86_64-apple-darwin/release/grin-${{ env.BUILD_LABEL }}-macos-x86_64.tar.gz
+            target/x86_64-apple-darwin/release/grin-${{ env.BUILD_LABEL }}-macos-x86_64-sha256sum.txt
+          retention-days: 14
+
+  macos-release-arm64:
+    name: macOS Release - arm64
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Check binary
+        run: |
+          file target/release/grin
+          target/release/grin --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin"
+
+      - name: Archive
+        working-directory: target/release
+        run: tar -czf grin-${{ env.BUILD_LABEL }}-macos-arm64.tar.gz grin
+
+      - name: Create checksum
+        working-directory: target/release
+        run: openssl sha256 grin-${{ env.BUILD_LABEL }}-macos-arm64.tar.gz > grin-${{ env.BUILD_LABEL }}-macos-arm64-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-arm64
+          path: |
+            target/release/grin-${{ env.BUILD_LABEL }}-macos-arm64.tar.gz
+            target/release/grin-${{ env.BUILD_LABEL }}-macos-arm64-sha256sum.txt
+          retention-days: 14
+
+  windows-release:
+    name: Windows Release
+    runs-on: windows-2022
+    env:
+      ROARING_ARCH: x86-64-v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Check binary
+        shell: pwsh
+        run: |
+          Get-Item target/release/grin.exe
+          target/release/grin.exe --version
+
+      - name: Smoke test
+        shell: bash
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin.exe"
+
+      - name: Archive
+        working-directory: target/release
+        shell: pwsh
+        run: Compress-Archive -Path grin.exe -DestinationPath grin-${{ env.BUILD_LABEL }}-win-x86_64.zip
+
+      - name: Create checksum
+        working-directory: target/release
+        shell: pwsh
+        run: Get-FileHash -Algorithm SHA256 grin-${{ env.BUILD_LABEL }}-win-x86_64.zip | Format-List | Out-String | ForEach-Object { $_.Trim() } > grin-${{ env.BUILD_LABEL }}-win-x86_64-sha256sum.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-x86_64
+          path: |
+            target/release/grin-${{ env.BUILD_LABEL }}-win-x86_64.zip
+            target/release/grin-${{ env.BUILD_LABEL }}-win-x86_64-sha256sum.txt
+          retention-days: 14
+
+  docker:
+    name: Docker
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+    uses: ./.github/workflows/publish-ghcr.yaml
+    permissions:
+      contents: read
+      packages: write
+
+  snap:
+    name: Snap
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+    uses: ./.github/workflows/snap.yaml
+    secrets: inherit
+
+  release:
+    name: Publish release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+      - docker
+      - snap
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: release
+          pattern: "!digests-*"
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: release/*

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -306,6 +306,8 @@ jobs:
     name: Snap
     uses: ./.github/workflows/snap.yaml
     secrets: inherit
+    with:
+      build_label: ${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'staging' && 'staging-latest' || github.ref_name }}
 
   release:
     name: Publish release

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -333,3 +333,33 @@ jobs:
         with:
           generate_release_notes: true
           files: release/*
+
+  telegram-notify:
+    name: Telegram Notification
+    if: always()
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+      - docker
+      - snap
+      - release
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin CD
+      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
+      details: |
+        <b>Linux:</b> ${{ needs['linux-release'].result }}
+        <b>musl:</b> ${{ needs['linux-musl'].result }}
+        <b>BSD:</b> ${{ needs.bsd.result }}
+        <b>macOS x86:</b> ${{ needs['macos-release-x86'].result }}
+        <b>macOS arm64:</b> ${{ needs['macos-release-arm64'].result }}
+        <b>Windows:</b> ${{ needs['windows-release'].result }}
+        <b>Docker:</b> ${{ needs.docker.result }}
+        <b>Snap:</b> ${{ needs.snap.result }}
+      artifact_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -147,10 +147,6 @@ jobs:
       - name: Install dependencies
         run: ${{ matrix.install }}
 
-      - name: Store test
-        if: matrix.os == 'openbsd'
-        run: cargo test -p grin_store --lib flush_map
-
       - name: Build
         run: cargo build --release --locked
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -335,6 +335,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: release/*
 
   telegram-notify:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
 
   bsd-tests:
     name: ${{ matrix.name }} Tests
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     defaults:
       run:
@@ -66,10 +66,14 @@ jobs:
           - name: OpenBSD
             os: openbsd
             version: "7.9"
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-24.04' }}
+            memory: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && '12G' || '6G' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
           - name: FreeBSD
             os: freebsd
             version: "14.4"
+            runner: ubuntu-24.04
+            memory: 6G
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +85,7 @@ jobs:
           architecture: x86-64
           version: ${{ matrix.version }}
           cpu_count: 4
+          memory: ${{ matrix.memory }}
 
       - name: Install dependencies
         run: ${{ matrix.install }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,14 +5,10 @@ jobs:
   linux-tests:
     name: Linux Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        job_args: [servers, chain, core, keychain, pool, p2p, src, api, util, store]
     steps:
       - uses: actions/checkout@v6
-      - name: Test ${{ matrix.job_args }}
-        working-directory: ${{ matrix.job_args }}
-        run: cargo test --release
+      - name: Tests
+        run: cargo test --release --all
 
   musl-tests:
     name: Linux musl ${{ matrix.arch }} Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   linux-tests:
     name: Linux Tests
-    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-linux' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
       - name: Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   linux-tests:
     name: Linux Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
       - name: Tests
@@ -12,7 +12,7 @@ jobs:
 
   musl-tests:
     name: Linux musl ${{ matrix.arch }} Tests
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:
@@ -43,7 +43,7 @@ jobs:
 
   windows-tests:
     name: Windows Tests
-    runs-on: windows-2022
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-windows' || 'windows-2022' }}
     env:
       ROARING_ARCH: x86-64-v2
     steps:
@@ -72,17 +72,23 @@ jobs:
             runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-24.04' }}
             memory: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && '12G' || '6G' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
+            host: 192.168.178.146
+            key: openbsd_ci
+            test: ulimit -n 1024 && cargo test --release --all --locked -- --test-threads=1
           - name: FreeBSD
             os: freebsd
             version: "14.4"
-            runner: ubuntu-24.04
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-24.04' }}
             memory: 6G
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
+            host: 192.168.178.147
+            key: freebsd_ci
+            test: cargo test --release --all --locked
     steps:
       - uses: actions/checkout@v6
 
       - name: Start ${{ matrix.name }}
-        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
+        if: github.repository != 'wiesche89/grin' || github.event_name != 'push'
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ matrix.os }}
@@ -92,19 +98,19 @@ jobs:
           memory: ${{ matrix.memory }}
 
       - name: Install dependencies
-        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
+        if: github.repository != 'wiesche89/grin' || github.event_name != 'push'
         run: ${{ matrix.install }}
 
       - name: Tests
-        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
+        if: github.repository != 'wiesche89/grin' || github.event_name != 'push'
         run: cargo test --release --all --locked
 
-      - name: Tests on OpenBSD VM
-        if: matrix.name == 'OpenBSD' && github.repository == 'wiesche89/grin' && github.event_name == 'push'
+      - name: Tests on ${{ matrix.name }} VM
+        if: github.repository == 'wiesche89/grin' && github.event_name == 'push'
         shell: bash
         run: |
-          ssh -i ~/.ssh/openbsd_ci runner@192.168.178.146 \
-            "cd /home/runner/grin && git fetch --quiet origin $GITHUB_SHA && git checkout --quiet --force --detach $GITHUB_SHA && ulimit -n 1024 && cargo test --release --all --locked -- --test-threads=1"
+          ssh -i ~/.ssh/${{ matrix.key }} runner@${{ matrix.host }} \
+            "cd /home/runner/grin && git fetch --quiet origin $GITHUB_SHA && git checkout --quiet --force --detach $GITHUB_SHA && ${{ matrix.test }}"
 
   telegram-notify:
     name: Telegram Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
 
   musl-tests:
     name: Linux musl ${{ matrix.arch }} Tests
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
 
   windows-tests:
     name: Windows Tests
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
 
   bsd-tests:
     name: ${{ matrix.name }} Tests
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 120
     defaults:
       run:
-        shell: cpa.sh {0}
+        shell: cpa.sh {0} --sync-files runner-to-vm
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
         run: ${{ matrix.install }}
 
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
 
   telegram-notify:
     name: Telegram Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
   musl-tests:
     name: Linux musl ${{ matrix.arch }} Tests
-    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && matrix.arch == 'x86_64' && 'grin-build' || matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           - name: OpenBSD
             os: openbsd
             version: "7.9"
-            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-openbsd' || 'ubuntu-24.04' }}
             memory: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && '12G' || '6G' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
             host: 192.168.178.146
@@ -78,7 +78,7 @@ jobs:
           - name: FreeBSD
             os: freebsd
             version: "14.4"
-            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-build' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-freebsd' || 'ubuntu-24.04' }}
             memory: 6G
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
             host: 192.168.178.147

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,28 @@ jobs:
         working-directory: ${{ matrix.job_args }}
         run: cargo test --release
 
+  musl-tests:
+    name: Linux musl ${{ matrix.arch }} Tests
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            image: messense/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            image: messense/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643
+    steps:
+      - uses: actions/checkout@v6
+      - name: Tests
+        run: cargo test --release --all --locked --target ${{ matrix.target }}
+
   macos-tests:
     name: macOS Tests
     runs-on: macos-latest
@@ -34,9 +56,45 @@ jobs:
       - name: Tests
         run: cargo test --release --all
 
+  bsd-tests:
+    name: ${{ matrix.name }} Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: cpa.sh {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: OpenBSD
+            os: openbsd
+            version: "7.9"
+            install: sudo pkg_add rust git cmake pkgconf gmake curl
+          - name: FreeBSD
+            os: freebsd
+            version: "14.4"
+            install: sudo pkg install -y rust git cmake pkgconf gmake curl
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start ${{ matrix.name }}
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os }}
+          architecture: x86-64
+          version: ${{ matrix.version }}
+          cpu_count: 4
+
+      - name: Install dependencies
+        run: ${{ matrix.install }}
+
+      - name: Tests
+        run: cargo test --release --all
+
   telegram-notify:
     name: Telegram Notification
-    needs: [linux-tests, macos-tests, windows-tests]
+    needs: [linux-tests, musl-tests, macos-tests, windows-tests, bsd-tests]
     if: always() && github.event_name == 'push'
     uses: ./.github/workflows/telegram.yaml
     secrets: inherit
@@ -45,6 +103,8 @@ jobs:
       status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
       details: |
         <b>Linux:</b> ${{ needs.linux-tests.result }}
+        <b>musl:</b> ${{ needs.musl-tests.result }}
         <b>macOS:</b> ${{ needs.macos-tests.result }}
         <b>Windows:</b> ${{ needs.windows-tests.result }}
+        <b>BSD:</b> ${{ needs.bsd-tests.result }}
       commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,9 @@ jobs:
     name: ${{ matrix.name }} Tests
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    concurrency:
+      group: bsd-${{ matrix.os }}
+      cancel-in-progress: false
     defaults:
       run:
         shell: cpa.sh {0} --sync-files runner-to-vm
@@ -79,6 +82,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Start ${{ matrix.name }}
+        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ matrix.os }}
@@ -88,10 +92,19 @@ jobs:
           memory: ${{ matrix.memory }}
 
       - name: Install dependencies
+        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
         run: ${{ matrix.install }}
 
       - name: Tests
+        if: matrix.name != 'OpenBSD' || github.repository != 'wiesche89/grin' || github.event_name != 'push'
         run: cargo test --release --all --locked
+
+      - name: Tests on OpenBSD VM
+        if: matrix.name == 'OpenBSD' && github.repository == 'wiesche89/grin' && github.event_name == 'push'
+        shell: bash
+        run: |
+          ssh -i ~/.ssh/openbsd_ci runner@192.168.178.146 \
+            "cd /home/runner/grin && git fetch --quiet origin $GITHUB_SHA && git checkout --quiet --force --detach $GITHUB_SHA && ulimit -n 1024 && cargo test --release --all --locked -- --test-threads=1"
 
   telegram-notify:
     name: Telegram Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   linux-tests:
     name: Linux Tests
-    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'linux-gnu-x64' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
       - name: Tests
@@ -12,7 +12,7 @@ jobs:
 
   musl-tests:
     name: Linux musl ${{ matrix.arch }} Tests
-    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && matrix.arch == 'x86_64' && 'grin-build' || matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && matrix.arch == 'x86_64' && 'linux-musl-x64' || matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:
@@ -43,7 +43,7 @@ jobs:
 
   windows-tests:
     name: Windows Tests
-    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-windows' || 'windows-2022' }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'windows-x64' || 'windows-2022' }}
     env:
       ROARING_ARCH: x86-64-v2
     steps:
@@ -69,7 +69,7 @@ jobs:
           - name: OpenBSD
             os: openbsd
             version: "7.9"
-            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-openbsd' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'openbsd-x64' || 'ubuntu-24.04' }}
             memory: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && '12G' || '6G' }}
             install: sudo pkg_add rust git cmake pkgconf gmake curl
             host: 192.168.178.146
@@ -78,7 +78,7 @@ jobs:
           - name: FreeBSD
             os: freebsd
             version: "14.4"
-            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'grin-freebsd' || 'ubuntu-24.04' }}
+            runner: ${{ github.repository == 'wiesche89/grin' && github.event_name == 'push' && 'freebsd-x64' || 'ubuntu-24.04' }}
             memory: 6G
             install: sudo pkg install -y rust git cmake pkgconf gmake curl
             host: 192.168.178.147

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         job_args: [servers, chain, core, keychain, pool, p2p, src, api, util, store]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Test ${{ matrix.job_args }}
         working-directory: ${{ matrix.job_args }}
         run: cargo test --release
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Tests
         run: cargo test --release --all
 
@@ -30,7 +30,7 @@ jobs:
       ROARING_ARCH: x86-64-v2
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Tests
         run: cargo test --release --all
 

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.platform == 'linux/amd64' && 'grin-build' || matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.platform == 'linux/amd64' && 'docker-x64' || matrix.runner }}
     name: Build Docker image for ${{ matrix.platform }}
     steps:
       - name: Prepare

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -138,18 +138,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  telegram-notify:
-    name: Telegram Notification
-    needs: [build, merge]
-    if: always()
-    uses: ./.github/workflows/telegram.yaml
-    secrets: inherit
-    with:
-      title: Grin Docker
-      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
-      details: |
-        <b>Images:</b> ${{ needs.build.result }}
-        <b>Manifest:</b> ${{ needs.merge.result }}
-      image_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.ref_name == 'master' && 'latest' || 'staging' }}
-      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+  DOCKER_BUILD_RECORD_UPLOAD: false
 
 permissions:
   contents: read

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -2,6 +2,10 @@ name: Build and Push to GHCR
 
 on:
   workflow_call:
+    outputs:
+      image_tag:
+        description: Published image tag
+        value: ${{ jobs.merge.outputs.image_tag }}
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
@@ -79,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    outputs:
+      image_tag: ${{ steps.vars.outputs.tag || steps.vars.outputs.version }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v7
@@ -106,7 +112,11 @@ jobs:
           version=$(awk -F'"' '/^version/{ print $2; exit; }' Cargo.toml)
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            if [[ "$GITHUB_REF_NAME" != *-* ]]; then
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+            else
+              echo "tag=" >> "$GITHUB_OUTPUT"
+            fi
           elif [ "$GITHUB_REF_NAME" = master ]; then
             echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "tag=latest" >> "$GITHUB_OUTPUT"
@@ -126,7 +136,7 @@ jobs:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=${{ steps.vars.outputs.version }},enable=true
-            type=raw,value=${{ steps.vars.outputs.tag }},enable=true
+            type=raw,value=${{ steps.vars.outputs.tag }},enable=${{ steps.vars.outputs.tag != '' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -25,7 +25,7 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.platform == 'linux/amd64' && 'grin-build' || matrix.runner }}
     name: Build Docker image for ${{ matrix.platform }}
     steps:
       - name: Prepare

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -1,11 +1,14 @@
 name: Build and Push to GHCR
 
 on:
-  push:
-    branches: [master, staging]
+  workflow_call:
 
 env:
-  GHCR_IMAGE: ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ github.event.repository.name }}
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:
@@ -23,27 +26,27 @@ jobs:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
@@ -53,6 +56,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           tags: ${{ env.GHCR_IMAGE }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -83,14 +88,14 @@ jobs:
           merge-multiple: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -99,17 +104,24 @@ jobs:
         id: vars
         run: |
           version=$(awk -F'"' '/^version/{ print $2; exit; }' Cargo.toml)
-          if ${{ github.ref_name == 'master' }}; then
-            echo "version=$version" >> $GITHUB_OUTPUT
-            echo "tag=latest" >> $GITHUB_OUTPUT
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REF_NAME" = master ]; then
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REF_NAME" = staging ]; then
+            echo "version=${version}-staging" >> "$GITHUB_OUTPUT"
+            echo "tag=staging" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${version}-staging" >> $GITHUB_OUTPUT
-            echo "tag=staging" >> $GITHUB_OUTPUT
+            tag=${GITHUB_REF_NAME//\//-}
+            echo "version=${version}-${tag}" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
@@ -119,6 +131,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
 
@@ -138,5 +151,5 @@ jobs:
       details: |
         <b>Images:</b> ${{ needs.build.result }}
         <b>Manifest:</b> ${{ needs.merge.result }}
-      image_tag: ${{ github.ref_name == 'master' && 'latest' || 'staging' }}
+      image_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.ref_name == 'master' && 'latest' || 'staging' }}
       commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -24,7 +24,7 @@ jobs:
             runner: ubuntu-latest
           - arch: arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'grin-snap' || matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'snap-x64' || matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,19 +1,26 @@
 name: Snap Package
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - master
-      - staging
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  BUILD_LABEL: ${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'staging' && 'staging-latest' || github.ref_name }}
 
 jobs:
   build-snap:
-    name: Build snap
+    name: Snap ${{ matrix.arch }}
     strategy:
+      fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.runs-on }}
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -21,32 +28,36 @@ jobs:
       - name: Prepare snapcraft project
         run: |
           grade=devel
-          if [ "${{ github.ref_name }}" = "master" ]; then
+          if [ "$GITHUB_REF_NAME" = master ] || [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             grade=stable
           fi
-
           mkdir -p snap
           sed "s/SNAP_GRADE/$grade/" .packaging/snaps/snapcraft.yaml > snap/snapcraft.yaml
 
       - name: Build snap package
-        id: build
         uses: snapcore/action-build@v1
         with:
           path: .
 
-      - name: Show snap package
-        run: find . -maxdepth 1 -name "*.snap" -ls
+      - name: Prepare artifact
+        run: |
+          snap=$(find . -maxdepth 1 -name "*.snap" -print -quit)
+          asset=grin-${BUILD_LABEL}-linux-${{ matrix.arch }}.snap
+          mv "$snap" "$asset"
+          openssl sha256 "$asset" > "${asset%.snap}-sha256sum.txt"
 
-      - name: Upload snap artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: grin-snap
-          path: "*.snap"
-          if-no-files-found: error
+          name: snap-${{ matrix.arch }}
+          path: |
+            grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap
+            grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-sha256sum.txt
+          retention-days: 14
 
   telegram-notify:
     name: Telegram Notification
-    needs: [build-snap]
+    needs: build-snap
     if: always()
     uses: ./.github/workflows/telegram.yaml
     secrets: inherit

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -2,12 +2,16 @@ name: Snap Package
 
 on:
   workflow_call:
+    inputs:
+      build_label:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  BUILD_LABEL: ${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'staging' && 'staging-latest' || github.ref_name }}
+  BUILD_LABEL: ${{ inputs.build_label }}
 
 jobs:
   build-snap:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -53,4 +53,5 @@ jobs:
           path: |
             grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap
             grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-sha256sum.txt
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -32,7 +32,9 @@ jobs:
       - name: Prepare snapcraft project
         run: |
           grade=devel
-          if [ "$GITHUB_REF_NAME" = master ] || [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          if [ "$GITHUB_REF_NAME" = master ]; then
+            grade=stable
+          elif [[ "$GITHUB_REF" == refs/tags/v* && "$GITHUB_REF_NAME" != *-* ]]; then
             grade=stable
           fi
           mkdir -p snap
@@ -48,7 +50,7 @@ jobs:
           snap=$(find . -maxdepth 1 -name "*.snap" -print -quit)
           asset=grin-${BUILD_LABEL}-linux-${{ matrix.arch }}.snap
           mv "$snap" "$asset"
-          openssl sha256 "$asset" > "${asset%.snap}-sha256sum.txt"
+          openssl sha256 "$asset" > "${asset}-sha256sum.txt"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6
@@ -56,6 +58,6 @@ jobs:
           name: snap-${{ matrix.arch }}
           path: |
             grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap
-            grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-sha256sum.txt
+            grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap-sha256sum.txt
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -24,7 +24,7 @@ jobs:
             runner: ubuntu-latest
           - arch: arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'wiesche89/grin' && matrix.arch == 'x86_64' && 'grin-snap' || matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -54,17 +54,3 @@ jobs:
             grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap
             grin-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-sha256sum.txt
           retention-days: 14
-
-  telegram-notify:
-    name: Telegram Notification
-    needs: build-snap
-    if: always()
-    uses: ./.github/workflows/telegram.yaml
-    secrets: inherit
-    with:
-      title: Grin Snap
-      status: ${{ needs.build-snap.result }}
-      details: |
-        <b>Package:</b> ${{ needs.build-snap.result }}
-      artifact_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      commit_message: ${{ github.event.head_commit.message }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6"
-source = "git+https://github.com/wiesche89/heed?rev=5e96272597e02d5c0b2f354ce37e3edf08f648a8#5e96272597e02d5c0b2f354ce37e3edf08f648a8"
+source = "git+https://github.com/wiesche89/heed?rev=4c7252128a58819406f2978adfc8d41365e7f77a#4c7252128a58819406f2978adfc8d41365e7f77a"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,8 +1818,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+source = "git+https://github.com/wiesche89/heed?rev=6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142#6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6"
-source = "git+https://github.com/wiesche89/heed?rev=6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142#6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142"
+source = "git+https://github.com/wiesche89/heed?rev=5e96272597e02d5c0b2f354ce37e3edf08f648a8#5e96272597e02d5c0b2f354ce37e3edf08f648a8"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,4 @@ grin_chain = { path = "./chain", version = "5.5.1-alpha.0" }
 grin_store = { path = "./store", version = "5.5.1-alpha.0" }
 
 [patch.crates-io]
-lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "5e96272597e02d5c0b2f354ce37e3edf08f648a8" }
+lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "4c7252128a58819406f2978adfc8d41365e7f77a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ built = { version = "0.8.0", features = ["git2"]}
 [dev-dependencies]
 grin_chain = { path = "./chain", version = "5.5.1-alpha.0" }
 grin_store = { path = "./store", version = "5.5.1-alpha.0" }
+
+[patch.crates-io]
+lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,4 @@ grin_chain = { path = "./chain", version = "5.5.1-alpha.0" }
 grin_store = { path = "./store", version = "5.5.1-alpha.0" }
 
 [patch.crates-io]
-lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "6a5cd5fb7b781f2b7bcbeb8cc1dbebe3308bb142" }
+lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "5e96272597e02d5c0b2f354ce37e3edf08f648a8" }

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -415,7 +415,9 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 	if !ctx.opts.contains(Options::SKIP_POW) {
 		// Quick check of this header in isolation. No point proceeding if this fails.
 		// We can do this without needing to iterate over previous headers.
-		validate_pow_only(header, ctx)?;
+		if !ctx.opts.contains(Options::POW_VERIFIED) {
+			validate_pow_only(header, ctx)?;
+		}
 
 		if header.total_difficulty() <= prev.total_difficulty() {
 			return Err(Error::DifficultyTooLow);

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -417,7 +417,6 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 		// We can do this without needing to iterate over previous headers.
 		if ctx.opts.contains(Options::POW_VERIFIED_ON_READ) {
 			debug_assert!(header.pow.is_primary() || header.pow.is_secondary());
-			debug_assert!((ctx.pow_verifier)(header).is_ok());
 		} else {
 			validate_pow_only(header, ctx)?;
 		}

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -415,7 +415,10 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 	if !ctx.opts.contains(Options::SKIP_POW) {
 		// Quick check of this header in isolation. No point proceeding if this fails.
 		// We can do this without needing to iterate over previous headers.
-		if !ctx.opts.contains(Options::POW_VERIFIED) {
+		if ctx.opts.contains(Options::POW_VERIFIED_ON_READ) {
+			debug_assert!(header.pow.is_primary() || header.pow.is_secondary());
+			debug_assert!((ctx.pow_verifier)(header).is_ok());
+		} else {
 			validate_pow_only(header, ctx)?;
 		}
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -198,6 +198,28 @@ impl ChainStore {
 			db: self.db.batch()?,
 		})
 	}
+
+	/// Builds a read-only batch to be used with this store.
+	pub fn read_batch(&self) -> Result<ReadBatch<'_>, Error> {
+		Ok(ReadBatch {
+			db: self.db.read_batch()?,
+		})
+	}
+}
+
+/// A read-only view of the chain store.
+pub struct ReadBatch<'a> {
+	db: store::ReadBatch<'a>,
+}
+
+impl ReadBatch<'_> {
+	/// Get block header.
+	pub fn get_block_header(&self, h: &Hash) -> Result<BlockHeader, Error> {
+		option_to_not_found(
+			self.db.get_ser(Some(BLOCK_HEADER_PREFIX), h.as_ref(), None),
+			|| format!("BLOCK HEADER: {}", h),
+		)
+	}
 }
 
 /// An atomic batch in which all changes can be committed all at once or

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -184,11 +184,12 @@ impl Desegmenter {
 
 		let res = {
 			let header_pmmr = self.header_pmmr.read();
+			let batch = self.store.read_batch()?;
 			header_pmmr.get_first_header_with(
 				latest_output_size,
 				local_kernel_mmr_size,
 				self.latest_block_height,
-				self.store.clone(),
+				&batch,
 			)
 		};
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -2320,16 +2320,20 @@ mod tests {
 		let mut headers = vec![global::get_genesis_block().header];
 
 		for height in 1..=5 {
-			let mut header = BlockHeader::default();
-			header.height = height;
-			header.prev_hash = headers.last().unwrap().hash();
-			*header.pow.proof.nonces.last_mut().unwrap() = height;
-			header.output_mmr_size = if height == 3 || height == 5 {
+			// Make an early scan return the wrong header
+			let output_mmr_size = if height == 3 || height == 5 {
 				5
 			} else {
 				height
 			};
-			header.kernel_mmr_size = header.output_mmr_size;
+			let mut header = BlockHeader {
+				height,
+				prev_hash: headers.last().unwrap().hash(),
+				output_mmr_size,
+				kernel_mmr_size: output_mmr_size,
+				..Default::default()
+			};
+			*header.pow.proof.nonces.last_mut().unwrap() = height;
 			headers.push(header);
 		}
 

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -2307,4 +2307,51 @@ mod tests {
 
 		fs::remove_dir_all(dir).unwrap();
 	}
+
+	#[test]
+	fn resume_header() {
+		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+
+		let dir = test_dir("resume_header");
+		let store = ChainStore::new(dir.join("db").to_str().unwrap(), None).unwrap();
+		let mut handle =
+			PMMRHandle::<BlockHeader>::new(dir.join("pmmr"), false, ProtocolVersion(1), None)
+				.unwrap();
+		let mut headers = vec![global::get_genesis_block().header];
+
+		for height in 1..=5 {
+			let mut header = BlockHeader::default();
+			header.height = height;
+			header.prev_hash = headers.last().unwrap().hash();
+			*header.pow.proof.nonces.last_mut().unwrap() = height;
+			header.output_mmr_size = if height == 3 || height == 5 {
+				5
+			} else {
+				height
+			};
+			header.kernel_mmr_size = header.output_mmr_size;
+			headers.push(header);
+		}
+
+		let mut batch = store.batch().unwrap();
+		{
+			let mut pmmr = PMMR::at(&mut handle.backend, handle.size);
+			for header in &headers {
+				pmmr.push(header).unwrap();
+				batch.save_block_header(header).unwrap();
+			}
+			handle.size = pmmr.unpruned_size();
+		}
+		handle.backend.sync().unwrap();
+		batch.commit().unwrap();
+
+		let batch = store.read_batch().unwrap();
+		let header = handle.get_first_header_with(4, 4, 4, &batch).unwrap();
+		assert_eq!(header.height, 4);
+
+		drop(batch);
+		drop(store);
+		drop(handle);
+		fs::remove_dir_all(dir).unwrap();
+	}
 }

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -29,7 +29,7 @@ use crate::core::global;
 use crate::core::ser::{PMMRable, ProtocolVersion};
 use crate::error::Error;
 use crate::linked_list::{ListIndex, PruneableListIndex, RewindableListIndex};
-use crate::store::{self, Batch, ChainStore};
+use crate::store::{self, Batch, ChainStore, ReadBatch};
 use crate::txhashset::bitmap_accumulator::{BitmapAccumulator, BitmapChunk};
 use crate::txhashset::{RewindableKernelView, UTXOView};
 use crate::types::{CommitPos, OutputRoots, Tip, TxHashSetRoots, TxHashsetWriteStatus};
@@ -212,9 +212,9 @@ impl PMMRHandle<BlockHeader> {
 		output_pos: u64,
 		kernel_pos: u64,
 		from_height: u64,
-		store: Arc<store::ChainStore>,
+		store: &ReadBatch<'_>,
 	) -> Option<BlockHeader> {
-		let mut cur_height = pmmr::round_up_to_leaf_pos(from_height);
+		let mut cur_height = pmmr::insertion_to_pmmr_index(from_height);
 		let header_pmmr = ReadonlyPMMR::at(&self.backend, self.size);
 		let mut candidate: Option<BlockHeader> = None;
 		while let Some(header_entry) = header_pmmr.get_data(cur_height) {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -43,8 +43,8 @@ bitflags! {
 		const SYNC = 0b0000_0010;
 		/// Block validation on a block we mined ourselves
 		const MINE = 0b0000_0100;
-		/// Proof of work was verified while reading from the network.
-		const POW_VERIFIED = 0b0000_1000;
+		/// Proof of work was verified while reading untrusted network data.
+		const POW_VERIFIED_ON_READ = 0b0000_1000;
 	}
 }
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -43,6 +43,8 @@ bitflags! {
 		const SYNC = 0b0000_0010;
 		/// Block validation on a block we mined ourselves
 		const MINE = 0b0000_0100;
+		/// Proof of work was verified while reading from the network.
+		const POW_VERIFIED = 0b0000_1000;
 	}
 }
 

--- a/core/src/pow/siphash.rs
+++ b/core/src/pow/siphash.rs
@@ -43,7 +43,7 @@ pub fn siphash_block(v: &[u64; 4], nonce: u64, rot_e: u8, xor_all: bool) -> u64 
 	// beginning of the block of hashes
 	let nonce0 = nonce & !SIPHASH_BLOCK_MASK;
 	let nonce_i = nonce & SIPHASH_BLOCK_MASK;
-	let mut nonce_hash = vec![0u64; SIPHASH_BLOCK_SIZE as usize];
+	let mut nonce_hash = [0u64; SIPHASH_BLOCK_SIZE as usize];
 
 	// repeated hashing over the whole block
 	let mut siphash = SipHash24::new(v);

--- a/p2p/src/codec.rs
+++ b/p2p/src/codec.rs
@@ -281,3 +281,40 @@ fn decode_message(
 	};
 	Ok(c)
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::core::core::BlockHeader;
+	use crate::core::{global, ser};
+	use crate::msg::Headers;
+	use std::io::Write;
+	use std::net::TcpListener;
+
+	#[test]
+	fn bad_header_pow() {
+		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+		let version = ProtocolVersion::local();
+		let body = ser::ser_vec(
+			&Headers {
+				headers: vec![BlockHeader::default()],
+			},
+			version,
+		)
+		.unwrap();
+		let mut bytes =
+			ser::ser_vec(&MsgHeader::new(Type::Headers, body.len() as u64), version).unwrap();
+		bytes.extend(body);
+
+		let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+		let mut sender = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+		let (receiver, _) = listener.accept().unwrap();
+		sender.write_all(&bytes).unwrap();
+
+		let (result, _) = Codec::new(version, receiver).read();
+		assert!(matches!(
+			result,
+			Err(Error::Serialization(ser::Error::CorruptedData))
+		));
+	}
+}

--- a/p2p/tests/ser_deser.rs
+++ b/p2p/tests/ser_deser.rs
@@ -14,7 +14,8 @@
 
 use grin_p2p as p2p;
 
-use grin_core::core::SegmentIdentifier;
+use grin_core::core::{BlockHeader, SegmentIdentifier};
+use grin_core::global;
 use grin_core::ser::{self, ProtocolVersion};
 use num::FromPrimitive;
 
@@ -94,4 +95,24 @@ fn test_header_segment_limit() {
 	);
 
 	assert_eq!(res.err(), Some(ser::Error::TooLargeReadErr));
+}
+
+#[test]
+fn bad_segment_pow() {
+	global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+	let segment = p2p::msg::HeaderSegment {
+		identifier: SegmentIdentifier {
+			height: p2p::PIHD_HEADER_SEGMENT_HEIGHT,
+			idx: 0,
+		},
+		headers: vec![BlockHeader::default()],
+	};
+	let bytes = ser::ser_vec(&segment, ProtocolVersion::local()).unwrap();
+	let result: Result<p2p::msg::HeaderSegment, _> = ser::deserialize(
+		&mut &bytes[..],
+		ProtocolVersion::local(),
+		ser::DeserializationMode::default(),
+	);
+
+	assert_eq!(result.err(), Some(ser::Error::CorruptedData));
 }

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -952,10 +952,11 @@ where
 		headers: &[BlockHeader],
 		sync_head: chain::Tip,
 	) -> Result<bool, chain::Error> {
-		match self
-			.chain()
-			.sync_block_headers(headers, sync_head, chain::Options::SYNC)
-		{
+		match self.chain().sync_block_headers(
+			headers,
+			sync_head,
+			chain::Options::SYNC | chain::Options::POW_VERIFIED,
+		) {
 			Ok(sync_head) => {
 				if let Some(sync_head) = sync_head {
 					self.sync_state.update_header_sync(sync_head);

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -952,10 +952,11 @@ where
 		headers: &[BlockHeader],
 		sync_head: chain::Tip,
 	) -> Result<bool, chain::Error> {
+		// PoW is checked while decoding legacy and PIHD headers.
 		match self.chain().sync_block_headers(
 			headers,
 			sync_head,
-			chain::Options::SYNC | chain::Options::POW_VERIFIED,
+			chain::Options::SYNC | chain::Options::POW_VERIFIED_ON_READ,
 		) {
 			Ok(sync_head) => {
 				if let Some(sync_head) = sync_head {

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -641,6 +641,12 @@ impl Store {
 		Batch::new(self)
 	}
 
+	/// Builds a read-only batch to be used with this store.
+	pub fn read_batch(&self) -> Result<ReadBatch<'_>, Error> {
+		self.maybe_resize();
+		ReadBatch::new(self)
+	}
+
 	/// Increment the open-tx counter, blocking during resize unless this thread already holds a tx.
 	fn enter_tx(&self) -> TxCounter {
 		loop {
@@ -691,6 +697,42 @@ impl Drop for TxCounter {
 		env_state
 			.open_txs_count
 			.store(open_txs_count - 1, Ordering::Relaxed);
+	}
+}
+
+/// A read-only batch backed by a single transaction.
+pub struct ReadBatch<'a> {
+	store: &'a Store,
+	read: RoTxn<'a, WithoutTls>,
+	#[allow(dead_code)]
+	tx_counter: TxCounter,
+}
+
+impl<'a> ReadBatch<'a> {
+	fn new(store: &'a Store) -> Result<ReadBatch<'a>, Error> {
+		let tx_counter = store.enter_tx();
+		let read = store.env.read_txn()?;
+		Ok(ReadBatch {
+			store,
+			read,
+			tx_counter,
+		})
+	}
+
+	/// Gets and deserializes a value from the database.
+	pub fn get_ser<T: ser::Readable>(
+		&self,
+		db_key: Option<u8>,
+		key: &[u8],
+		deser_mode: Option<DeserializationMode>,
+	) -> Result<Option<T>, Error> {
+		let d = match deser_mode {
+			Some(d) => d,
+			_ => DeserializationMode::default(),
+		};
+		self.store.get_with(db_key, key, &self.read, |_, mut data| {
+			ser::deserialize(&mut data, self.store.protocol_version(), d).map_err(From::from)
+		})
 	}
 }
 
@@ -765,8 +807,7 @@ impl<'a> Batch<'a> {
 	where
 		F: Fn(&[u8], &[u8]) -> Result<T, Error>,
 	{
-		let read = self.write.nested_read_txn()?;
-		self.store.get_with(db_key, key, &read, deserialize)
+		self.store.get_with(db_key, key, &self.write, deserialize)
 	}
 
 	/// Whether the provided key exists.

--- a/store/src/lmdb.rs
+++ b/store/src/lmdb.rs
@@ -813,9 +813,8 @@ impl<'a> Batch<'a> {
 	/// Whether the provided key exists.
 	/// This is in the context of the current write transaction.
 	pub fn exists(&self, db_key: Option<u8>, key: &[u8]) -> Result<bool, Error> {
-		let read = self.write.nested_read_txn()?;
 		let db = self.store.get_db(db_key)?;
-		let res = db.get(&read, key)?;
+		let res = db.get(&self.write, key)?;
 		Ok(res.is_some())
 	}
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -624,7 +624,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 	use super::*;
 
 	#[test]

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -622,7 +622,7 @@ where
 	}
 }
 
-#[cfg(all(test, target_os = "openbsd"))]
+#[cfg(test)]
 mod test {
 	use super::*;
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -356,6 +356,7 @@ where
 	pub fn flush(&mut self) -> io::Result<()> {
 		#[cfg(target_os = "openbsd")]
 		{
+			// Refresh the mapping after writes on OpenBSD
 			self.mmap = None;
 		}
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -356,7 +356,7 @@ where
 	pub fn flush(&mut self) -> io::Result<()> {
 		#[cfg(target_os = "openbsd")]
 		{
-			// Refresh the mapping after writes on OpenBSD
+			// OpenBSD may keep reading from the old mapping after a write
 			self.mmap = None;
 		}
 

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -354,6 +354,11 @@ where
 	/// Syncs all writes (fsync), reallocating the memory map to make the newly
 	/// written data accessible.
 	pub fn flush(&mut self) -> io::Result<()> {
+		#[cfg(target_os = "openbsd")]
+		{
+			self.mmap = None;
+		}
+
 		if let SizeInfo::VariableSize(ref mut size_file) = &mut self.size_info {
 			// Flush the associated size_file if we have one.
 			size_file.flush()?
@@ -614,5 +619,33 @@ where
 	/// Path of the underlying file
 	pub fn path(&self) -> &Path {
 		&self.path
+	}
+}
+
+#[cfg(all(test, target_os = "openbsd"))]
+mod test {
+	use super::*;
+
+	#[test]
+	fn flush_map() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("data");
+		let mut file = AppendOnlyFile::<SizeEntry>::open(
+			path,
+			SizeInfo::FixedSize(SizeEntry::LEN),
+			ProtocolVersion(1),
+		)
+		.unwrap();
+
+		for value in 0..3 {
+			file.append_elmt(&SizeEntry {
+				offset: value,
+				size: value as u16,
+			})
+			.unwrap();
+			file.flush().unwrap();
+			let entry = file.read_as_elmt(value).unwrap();
+			assert_eq!((entry.offset, entry.size), (value, value as u16));
+		}
 	}
 }


### PR DESCRIPTION
**Summary**
Adds CI and release builds for OpenBSD, FreeBSD and static musl.

Every binary is checked and smoke-tested before packaging. Docker and Snap build in parallel, while GitHub releases are only created for version tags.

Fixes PIBD resume scans starting too early and reading old headers again. It also reduces database reads during PIBD and avoids an allocation in SipHash.

Header sync no longer verifies proof of work twice. Invalid headers are still rejected while decoding both legacy and PIHD data.

On OpenBSD, PMMR file mappings are refreshed after writes to prevent stale reads.

A single Telegram notification is sent after all CD jobs finish.

Fixes #3927

**OpenBSD note**

The issue is tracked in https://github.com/meilisearch/heed/issues/383 and the upstream fix is in https://github.com/meilisearch/lmdb/pull/5. This PR temporarily uses the patched LMDB revision until the fix is available through heed.

OpenBSD may also need a higher open file limit:
ulimit -n 1024
Without it, the node can get stuck during sync.
