### PR TITLE
Fix PIBD resume stall with newer archive target

### DIFF
--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -860,7 +860,7 @@ impl Desegmenter {
 	}
 
 	fn next_required_segment_index(
-		segment_type: &str,
+		segment_type: SegmentType,
 		local_mmr_size: u64,
 		target_mmr_size: u64,
 		segment_height: u8,
@@ -904,7 +904,7 @@ impl Desegmenter {
 		}
 
 		Self::next_required_segment_index(
-			"output",
+			SegmentType::Output,
 			local_output_mmr_size,
 			self.archive_header.output_mmr_size,
 			self.default_output_segment_height,
@@ -986,7 +986,7 @@ impl Desegmenter {
 		}
 
 		Self::next_required_segment_index(
-			"rangeproof",
+			SegmentType::RangeProof,
 			local_rangeproof_mmr_size,
 			self.archive_header.output_mmr_size,
 			self.default_rangeproof_segment_height,
@@ -1074,7 +1074,7 @@ impl Desegmenter {
 		}
 
 		Self::next_required_segment_index(
-			"kernel",
+			SegmentType::Kernel,
 			local_kernel_mmr_size,
 			self.archive_header.kernel_mmr_size,
 			self.default_kernel_segment_height,
@@ -1129,7 +1129,7 @@ mod tests {
 		);
 		assert_eq!(
 			Desegmenter::next_required_segment_index(
-				"test",
+				SegmentType::Output,
 				local_size,
 				target_size,
 				segment_height
@@ -1138,7 +1138,7 @@ mod tests {
 		);
 		assert_eq!(
 			Desegmenter::next_required_segment_index(
-				"test",
+				SegmentType::Output,
 				target_size,
 				target_size,
 				segment_height
@@ -1148,7 +1148,12 @@ mod tests {
 
 		let boundary = SegmentIdentifier::pmmr_size(4, segment_height);
 		assert_eq!(
-			Desegmenter::next_required_segment_index("test", boundary, target_size, segment_height),
+			Desegmenter::next_required_segment_index(
+				SegmentType::Output,
+				boundary,
+				target_size,
+				segment_height
+			),
 			Some(4)
 		);
 	}
@@ -1158,7 +1163,7 @@ mod tests {
 		let target_size = pmmr::insertion_to_pmmr_index(2);
 		assert_eq!(Desegmenter::local_segment_count(1, 11), 0);
 		assert_eq!(
-			Desegmenter::next_required_segment_index("test", 1, target_size, 11),
+			Desegmenter::next_required_segment_index(SegmentType::Output, 1, target_size, 11),
 			Some(0)
 		);
 	}

--- a/chain/src/txhashset/desegmenter.rs
+++ b/chain/src/txhashset/desegmenter.rs
@@ -846,6 +846,55 @@ impl Desegmenter {
 		Ok(())
 	}
 
+	// Special case here. If the mmr size is 1, this is a fresh chain
+	// with naught but a humble genesis block. We need segment 0, (and
+	// also need to skip the genesis block when applying the segment)
+	// note this is implementation-specific, the code for creating
+	// a new chain creates the genesis block pmmr entries by default
+	fn local_segment_count(local_mmr_size: u64, segment_height: u8) -> usize {
+		if local_mmr_size == 1 {
+			0
+		} else {
+			SegmentIdentifier::count_segments_required(local_mmr_size, segment_height)
+		}
+	}
+
+	fn next_required_segment_index(
+		segment_type: &str,
+		local_mmr_size: u64,
+		target_mmr_size: u64,
+		segment_height: u8,
+	) -> Option<u64> {
+		let mut current = Self::local_segment_count(local_mmr_size, segment_height);
+		let total = SegmentIdentifier::count_segments_required(target_mmr_size, segment_height);
+		let theoretical_pmmr_size = SegmentIdentifier::pmmr_size(current, segment_height);
+
+		// When resuming, request the previous segment if the local PMMR is partial.
+		// Compare PMMR sizes because local and target may have the same segment count.
+		// Do not repeat the final partial segment once the target size is reached.
+		if local_mmr_size < target_mmr_size && local_mmr_size < theoretical_pmmr_size {
+			trace!(
+				"theoretical_pmmr_size {} is bigger than the current {} mmr size {}",
+				theoretical_pmmr_size,
+				segment_type,
+				local_mmr_size
+			);
+			current -= 1;
+		}
+
+		trace!(
+			"Next required {} segment is {} of {}",
+			segment_type,
+			current,
+			total
+		);
+		if current == total {
+			None
+		} else {
+			Some(current as u64)
+		}
+	}
+
 	/// Return an identifier for the next segment we need for the output pmmr
 	fn next_required_output_segment_index(&self) -> Option<u64> {
 		let local_output_mmr_size;
@@ -854,45 +903,12 @@ impl Desegmenter {
 			local_output_mmr_size = txhashset.output_mmr_size();
 		}
 
-		// Special case here. If the mmr size is 1, this is a fresh chain
-		// with naught but a humble genesis block. We need segment 0, (and
-		// also need to skip the genesis block when applying the segment)
-		// note this is implementation-specific, the code for creating
-		// a new chain creates the genesis block pmmr entries by default
-
-		let mut cur_segment_count = if local_output_mmr_size == 1 {
-			0
-		} else {
-			SegmentIdentifier::count_segments_required(
-				local_output_mmr_size,
-				self.default_output_segment_height,
-			)
-		};
-
-		let total_segment_count = SegmentIdentifier::count_segments_required(
+		Self::next_required_segment_index(
+			"output",
+			local_output_mmr_size,
 			self.archive_header.output_mmr_size,
 			self.default_output_segment_height,
-		);
-
-		// When resuming, we need to ensure we're getting the previous segment if needed.
-		// Do not apply this to the final partial segment once the target size is reached.
-		if total_segment_count != cur_segment_count {
-			let theoretical_pmmr_size =
-				SegmentIdentifier::pmmr_size(cur_segment_count, self.default_output_segment_height);
-			if local_output_mmr_size < theoretical_pmmr_size {
-				cur_segment_count -= 1;
-			}
-		}
-		trace!(
-			"Next required output segment is {} of {}",
-			cur_segment_count,
-			total_segment_count
-		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		)
 	}
 
 	/// Add an output segment.
@@ -969,45 +985,12 @@ impl Desegmenter {
 			local_rangeproof_mmr_size = txhashset.rangeproof_mmr_size();
 		}
 
-		// Special case here. If the mmr size is 1, this is a fresh chain
-		// with naught but a humble genesis block. We need segment 0, (and
-		// also need to skip the genesis block when applying the segment)
-
-		let mut cur_segment_count = if local_rangeproof_mmr_size == 1 {
-			0
-		} else {
-			SegmentIdentifier::count_segments_required(
-				local_rangeproof_mmr_size,
-				self.default_rangeproof_segment_height,
-			)
-		};
-
-		let total_segment_count = SegmentIdentifier::count_segments_required(
+		Self::next_required_segment_index(
+			"rangeproof",
+			local_rangeproof_mmr_size,
 			self.archive_header.output_mmr_size,
 			self.default_rangeproof_segment_height,
-		);
-
-		// When resuming, we need to ensure we're getting the previous segment if needed.
-		// Do not apply this to the final partial segment once the target size is reached.
-		if total_segment_count != cur_segment_count {
-			let theoretical_pmmr_size = SegmentIdentifier::pmmr_size(
-				cur_segment_count,
-				self.default_rangeproof_segment_height,
-			);
-			if local_rangeproof_mmr_size < theoretical_pmmr_size {
-				cur_segment_count -= 1;
-			}
-		}
-		trace!(
-			"Next required rangeproof segment is {} of {}",
-			cur_segment_count,
-			total_segment_count
-		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		)
 	}
 
 	/// Adds a Rangeproof segment
@@ -1090,44 +1073,12 @@ impl Desegmenter {
 			local_kernel_mmr_size = txhashset.kernel_mmr_size();
 		}
 
-		let mut cur_segment_count = if local_kernel_mmr_size == 1 {
-			0
-		} else {
-			SegmentIdentifier::count_segments_required(
-				local_kernel_mmr_size,
-				self.default_kernel_segment_height,
-			)
-		};
-
-		let total_segment_count = SegmentIdentifier::count_segments_required(
+		Self::next_required_segment_index(
+			"kernel",
+			local_kernel_mmr_size,
 			self.archive_header.kernel_mmr_size,
 			self.default_kernel_segment_height,
-		);
-
-		// When resuming, we need to ensure we're getting the previous segment if needed
-		if total_segment_count != cur_segment_count {
-			let theoretical_pmmr_size =
-				SegmentIdentifier::pmmr_size(cur_segment_count, self.default_kernel_segment_height);
-			if local_kernel_mmr_size < theoretical_pmmr_size {
-				trace!(
-					"theoretical_pmmr_size {} is bigger than the current mmr size {}",
-					theoretical_pmmr_size,
-					local_kernel_mmr_size
-				);
-				cur_segment_count -= 1;
-			}
-		}
-
-		trace!(
-			"Next required kernel segment is {} of {}",
-			cur_segment_count,
-			total_segment_count
-		);
-		if cur_segment_count == total_segment_count {
-			None
-		} else {
-			Some(cur_segment_count as u64)
-		}
+		)
 	}
 
 	/// Adds a Kernel segment
@@ -1158,5 +1109,57 @@ impl Desegmenter {
 			self.kernel_segment_cache.len()
 		);
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn resume_same_segment() {
+		let segment_height = 11;
+		// Both leaf counts fall within segment 4 at this height
+		let local_size = pmmr::insertion_to_pmmr_index(9_000);
+		let target_size = pmmr::insertion_to_pmmr_index(9_720);
+
+		assert_eq!(
+			SegmentIdentifier::count_segments_required(local_size, segment_height),
+			SegmentIdentifier::count_segments_required(target_size, segment_height)
+		);
+		assert_eq!(
+			Desegmenter::next_required_segment_index(
+				"test",
+				local_size,
+				target_size,
+				segment_height
+			),
+			Some(4)
+		);
+		assert_eq!(
+			Desegmenter::next_required_segment_index(
+				"test",
+				target_size,
+				target_size,
+				segment_height
+			),
+			None
+		);
+
+		let boundary = SegmentIdentifier::pmmr_size(4, segment_height);
+		assert_eq!(
+			Desegmenter::next_required_segment_index("test", boundary, target_size, segment_height),
+			Some(4)
+		);
+	}
+
+	#[test]
+	fn genesis_segment_count() {
+		let target_size = pmmr::insertion_to_pmmr_index(2);
+		assert_eq!(Desegmenter::local_segment_count(1, 11), 0);
+		assert_eq!(
+			Desegmenter::next_required_segment_index("test", 1, target_size, 11),
+			Some(0)
+		);
 	}
 }

--- a/core/src/core/pmmr/segment.rs
+++ b/core/src/core/pmmr/segment.rs
@@ -19,6 +19,7 @@ use crate::core::pmmr::{self, Backend, ReadablePMMR, ReadonlyPMMR};
 use crate::ser::{Error, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer};
 use croaring::Bitmap;
 use std::cmp::min;
+use std::fmt;
 use std::fmt::Debug;
 
 const MAX_SEGMENT_READ_ITEMS: u64 = 1_000_000;
@@ -65,6 +66,17 @@ pub enum SegmentType {
 	RangeProof,
 	/// Kernel
 	Kernel,
+}
+
+impl fmt::Display for SegmentType {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match *self {
+			SegmentType::Bitmap => f.write_str("bitmap"),
+			SegmentType::Output => f.write_str("output"),
+			SegmentType::RangeProof => f.write_str("range proof"),
+			SegmentType::Kernel => f.write_str("kernel"),
+		}
+	}
 }
 
 /// Lumps possible types with segment ids to enable a unique identifier


### PR DESCRIPTION
PIBD could stop requesting output, rangeproof and kernel segments when
resuming against a newer archive target if both pmmr sizes were within the
same segment.

This could be fixed with three small changes, but the surrounding logic was
duplicated for all three pmmr. I moved it into a shared helper to keep the
behavior consistent and make it easier to test.

Tests cover the reported resume case, segment boundaries, completed targets
and Genesis (https://forum.grin.mw/t/grim-cross-platform-gui-for-grin/11128/115?u=wiesche).

Fixes #3931


